### PR TITLE
fix(web): fix pause and cancel pause ux

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CustomerPauseSubscriptionModal.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPauseSubscriptionModal.tsx
@@ -90,7 +90,9 @@ const CustomerPauseSubscriptionModal = ({
                 <DatePicker
                   value={field.value}
                   onChange={field.onChange}
-                  disabled={periodEnd ? { before: periodEnd } : undefined}
+                  disabled={
+                    periodEnd ? [{ before: periodEnd }, periodEnd] : undefined
+                  }
                 />
                 <FormDescription>
                   Leave empty to pause indefinitely until you resume manually.

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/hooks/queries/customerPortal'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import { hasBillingPermission } from '@/utils/customerPortal'
+import { getPauseAction } from '@/utils/subscription'
 import { Client, schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import { Button } from '@polar-sh/orbit'
@@ -95,14 +96,7 @@ const CustomerPortalSubscription = ({
   const showSeatManagement = portalSettings.subscription.update_seats === true
   const showPauseResume = portalSettings.subscription.pause === true
 
-  const pauseAction: 'resume' | 'cancel_scheduled_pause' | 'pause' | null =
-    subscription.status === 'paused'
-      ? 'resume'
-      : subscription.pause_at_period_end && !isCancelled
-        ? 'cancel_scheduled_pause'
-        : !isCancelled && subscription.status === 'active'
-          ? 'pause'
-          : null
+  const pauseAction = getPauseAction(subscription)
 
   const showCancelAction = !isCancelled && canManageBilling
   const showPauseAction =

--- a/clients/apps/web/src/components/Subscriptions/PauseSubscriptionModal.tsx
+++ b/clients/apps/web/src/components/Subscriptions/PauseSubscriptionModal.tsx
@@ -85,7 +85,9 @@ const PauseSubscriptionModal = ({
                   <DatePicker
                     value={field.value}
                     onChange={field.onChange}
-                    disabled={periodEnd ? { before: periodEnd } : undefined}
+                    disabled={
+                      periodEnd ? [{ before: periodEnd }, periodEnd] : undefined
+                    }
                   />
                   <FormDescription>
                     Leave empty to pause indefinitely until resumed manually.

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionActionsMenu.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionActionsMenu.tsx
@@ -10,6 +10,7 @@ import {
   useUncancelSubscription,
 } from '@/hooks/queries'
 import { extractApiErrorMessage } from '@/utils/api/errors'
+import { getPauseAction } from '@/utils/subscription'
 import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined'
 import { schemas } from '@polar-sh/client'
 import { Button, InlineModal } from '@polar-sh/orbit'
@@ -29,6 +30,8 @@ const SubscriptionActionsMenu = ({
 }: SubscriptionActionsMenuProps) => {
   const cancellationModal = useModal()
   const pauseModal = useModal()
+
+  const pauseAction = getPauseAction(subscription)
 
   const uncancelSubscription = useUncancelSubscription(subscription.id)
   const resumeSubscription = useResumeSubscription(subscription.id)
@@ -124,23 +127,21 @@ const SubscriptionActionsMenu = ({
                 Cancel Subscription
               </DropdownMenuItem>
             ))}
-          {subscription.ended_at ? null : subscription.status === 'paused' ? (
+          {pauseAction === 'resume' ? (
             <DropdownMenuItem
               onClick={handleResume}
               disabled={resumeSubscription.isPending}
             >
               Resume Now
             </DropdownMenuItem>
-          ) : subscription.pause_at_period_end &&
-            !subscription.cancel_at_period_end ? (
+          ) : pauseAction === 'cancel_scheduled_pause' ? (
             <DropdownMenuItem
               onClick={handleCancelScheduledPause}
               disabled={cancelScheduledPause.isPending}
             >
               Cancel Scheduled Pause
             </DropdownMenuItem>
-          ) : subscription.status === 'active' &&
-            !subscription.cancel_at_period_end ? (
+          ) : pauseAction === 'pause' ? (
             <DropdownMenuItem onClick={pauseModal.show}>
               Pause Subscription
             </DropdownMenuItem>

--- a/clients/apps/web/src/utils/subscription.test.ts
+++ b/clients/apps/web/src/utils/subscription.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { getPauseAction, PauseActionSubscription } from './subscription'
+
+const subscription = (
+  overrides: Partial<PauseActionSubscription>,
+): PauseActionSubscription => ({
+  status: 'active',
+  pause_at_period_end: false,
+  cancel_at_period_end: false,
+  ended_at: null,
+  ...overrides,
+})
+
+describe('getPauseAction', () => {
+  it('offers a pause on an active subscription', () => {
+    expect(getPauseAction(subscription({}))).toBe('pause')
+  })
+
+  it('offers a resume on a paused subscription', () => {
+    expect(getPauseAction(subscription({ status: 'paused' }))).toBe('resume')
+  })
+
+  it('offers to cancel a pause scheduled on an active subscription', () => {
+    expect(getPauseAction(subscription({ pause_at_period_end: true }))).toBe(
+      'cancel_scheduled_pause',
+    )
+  })
+
+  it('offers nothing on a past due subscription with a scheduled pause', () => {
+    expect(
+      getPauseAction(
+        subscription({ status: 'past_due', pause_at_period_end: true }),
+      ),
+    ).toBeNull()
+  })
+
+  it('offers nothing on a subscription scheduled to cancel', () => {
+    expect(
+      getPauseAction(
+        subscription({ cancel_at_period_end: true, pause_at_period_end: true }),
+      ),
+    ).toBeNull()
+  })
+
+  it('offers nothing on an ended subscription', () => {
+    expect(
+      getPauseAction(
+        subscription({ status: 'canceled', ended_at: '2026-08-12T00:00:00Z' }),
+      ),
+    ).toBeNull()
+  })
+})

--- a/clients/apps/web/src/utils/subscription.ts
+++ b/clients/apps/web/src/utils/subscription.ts
@@ -23,3 +23,28 @@ const _getSubscriptionById = async (
 
 // Tell React to memoize it for the duration of the request
 export const getSubscriptionById = cache(_getSubscriptionById)
+
+export type PauseActionSubscription = Pick<
+  schemas['Subscription'],
+  'status' | 'pause_at_period_end' | 'cancel_at_period_end' | 'ended_at'
+>
+
+export type PauseAction = 'resume' | 'cancel_scheduled_pause' | 'pause' | null
+
+export const getPauseAction = (
+  subscription: PauseActionSubscription,
+): PauseAction => {
+  if (subscription.ended_at) {
+    return null
+  }
+
+  if (subscription.status === 'paused') {
+    return 'resume'
+  }
+
+  if (subscription.status !== 'active' || subscription.cancel_at_period_end) {
+    return null
+  }
+
+  return subscription.pause_at_period_end ? 'cancel_scheduled_pause' : 'pause'
+}


### PR DESCRIPTION
## Summary

Closes https://github.com/polarsource/feedback/issues/261
Closes https://github.com/polarsource/feedback/issues/259

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pause and cancel‑pause UX by enforcing correct action guards and preventing scheduling a pause on the current period end date. Previously, menus could show “Cancel Scheduled Pause” on non‑active or canceling subscriptions, and date pickers allowed choosing the period end; now only valid actions appear and the period end date is disabled.

- Centralizes pause logic in `getPauseAction(subscription)` and applies it in `CustomerPortalSubscription` and `SubscriptionActionsMenu`. Returns: `pause` (active), `resume` (paused), `cancel_scheduled_pause` (active + `pause_at_period_end`), or `null` (ended, non‑active, or `cancel_at_period_end`). Ensures “Cancel Scheduled Pause” only shows when the subscription is active.
- Disables the period end date in pause schedulers by setting `DatePicker` `disabled={[{ before: periodEnd }, periodEnd]}` in both pause modals to block invalid selections.
- Adds unit tests in `utils/subscription.test.ts` for edge cases. No migration required.

<sup>Written for commit 0bdbce459762e2415cdfc6b47828a3ce754e3027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

