### PR TITLE
polar: Pass usage_id as an uuid for stable IDs

### DIFF
--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -739,6 +739,7 @@ class PolarSelfClient:
         input_tokens: int,
         output_tokens: int,
         cost_usd: Decimal,
+        usage_id: str | None = None,
     ) -> None:
         await self._track_llm_span_usage(
             operation="track_organization_review_usage",
@@ -750,6 +751,7 @@ class PolarSelfClient:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cost_usd=cost_usd,
+            usage_id=usage_id,
         )
 
     async def track_compass_assistant_usage(

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -213,6 +213,7 @@ class PolarSelfService:
         input_tokens: int,
         output_tokens: int,
         cost_usd: Decimal | float | None,
+        usage_id: str,
     ) -> None:
         if not self.is_configured:
             return
@@ -232,6 +233,7 @@ class PolarSelfService:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cost_usd=str(cost_decimal),
+            usage_id=usage_id,
         )
 
     def enqueue_track_compass_assistant_usage(

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -206,6 +206,7 @@ async def track_organization_review_usage(
     input_tokens: int,
     output_tokens: int,
     cost_usd: str,
+    usage_id: str | None = None,
 ) -> None:
     await get_client().track_organization_review_usage(
         external_customer_id=external_customer_id,
@@ -215,6 +216,7 @@ async def track_organization_review_usage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         cost_usd=Decimal(cost_usd),
+        usage_id=usage_id,
     )
 
 

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -113,6 +113,7 @@ async def _persist_agent_result(
         input_tokens=result.usage.input_tokens,
         output_tokens=result.usage.output_tokens,
         cost_usd=result.usage.estimated_cost_usd,
+        usage_id=str(uuid.uuid4()),
     )
 
     review_repository = OrganizationReviewRepository.from_session(session)

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -368,6 +368,7 @@ class TestEnqueueTrackOrganizationReviewUsage:
             input_tokens=100,
             output_tokens=50,
             cost_usd=cost_usd,
+            usage_id="usage-123",
         )
 
     def test_noop_when_not_configured(self, mocker: MockerFixture) -> None:
@@ -422,6 +423,7 @@ class TestEnqueueTrackOrganizationReviewUsage:
             input_tokens=100,
             output_tokens=50,
             cost_usd="0.0123",
+            usage_id="usage-123",
         )
 
     def test_accepts_float_cost(self, configured: None, mocker: MockerFixture) -> None:

--- a/server/tests/integrations/polar/test_tasks.py
+++ b/server/tests/integrations/polar/test_tasks.py
@@ -484,6 +484,7 @@ class TestTrackOrganizationReviewUsage:
             input_tokens=100,
             output_tokens=50,
             cost_usd="0.0123",
+            usage_id="usage-123",
         )
 
         client.track_organization_review_usage.assert_called_once_with(
@@ -494,4 +495,5 @@ class TestTrackOrganizationReviewUsage:
             input_tokens=100,
             output_tokens=50,
             cost_usd=Decimal("0.0123"),
+            usage_id="usage-123",
         )


### PR DESCRIPTION
Otherwise if polar_self.track_organization_review_usage retries due to a false failure where the request got stored but the response failed (mid task retry, failure after write, etc) we will double track the usage events.

Fixes https://github.com/polarsource/feedback/issues/294, extremely minor bug / risk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a usage_id (UUID) to organization review usage tracking and threads it through the service, task, and client. This provides a stable idempotency key so retries no longer double-track events when a write succeeds but the response fails.

- Migration: Callers of PolarService.enqueue_track_organization_review_usage must pass usage_id: str (use a UUID). Internal calls now generate uuid4; client and task accept an optional usage_id for compatibility.

<sup>Written for commit 3c42f1241b9903f08bfb65273674f8175718c2d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

