### PR TITLE
feat(billing): skip metered on update

### DIFF
--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -74,6 +74,7 @@ class BillingEntryService:
         session: AsyncSession,
         subscription: Subscription,
         *,
+        include_metered: bool = True,
         cutoff: datetime | None = None,
     ) -> AsyncGenerator[Sequence[OrderItem]]:
         repository = BillingEntryRepository.from_session(session)
@@ -84,6 +85,7 @@ class BillingEntryService:
         async for line_item, selector in self.compute_pending_subscription_line_items(
             session,
             subscription,
+            include_metered=include_metered,
             cutoff=cutoff,
         ):
             order_item = OrderItem(
@@ -123,6 +125,7 @@ class BillingEntryService:
         session: AsyncSession,
         subscription: Subscription,
         *,
+        include_metered: bool = True,
         cutoff: datetime | None = None,
     ) -> AsyncGenerator[tuple[StaticLineItem | MeteredLineItem, BillingEntrySelector]]:
         cutoff = cutoff or utc_now()
@@ -136,6 +139,12 @@ class BillingEntryService:
                 session, static_price, entry, seats=subscription.seats
             )
             yield static_line_item, [entry.id]
+
+        if not include_metered:
+            # Metered usage and its credits belong to the whole billing period.
+            # Settling them mid-period consumes the period's credit early, so the
+            # entries stay pending and are billed on the next cycle.
+            return
 
         # 👋 Reading the code below, you might wonder:
         # "Why is this so complex?"

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1310,8 +1310,11 @@ class OrderService:
         Returns:
             The created Order object.
         """
+        include_metered = (
+            billing_reason != OrderBillingReasonInternal.subscription_update
+        )
         async with billing_entry_service.create_order_items_from_pending(
-            session, subscription, cutoff=cutoff
+            session, subscription, include_metered=include_metered, cutoff=cutoff
         ) as items:
             if len(items) == 0:
                 raise NoPendingBillingEntries(subscription)

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -2709,7 +2709,7 @@ class SubscriptionService:
             line_item,
             _,
         ) in billing_entry_service.compute_pending_subscription_line_items(
-            session, subscription
+            session, subscription, include_metered=False
         ):
             if not line_item.proration:
                 continue

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -1883,54 +1883,71 @@ class TestCreateSubscriptionOrder:
 
         subscription_service_mock.reset_meters.assert_not_awaited()
 
-    async def test_subscription_update_does_not_reset_meters(
+    async def test_subscription_update_leaves_metered_entries_pending(
         self,
         mocker: MockerFixture,
         save_fixture: SaveFixture,
         session: AsyncSession,
-        product_recurring_metered: Product,
+        product_recurring_fixed_and_metered: Product,
         customer: Customer,
         organization: Organization,
     ) -> None:
         """
-        Regression test for meter credit loss during subscription updates.
-
-        When a subscription_update order is created, meters should NOT be reset.
-        This ensures that meter credits from benefit grants remain valid for
-        the current billing cycle.
-
-        Bug context: Customers were being charged for metered usage even when
-        they had sufficient credited units, because subscription_update orders
-        were resetting meters mid-cycle without re-applying benefit credits.
+        Metered usage and its credits belong to the whole billing period, so an
+        update order bills the prorated static prices only and leaves the metered
+        entries pending for the next cycle. Meters are not reset either.
         """
         subscription_service_mock = mocker.patch(
             "polar.order.service.subscription_service", spec=SubscriptionService
         )
 
         subscription = await create_active_subscription(
-            save_fixture, product=product_recurring_metered, customer=customer
+            save_fixture,
+            product=product_recurring_fixed_and_metered,
+            customer=customer,
         )
 
+        fixed_price = next(
+            price
+            for price in product_recurring_fixed_and_metered.prices
+            if is_fixed_price(price)
+        )
+        await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.cycle,
+            customer=customer,
+            product_price=fixed_price,
+            amount=2000,
+            currency=fixed_price.price_currency,
+            subscription=subscription,
+        )
+
+        metered_subscription_price = next(
+            subscription_price
+            for subscription_price in subscription.subscription_product_prices
+            if not is_static_price(subscription_price.product_price)
+        )
         event = await create_event(
             save_fixture,
             organization=organization,
             customer=customer,
         )
-        await save_fixture(
-            BillingEntry.from_metered_event(
-                customer, subscription.subscription_product_prices[0], event
-            )
+        metered_entry = BillingEntry.from_metered_event(
+            customer, metered_subscription_price, event
         )
+        await save_fixture(metered_entry)
 
         order = await order_service.create_subscription_order(
             session, subscription, OrderBillingReasonInternal.subscription_update
         )
 
         assert len(order.items) == 1
-        assert order.subtotal_amount == 100
+        assert order.items[0].product_price == fixed_price
+        assert order.subtotal_amount == 2000
 
-        # subscription_update should NOT reset meters
-        # This ensures meter credits from benefit grants remain valid
+        await session.refresh(metered_entry)
+        assert metered_entry.order_item_id is None
+
         subscription_service_mock.reset_meters.assert_not_awaited()
 
     async def test_positive_order_positive_customer_balance(


### PR DESCRIPTION
## Summary

**Related Issue**: https://github.com/polarsource/polar-internal/issues/113

This leaves metered entries pending on update orders; to be invoiced at next cycle, the the credit is not consumed when changing plans.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip metered usage when creating subscription_update orders to prevent mid‑cycle consumption of period credits. Previously, updates could bill metered usage; now only static/prorated items are billed and meters are not reset.

**Review notes**
- Adds include_metered flag (default True) to create_order_items_from_pending and compute_pending_subscription_line_items; metered items are early-returned when False.
- create_subscription_order sets include_metered=False for billing_reason=subscription_update; other billing reasons are unchanged.
- _collect_pending_prorations now calls compute_pending_subscription_line_items with include_metered=False.
- Tests assert that update orders include only static items, metered entries remain pending, and reset_meters is not called.

<sup>Written for commit 1bba00958ea2129662f74c7ea5c42bdb2c7f6281. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

