### PR TITLE
refactor(migrations): share the table selection cell and selection model

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/SelectCheckbox.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/SelectCheckbox.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Checkbox } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+
+// The table zeroes the padding of any cell holding a checkbox
+// (`[&:has([role=checkbox])]:p-0`), so a selection column has to put the inset
+// back itself. Without this the checkbox sits flush against the table edge
+// while every other column is indented, and the column reads as misaligned.
+//
+// Orbit's own `createSelectionColumn` does the same thing, but its header
+// selects the current page; the migration tables select across the whole
+// catalog, so they build their own column and share this cell.
+export function SelectCheckbox({
+  checked,
+  disabled = false,
+  ariaLabel,
+  onToggle,
+}: {
+  checked: boolean | 'indeterminate'
+  disabled?: boolean
+  ariaLabel: string
+  onToggle?: () => void
+}) {
+  return (
+    <Box alignItems="center" paddingLeft="l">
+      <Checkbox
+        checked={checked}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        onCheckedChange={() => onToggle?.()}
+        // The row itself opens the detail modal.
+        onClick={(event) => event.stopPropagation()}
+      />
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/SelectCheckbox.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/SelectCheckbox.tsx
@@ -3,14 +3,9 @@
 import { Checkbox } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 
-// The table zeroes the padding of any cell holding a checkbox
-// (`[&:has([role=checkbox])]:p-0`), so a selection column has to put the inset
-// back itself. Without this the checkbox sits flush against the table edge
-// while every other column is indented, and the column reads as misaligned.
-//
-// Orbit's own `createSelectionColumn` does the same thing, but its header
-// selects the current page; the migration tables select across the whole
-// catalog, so they build their own column and share this cell.
+// The table zeroes padding on any cell holding a checkbox, so the inset has to
+// come from here. Orbit's `createSelectionColumn` does the same, but its header
+// selects the page rather than the whole catalog.
 export function SelectCheckbox({
   checked,
   disabled = false,

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -11,13 +11,13 @@ import { useCallback, useState } from 'react'
 import { useRecordSummary } from './recordSummary'
 import { ReviewScope } from './reviewRows'
 import {
-  importPayload,
+  selectionPayload,
   initialSelection,
-  selectionAfterImport,
+  selectionAfterSubmit,
   SelectionState,
   toggleAll,
   toggleRow,
-} from './reviewSelection'
+} from '../selection'
 import { ReviewFilter } from './ReviewStatusTabs'
 import { ReviewTableView } from './ReviewTableView'
 
@@ -107,9 +107,9 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
       onToggleAll={onToggleAll}
       onImport={() => {
         const submitted = selection
-        importCatalog.mutate(importPayload(submitted), {
+        importCatalog.mutate(selectionPayload(submitted), {
           onSuccess: () =>
-            setSelection((current) => selectionAfterImport(submitted, current)),
+            setSelection((current) => selectionAfterSubmit(submitted, current)),
         })
       }}
       importing={importCatalog.isPending}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -19,7 +19,7 @@ import {
   isRowSelected,
   selectedCount,
   SelectionState,
-} from './reviewSelection'
+} from '../selection'
 import { ReviewRow, ReviewScope } from './reviewRows'
 
 const numberFormat = new Intl.NumberFormat('en-US')

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewColumns.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewColumns.tsx
@@ -1,8 +1,9 @@
-import { Checkbox, Text } from '@polar-sh/orbit'
+import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { DataTableColumnDef } from '@polar-sh/orbit'
 import { ReviewStatusIndicator } from './ReviewStatusIndicator'
-import { HeaderCheckState } from './reviewSelection'
+import { SelectCheckbox } from '../SelectCheckbox'
+import { HeaderCheckState } from '../selection'
 import {
   entityLabelSingular,
   isImported,
@@ -138,11 +139,13 @@ function SelectCell({
   // A row that can't be picked keeps a disabled box, so the column stays a
   // column instead of a run of gaps.
   if (isImported(row)) {
-    return <SelectBox checked disabled ariaLabel={`${row.title} is imported`} />
+    return (
+      <SelectCheckbox checked disabled ariaLabel={`${row.title} is imported`} />
+    )
   }
   if (!isSelectable(row) || !id) {
     return (
-      <SelectBox
+      <SelectCheckbox
         checked={false}
         disabled
         ariaLabel={`${row.title} can't be imported`}
@@ -150,7 +153,7 @@ function SelectCell({
     )
   }
   return (
-    <SelectBox
+    <SelectCheckbox
       checked={isSelected(id)}
       ariaLabel={`Import ${row.title}`}
       onToggle={() => onToggle(id)}
@@ -168,36 +171,13 @@ function HeaderCheckbox({
   onToggle: () => void
 }) {
   return (
-    <SelectBox
+    <SelectCheckbox
       checked={
         state === 'indeterminate' ? 'indeterminate' : state === 'checked'
       }
       disabled={disabled}
       ariaLabel="Select all"
       onToggle={onToggle}
-    />
-  )
-}
-
-function SelectBox({
-  checked,
-  disabled = false,
-  ariaLabel,
-  onToggle,
-}: {
-  checked: boolean | 'indeterminate'
-  disabled?: boolean
-  ariaLabel: string
-  onToggle?: () => void
-}) {
-  return (
-    <Checkbox
-      checked={checked}
-      disabled={disabled}
-      aria-label={ariaLabel}
-      onCheckedChange={() => onToggle?.()}
-      // The row itself opens the detail modal.
-      onClick={(event) => event.stopPropagation()}
     />
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/selection.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/selection.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   initialSelection,
-  selectionAfterImport,
+  selectionAfterSubmit,
   SelectionState,
-} from './reviewSelection'
+} from './selection'
 
 const state = (mode: 'all' | 'none', ...ids: string[]): SelectionState => ({
   mode,
@@ -12,41 +12,41 @@ const state = (mode: 'all' | 'none', ...ids: string[]): SelectionState => ({
 
 const kept = (result: SelectionState) => [...result.toggled].sort()
 
-describe('selectionAfterImport', () => {
+describe('selectionAfterSubmit', () => {
   describe('opt-out mode, where everything outside `toggled` is sent', () => {
     it('keeps the excluded rows, which never left the ledger as pending', () => {
       const submitted = state('all', 'a')
-      expect(kept(selectionAfterImport(submitted, submitted))).toEqual(['a'])
+      expect(kept(selectionAfterSubmit(submitted, submitted))).toEqual(['a'])
     })
 
     it('drops a row excluded after submit, because it was already sent', () => {
       const submitted = state('all', 'a')
       const current = state('all', 'a', 'b')
-      expect(kept(selectionAfterImport(submitted, current))).toEqual(['a'])
+      expect(kept(selectionAfterSubmit(submitted, current))).toEqual(['a'])
     })
   })
 
   describe('opt-in mode, where only `toggled` is sent', () => {
     it('drops the rows it sent', () => {
       const submitted = state('none', 'a', 'b')
-      expect(kept(selectionAfterImport(submitted, submitted))).toEqual([])
+      expect(kept(selectionAfterSubmit(submitted, submitted))).toEqual([])
     })
 
     it('keeps a row picked after submit, which was not sent', () => {
       const submitted = state('none', 'a')
       const current = state('none', 'a', 'b')
-      expect(kept(selectionAfterImport(submitted, current))).toEqual(['b'])
+      expect(kept(selectionAfterSubmit(submitted, current))).toEqual(['b'])
     })
   })
 
   it('clears everything when the mode flipped mid-flight', () => {
-    const result = selectionAfterImport(state('all', 'a'), state('none', 'b'))
+    const result = selectionAfterSubmit(state('all', 'a'), state('none', 'b'))
     expect(result.mode).toBe('none')
     expect(kept(result)).toEqual([])
   })
 
   it('leaves the default selection untouched', () => {
-    const result = selectionAfterImport(initialSelection, initialSelection)
+    const result = selectionAfterSubmit(initialSelection, initialSelection)
     expect(result.mode).toBe('all')
     expect(kept(result)).toEqual([])
   })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/selection.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/selection.ts
@@ -77,11 +77,13 @@ export function selectionAfterSubmit(
   }
 }
 
-// Never both. Neither means everything.
-export interface SelectionPayload {
-  recordIds?: string[]
-  excludeRecordIds?: string[]
-}
+// Opt in, opt out, or neither for everything. The `never` arms are what stop a
+// caller sending both, which the server would silently resolve in favour of
+// `recordIds`.
+export type SelectionPayload =
+  | { recordIds: string[]; excludeRecordIds?: never }
+  | { recordIds?: never; excludeRecordIds: string[] }
+  | { recordIds?: never; excludeRecordIds?: never }
 
 export function selectionPayload(state: SelectionState): SelectionPayload {
   if (state.mode === 'all') {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/selection.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/selection.ts
@@ -1,3 +1,7 @@
+// Migration-wide rather than review-only: every table here sends the server a
+// set of ledger record ids to act on, over a catalog too big to enumerate
+// client-side. Lives above `review/` so the next one can reuse it.
+//
 // Selection scales past one page with a Gmail-style model: either everything is
 // selected except `toggled` (mode `all`, the opt-out default), or nothing is
 // selected except `toggled` (mode `none`). Row ids never all live client-side,
@@ -53,13 +57,13 @@ export function toggleAll(state: SelectionState): SelectionState {
   return { mode: allSelected ? 'none' : 'all', toggled: new Set() }
 }
 
-// The selection to carry over once `submitted` has imported. The payload below
+// The selection to carry over once `submitted` has been sent. The payload below
 // makes membership derivable: in `all` mode everything outside `toggled` was
 // sent, in `none` mode everything inside it was. Those rows have settled in the
 // ledger, so they can't be selected again — and their checkboxes are disabled,
 // so an id left behind could never be cleared and would decrement the count for
 // good. Anything toggled after submit wasn't sent, so it survives.
-export function selectionAfterImport(
+export function selectionAfterSubmit(
   submitted: SelectionState,
   current: SelectionState,
 ): SelectionState {
@@ -77,10 +81,14 @@ export function selectionAfterImport(
   }
 }
 
-export function importPayload(state: SelectionState): {
+// What a write takes: the ledger record ids to act on, as either an opt-in or
+// an opt-out list. Never both, and neither means "everything".
+export interface SelectionPayload {
   recordIds?: string[]
   excludeRecordIds?: string[]
-} {
+}
+
+export function selectionPayload(state: SelectionState): SelectionPayload {
   if (state.mode === 'all') {
     return state.toggled.size ? { excludeRecordIds: [...state.toggled] } : {}
   }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/selection.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/selection.ts
@@ -1,7 +1,3 @@
-// Migration-wide rather than review-only: every table here sends the server a
-// set of ledger record ids to act on, over a catalog too big to enumerate
-// client-side. Lives above `review/` so the next one can reuse it.
-//
 // Selection scales past one page with a Gmail-style model: either everything is
 // selected except `toggled` (mode `all`, the opt-out default), or nothing is
 // selected except `toggled` (mode `none`). Row ids never all live client-side,
@@ -81,8 +77,7 @@ export function selectionAfterSubmit(
   }
 }
 
-// What a write takes: the ledger record ids to act on, as either an opt-in or
-// an opt-out list. Never both, and neither means "everything".
+// Never both. Neither means everything.
 export interface SelectionPayload {
   recordIds?: string[]
   excludeRecordIds?: string[]


### PR DESCRIPTION
## Summary

The selection column of the migration review table put a bare `Checkbox` straight into the cell.  That is not the right approach.

## What

- Add `SelectCheckbox`, which puts the inset back, and use it in the review column.
- Move the selection model out of `review/` up to `migrations/selection.ts`.
- Rename `importPayload` to `selectionPayload` and `selectionAfterImport` to `selectionAfterSubmit`, since it is no longer import-only.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

