### PR TITLE
server: keep SQLAlchemy boolean predicates indexable

### DIFF
--- a/handbook/docs.json
+++ b/handbook/docs.json
@@ -105,7 +105,8 @@
               "engineering/decisions/0005-auth-subject-and-scopes",
               "engineering/decisions/0006-migration-and-backfill-safety",
               "engineering/decisions/0007-no-default-in-output-schemas",
-              "engineering/decisions/0008-encrypt-secrets-at-rest"
+              "engineering/decisions/0008-encrypt-secrets-at-rest",
+              "engineering/decisions/0009-use-bare-boolean-expressions-in-sqlalchemy-predicates"
             ]
           },
           "engineering/tech-notes",

--- a/handbook/engineering/decisions/0009-use-bare-boolean-expressions-in-sqlalchemy-predicates.mdx
+++ b/handbook/engineering/decisions/0009-use-bare-boolean-expressions-in-sqlalchemy-predicates.mdx
@@ -1,0 +1,52 @@
+---
+title: "ADR-0009: Use bare boolean expressions in SQLAlchemy predicates"
+description: "Avoid wrapping SQLAlchemy query predicates in IS TRUE or IS FALSE so PostgreSQL can match indexes."
+---
+
+<Info>
+**Status**: Accepted
+
+**Area**: Backend
+
+**Date**: 2026-08-12
+</Info>
+
+## Context
+
+SQLAlchemy hybrid properties often expand to comparisons such as
+`payment_lock_acquired_at <= cutoff` or `deleted_at IS NOT NULL`. Wrapping such an expression
+in `.is_(True)` or `.is_(False)` produces an outer `IS TRUE` or `IS FALSE` node; PostgreSQL's
+limited predicate implication logic may then fail to see the underlying indexable condition,
+particularly when matching a partial index, and choose a sequential scan instead.
+
+## Decision
+
+In SQL predicate positions, write a boolean expression directly for truth and negate it with
+`~expression` or `sqlalchemy.not_(expression)` for falsehood. Do not use `.is_(True)` or
+`.is_(False)` unless SQL identity semantics are intentionally required.
+
+```python
+statement.where(Order.is_payment_lock_stale)
+statement.where(~Order.is_deleted)
+```
+
+Identity tests remain valid when their three-valued behavior is the requirement. For example,
+`expression.is_not(True)` means "false or unknown" and therefore includes `NULL`, while
+`~expression` means strict falsehood and excludes `NULL`. The rule does not apply to
+`.is_(None)` / `.is_not(None)`, which express SQL null checks.
+
+## Consequences
+
+- PostgreSQL can see comparisons and null checks inside hybrid properties, making ordinary and
+  partial indexes available to the planner.
+- Predicate code consistently uses `expression` for true and `~expression` for false.
+- Every replacement must preserve the intended handling of `NULL`; `IS NOT TRUE`, projections,
+  constraints, and other contexts where `UNKNOWN` is distinct require explicit review.
+- We accept that identity tests remain in exceptional cases and should make the required null
+  semantics evident from their context or a short comment.
+
+## References
+
+- [PR #13687: stop the stale payment lock sweep from scanning every order](https://github.com/polarsource/polar/pull/13687)
+- [Issue #13690: audit `IS TRUE` / `IS FALSE` wrappers](https://github.com/polarsource/polar/issues/13690)
+- [PostgreSQL partial indexes](https://www.postgresql.org/docs/current/indexes-partial.html)

--- a/handbook/engineering/decisions/index.mdx
+++ b/handbook/engineering/decisions/index.mdx
@@ -89,3 +89,4 @@ To check a diff against these ADRs, run the `adr-check` skill.
 - [ADR-0006: Migrations and backfills are deploy-safe by construction](/engineering/decisions/0006-migration-and-backfill-safety) · Backend · Accepted
 - [ADR-0007: No default in output schemas](/engineering/decisions/0007-no-default-in-output-schemas) · Backend · Accepted
 - [ADR-0008: Encrypt secrets at rest](/engineering/decisions/0008-encrypt-secrets-at-rest) · Backend · Accepted
+- [ADR-0009: Use bare boolean expressions in SQLAlchemy predicates](/engineering/decisions/0009-use-bare-boolean-expressions-in-sqlalchemy-predicates) · Backend · Accepted

--- a/server/polar/authz/repository.py
+++ b/server/polar/authz/repository.py
@@ -32,7 +32,7 @@ def select_user_org_ids(
         .join(Organization, UserOrganization.organization_id == Organization.id)
         .where(
             UserOrganization.user_id == user_id,
-            UserOrganization.is_deleted.is_(False),
+            ~UserOrganization.is_deleted,
             Organization.can_authenticate,
         )
     )

--- a/server/polar/backoffice/organizations_v2/analytics.py
+++ b/server/polar/backoffice/organizations_v2/analytics.py
@@ -202,7 +202,7 @@ class OrganizationSetupAnalyticsService:
         result = await self.session.execute(
             select(func.count(CheckoutLink.id)).where(
                 CheckoutLink.organization_id == organization_id,
-                CheckoutLink.is_deleted.is_(False),
+                ~CheckoutLink.is_deleted,
             )
         )
         return result.scalar() or 0
@@ -212,7 +212,7 @@ class OrganizationSetupAnalyticsService:
         result = await self.session.execute(
             select(func.count(WebhookEndpoint.id)).where(
                 WebhookEndpoint.organization_id == organization_id,
-                WebhookEndpoint.is_deleted.is_(False),
+                ~WebhookEndpoint.is_deleted,
             )
         )
         return result.scalar() or 0
@@ -222,7 +222,7 @@ class OrganizationSetupAnalyticsService:
         result = await self.session.execute(
             select(func.count(OrganizationAccessToken.id)).where(
                 OrganizationAccessToken.organization_id == organization_id,
-                OrganizationAccessToken.is_deleted.is_(False),
+                ~OrganizationAccessToken.is_deleted,
             )
         )
         return result.scalar() or 0
@@ -232,8 +232,8 @@ class OrganizationSetupAnalyticsService:
         result = await self.session.execute(
             select(func.count(Product.id)).where(
                 Product.organization_id == organization_id,
-                Product.is_archived.is_(False),
-                Product.is_deleted.is_(False),
+                ~Product.is_archived,
+                ~Product.is_deleted,
             )
         )
         return result.scalar() or 0
@@ -243,7 +243,7 @@ class OrganizationSetupAnalyticsService:
         result = await self.session.execute(
             select(func.count(Benefit.id)).where(
                 Benefit.organization_id == organization_id,
-                Benefit.is_deleted.is_(False),
+                ~Benefit.is_deleted,
             )
         )
         return result.scalar() or 0
@@ -255,7 +255,7 @@ class OrganizationSetupAnalyticsService:
             .join(ProductBenefit, Benefit.id == ProductBenefit.benefit_id)
             .where(
                 Benefit.organization_id == organization_id,
-                Benefit.is_deleted.is_(False),
+                ~Benefit.is_deleted,
             )
         )
         return result.scalar() or 0

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -702,9 +702,9 @@ async def list_organizations(
             stmt = stmt.where(OrganizationReview.appeal_submitted_at.is_(None))
 
     if first_reviews == "true":
-        stmt = stmt.where(Organization.is_first_review.is_(True))
+        stmt = stmt.where(Organization.is_first_review)
     elif first_reviews == "false":
-        stmt = stmt.where(Organization.is_first_review.is_(False))
+        stmt = stmt.where(~Organization.is_first_review)
 
     stmt = apply_deleted_filter(stmt, deleted_filter)
 
@@ -858,8 +858,8 @@ async def get_organization_detail(
         .options(contains_eager(UserOrganization.user))
         .where(
             UserOrganization.organization_id == organization_id,
-            UserOrganization.is_deleted.is_(False),
-            User.is_deleted.is_(False),
+            ~UserOrganization.is_deleted,
+            ~User.is_deleted,
         )
     )
     members_result = await session.execute(members_stmt)

--- a/server/polar/backoffice/organizations_v2/orders_import.py
+++ b/server/polar/backoffice/organizations_v2/orders_import.py
@@ -49,7 +49,7 @@ async def _get_product_by_name(
 ) -> Product | None:
     statement = repository.get_base_statement().where(
         Product.organization_id == organization.id,
-        Product.is_archived.is_(False),
+        ~Product.is_archived,
         func.lower(func.trim(Product.name)) == name.lower(),
     )
     try:

--- a/server/polar/backoffice/support_cases/queries.py
+++ b/server/polar/backoffice/support_cases/queries.py
@@ -143,7 +143,7 @@ def cases_statement(
         statement = statement.where(SupportCase.type == case_type)
     disputes_enabled = Organization.feature_settings["disputes_enabled"].as_boolean()
     if self_service == "enabled":
-        statement = statement.where(disputes_enabled.is_(True))
+        statement = statement.where(disputes_enabled)
     elif self_service == "disabled":
         statement = statement.where(disputes_enabled.isnot(True))
     order_by: tuple[Any, ...]

--- a/server/polar/backoffice/users/endpoints.py
+++ b/server/polar/backoffice/users/endpoints.py
@@ -584,7 +584,7 @@ async def get(
         active_oauth_result = await session.execute(
             select(OAuthAccount).where(
                 OAuthAccount.user_id == user.id,
-                OAuthAccount.is_deleted.is_(False),
+                ~OAuthAccount.is_deleted,
             )
         )
         active_oauth_accounts = active_oauth_result.scalars().all()
@@ -592,7 +592,7 @@ async def get(
         deleted_oauth_result = await session.execute(
             select(OAuthAccount).where(
                 OAuthAccount.user_id == user.id,
-                OAuthAccount.is_deleted.is_(True),
+                OAuthAccount.is_deleted,
             )
         )
         deleted_oauth_accounts = deleted_oauth_result.scalars().all()

--- a/server/polar/benefit/grant/repository.py
+++ b/server/polar/benefit/grant/repository.py
@@ -58,7 +58,7 @@ class BenefitGrantRepository(
             BenefitGrant.customer_id == customer.id,
             BenefitGrant.benefit_id == benefit.id,
             BenefitGrant.member_id == (member.id if member else None),
-            BenefitGrant.is_deleted.is_(False),
+            ~BenefitGrant.is_deleted,
             BenefitGrant.scope == scope,
         )
         if for_update:
@@ -70,8 +70,8 @@ class BenefitGrantRepository(
     ) -> Sequence[BenefitGrant]:
         statement = self.get_base_statement().where(
             BenefitGrant.scope == scope,
-            BenefitGrant.is_granted.is_(True),
-            BenefitGrant.is_deleted.is_(False),
+            BenefitGrant.is_granted,
+            ~BenefitGrant.is_deleted,
         )
         return await self.get_all(statement)
 
@@ -85,8 +85,8 @@ class BenefitGrantRepository(
             self.get_base_statement()
             .where(
                 BenefitGrant.benefit_id == benefit.id,
-                BenefitGrant.is_granted.is_(True),
-                BenefitGrant.is_deleted.is_(False),
+                BenefitGrant.is_granted,
+                ~BenefitGrant.is_deleted,
             )
             .options(*options)
         )
@@ -102,8 +102,8 @@ class BenefitGrantRepository(
             self.get_base_statement()
             .where(
                 BenefitGrant.customer_id == customer_id,
-                BenefitGrant.is_granted.is_(True),
-                BenefitGrant.is_deleted.is_(False),
+                BenefitGrant.is_granted,
+                ~BenefitGrant.is_deleted,
             )
             .options(*options)
         )
@@ -132,8 +132,8 @@ class BenefitGrantRepository(
             self.get_base_statement()
             .where(
                 BenefitGrant.member_id == member_id,
-                BenefitGrant.is_granted.is_(True),
-                BenefitGrant.is_deleted.is_(False),
+                BenefitGrant.is_granted,
+                ~BenefitGrant.is_deleted,
             )
             .options(*options)
         )
@@ -151,8 +151,8 @@ class BenefitGrantRepository(
             .where(
                 BenefitGrant.benefit_id == benefit.id,
                 BenefitGrant.customer_id == customer.id,
-                BenefitGrant.is_granted.is_(True),
-                BenefitGrant.is_deleted.is_(False),
+                BenefitGrant.is_granted,
+                ~BenefitGrant.is_deleted,
             )
             .options(*options)
         )
@@ -170,9 +170,9 @@ class BenefitGrantRepository(
             .where(
                 BenefitGrant.customer_id == customer.id,
                 Benefit.type == benefit_type,
-                BenefitGrant.is_granted.is_(False),
-                BenefitGrant.is_revoked.is_(False),
-                BenefitGrant.is_deleted.is_(False),
+                ~BenefitGrant.is_granted,
+                ~BenefitGrant.is_revoked,
+                ~BenefitGrant.is_deleted,
                 BenefitGrant.error.is_not(None),
                 BenefitGrant.error["type"].as_string() == error_type,
             )
@@ -191,9 +191,9 @@ class BenefitGrantRepository(
             .where(
                 BenefitGrant.member_id == member.id,
                 Benefit.type == benefit_type,
-                BenefitGrant.is_granted.is_(False),
-                BenefitGrant.is_revoked.is_(False),
-                BenefitGrant.is_deleted.is_(False),
+                ~BenefitGrant.is_granted,
+                ~BenefitGrant.is_revoked,
+                ~BenefitGrant.is_deleted,
                 BenefitGrant.error.is_not(None),
                 BenefitGrant.error["type"].as_string() == error_type,
             )
@@ -208,7 +208,7 @@ class BenefitGrantRepository(
         statement = self.get_base_statement().where(
             BenefitGrant.customer_id == customer.id,
             BenefitGrant.scope == scope,
-            BenefitGrant.is_deleted.is_(False),
+            ~BenefitGrant.is_deleted,
         )
         return await self.get_all(statement)
 
@@ -220,7 +220,7 @@ class BenefitGrantRepository(
         statement = self.get_base_statement().where(
             BenefitGrant.member_id == member.id,
             BenefitGrant.scope == scope,
-            BenefitGrant.is_deleted.is_(False),
+            ~BenefitGrant.is_deleted,
         )
         return await self.get_all(statement)
 
@@ -288,8 +288,8 @@ class BenefitGrantRepository(
             .where(
                 BenefitGrant.properties[key].as_string() == value,
                 Benefit.organization_id == organization_id,
-                BenefitGrant.is_granted.is_(True),
-                BenefitGrant.is_deleted.is_(False),
+                BenefitGrant.is_granted,
+                ~BenefitGrant.is_deleted,
             )
         )
         result = await self.session.execute(statement)
@@ -306,8 +306,8 @@ class BenefitGrantRepository(
         statement = self.get_base_statement().where(
             BenefitGrant.scope == scope,
             BenefitGrant.benefit_id.not_in(product_benefits_statement),
-            BenefitGrant.is_granted.is_(True),
-            BenefitGrant.is_deleted.is_(False),
+            BenefitGrant.is_granted,
+            ~BenefitGrant.is_deleted,
         )
         return await self.get_all(statement)
 

--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -69,7 +69,7 @@ class BenefitGrantService:
             select(BenefitGrant)
             .where(
                 BenefitGrant.benefit_id == benefit.id,
-                BenefitGrant.is_deleted.is_(False),
+                ~BenefitGrant.is_deleted,
             )
             .order_by(BenefitGrant.created_at.desc())
             .options(
@@ -111,7 +111,7 @@ class BenefitGrantService:
         statement = (
             repository.get_statement_by_org_ids(org_ids)
             .join(Customer, BenefitGrant.customer_id == Customer.id)
-            .where(BenefitGrant.is_deleted.is_(False))
+            .where(~BenefitGrant.is_deleted)
             .options(
                 joinedload(BenefitGrant.customer),
                 joinedload(BenefitGrant.benefit).joinedload(Benefit.organization),

--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -82,7 +82,7 @@ class BillingEntryRepository(
             # pending set — which was timing out on high-volume subscriptions.
             .where(
                 BillingEntry.type != BillingEntryType.metered,
-                ProductPrice.is_static.is_(True),
+                ProductPrice.is_static,
             )
             .options(
                 contains_eager(BillingEntry.product_price),

--- a/server/polar/checkout/repository.py
+++ b/server/polar/checkout/repository.py
@@ -77,7 +77,7 @@ class CheckoutRepository(
         statement = (
             update(Checkout)
             .where(
-                Checkout.is_deleted.is_(False),
+                ~Checkout.is_deleted,
                 Checkout.expires_at <= utc_now(),
                 Checkout.status == CheckoutStatus.open,
             )
@@ -91,7 +91,7 @@ class CheckoutRepository(
         statement = select(
             select(Checkout.id)
             .where(
-                Checkout.is_deleted.is_(False),
+                ~Checkout.is_deleted,
                 Checkout.organization_id == organization_id,
                 Checkout.embed_origin.is_not(None),
             )
@@ -110,7 +110,7 @@ class CheckoutRepository(
                 func.max(Checkout.created_at).label("last_seen_at"),
             )
             .where(
-                Checkout.is_deleted.is_(False),
+                ~Checkout.is_deleted,
                 Checkout.organization_id == organization_id,
                 Checkout.embed_origin.is_not(None),
                 Checkout.created_at >= since,

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2535,7 +2535,7 @@ class CheckoutService:
             .join(Product, onclause=Product.id == Subscription.product_id)
             .where(
                 Product.organization_id == organization.id,
-                Subscription.billable.is_(True),
+                Subscription.billable,
             )
         )
         if checkout.customer is not None:
@@ -2547,7 +2547,7 @@ class CheckoutService:
                 Customer, onclause=Customer.id == Subscription.customer_id
             ).where(
                 func.lower(Customer.email) == checkout.customer_email.lower(),
-                Customer.is_deleted.is_(False),
+                ~Customer.is_deleted,
             )
 
         result = await session.execute(statement)

--- a/server/polar/checkout_link/repository.py
+++ b/server/polar/checkout_link/repository.py
@@ -43,7 +43,7 @@ class CheckoutLinkRepository(
             )
             .where(
                 CheckoutLink.client_secret == client_secret,
-                Organization.can_authenticate.is_(True),
+                Organization.can_authenticate,
             )
             .options(*options)
         )
@@ -103,7 +103,7 @@ class CheckoutLinkRepository(
             .where(
                 CheckoutLinkProduct.checkout_link_id == CheckoutLink.id,
                 Product.deleted_at.is_(None),
-                Product.is_archived.is_(False),
+                ~Product.is_archived,
                 ~grants_benefit,
             )
             .exists()

--- a/server/polar/compass/assistant/entity_tools.py
+++ b/server/polar/compass/assistant/entity_tools.py
@@ -401,7 +401,7 @@ async def list_products(
     count = await product_repository.count(
         product_repository.get_base_statement().where(
             Product.organization_id == deps.organization_id,
-            Product.is_archived.is_(False),
+            ~Product.is_archived,
         )
     )
     rows: list[Row] = [

--- a/server/polar/custom_field/service.py
+++ b/server/polar/custom_field/service.py
@@ -244,7 +244,7 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
         self, session: AsyncSession, id: uuid.UUID, organization_id: uuid.UUID
     ) -> CustomField | None:
         statement = select(CustomField).where(
-            CustomField.is_deleted.is_(False),
+            ~CustomField.is_deleted,
             CustomField.organization_id == organization_id,
             CustomField.id == id,
         )
@@ -256,7 +256,7 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
     ) -> Select[tuple[CustomField]]:
         statement = (
             select(CustomField)
-            .where(CustomField.is_deleted.is_(False))
+            .where(~CustomField.is_deleted)
             .join(Organization, Organization.id == CustomField.organization_id)
             .options(contains_eager(CustomField.organization))
         )

--- a/server/polar/customer_meter/service.py
+++ b/server/polar/customer_meter/service.py
@@ -478,7 +478,7 @@ class CustomerMeterService:
                 by_external_id=False,
                 cutoff=cutoff,
             )
-            .where(Event.is_meter_credit.is_(True))
+            .where(Event.is_meter_credit)
             .order_by(Event.timestamp.asc())
         )
 

--- a/server/polar/customer_portal/repository/downloadable.py
+++ b/server/polar/customer_portal/repository/downloadable.py
@@ -59,12 +59,12 @@ class DownloadableRepository(RepositoryBase[Downloadable]):
             .join(Benefit)
             .where(
                 Downloadable.status == DownloadableStatus.granted,
-                Downloadable.is_deleted.is_(False),
-                File.is_deleted.is_(False),
+                ~Downloadable.is_deleted,
+                ~File.is_deleted,
                 File.is_uploaded == True,  # noqa: E712
                 File.is_enabled == True,  # noqa: E712
                 File.flagged_malicious_at.is_(None),
-                Benefit.is_deleted.is_(False),
+                ~Benefit.is_deleted,
             )
             .order_by(Downloadable.created_at.desc())
         )

--- a/server/polar/customer_portal/service/benefit_grant.py
+++ b/server/polar/customer_portal/service/benefit_grant.py
@@ -253,8 +253,8 @@ class CustomerBenefitGrantService(ResourceServiceReader[BenefitGrant]):
             .join(Benefit, onclause=Benefit.id == BenefitGrant.benefit_id)
             .join(Organization, onclause=Benefit.organization_id == Organization.id)
             .where(
-                BenefitGrant.is_deleted.is_(False),
-                BenefitGrant.is_revoked.is_(False),
+                ~BenefitGrant.is_deleted,
+                ~BenefitGrant.is_revoked,
                 Benefit.visibility == Visibility.public,
             )
             .options(

--- a/server/polar/customer_portal/service/downloadables.py
+++ b/server/polar/customer_portal/service/downloadables.py
@@ -111,7 +111,7 @@ class DownloadableService(
                 Downloadable.customer_id == customer.id,
                 Downloadable.benefit_id == benefit_id,
                 Downloadable.status == DownloadableStatus.granted,
-                Downloadable.is_deleted.is_(False),
+                ~Downloadable.is_deleted,
             )
             .values(
                 status=DownloadableStatus.revoked,

--- a/server/polar/customer_portal/service/organization.py
+++ b/server/polar/customer_portal/service/organization.py
@@ -14,14 +14,14 @@ class CustomerOrganizationService(ResourceServiceReader[Organization]):
         statement = (
             select(Organization)
             .where(
-                Organization.can_authenticate.is_(True),
+                Organization.can_authenticate,
                 Organization.slug == slug,
             )
             .options(
                 selectinload(
                     Organization.products.and_(
-                        Product.is_deleted.is_(False),
-                        Product.is_archived.is_(False),
+                        ~Product.is_deleted,
+                        ~Product.is_archived,
                         Product.visibility == Visibility.public,
                     )
                 ).options(

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -121,9 +121,9 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
 
         if active is not None:
             if active:
-                statement = statement.where(Subscription.active.is_(True))
+                statement = statement.where(Subscription.active)
             else:
-                statement = statement.where(Subscription.revoked.is_(True))
+                statement = statement.where(Subscription.revoked)
 
         if query is not None:
             statement = statement.where(Product.name.icontains(query, autoescape=True))
@@ -369,7 +369,7 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
         self, auth_subject: AuthSubject[Customer | Member]
     ) -> Select[tuple[Subscription]]:
         return select(Subscription).where(
-            Subscription.is_deleted.is_(False),
+            ~Subscription.is_deleted,
             Subscription.customer_id == get_customer_id(auth_subject),
         )
 

--- a/server/polar/customer_seat/repository.py
+++ b/server/polar/customer_seat/repository.py
@@ -447,8 +447,8 @@ class CustomerSeatRepository(RepositoryBase[CustomerSeat]):
             .join(Subscription, CustomerSeat.subscription_id == Subscription.id)
             .where(
                 Subscription.product_id == product_id,
-                Subscription.is_deleted.is_(False),
-                Subscription.active.is_(True),
+                ~Subscription.is_deleted,
+                Subscription.active,
                 CustomerSeat.status == SeatStatus.claimed,
                 CustomerSeat.customer_id.is_not(None),
             )
@@ -463,7 +463,7 @@ class CustomerSeatRepository(RepositoryBase[CustomerSeat]):
             .join(Order, CustomerSeat.order_id == Order.id)
             .where(
                 Order.product_id == product_id,
-                Order.is_deleted.is_(False),
+                ~Order.is_deleted,
                 CustomerSeat.status == SeatStatus.claimed,
                 CustomerSeat.customer_id.is_not(None),
             )

--- a/server/polar/customer_session/service.py
+++ b/server/polar/customer_session/service.py
@@ -233,8 +233,8 @@ class CustomerSessionService(ResourceServiceReader[CustomerSession]):
             .join(CustomerSession.customer)
             .where(
                 CustomerSession.token == token_hash,
-                CustomerSession.is_deleted.is_(False),
-                Customer.can_authenticate.is_(True),
+                ~CustomerSession.is_deleted,
+                Customer.can_authenticate,
             )
             .options(
                 contains_eager(CustomerSession.customer).joinedload(

--- a/server/polar/discount/repository.py
+++ b/server/polar/discount/repository.py
@@ -43,7 +43,7 @@ class DiscountRepository(RepositoryBase[Discount], RepositoryIDMixin[Discount, U
             .where(
                 func.upper(Discount.code) == code.upper(),
                 Discount.organization_id == organization_id,
-                Discount.is_deleted.is_(False),
+                ~Discount.is_deleted,
             )
             .with_for_update(nowait=nowait)
             .options(raiseload(Discount.organization))

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -366,7 +366,7 @@ class DiscountService(ResourceServiceReader[Discount]):
         statement = select(Discount).where(
             Discount.id == id,
             Discount.organization_id == organization.id,
-            Discount.is_deleted.is_(False),
+            ~Discount.is_deleted,
         )
         result = await session.execute(statement)
         discount = result.scalar_one_or_none()
@@ -400,7 +400,7 @@ class DiscountService(ResourceServiceReader[Discount]):
         statement = select(Discount).where(
             func.upper(Discount.code) == code.upper(),
             Discount.organization_id == organization.id,
-            Discount.is_deleted.is_(False),
+            ~Discount.is_deleted,
         )
         result = await session.execute(statement)
         discount = result.scalar_one_or_none()
@@ -554,7 +554,7 @@ class DiscountService(ResourceServiceReader[Discount]):
     def _get_readable_discount_statement(
         self, auth_subject: AuthSubject[User | Organization]
     ) -> Select[tuple[Discount]]:
-        statement = select(Discount).where(Discount.is_deleted.is_(False))
+        statement = select(Discount).where(~Discount.is_deleted)
 
         if is_user(auth_subject):
             statement = statement.where(

--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -164,8 +164,8 @@ class DisputeRepository(
             .where(
                 Dispute.status == DisputeStatus.needs_response,
                 announced,
-                feature_settings["disputes_enabled"].as_boolean().is_(True),
-                feature_settings["dispute_auto_accept_enabled"].as_boolean().is_(True),
+                feature_settings["disputes_enabled"].as_boolean(),
+                feature_settings["dispute_auto_accept_enabled"].as_boolean(),
                 Organization.dispute_settings["auto_accept_below_amount"]
                 .as_integer()
                 .isnot(None),

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -1243,7 +1243,7 @@ class EventService:
             allowed_customers: set[uuid.UUID] = set()
         else:
             statement = select(Customer.id).where(
-                Customer.is_deleted.is_(False),
+                ~Customer.is_deleted,
                 Customer.id.in_(customer_ids),
             )
             if is_user(auth_subject):
@@ -1286,7 +1286,7 @@ class EventService:
             allowed_members: set[uuid.UUID] = set()
         else:
             statement = select(Member.id).where(
-                Member.is_deleted.is_(False),
+                ~Member.is_deleted,
                 Member.id.in_(member_ids),
             )
             if is_user(auth_subject):

--- a/server/polar/event_type/repository.py
+++ b/server/polar/event_type/repository.py
@@ -25,7 +25,7 @@ class EventTypeRepository(
         statement = select(EventType).where(
             EventType.name == name,
             EventType.organization_id == organization_id,
-            EventType.is_deleted.is_(False),
+            ~EventType.is_deleted,
         )
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()
@@ -43,7 +43,7 @@ class EventTypeRepository(
         statement = select(EventType).where(
             EventType.name.in_(names),
             org_filter,
-            EventType.is_deleted.is_(False),
+            ~EventType.is_deleted,
         )
         result = await self.session.execute(statement)
         return {(et.organization_id, et.name): et for et in result.scalars().all()}

--- a/server/polar/file/repository.py
+++ b/server/polar/file/repository.py
@@ -55,7 +55,7 @@ class FileRepository(
         """Get paginated files for an organization, optionally filtered by service type."""
         statement = self.get_base_statement().where(
             File.organization_id == organization_id,
-            File.is_uploaded.is_(True),
+            File.is_uploaded,
         )
 
         if service is not None:

--- a/server/polar/file/service.py
+++ b/server/polar/file/service.py
@@ -49,7 +49,7 @@ class FileService:
         )
 
         statement = repository.get_statement_by_org_ids(org_ids).where(
-            File.is_uploaded.is_(True),
+            File.is_uploaded,
             File.service != FileServiceTypes.support_case_attachment,
         )
 
@@ -194,9 +194,9 @@ class FileService:
         statement = sql.select(ProductMediaFile).where(
             File.id == id,
             File.organization_id == organization_id,
-            File.is_uploaded.is_(True),
-            File.is_enabled.is_(True),
-            File.is_deleted.is_(False),
+            File.is_uploaded,
+            File.is_enabled,
+            ~File.is_deleted,
             File.flagged_malicious_at.is_(None),
         )
         result = await session.execute(statement)

--- a/server/polar/kit/services.py
+++ b/server/polar/kit/services.py
@@ -28,7 +28,7 @@ class ResourceServiceReader[ModelType: RecordModel]:
     ) -> ModelType | None:
         query = sql.select(self.model).where(self.model.id == id)
         if not allow_deleted:
-            query = query.where(self.model.is_deleted.is_(False))
+            query = query.where(~self.model.is_deleted)
         if options is not None:
             query = query.options(*options)
         res = await session.execute(query)
@@ -42,7 +42,7 @@ class ResourceServiceReader[ModelType: RecordModel]:
     async def soft_delete(self, session: AsyncSession, id: UUID) -> None:
         stmt = (
             sql.update(self.model)
-            .where(self.model.id == id, self.model.is_deleted.is_(False))
+            .where(self.model.id == id, ~self.model.is_deleted)
             .values(
                 deleted_at=utc_now(),
             )

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -132,7 +132,7 @@ class LicenseKeyService:
         query = select(LicenseKeyActivation).where(
             LicenseKeyActivation.id == activation_id,
             LicenseKeyActivation.license_key_id == license_key.id,
-            LicenseKeyActivation.is_deleted.is_(False),
+            ~LicenseKeyActivation.is_deleted,
         )
         result = await session.execute(query)
         record = result.scalar_one_or_none()
@@ -263,7 +263,7 @@ class LicenseKeyService:
     ) -> int:
         query = select(func.count(LicenseKeyActivation.id)).where(
             LicenseKeyActivation.license_key_id == license_key.id,
-            LicenseKeyActivation.is_deleted.is_(False),
+            ~LicenseKeyActivation.is_deleted,
         )
         res = await session.execute(query)
         count = res.scalar()

--- a/server/polar/member/repository.py
+++ b/server/polar/member/repository.py
@@ -38,7 +38,7 @@ class MemberRepository(
         statement = select(Member).where(
             Member.customer_id == customer.id,
             func.lower(Member.email) == email.lower(),
-            Member.is_deleted.is_(False),
+            ~Member.is_deleted,
         )
         return await self.get_one_or_none(statement)
 
@@ -56,7 +56,7 @@ class MemberRepository(
         statement = select(Member).where(
             Member.customer_id == customer_id,
             func.lower(Member.email) == email.lower(),
-            Member.is_deleted.is_(False),
+            ~Member.is_deleted,
         )
         return await self.get_one_or_none(statement)
 
@@ -74,7 +74,7 @@ class MemberRepository(
         statement = select(Member).where(
             Member.customer_id == customer_id,
             Member.external_id == external_id,
-            Member.is_deleted.is_(False),
+            ~Member.is_deleted,
         )
         return await self.get_one_or_none(statement)
 
@@ -92,7 +92,7 @@ class MemberRepository(
         statement = select(Member).where(
             Member.id == member_id,
             Member.customer_id == customer_id,
-            Member.is_deleted.is_(False),
+            ~Member.is_deleted,
         )
         return await self.get_one_or_none(statement)
 
@@ -102,7 +102,7 @@ class MemberRepository(
     ) -> Sequence[Member]:
         statement = select(Member).where(
             Member.customer_id == customer_id,
-            Member.is_deleted.is_(False),
+            ~Member.is_deleted,
         )
         return await self.get_all(statement)
 
@@ -126,7 +126,7 @@ class MemberRepository(
             .options(joinedload(Member.customer).joinedload(Customer.organization))
         )
         if not include_deleted:
-            statement = statement.where(Member.is_deleted.is_(False))
+            statement = statement.where(~Member.is_deleted)
         return await self.get_one_or_none(statement)
 
     async def transfer_ownership(
@@ -173,7 +173,7 @@ class MemberRepository(
             .where(
                 func.lower(Member.email) == email.lower(),
                 Member.organization_id == organization_id,
-                Member.is_deleted.is_(False),
+                ~Member.is_deleted,
             )
             .options(joinedload(Member.customer))
         )

--- a/server/polar/member_session/repository.py
+++ b/server/polar/member_session/repository.py
@@ -29,9 +29,9 @@ class MemberSessionRepository(
             .join(Member.customer)
             .where(
                 MemberSession.token == token_hash,
-                MemberSession.is_deleted.is_(False),
-                Member.is_deleted.is_(False),
-                Customer.can_authenticate.is_(True),
+                ~MemberSession.is_deleted,
+                ~Member.is_deleted,
+                Customer.can_authenticate,
             )
             .options(
                 contains_eager(MemberSession.member)

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -230,10 +230,10 @@ class MeterService:
             select(func.count(ProductPriceMeteredUnit.id))
             .join(Product)
             .where(
-                Product.is_archived.is_(False),
+                ~Product.is_archived,
                 ProductPriceMeteredUnit.meter_id == meter.id,
-                ProductPriceMeteredUnit.is_archived.is_(False),
-                ProductPriceMeteredUnit.is_deleted.is_(False),
+                ~ProductPriceMeteredUnit.is_archived,
+                ~ProductPriceMeteredUnit.is_deleted,
             )
         )
 
@@ -254,7 +254,7 @@ class MeterService:
             select(func.count(Benefit.id)).where(
                 Benefit.type == "meter_credit",
                 Benefit.properties["meter_id"].as_string() == str(meter.id),
-                Benefit.is_deleted.is_(False),
+                ~Benefit.is_deleted,
             )
         )
 
@@ -296,7 +296,7 @@ class MeterService:
 
         if clauses:
             statement = customer_repository.get_base_statement().where(
-                Customer.is_deleted.is_(False), or_(*clauses)
+                ~Customer.is_deleted, or_(*clauses)
             )
             async for customer in customer_repository.stream(statement):
                 enqueue_job("customer_meter.update_customer", customer.id)

--- a/server/polar/metrics/service.py
+++ b/server/polar/metrics/service.py
@@ -510,7 +510,7 @@ class MetricsService:
             product_stmt = select(Product.id).where(
                 Product.organization_id.in_(tb_org_ids),
                 Product.billing_type.in_(billing_type),
-                Product.is_deleted.is_(False),
+                ~Product.is_deleted,
             )
             billing_type_product_ids = list(await session.scalars(product_stmt))
             if product_id is not None:

--- a/server/polar/models/account.py
+++ b/server/polar/models/account.py
@@ -89,10 +89,7 @@ class Account(RecordModel):
             "Organization",
             lazy="raise",
             primaryjoin=(
-                "and_("
-                "Organization.account_id == Account.id,"
-                "Organization.is_deleted.is_(False)"
-                ")"
+                "and_(Organization.account_id == Account.id,~Organization.is_deleted)"
             ),
             viewonly=True,
         )

--- a/server/polar/models/customer.py
+++ b/server/polar/models/customer.py
@@ -327,7 +327,7 @@ class Customer(MetadataMixin, RecordModel):
     @can_authenticate.inplace.expression
     @classmethod
     def _can_authenticate_expression(cls) -> ColumnElement[bool]:
-        return cls.is_deleted.is_(False)
+        return ~cls.is_deleted
 
     def get_oauth_account(
         self, account_id: str, platform: CustomerOAuthPlatform

--- a/server/polar/models/license_key.py
+++ b/server/polar/models/license_key.py
@@ -98,7 +98,7 @@ class LicenseKey(RecordModel):
             primaryjoin=(
                 "and_("
                 "LicenseKeyActivation.license_key_id == LicenseKey.id, "
-                "LicenseKeyActivation.is_deleted.is_(False)"
+                "~LicenseKeyActivation.is_deleted"
                 ")"
             ),
             viewonly=True,

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -773,8 +773,8 @@ class Organization(RateLimitGroupMixin, RecordModel):
     @classmethod
     def _can_authenticate_expression(cls) -> ColumnElement[bool]:
         return and_(
-            cls.is_deleted.is_(False),
-            cls.capabilities["api_access"].as_boolean().is_(True),
+            ~cls.is_deleted,
+            cls.capabilities["api_access"].as_boolean(),
         )
 
     @hybrid_property
@@ -785,8 +785,8 @@ class Organization(RateLimitGroupMixin, RecordModel):
     @classmethod
     def _can_access_dashboard_expression(cls) -> ColumnElement[bool]:
         return and_(
-            cls.is_deleted.is_(False),
-            cls.capabilities["dashboard_access"].as_boolean().is_(True),
+            ~cls.is_deleted,
+            cls.capabilities["dashboard_access"].as_boolean(),
         )
 
     @hybrid_property
@@ -796,7 +796,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
     @can_accept_payments.inplace.expression
     @classmethod
     def _can_accept_payments_expression(cls) -> ColumnElement[bool]:
-        return cls.capabilities["checkout_payments"].as_boolean().is_(True)
+        return cls.capabilities["checkout_payments"].as_boolean()
 
     @hybrid_property
     def can_renew_subscriptions(self) -> bool:
@@ -805,7 +805,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
     @can_renew_subscriptions.inplace.expression
     @classmethod
     def _can_renew_subscriptions_expression(cls) -> ColumnElement[bool]:
-        return cls.capabilities["subscription_renewals"].as_boolean().is_(True)
+        return cls.capabilities["subscription_renewals"].as_boolean()
 
     @hybrid_property
     def can_payout(self) -> bool:
@@ -814,7 +814,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
     @can_payout.inplace.expression
     @classmethod
     def _can_payout_expression(cls) -> ColumnElement[bool]:
-        return cls.capabilities["payouts"].as_boolean().is_(True)
+        return cls.capabilities["payouts"].as_boolean()
 
     @hybrid_property
     def can_refund(self) -> bool:
@@ -823,7 +823,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
     @can_refund.inplace.expression
     @classmethod
     def _can_refund_expression(cls) -> ColumnElement[bool]:
-        return cls.capabilities["refunds"].as_boolean().is_(True)
+        return cls.capabilities["refunds"].as_boolean()
 
     def set_status(self, status: OrganizationStatus) -> None:
         if (
@@ -926,10 +926,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
             "Product",
             lazy="raise",
             primaryjoin=(
-                "and_("
-                "Product.organization_id == Organization.id, "
-                "Product.is_archived.is_(False)"
-                ")"
+                "and_(Product.organization_id == Organization.id, ~Product.is_archived)"
             ),
             viewonly=True,
         )

--- a/server/polar/models/product.py
+++ b/server/polar/models/product.py
@@ -131,7 +131,7 @@ class Product(VisibilityMixin, TrialConfigurationMixin, MetadataMixin, RecordMod
             primaryjoin=(
                 "and_("
                 "ProductPrice.product_id == Product.id, "
-                "ProductPrice.is_archived.is_(False), "
+                "~ProductPrice.is_archived, "
                 "ProductPrice.source == 'catalog'"
                 ")"
             ),
@@ -209,7 +209,7 @@ class Product(VisibilityMixin, TrialConfigurationMixin, MetadataMixin, RecordMod
             cls.id.in_(
                 select(ProductPrice.product_id).where(
                     ProductPrice.type == ProductPriceType.recurring,
-                    ProductPrice.is_archived.is_(False),
+                    ~ProductPrice.is_archived,
                 )
             ),
         )
@@ -224,7 +224,7 @@ class Product(VisibilityMixin, TrialConfigurationMixin, MetadataMixin, RecordMod
     @classmethod
     def _billing_type_expression(cls) -> ColumnElement[ProductBillingType]:
         return case(
-            (cls.is_recurring.is_(True), ProductBillingType.recurring),
+            (cls.is_recurring, ProductBillingType.recurring),
             else_=ProductBillingType.one_time,
         )
 

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -499,7 +499,7 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
                 cls.status.in_(SubscriptionStatus.billable_statuses())
                 & (
                     ~cls.status.in_(SubscriptionStatus.active_statuses())
-                    | cls.cancel_at_period_end.is_(False)
+                    | ~cls.cancel_at_period_end
                     | has_metered_price
                 )
             ),

--- a/server/polar/models/user.py
+++ b/server/polar/models/user.py
@@ -266,7 +266,7 @@ class User(RecordModel):
     @can_authenticate.inplace.expression
     @classmethod
     def _can_authenticate_expression(cls) -> ColumnElement[bool]:
-        return and_(cls.is_deleted.is_(False), cls.blocked_at.is_(None))
+        return and_(~cls.is_deleted, cls.blocked_at.is_(None))
 
     @property
     def signup_attribution(self) -> dict[str, Any]:

--- a/server/polar/oauth2/authorization_server.py
+++ b/server/polar/oauth2/authorization_server.py
@@ -181,7 +181,7 @@ class ClientConfigurationEndpoint(_ClientConfigurationEndpoint):
             return None
 
         statement = select(OAuth2Client).where(
-            OAuth2Client.is_deleted.is_(False), OAuth2Client.client_id == client_id
+            ~OAuth2Client.is_deleted, OAuth2Client.client_id == client_id
         )
         result = self.server.session.execute(statement)
         client = result.unique().scalar_one_or_none()
@@ -325,7 +325,7 @@ class AuthorizationServer(_AuthorizationServer):
 
     def query_client(self, client_id: str) -> OAuth2Client | None:
         statement = select(OAuth2Client).where(
-            OAuth2Client.is_deleted.is_(False), OAuth2Client.client_id == client_id
+            ~OAuth2Client.is_deleted, OAuth2Client.client_id == client_id
         )
         result = self.session.execute(statement)
         return result.unique().scalar_one_or_none()

--- a/server/polar/oauth2/grants/refresh_token.py
+++ b/server/polar/oauth2/grants/refresh_token.py
@@ -69,7 +69,7 @@ class RefreshTokenGrant(_RefreshTokenGrant):
             .join(UserOrganization, UserOrganization.user_id == User.id)
             .where(
                 UserOrganization.organization_id == organization_id,
-                UserOrganization.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
             )
         )
         members = (

--- a/server/polar/oauth2/service/oauth2_client.py
+++ b/server/polar/oauth2/service/oauth2_client.py
@@ -33,7 +33,7 @@ class OAuth2ClientService(ResourceServiceReader[OAuth2Client]):
             select(OAuth2Client)
             .where(
                 OAuth2Client.user_id == auth_subject.subject.id,
-                OAuth2Client.is_deleted.is_(False),
+                ~OAuth2Client.is_deleted,
             )
             .order_by(OAuth2Client.created_at.desc())
         )
@@ -43,7 +43,7 @@ class OAuth2ClientService(ResourceServiceReader[OAuth2Client]):
         self, session: AsyncSession, client_id: str
     ) -> OAuth2Client | None:
         statement = select(OAuth2Client).where(
-            OAuth2Client.client_id == client_id, OAuth2Client.is_deleted.is_(False)
+            OAuth2Client.client_id == client_id, ~OAuth2Client.is_deleted
         )
         result = await session.execute(statement)
         return result.scalar_one_or_none()

--- a/server/polar/observability/invariants/rules/subscriptions_canceled_deleted_customer.py
+++ b/server/polar/observability/invariants/rules/subscriptions_canceled_deleted_customer.py
@@ -43,7 +43,7 @@ class SubscriptionsCanceledDeletedCustomerInvariant(Invariant):
             .where(
                 and_(
                     Customer.deleted_at.is_not(None),
-                    Subscription.active.is_(True),
+                    Subscription.active,
                 )
             )
             .limit(self.LIMIT)

--- a/server/polar/observability/invariants/rules/subscriptions_current_period_end.py
+++ b/server/polar/observability/invariants/rules/subscriptions_current_period_end.py
@@ -50,10 +50,10 @@ class SubscriptionsCurrentPeriodEndInvariant(Invariant):
             select(Subscription.id, over(func.count()))
             .join(Subscription.organization)
             .where(
-                Subscription.active.is_(True),
+                Subscription.active,
                 Organization.deleted_at.is_(None),
                 Subscription.current_period_end < (func.now() - self.LEEWAY),
-                Organization.can_renew_subscriptions.is_(True),
+                Organization.can_renew_subscriptions,
                 last_write < (func.now() - self.SETTLE_GRACE),
             )
             .order_by(Subscription.current_period_end.asc(), Subscription.id.asc())

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -86,7 +86,7 @@ class OrderRepository(
             .where(
                 Order.organization_id == organization_id,
                 Order.status.in_(OrderStatus.paid_statuses()),
-                Order.is_deleted.is_(False),
+                ~Order.is_deleted,
             )
             .group_by(Customer.id)
             .order_by(net_revenue.desc())
@@ -118,7 +118,7 @@ class OrderRepository(
             .where(
                 Order.organization_id == organization_id,
                 Order.status.in_(OrderStatus.paid_statuses()),
-                Order.is_deleted.is_(False),
+                ~Order.is_deleted,
                 Order.created_at >= since,
                 country.is_not(None),
             )
@@ -151,7 +151,7 @@ class OrderRepository(
             .where(
                 Order.organization_id == organization_id,
                 Order.status.in_(OrderStatus.paid_statuses()),
-                Order.is_deleted.is_(False),
+                ~Order.is_deleted,
                 # product_id is nullable; a NULL revenue group would waste a
                 # candidate slot and poison the returned id list.
                 Order.product_id.is_not(None),
@@ -280,9 +280,9 @@ class OrderRepository(
             .where(
                 Order.next_payment_attempt_at.is_not(None),
                 Order.next_payment_attempt_at <= utc_now(),
-                Order.is_void.is_(False),
-                Organization.is_deleted.is_(False),
-                Organization.can_renew_subscriptions.is_(True),
+                ~Order.is_void,
+                ~Organization.is_deleted,
+                Organization.can_renew_subscriptions,
             )
             .order_by(Order.next_payment_attempt_at.asc())
             .options(*options)
@@ -422,13 +422,13 @@ class OrderRepository(
             customer = auth_subject.subject
             statement = statement.where(
                 Order.customer_id == customer.id,
-                Order.is_deleted.is_(False),
+                ~Order.is_deleted,
             )
         elif is_member(auth_subject):
             member = auth_subject.subject
             statement = statement.where(
                 Order.customer_id == member.customer_id,
-                Order.is_deleted.is_(False),
+                ~Order.is_deleted,
             )
 
         return statement

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -431,7 +431,7 @@ class OrderService:
         if external_customer_id is not None:
             statement = statement.where(
                 Customer.external_id.in_(external_customer_id),
-                Customer.is_deleted.is_(False),
+                ~Customer.is_deleted,
             )
 
         if checkout_id is not None:
@@ -2486,10 +2486,10 @@ class OrderService:
             .join(Order.customer)
             .where(
                 Order.product_id == product.id,
-                Order.is_deleted.is_(False),
+                ~Order.is_deleted,
                 Order.subscription_id.is_(None),
                 Order.seats.is_(None),
-                Customer.is_deleted.is_(False),
+                ~Customer.is_deleted,
             )
             .options(joinedload(Order.customer))
         )

--- a/server/polar/organization/member_backfill.py
+++ b/server/polar/organization/member_backfill.py
@@ -20,7 +20,7 @@ from polar.models import Benefit, BenefitGrant, Downloadable, LicenseKey, Organi
 
 def _member_model_org_ids() -> Select[tuple[UUID]]:
     return select(Organization.id).where(
-        Organization.feature_settings["member_model_enabled"].as_boolean().is_(True)
+        Organization.feature_settings["member_model_enabled"].as_boolean()
     )
 
 

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -190,7 +190,7 @@ class OrganizationRepository(
             .join(UserOrganization)
             .where(
                 UserOrganization.user_id == user,
-                UserOrganization.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
                 Organization.status != OrganizationStatus.BLOCKED,
             )
         )
@@ -358,8 +358,8 @@ class OrganizationRepository(
             .where(
                 UserOrganization.organization_id == organization.id,
                 UserOrganization.role == OrganizationRole.owner,
-                UserOrganization.is_deleted.is_(False),
-                User.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
+                ~User.is_deleted,
             )
         )
         result = await self.session.execute(statement)
@@ -376,7 +376,7 @@ class OrganizationRepository(
             .join(Customer, Order.customer_id == Customer.id)
             .where(
                 Customer.organization_id == organization_id,
-                Customer.is_deleted.is_(False),
+                ~Customer.is_deleted,
                 Order.total_amount > 0,
             )
         )
@@ -399,7 +399,7 @@ class OrganizationRepository(
             .outerjoin(Discount, Subscription.discount_id == Discount.id)
             .where(
                 Customer.organization_id == organization_id,
-                Customer.is_deleted.is_(False),
+                ~Customer.is_deleted,
                 Subscription.status.in_(SubscriptionStatus.active_statuses()),
                 ~(
                     (Subscription.amount == 0)
@@ -514,7 +514,7 @@ class OrganizationRepository(
             .where(
                 UserOrganization.user_id == user_id,
                 UserOrganization.role == OrganizationRole.owner,
-                UserOrganization.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
             )
         )
         return await self.get_all(statement)
@@ -528,6 +528,6 @@ class OrganizationReviewRepository(RepositoryBase[OrganizationReview]):
     ) -> OrganizationReview | None:
         statement = self.get_base_statement().where(
             OrganizationReview.organization_id == organization_id,
-            OrganizationReview.is_deleted.is_(False),
+            ~OrganizationReview.is_deleted,
         )
         return await self.get_one_or_none(statement)

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -331,11 +331,11 @@ async def _backfill_owner_members(
             Member,
             (Customer.id == Member.customer_id)
             & (Member.role == MemberRole.owner)
-            & (Member.is_deleted.is_(False)),
+            & (~Member.is_deleted),
         )
         .where(
             Customer.organization_id == organization.id,
-            Customer.is_deleted.is_(False),
+            ~Customer.is_deleted,
             Member.id.is_(None),
         )
     )
@@ -589,7 +589,7 @@ async def _backfill_benefit_grants(
         .where(
             Customer.organization_id == organization.id,
             BenefitGrant.member_id.is_(None),
-            BenefitGrant.is_deleted.is_(False),
+            ~BenefitGrant.is_deleted,
         )
     )
     results = await session.stream_scalars(
@@ -671,7 +671,7 @@ async def _backfill_benefit_grants(
                         BenefitGrant.member_id == target_member_id,
                         BenefitGrant.benefit_id == grant.benefit_id,
                         BenefitGrant.id != grant.id,
-                        BenefitGrant.is_deleted.is_(False),
+                        ~BenefitGrant.is_deleted,
                     )
                 )
                 if existing_id is not None:
@@ -1100,7 +1100,7 @@ async def _prepare_benefit_grants(
         .where(
             Customer.organization_id == organization.id,
             BenefitGrant.member_id.is_(None),
-            BenefitGrant.is_deleted.is_(False),
+            ~BenefitGrant.is_deleted,
         )
     )
     results = await session.stream_scalars(
@@ -1173,7 +1173,7 @@ async def _prepare_benefit_grants(
                         BenefitGrant.subscription_id == grant.subscription_id,
                         BenefitGrant.order_id == grant.order_id,
                         BenefitGrant.id != grant.id,
-                        BenefitGrant.is_deleted.is_(False),
+                        ~BenefitGrant.is_deleted,
                     )
                 )
                 if scope_conflict_id is not None:

--- a/server/polar/organization_access_token/repository.py
+++ b/server/polar/organization_access_token/repository.py
@@ -30,7 +30,7 @@ class OrganizationAccessTokenRepository(
             .join(OrganizationAccessToken.organization)
             .where(
                 OrganizationAccessToken.token == token_hash,
-                Organization.can_authenticate.is_(True),
+                Organization.can_authenticate,
             )
             .options(contains_eager(OrganizationAccessToken.organization))
         )
@@ -64,7 +64,7 @@ class OrganizationAccessTokenRepository(
             sql.select(OrganizationAccessToken.id)
             .where(
                 OrganizationAccessToken.organization_id == organization_id,
-                OrganizationAccessToken.is_deleted.is_(False),
+                ~OrganizationAccessToken.is_deleted,
             )
             .limit(1)
         )

--- a/server/polar/organization_access_token/service.py
+++ b/server/polar/organization_access_token/service.py
@@ -103,7 +103,7 @@ class OrganizationAccessTokenService:
         )
         statement = repository.get_statement_by_org_ids(org_ids).where(
             OrganizationAccessToken.id == id,
-            OrganizationAccessToken.is_deleted.is_(False),
+            ~OrganizationAccessToken.is_deleted,
         )
         return await repository.get_one_or_none(statement)
 

--- a/server/polar/organization_review/repository.py
+++ b/server/polar/organization_review/repository.py
@@ -73,7 +73,7 @@ class OrganizationReviewRepository(
             select(OrganizationAgentReview)
             .where(
                 OrganizationAgentReview.organization_id == organization_id,
-                OrganizationAgentReview.is_deleted.is_(False),
+                ~OrganizationAgentReview.is_deleted,
             )
             .order_by(OrganizationAgentReview.reviewed_at.desc())
             .limit(1)
@@ -93,7 +93,7 @@ class OrganizationReviewRepository(
             select(OrganizationAgentReview)
             .where(
                 OrganizationAgentReview.organization_id == organization_id,
-                OrganizationAgentReview.is_deleted.is_(False),
+                ~OrganizationAgentReview.is_deleted,
             )
             .options(
                 selectinload(OrganizationAgentReview.review_feedbacks).joinedload(
@@ -114,9 +114,7 @@ class OrganizationReviewRepository(
                 Organization,
                 onclause=Organization.payout_account_id == PayoutAccount.id,
             )
-            .where(
-                Organization.id == organization_id, PayoutAccount.is_deleted.is_(False)
-            )
+            .where(Organization.id == organization_id, ~PayoutAccount.is_deleted)
             .options(joinedload(PayoutAccount.admin))
         )
         result = await self.session.execute(statement)
@@ -127,8 +125,8 @@ class OrganizationReviewRepository(
             select(Product)
             .where(
                 Product.organization_id == organization_id,
-                Product.is_archived.is_(False),
-                Product.is_deleted.is_(False),
+                ~Product.is_archived,
+                ~Product.is_deleted,
             )
             .options(selectinload(Product.prices))
         )
@@ -143,7 +141,7 @@ class OrganizationReviewRepository(
             .where(
                 Product.organization_id == organization_id,
                 ProductPrice.source == ProductPriceSource.ad_hoc,
-                ProductPrice.is_archived.is_(False),
+                ~ProductPrice.is_archived,
             )
         )
         result = await self.session.execute(statement)
@@ -162,7 +160,7 @@ class OrganizationReviewRepository(
             ),
         ).where(
             Payment.organization_id == organization_id,
-            Payment.is_deleted.is_(False),
+            ~Payment.is_deleted,
         )
         result = await self.session.execute(statement)
         row = result.one()
@@ -179,7 +177,7 @@ class OrganizationReviewRepository(
             Payment.organization_id == organization_id,
             Payment.status == PaymentStatus.succeeded,
             Payment.risk_score.is_not(None),
-            Payment.is_deleted.is_(False),
+            ~Payment.is_deleted,
         )
         result = await self.session.execute(statement)
         row = result.one()
@@ -209,10 +207,10 @@ class OrganizationReviewRepository(
             Dispute.payment_id.in_(
                 select(Payment.id).where(
                     Payment.organization_id == organization_id,
-                    Payment.is_deleted.is_(False),
+                    ~Payment.is_deleted,
                 )
             ),
-            Dispute.is_deleted.is_(False),
+            ~Dispute.is_deleted,
         )
         result = await self.session.execute(statement)
         row = result.one()
@@ -235,7 +233,7 @@ class OrganizationReviewRepository(
             .where(
                 UserOrganization.user_id == user_id,
                 Organization.id != exclude_organization_id,
-                Organization.is_deleted.is_(False),
+                ~Organization.is_deleted,
             )
             .options(joinedload(Organization.review))
         )
@@ -415,7 +413,7 @@ class OrganizationReviewRepository(
             .where(
                 Checkout.organization_id == organization_id,
                 Checkout.return_url.is_not(None),
-                Checkout.is_deleted.is_(False),
+                ~Checkout.is_deleted,
                 Checkout.created_at >= cutoff,
             )
             .distinct()
@@ -438,7 +436,7 @@ class OrganizationReviewRepository(
             .where(
                 Checkout.organization_id == organization_id,
                 Checkout._success_url.is_not(None),
-                Checkout.is_deleted.is_(False),
+                ~Checkout.is_deleted,
                 Checkout.created_at >= cutoff,
             )
             .distinct()
@@ -454,7 +452,7 @@ class OrganizationReviewRepository(
             select(CheckoutLink)
             .where(
                 CheckoutLink.organization_id == organization_id,
-                CheckoutLink.is_deleted.is_(False),
+                ~CheckoutLink.is_deleted,
             )
             .options(
                 selectinload(CheckoutLink.checkout_link_products)
@@ -469,7 +467,7 @@ class OrganizationReviewRepository(
         """Count organization access tokens."""
         statement = select(func.count(OrganizationAccessToken.id)).where(
             OrganizationAccessToken.organization_id == organization_id,
-            OrganizationAccessToken.is_deleted.is_(False),
+            ~OrganizationAccessToken.is_deleted,
         )
         result = await self.session.execute(statement)
         return result.scalar() or 0
@@ -480,7 +478,7 @@ class OrganizationReviewRepository(
         """Get webhook endpoints for the organization."""
         statement = select(WebhookEndpoint).where(
             WebhookEndpoint.organization_id == organization_id,
-            WebhookEndpoint.is_deleted.is_(False),
+            ~WebhookEndpoint.is_deleted,
         )
         result = await self.session.execute(statement)
         return list(result.scalars().all())

--- a/server/polar/payment/repository.py
+++ b/server/polar/payment/repository.py
@@ -37,7 +37,7 @@ class PaymentRepository(
         statement = (
             self.get_base_statement()
             .join(Order, Payment.order_id == Order.id)
-            .where(Order.is_deleted.is_(False), Order.customer_id == customer_id)
+            .where(~Order.is_deleted, Order.customer_id == customer_id)
         )
         if status is not None:
             statement = statement.where(Payment.status == status)

--- a/server/polar/payment/service.py
+++ b/server/polar/payment/service.py
@@ -87,7 +87,7 @@ class PaymentService:
 
             statement = statement.where(
                 effective_customer_id.in_(customer_id),
-                or_(Order.is_deleted.is_(False), Order.id.is_(None)),
+                or_(~Order.is_deleted, Order.id.is_(None)),
             )
 
         if status is not None:

--- a/server/polar/payment_method/repository.py
+++ b/server/polar/payment_method/repository.py
@@ -139,7 +139,7 @@ class PaymentMethodRepository(
             select(Subscription.id)
             .where(
                 Subscription.payment_method_id == PaymentMethod.id,
-                Subscription.requires_payment_method.is_(True),
+                Subscription.requires_payment_method,
                 Subscription.deleted_at.is_(None),
             )
             .correlate(PaymentMethod)

--- a/server/polar/personal_access_token/service.py
+++ b/server/polar/personal_access_token/service.py
@@ -43,7 +43,7 @@ class PersonalAccessTokenService(ResourceServiceReader[PersonalAccessToken]):
     ) -> PersonalAccessToken | None:
         statement = self._get_readable_order_statement(auth_subject).where(
             PersonalAccessToken.id == id,
-            PersonalAccessToken.is_deleted.is_(False),
+            ~PersonalAccessToken.is_deleted,
         )
         result = await session.execute(statement)
         return result.scalar_one_or_none()
@@ -57,8 +57,8 @@ class PersonalAccessTokenService(ResourceServiceReader[PersonalAccessToken]):
             .join(PersonalAccessToken.user)
             .where(
                 PersonalAccessToken.token == token_hash,
-                PersonalAccessToken.is_deleted.is_(False),
-                User.can_authenticate.is_(True),
+                ~PersonalAccessToken.is_deleted,
+                User.can_authenticate,
             )
             .options(contains_eager(PersonalAccessToken.user))
         )
@@ -135,7 +135,7 @@ class PersonalAccessTokenService(ResourceServiceReader[PersonalAccessToken]):
     ) -> Select[tuple[PersonalAccessToken]]:
         return select(PersonalAccessToken).where(
             PersonalAccessToken.user_id == auth_subject.subject.id,
-            PersonalAccessToken.is_deleted.is_(False),
+            ~PersonalAccessToken.is_deleted,
         )
 
 

--- a/server/polar/product/repository.py
+++ b/server/polar/product/repository.py
@@ -56,8 +56,8 @@ class ProductRepository(
             .join(Product, Product.id == ProductPrice.product_id)
             .where(
                 Product.organization_id == organization_id,
-                Product.is_archived.is_(False),
-                ProductPrice.is_archived.is_(False),
+                ~Product.is_archived,
+                ~ProductPrice.is_archived,
                 ProductPrice.price_currency.is_not(None),
             )
             .distinct()
@@ -70,7 +70,7 @@ class ProductRepository(
         migration source product would duplicate one that already exists."""
         statement = select(func.lower(Product.name)).where(
             Product.organization_id == organization_id,
-            Product.is_archived.is_(False),
+            ~Product.is_archived,
             Product.deleted_at.is_(None),
         )
         result = await self.session.execute(statement)
@@ -87,7 +87,7 @@ class ProductRepository(
             self.get_base_statement()
             .where(
                 Product.organization_id == organization_id,
-                Product.is_archived.is_(False),
+                ~Product.is_archived,
             )
             .order_by(Product.created_at.asc())
             .options(*options)
@@ -138,7 +138,7 @@ class ProductRepository(
         """Count products for an organization with optional archived filter."""
         statement = sql.select(sql.func.count(Product.id)).where(
             Product.organization_id == organization_id,
-            Product.is_deleted.is_(False),
+            ~Product.is_deleted,
         )
 
         if is_archived is not None:
@@ -186,7 +186,7 @@ class ProductRepository(
                 ProductPrice,
                 and_(
                     ProductPrice.product_id == Product.id,
-                    ProductPrice.is_archived.is_(False),
+                    ~ProductPrice.is_archived,
                     ProductPrice.price_currency == currency,
                     ProductPrice.source == ProductPriceSource.catalog,
                 ),
@@ -194,7 +194,7 @@ class ProductRepository(
             )
             .where(
                 Product.organization_id == organization_id,
-                Product.is_archived.is_(False),
+                ~Product.is_archived,
                 ProductPrice.id.is_(None),
             )
         )

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -100,8 +100,8 @@ class ProductService:
                 .with_only_columns(ProductPrice.id)
                 .where(
                     ProductPrice.product_id == Product.id,
-                    ProductPrice.is_archived.is_(False),
-                    ProductPrice.is_deleted.is_(False),
+                    ~ProductPrice.is_archived,
+                    ~ProductPrice.is_deleted,
                 )
                 .order_by(ProductPrice.created_at.asc())
                 .limit(1)

--- a/server/polar/search/service.py
+++ b/server/polar/search/service.py
@@ -140,7 +140,7 @@ class SearchService:
             literal(None).cast(String).label("status"),
         ).where(
             Product.organization_id.in_(organization_subquery),
-            Product.is_deleted.is_(False),
+            ~Product.is_deleted,
         )
 
         if query_uuid:
@@ -174,7 +174,7 @@ class SearchService:
             literal(None).cast(String).label("status"),
         ).where(
             Customer.organization_id.in_(organization_subquery),
-            Customer.is_deleted.is_(False),
+            ~Customer.is_deleted,
         )
 
         if query_uuid:
@@ -224,7 +224,7 @@ class SearchService:
             .join(Product, Order.product_id == Product.id)
             .where(
                 Customer.organization_id.in_(organization_subquery),
-                Order.is_deleted.is_(False),
+                ~Order.is_deleted,
             )
         )
 
@@ -274,7 +274,7 @@ class SearchService:
             .join(Product, Subscription.product_id == Product.id)
             .where(
                 Customer.organization_id.in_(organization_subquery),
-                Subscription.is_deleted.is_(False),
+                ~Subscription.is_deleted,
             )
         )
 

--- a/server/polar/sso/repository.py
+++ b/server/polar/sso/repository.py
@@ -37,7 +37,7 @@ class OrganizationSSOConnectionRepository(
         self, organization_id: UUID
     ) -> Sequence[OrganizationSSOConnection]:
         statement = self.get_statement_by_organization(organization_id).where(
-            OrganizationSSOConnection.enabled.is_(True)
+            OrganizationSSOConnection.enabled
         )
         return await self.get_all(statement)
 
@@ -46,6 +46,6 @@ class OrganizationSSOConnectionRepository(
     ) -> OrganizationSSOConnection | None:
         statement = self.get_statement_by_organization(organization_id).where(
             OrganizationSSOConnection.id == id,
-            OrganizationSSOConnection.enabled.is_(True),
+            OrganizationSSOConnection.enabled,
         )
         return await self.get_one_or_none(statement)

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -91,7 +91,7 @@ class SubscriptionRepository(
             self.get_base_statement()
             .where(
                 Subscription.customer_id == customer_id,
-                Subscription.active.is_(True),
+                Subscription.active,
             )
             .options(*options)
         )
@@ -118,7 +118,7 @@ class SubscriptionRepository(
             self.get_base_statement()
             .where(
                 Subscription.payment_method_id == payment_method_id,
-                Subscription.requires_payment_method.is_(True),
+                Subscription.requires_payment_method,
                 Subscription.ended_at.is_(None),
             )
             .options(*options)
@@ -133,7 +133,7 @@ class SubscriptionRepository(
             .with_only_columns(Subscription.id)
             .where(
                 Subscription.payment_method_id == payment_method_id,
-                Subscription.requires_payment_method.is_(True),
+                Subscription.requires_payment_method,
                 Subscription.ended_at.is_(None),
             )
         )
@@ -166,7 +166,7 @@ class SubscriptionRepository(
     async def get_ids_by_product(self, product_id: UUID) -> Sequence[UUID]:
         statement = select(Subscription.id).where(
             Subscription.product_id == product_id,
-            Subscription.is_deleted.is_(False),
+            ~Subscription.is_deleted,
         )
         result = await self.session.execute(statement)
         return result.scalars().all()
@@ -186,7 +186,7 @@ class SubscriptionRepository(
                 Subscription.product_id == product_id,
                 Subscription.status.not_in(dead_statuses),
                 Subscription.ended_at.is_(None),
-                Subscription.is_deleted.is_(False),
+                ~Subscription.is_deleted,
             )
             .limit(1)
         )
@@ -222,7 +222,7 @@ class SubscriptionRepository(
                 Product.organization_id == organization_id,
                 Subscription.ended_at.is_not(None),
                 Subscription.ended_at >= since,
-                Subscription.is_deleted.is_(False),
+                ~Subscription.is_deleted,
             )
         )
         result = await self.session.execute(statement)
@@ -268,8 +268,8 @@ class SubscriptionRepository(
             select(Subscription.customer_id)
             .where(
                 Subscription.product_id == product_id,
-                Subscription.active.is_(True),
-                Subscription.is_deleted.is_(False),
+                Subscription.active,
+                ~Subscription.is_deleted,
             )
             .distinct()
         )
@@ -372,13 +372,13 @@ class SubscriptionRepository(
             customer = auth_subject.subject
             statement = statement.where(
                 Subscription.customer_id == customer.id,
-                Subscription.is_deleted.is_(False),
+                ~Subscription.is_deleted,
             )
         elif is_member(auth_subject):
             member = auth_subject.subject
             statement = statement.where(
                 Subscription.customer_id == member.customer_id,
-                Subscription.is_deleted.is_(False),
+                ~Subscription.is_deleted,
             )
 
         return statement
@@ -456,8 +456,8 @@ class SubscriptionRepository(
             self.get_base_statement()
             .where(
                 Subscription.status == SubscriptionStatus.active,
-                Subscription.cancel_at_period_end.is_(False),
-                Subscription.pause_at_period_end.is_(False),
+                ~Subscription.cancel_at_period_end,
+                ~Subscription.pause_at_period_end,
                 Subscription.current_period_end.isnot(None),
                 Subscription.current_period_end > now,
                 Subscription.current_period_end <= reminder_window_end,
@@ -529,7 +529,7 @@ class SubscriptionRepository(
             self.get_base_statement()
             .where(
                 Subscription.status == SubscriptionStatus.trialing,
-                Subscription.cancel_at_period_end.is_(False),
+                ~Subscription.cancel_at_period_end,
                 Subscription.trial_start.isnot(None),
                 Subscription.trial_end.isnot(None),
                 trial_window_condition,
@@ -554,8 +554,8 @@ class SubscriptionRepository(
                     (
                         Subscription.status == SubscriptionStatus.active,
                         case(
-                            (Subscription.cancel_at_period_end.is_(False), 4),
-                            (Subscription.cancel_at_period_end.is_(True), 5),
+                            (~Subscription.cancel_at_period_end, 4),
+                            (Subscription.cancel_at_period_end, 5),
                         ),
                     ),
                     (Subscription.status == SubscriptionStatus.paused, 6),
@@ -670,9 +670,9 @@ class SubscriptionProductPriceRepository(
                 Subscription.id == SubscriptionProductPrice.subscription_id,
             )
             .where(
-                ProductPrice.is_metered.is_(True),
+                ProductPrice.is_metered,
                 ProductPriceMeteredUnit.meter_id == meter_id,
-                Subscription.billable.is_(True),
+                Subscription.billable,
                 Subscription.customer_id == sa.any_(customer_ids_parameter),
             )
             # In case customer has several subscriptions, take the earliest one
@@ -821,7 +821,7 @@ class SubscriptionUpdateRepository(
             .where(
                 SubscriptionUpdate.subscription_id == subscription_id,
                 SubscriptionUpdate.applied_at.is_(None),
-                SubscriptionUpdate.is_deleted.is_(False),
+                ~SubscriptionUpdate.is_deleted,
             )
             .limit(1)
             .options(*options)

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -174,9 +174,9 @@ class SubscriptionJobStore(_SubscriptionScheduleJobStore):
             .join(Customer, onclause=Customer.id == Subscription.customer_id)
             .join(Organization, onclause=Organization.id == Customer.organization_id)
             .where(
-                Customer.is_deleted.is_(False),
-                Organization.is_deleted.is_(False),
-                Organization.can_renew_subscriptions.is_(True),
+                ~Customer.is_deleted,
+                ~Organization.is_deleted,
+                Organization.can_renew_subscriptions,
                 Subscription.scheduler_locked_at.is_(None),
                 Subscription.active,
                 Subscription.current_period_end.is_not(None),
@@ -204,9 +204,9 @@ class SubscriptionResumeJobStore(_SubscriptionScheduleJobStore):
             .join(Customer, onclause=Customer.id == Subscription.customer_id)
             .join(Organization, onclause=Organization.id == Customer.organization_id)
             .where(
-                Customer.is_deleted.is_(False),
-                Organization.is_deleted.is_(False),
-                Organization.can_renew_subscriptions.is_(True),
+                ~Customer.is_deleted,
+                ~Organization.is_deleted,
+                Organization.can_renew_subscriptions,
                 Subscription.scheduler_locked_at.is_(None),
                 Subscription.status == SubscriptionStatus.paused,
                 Subscription.resumes_at.is_not(None),

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -418,9 +418,9 @@ class SubscriptionService:
 
         if active is not None:
             if active:
-                statement = statement.where(Subscription.active.is_(True))
+                statement = statement.where(Subscription.active)
             else:
-                statement = statement.where(Subscription.revoked.is_(True))
+                statement = statement.where(Subscription.revoked)
 
         if status is not None:
             statement = statement.where(Subscription.status.in_(status))
@@ -3559,8 +3559,8 @@ class SubscriptionService:
         statement = select(BenefitGrant).where(
             BenefitGrant.subscription_id == subscription.id,
             BenefitGrant.benefit_id.not_in(subscription_tier_benefits_statement),
-            BenefitGrant.is_granted.is_(True),
-            BenefitGrant.is_deleted.is_(False),
+            BenefitGrant.is_granted,
+            ~BenefitGrant.is_deleted,
         )
 
         result = await session.execute(statement)

--- a/server/polar/user/repository.py
+++ b/server/polar/user/repository.py
@@ -123,7 +123,7 @@ class UserRepository(
             self.get_base_statement(include_deleted=include_deleted)
             .join(UserOrganization, UserOrganization.user_id == User.id)
             .where(
-                UserOrganization.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
                 UserOrganization.organization_id == organization_id,
             )
         )
@@ -139,7 +139,7 @@ class UserRepository(
         statement = select(UserOrganization).where(
             UserOrganization.user_id == user_id,
             UserOrganization.organization_id == organization_id,
-            UserOrganization.is_deleted.is_(False),
+            ~UserOrganization.is_deleted,
         )
         result = await self.session.execute(statement)
         return result.scalar_one_or_none() is not None

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -450,7 +450,7 @@ class UserService:
         stmt = (
             update(NotificationRecipient)
             .where(NotificationRecipient.user_id == user.id)
-            .where(NotificationRecipient.is_deleted.is_(False))
+            .where(~NotificationRecipient.is_deleted)
             .values(deleted_at=func.now())
         )
         await session.execute(stmt)

--- a/server/polar/user_organization/repository.py
+++ b/server/polar/user_organization/repository.py
@@ -30,7 +30,7 @@ class UserOrganizationRepository:
         statement = select(UserOrganization).where(
             UserOrganization.user_id == user_id,
             UserOrganization.organization_id == organization_id,
-            UserOrganization.is_deleted.is_(False),
+            ~UserOrganization.is_deleted,
         )
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()
@@ -49,7 +49,7 @@ class UserOrganizationRepository:
             )
             .where(
                 UserOrganization.user_id == user_id,
-                UserOrganization.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
                 Organization.can_authenticate,
             )
             .order_by(Organization.name)
@@ -67,7 +67,7 @@ class UserOrganizationRepository:
             .where(
                 UserOrganization.organization_id == organization_id,
                 UserOrganization.role == OrganizationRole.owner,
-                UserOrganization.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
             )
             .values(role=OrganizationRole.admin)
             .returning(UserOrganization.user_id)

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -115,7 +115,7 @@ class UserOrganizationService:
             sql.select(UserOrganization)
             .where(
                 UserOrganization.organization_id == org_id,
-                UserOrganization.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
             )
             .options(
                 joinedload(UserOrganization.user),
@@ -130,7 +130,7 @@ class UserOrganizationService:
         """Get the count of active members in an organization."""
         stmt = sql.select(func.count(UserOrganization.user_id)).where(
             UserOrganization.organization_id == org_id,
-            UserOrganization.is_deleted.is_(False),
+            ~UserOrganization.is_deleted,
         )
         res = await session.execute(stmt)
         count = res.scalar()
@@ -166,7 +166,7 @@ class UserOrganizationService:
             .where(
                 UserOrganization.user_id == user_id,
                 UserOrganization.organization_id == organization_id,
-                UserOrganization.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
             )
             .options(
                 joinedload(UserOrganization.user),
@@ -314,7 +314,7 @@ class UserOrganizationService:
             .where(
                 UserOrganization.user_id == user_id,
                 UserOrganization.organization_id == organization_id,
-                UserOrganization.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
             )
             .values(deleted_at=utc_now())
             .returning(UserOrganization.user_id)
@@ -356,7 +356,7 @@ class UserOrganizationService:
             .where(
                 UserOrganization.organization_id == organization_id,
                 UserOrganization.role.in_(ADMIN_CAPABLE_ROLES),
-                UserOrganization.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
             )
             .order_by(UserOrganization.user_id)
             .with_for_update()
@@ -412,7 +412,7 @@ class UserOrganizationService:
             sql.select(UserOrganization)
             .where(
                 UserOrganization.user_id == user_id,
-                UserOrganization.is_deleted.is_(False),
+                ~UserOrganization.is_deleted,
             )
             .options(
                 joinedload(UserOrganization.user),

--- a/server/polar/webhook/repository.py
+++ b/server/polar/webhook/repository.py
@@ -39,7 +39,7 @@ class WebhookEventRepository(
             .where(
                 WebhookDelivery.id.is_(None),
                 WebhookEvent.payload.is_not(None),
-                WebhookEvent.skipped.is_(False),
+                ~WebhookEvent.skipped,
             )
         )
         if older_than is not None:
@@ -82,7 +82,7 @@ class WebhookEventRepository(
         statement = self.get_base_statement().where(
             WebhookEvent.webhook_endpoint_id == endpoint_id,
             WebhookEvent.succeeded.is_(None),
-            WebhookEvent.skipped.is_(False),
+            ~WebhookEvent.skipped,
         )
         return await self.get_all(statement)
 
@@ -109,7 +109,7 @@ class WebhookEventRepository(
                 isouter=True,
             )
             .where(
-                WebhookEvent.is_deleted.is_(False),
+                ~WebhookEvent.is_deleted,
                 WebhookEvent.webhook_endpoint_id == event.webhook_endpoint_id,
                 WebhookEvent.id != event.id,
                 WebhookDelivery.id.is_(None),
@@ -142,7 +142,7 @@ class WebhookDeliveryRepository(
     async def count_by_event(self, event_id: UUID) -> int:
         statement = select(func.count(WebhookDelivery.id)).where(
             WebhookDelivery.webhook_event_id == event_id,
-            WebhookDelivery.is_deleted.is_(False),
+            ~WebhookDelivery.is_deleted,
         )
         res = await self.session.execute(statement)
         return res.scalar_one()

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -921,8 +921,8 @@ class WebhookService:
         target: Organization,
     ) -> Sequence[WebhookEndpoint]:
         statement = select(WebhookEndpoint).where(
-            WebhookEndpoint.is_deleted.is_(False),
-            WebhookEndpoint.enabled.is_(True),
+            ~WebhookEndpoint.is_deleted,
+            WebhookEndpoint.enabled,
             WebhookEndpoint.events.bool_op("@>")(text(f"'[\"{event}\"]'")),
             WebhookEndpoint.organization_id == target.id,
         )

--- a/server/scripts/backfill_email_log_deduplication_key.py
+++ b/server/scripts/backfill_email_log_deduplication_key.py
@@ -119,7 +119,7 @@ def _canonical_ids(
     # no row in the group is keyed, so that earliest row is guaranteed NULL.
     return select(ranked.c.id).where(
         ranked.c.rank == 1,
-        ranked.c.group_keyed.is_(False),
+        ~ranked.c.group_keyed,
     )
 
 

--- a/server/scripts/backfill_seat_customers_to_team.py
+++ b/server/scripts/backfill_seat_customers_to_team.py
@@ -48,7 +48,7 @@ def _target_customer_ids() -> Select[tuple[uuid.UUID]]:
     # Only organizations that have migrated to the member model; an absent flag
     # evaluates to NULL and is excluded, skipping pre-migration organizations.
     member_model_organizations = select(Organization.id).where(
-        Organization.feature_settings["member_model_enabled"].as_boolean().is_(True)
+        Organization.feature_settings["member_model_enabled"].as_boolean()
     )
     return select(Customer.id).where(
         Customer.deleted_at.is_(None),

--- a/server/scripts/batch_orders_refund.py
+++ b/server/scripts/batch_orders_refund.py
@@ -78,7 +78,7 @@ async def batch_orders_refund(
                     .join(Order.customer)
                     .where(
                         Customer.organization_id == organization_id,
-                        Order.paid.is_(True),
+                        Order.paid,
                     )
                     .options(*order_repository.get_eager_options())
                 )

--- a/server/scripts/batch_subscriptions_cancel.py
+++ b/server/scripts/batch_subscriptions_cancel.py
@@ -75,7 +75,7 @@ async def batch_subscriptions_cancel(
                 .join(Subscription.customer)
                 .where(
                     Customer.organization_id == organization_id,
-                    Subscription.billable.is_(True),
+                    Subscription.billable,
                 )
             )
 

--- a/server/scripts/cancel_subscriptions_deleted_customers.py
+++ b/server/scripts/cancel_subscriptions_deleted_customers.py
@@ -55,9 +55,7 @@ async def cancel_subscriptions_deleted_customers() -> None:
             statement = select(Customer).where(
                 Customer.deleted_at.is_not(None),
                 Customer.id.in_(
-                    select(Subscription.customer_id).where(
-                        Subscription.active.is_(True)
-                    )
+                    select(Subscription.customer_id).where(Subscription.active)
                 ),
             )
             count_statement = statement.with_only_columns(func.count()).order_by(None)

--- a/server/scripts/deleted_benefit_revoke.py
+++ b/server/scripts/deleted_benefit_revoke.py
@@ -57,7 +57,7 @@ async def deleted_benefit_revoke() -> None:
     async with sessionmaker() as session:
         async with JobQueueManager.open(dramatiq.get_broker(), redis) as manager:
             statement = select(Benefit.id).where(
-                Benefit.is_deleted.is_(True),
+                Benefit.is_deleted,
                 Benefit.id.in_(
                     select(BenefitGrant.benefit_id).where(
                         BenefitGrant.granted_at.is_not(None)

--- a/server/scripts/find_subscriptions_missing_reset_events.py
+++ b/server/scripts/find_subscriptions_missing_reset_events.py
@@ -68,7 +68,7 @@ def find_subscriptions_missing_reset_events(
             event_repository = EventRepository.from_session(session)
 
             statement = repository.get_base_statement().where(
-                Subscription.active.is_(True),
+                Subscription.active,
                 exists().where(SubscriptionMeter.subscription_id == Subscription.id),
             )
             count = await session.scalar(

--- a/server/scripts/migrate_organizations_members.py
+++ b/server/scripts/migrate_organizations_members.py
@@ -131,17 +131,15 @@ async def migrate_organizations(
                 Organization.status != OrganizationStatus.BLOCKED,
                 or_(
                     Organization.feature_settings["member_model_enabled"].is_(None),
-                    Organization.feature_settings["member_model_enabled"]
-                    .as_boolean()
-                    .is_(False),
+                    ~Organization.feature_settings["member_model_enabled"].as_boolean(),
                 ),
                 or_(
                     Organization.feature_settings["seat_based_pricing_enabled"].is_(
                         None
                     ),
-                    Organization.feature_settings["seat_based_pricing_enabled"]
-                    .as_boolean()
-                    .is_(False),
+                    ~Organization.feature_settings[
+                        "seat_based_pricing_enabled"
+                    ].as_boolean(),
                 ),
             )
             .order_by(Organization.next_review_threshold.asc())
@@ -305,16 +303,14 @@ async def repair(
             .where(
                 Organization.deleted_at.is_(None),
                 Organization.status != OrganizationStatus.BLOCKED,
-                Organization.feature_settings["member_model_enabled"]
-                .as_boolean()
-                .is_(True),
+                Organization.feature_settings["member_model_enabled"].as_boolean(),
                 or_(
                     Organization.feature_settings["seat_based_pricing_enabled"].is_(
                         None
                     ),
-                    Organization.feature_settings["seat_based_pricing_enabled"]
-                    .as_boolean()
-                    .is_(False),
+                    ~Organization.feature_settings[
+                        "seat_based_pricing_enabled"
+                    ].as_boolean(),
                 ),
             )
             .order_by(
@@ -342,16 +338,14 @@ async def repair(
             .where(
                 Organization.deleted_at.is_(None),
                 Organization.status != OrganizationStatus.BLOCKED,
-                Organization.feature_settings["member_model_enabled"]
-                .as_boolean()
-                .is_(True),
+                Organization.feature_settings["member_model_enabled"].as_boolean(),
                 or_(
                     Organization.feature_settings["seat_based_pricing_enabled"].is_(
                         None
                     ),
-                    Organization.feature_settings["seat_based_pricing_enabled"]
-                    .as_boolean()
-                    .is_(False),
+                    ~Organization.feature_settings[
+                        "seat_based_pricing_enabled"
+                    ].as_boolean(),
                 ),
             )
         )
@@ -480,14 +474,12 @@ async def prepare(
             .where(
                 Organization.deleted_at.is_(None),
                 Organization.status != OrganizationStatus.BLOCKED,
-                Organization.feature_settings["seat_based_pricing_enabled"]
-                .as_boolean()
-                .is_(True),
+                Organization.feature_settings[
+                    "seat_based_pricing_enabled"
+                ].as_boolean(),
                 or_(
                     Organization.feature_settings["member_model_enabled"].is_(None),
-                    Organization.feature_settings["member_model_enabled"]
-                    .as_boolean()
-                    .is_(False),
+                    ~Organization.feature_settings["member_model_enabled"].as_boolean(),
                 ),
             )
             .order_by(Organization.slug.asc())

--- a/server/scripts/prepare_organizations_members.py
+++ b/server/scripts/prepare_organizations_members.py
@@ -85,14 +85,12 @@ async def prepare(
             .where(
                 Organization.deleted_at.is_(None),
                 Organization.status != OrganizationStatus.BLOCKED,
-                Organization.feature_settings["seat_based_pricing_enabled"]
-                .as_boolean()
-                .is_(True),
+                Organization.feature_settings[
+                    "seat_based_pricing_enabled"
+                ].as_boolean(),
                 or_(
                     Organization.feature_settings["member_model_enabled"].is_(None),
-                    Organization.feature_settings["member_model_enabled"]
-                    .as_boolean()
-                    .is_(False),
+                    ~Organization.feature_settings["member_model_enabled"].as_boolean(),
                 ),
             )
             .order_by(Organization.slug.asc())

--- a/server/scripts/remove_backfilled_events.py
+++ b/server/scripts/remove_backfilled_events.py
@@ -65,7 +65,7 @@ async def remove_backfilled_events(
             .outerjoin(Meter, Meter.last_billed_event_id == Event.id)
             .where(
                 Event.name.in_([SystemEvent.order_paid, SystemEvent.order_refunded]),
-                Event.user_metadata["backfilled"].as_boolean().is_(True),
+                Event.user_metadata["backfilled"].as_boolean(),
                 Meter.id.is_(None),
             )
         )
@@ -93,9 +93,7 @@ async def remove_backfilled_events(
                                 Event.name.in_(
                                     [SystemEvent.order_paid, SystemEvent.order_refunded]
                                 ),
-                                Event.user_metadata["backfilled"]
-                                .as_boolean()
-                                .is_(True),
+                                Event.user_metadata["backfilled"].as_boolean(),
                                 Meter.id.is_(None),
                             )
                             .limit(batch_size)

--- a/server/scripts/subscription_tax_exempt.py
+++ b/server/scripts/subscription_tax_exempt.py
@@ -84,8 +84,8 @@ async def subscription_tax_exempt(
             select(Subscription)
             .join(Subscription.customer)
             .where(
-                Subscription.billable.is_(True),
-                Subscription.tax_exempted.is_(False),
+                Subscription.billable,
+                ~Subscription.tax_exempted,
             )
         )
         if id is not None:

--- a/server/scripts/unset_subscription_license_key_expiration.py
+++ b/server/scripts/unset_subscription_license_key_expiration.py
@@ -46,7 +46,7 @@ async def unset_subscription_license_key_expiration(
                 .where(
                     LicenseKey.expires_at.is_not(None),
                     LicenseKey.deleted_at.is_(None),
-                    BenefitGrant.is_deleted.is_(False),
+                    ~BenefitGrant.is_deleted,
                     Subscription.status.in_(SubscriptionStatus.billable_statuses()),
                 )
             )

--- a/server/scripts/void_eligible_orders.py
+++ b/server/scripts/void_eligible_orders.py
@@ -72,7 +72,7 @@ def get_query() -> Select[tuple[Order]]:
     deleted_customers_subquery = (
         select(Order.id)
         .join(Customer, Order.customer_id == Customer.id)
-        .where(Customer.is_deleted.is_(True))
+        .where(Customer.is_deleted)
     )
 
     # Subquery 3: Orders linked to blocked organizations
@@ -83,7 +83,7 @@ def get_query() -> Select[tuple[Order]]:
         .where(
             or_(
                 Organization.status == OrganizationStatus.BLOCKED,
-                Organization.is_deleted.is_(True),
+                Organization.is_deleted,
             )
         )
     )

--- a/server/scripts/webhook_trigger.py
+++ b/server/scripts/webhook_trigger.py
@@ -68,7 +68,7 @@ async def webhook_trigger(newer_than: datetime) -> None:
                     WebhookDelivery.id.is_(None),
                     WebhookEvent.created_at >= newer_than,
                     WebhookEvent.payload.is_not(None),
-                    WebhookEvent.skipped.is_(False),
+                    ~WebhookEvent.skipped,
                 )
             )
 

--- a/server/tests/models/test_subscription.py
+++ b/server/tests/models/test_subscription.py
@@ -90,7 +90,7 @@ async def _matches_expression(
     result = await session.execute(
         select(Subscription.id).where(
             Subscription.id == subscription.id,
-            Subscription.requires_payment_method.is_(True),
+            Subscription.requires_payment_method,
         )
     )
     return result.scalar_one_or_none() is not None


### PR DESCRIPTION
## Summary

- use bare SQLAlchemy boolean expressions for true predicates and explicit negation for false predicates
- avoid outer `IS TRUE` / `IS FALSE` wrappers across backend queries, hybrid expressions, and maintenance scripts
- preserve `IS NOT TRUE` where `NULL` intentionally represents a disabled setting
- add ADR-0009 to document the convention and its three-valued-logic exception

## Why

This generalizes the fix discovered in #13687.

SQLAlchemy's `.is_(True)` and `.is_(False)` wrap an existing boolean expression in `IS TRUE` or `IS FALSE`. PostgreSQL does not simplify those identity tests when proving that a query predicate implies a partial-index predicate. That can hide an otherwise indexable comparison—such as a timestamp inequality or null check—and cause a sequential scan.

Using the boolean expression directly, or negating it explicitly, keeps the underlying predicate visible to the planner.

The migration preserves identity tests where they express different SQL semantics. In particular, `expression.is_not(True)` remains appropriate when both explicit `false` and `NULL` should match.

## Impact

Query results remain equivalent for strict true and false predicate filtering, while PostgreSQL can make use of matching ordinary and partial indexes. ADR-0009 records the convention for future backend queries.

## Validation

- lint passes
- tests pass
- branch diff checked against all Accepted ADRs: no violations

Closes #13690


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

