### PR TITLE
tf: Set up Redis drain services

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -414,7 +414,7 @@ resource "render_web_service" "worker" {
       dramatiq_prom_port       = { value = each.value.dramatiq_prom_port }
       POLAR_DATABASE_POOL_SIZE = { value = each.value.database_pool_size }
     },
-    (each.value.redis_host != null && each.value.redis_port != null && each.value.redis_db) ? {
+    (each.value.redis_host != null && each.value.redis_port != null && each.value.redis_db != null) ? {
       POLAR_REDIS_HOST = { value = each.value.redis_host }
       POLAR_REDIS_PORT = { value = each.value.redis_port }
       POLAR_REDIS_DB   = { value = each.value.redis_db }

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -212,6 +212,13 @@ module "production" {
       start_command      = "uv run dramatiq polar.worker.run_without_db -p 4 -t 32 --queues tinybird"
       dramatiq_prom_port = "10002"
     }
+    worker-drain = {
+      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 8"
+      dramatiq_prom_port = "10004"
+      redis_host         = render_redis.redis.id
+      redis_port         = "6379"
+      redis_db           = "0"
+    }
     worker-invoices-receipts = {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
       plan               = "standard"

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -153,6 +153,12 @@ module "sandbox" {
       start_command      = "uv run dramatiq polar.worker.run_without_db -p 1 -t 16 --queues tinybird"
       dramatiq_prom_port = "10002"
     }
+    worker-sandbox-drain = {
+      start_command = "uv run dramatiq polar.worker.run -p 2 -t 8"
+      redis_host    = render_redis.redis_sandbox.id
+      redis_port    = "6379"
+      redis_db      = "1"
+    }
     worker-sandbox-invoices-receipts = {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
       plan               = "standard"


### PR DESCRIPTION
As we migrate Redis away, we use these services to drain the old Redis queues


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

