### PR TITLE
feat(merchant-migration): subscription switch engine

### DIFF
--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -286,7 +286,12 @@ class StripeAdapter:
             cancel_at_period_end=bool(subscription.cancel_at_period_end),
             trial_end=self._to_datetime(subscription.trial_end),
             stopped_for_migration=self._stopped_for_migration(subscription),
+            anchor_day=self._anchor_day(subscription),
         )
+
+    def _anchor_day(self, subscription: stripe_lib.Subscription) -> int | None:
+        anchor = self._to_datetime(subscription.billing_cycle_anchor)
+        return anchor.day if anchor is not None else None
 
     def _stopped_for_migration(self, subscription: stripe_lib.Subscription) -> bool:
         """Prefix, not the full reference: missing our own cancellation strands a

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -124,6 +124,9 @@ class CanonicalSubscription:
     # cutover, so a retry after a crash finishes the move instead of reading its
     # own cancellation as the customer having churned.
     stopped_for_migration: bool = False
+    # The renewal day before any month-end clamping. A period boundary can't be
+    # trusted for it: a 31st anchor reads as Feb 28 in a February period.
+    anchor_day: int | None = None
 
     type = MerchantMigrationRecordType.subscription
 
@@ -210,6 +213,7 @@ def deserialize(
                 cancel_at_period_end=data.get("cancel_at_period_end", False),
                 trial_end=_parse_datetime(data.get("trial_end")),
                 stopped_for_migration=data.get("stopped_for_migration", False),
+                anchor_day=data.get("anchor_day"),
             )
         case _:
             raise ValueError(f"Cannot deserialize record of type {type}")

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 
 import stripe as stripe_lib
 import structlog
+from sqlalchemy.orm import joinedload
 
 from polar.integrations.stripe.service import stripe as stripe_service
 from polar.kit.utils import utc_now
@@ -176,20 +177,23 @@ class SubscriptionCutover:
         # A previous attempt already stopped it on the source: the money side is
         # committed, so the only safe move is to finish, not re-run the checks
         # against the cancellation we made ourselves.
-        if not source.stopped_for_migration:
+        already_stopped = source.stopped_for_migration
+        if not already_stopped:
             reason = self._source_reason(source, record)
             if reason is not None:
                 return _skip(reason)
 
+        # Stays behind the source gate above: resolving writes, because it
+        # upserts the copied methods and may set the customer's default.
         payment_method = await self._resolve_payment_method(
             subscription, customer, source.payment_method
         )
-        if source.stopped_for_migration:
-            # The source is already stopped, so declining to finish here would
-            # leave the customer billed by nobody. A card we can't prove is
-            # still better than that: an unpaid first renewal goes to dunning,
-            # which is recoverable. Only having no method at all blocks us, and
-            # that's a failure to chase rather than a deliberate skip.
+        if already_stopped:
+            # Declining to finish now would leave the customer billed by nobody.
+            # A card we can't prove is still better than that: an unpaid first
+            # renewal goes to dunning, which is recoverable. Only having no
+            # method at all blocks us, and that's a failure to chase rather than
+            # a deliberate skip.
             if payment_method is None:
                 log.error(
                     "merchant_migration.cutover.stranded",
@@ -204,8 +208,6 @@ class SubscriptionCutover:
             card_reason = await self._card_reason(customer, payment_method)
             if card_reason is not None:
                 return _skip(card_reason)
-
-        if not source.stopped_for_migration:
             await self.adapter.stop_source_subscription(
                 record.source_id, reference=str(self.migration.id)
             )
@@ -253,29 +255,29 @@ class SubscriptionCutover:
     ) -> Subscription | None:
         if record.target_id is None:
             return None
+        # Only the customer: `activate_imported` re-reads the product for the
+        # benefit grants, and the webhook re-loads the whole graph itself, so
+        # the repository's eager options would be fetched and thrown away.
         return await self.subscription_repository.get_by_id(
-            record.target_id,
-            options=self.subscription_repository.get_eager_options(),
+            record.target_id, options=(joinedload(Subscription.customer),)
         )
 
     def _source_reason(
         self, source: CanonicalSubscription, record: MerchantMigrationRecord
     ) -> str | None:
         """Why the source says this subscription shouldn't move today."""
-        if source.status not in MIGRATABLE_SOURCE_STATUSES:
-            if source.status == CanonicalSubscriptionStatus.canceled:
-                return _SOURCE_CANCELED
-            reason = subscription_import_reason(source)
-            if reason is not None:
-                return reason.message
-            return _SOURCE_NOT_LIVE.format(status=source.status.value)
-        if source.cancel_at_period_end:
+        if source.status == CanonicalSubscriptionStatus.canceled:
+            return _SOURCE_CANCELED
+        migratable = source.status in MIGRATABLE_SOURCE_STATUSES
+        if migratable and source.cancel_at_period_end:
             return _ENDING
         # Everything the import refused to take, re-applied: the source has had
         # weeks to grow a second line item, a coupon or a manual invoice.
         reason = subscription_import_reason(source)
         if reason is not None:
             return reason.message
+        if not migratable:
+            return _SOURCE_NOT_LIVE.format(status=source.status.value)
         try:
             staged = deserialize(record.type, record.canonical)
         except (KeyError, TypeError, ValueError):

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -240,12 +240,11 @@ class SubscriptionCutover:
         except Exception:
             # The source is stopped and this rolls back, ledger row included, so
             # the log is the only trace of a customer nobody is billing.
-            log.error(
+            log.exception(
                 "merchant_migration.cutover.stopped_but_unfinished",
                 migration_id=self.migration.id,
                 record_id=record.id,
                 source_id=record.source_id,
-                exc_info=True,
             )
             raise
         log.info(
@@ -305,7 +304,7 @@ class SubscriptionCutover:
             return _SOURCE_NOT_LIVE.format(status=source.status.value)
         try:
             staged = deserialize(record.type, record.canonical)
-        except (KeyError, TypeError, ValueError):
+        except KeyError, TypeError, ValueError:
             # Raising would stall the chain, so it stops at this record instead.
             return _UNREADABLE
         if (

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -1,27 +1,18 @@
 """The cutover: Polar takes over billing for the imported subscriptions.
 
 Imported subscriptions sit paused so nothing bills while the cards move. Cutting
-over switches one on, and stops it on the old provider, in that order of checks:
-
-1. the subscription is still live on the source, on the same plan;
-2. its renewal is far enough out that the source can't bill the period first;
-3. the copied card is on Polar and can actually be charged;
-4. only then: stop it on the source, and unpause it on Polar.
-
-Everything before step 4 is read-only, so a subscription that fails any check is
-left exactly where it is — still billing on the source, still paused on Polar —
-with a reason the merchant can act on. The one irreversible act is fenced by all
-of them.
+one over stops it on the source, then unpauses it on Polar. Every check runs
+before the stop, so a subscription that fails one is left billing on the source.
 """
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from uuid import UUID
 
 import stripe as stripe_lib
 import structlog
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, noload
 
-from polar.integrations.stripe.service import stripe as stripe_service
 from polar.kit.utils import utc_now
 from polar.logging import Logger
 from polar.models import (
@@ -45,25 +36,23 @@ from .canonical import (
     CanonicalSubscriptionStatus,
     deserialize,
 )
-from .cards import CARD_TYPE, AmbiguousCopiedCard, link_payment_method
+from .cards import AmbiguousCopiedCard, link_payment_method
 from .precheck import subscription_import_reason
 
 log: Logger = structlog.get_logger()
 
-# The source must not get the chance to bill the period we're taking over. A
-# renewal landing inside this window stays where it is: once the source has
-# charged it, the next period opens up and the cutover can be retried.
+# Renewing sooner than this stays on the source: once it has charged, the next
+# period opens up and the cutover can be retried.
 RENEWAL_SAFETY_WINDOW = timedelta(hours=24)
 
-# Source states we can hand over. Anything else means the customer isn't cleanly
-# subscribed there, so there is no healthy billing relationship to take on.
 MIGRATABLE_SOURCE_STATUSES = frozenset(
     {CanonicalSubscriptionStatus.active, CanonicalSubscriptionStatus.trialing}
 )
 
-# Floor for a period we have to reconstruct, so an activated subscription never
-# starts on a cycle of zero length.
 _MINIMUM_PERIOD = timedelta(days=1)
+
+# Re-read under the lock, so anything the activation decides on belongs here.
+_LOCKED_COLUMNS = ["status", "current_period_start", "current_period_end"]
 
 _GONE = "It no longer exists on the source, so there is nothing to take over."
 _SOURCE_CANCELED = (
@@ -91,21 +80,41 @@ _STRANDED = (
     "Polar for this customer, so nobody is billing them. They need to enter "
     "their billing details, then run this again."
 )
+_CARD_EXPIRED = (
+    "The copied card has expired, so the first Polar renewal will fail and go to "
+    "dunning. The customer needs to enter a new one."
+)
 _UNREADABLE = (
     "We can't read what was imported for this subscription, so we can't tell "
     "whether it still matches the source. Re-run the import for this customer."
 )
 _CUSTOMER_DELETED = "The Polar customer was deleted, so it can't be billed."
 _SUBSCRIPTION_GONE = "The imported Polar subscription no longer exists."
+_NOT_IMPORTED = (
+    "It was never imported into Polar, so there is nothing to switch on. Re-run "
+    "the import for this customer."
+)
+_LAPSED = (
+    "It was stopped on the source more than one renewal ago, so switching it on "
+    "now would bill the customer for every period missed since. Contact support "
+    "to set its next billing date first."
+)
+_RENEWALS_DISABLED = (
+    "Your organization can't renew subscriptions yet, so Polar wouldn't bill "
+    "this one after taking it over. It stays on the source until your account "
+    "is active."
+)
 
 
 @dataclass(frozen=True)
 class CutoverOutcome:
     status: MerchantMigrationCutoverStatus
-    reason: str | None = None
+    # Why it didn't move, or what to chase on one that did.
+    message: str | None = None
 
 
-_MOVED = CutoverOutcome(MerchantMigrationCutoverStatus.moved)
+def _moved(message: str | None = None) -> CutoverOutcome:
+    return CutoverOutcome(MerchantMigrationCutoverStatus.moved, message)
 
 
 def _skip(reason: str) -> CutoverOutcome:
@@ -134,9 +143,7 @@ class SubscriptionCutover:
         try:
             return await self._run(record)
         except AmbiguousCopiedCard as e:
-            # One customer nobody can pick a card for must not stop the run for
-            # everyone else. Recorded so it surfaces, and retryable once someone
-            # has removed the duplicate.
+            # Recorded rather than raised: one customer must not stop the run.
             log.warning(
                 "merchant_migration.cutover.ambiguous_card",
                 migration_id=self.migration.id,
@@ -145,9 +152,7 @@ class SubscriptionCutover:
             )
             return _fail(str(e))
         except stripe_lib.StripeError as e:
-            # Reaching Stripe is the one thing that fails for reasons that have
-            # nothing to do with this subscription, so it's recorded as failed
-            # (retryable) rather than skipped, and the run moves on.
+            # Failed, not skipped: nothing here is this subscription's fault.
             log.warning(
                 "merchant_migration.cutover.stripe_error",
                 migration_id=self.migration.id,
@@ -158,7 +163,9 @@ class SubscriptionCutover:
             return _fail(e.user_message or str(e))
 
     async def _run(self, record: MerchantMigrationRecord) -> CutoverOutcome:
-        subscription = await self._load_subscription(record)
+        if record.target_id is None:
+            return _fail(_NOT_IMPORTED)
+        subscription = await self._load_subscription(record.target_id)
         if subscription is None:
             return _fail(_SUBSCRIPTION_GONE)
         if SubscriptionStatus.is_active(subscription.status):
@@ -174,26 +181,27 @@ class SubscriptionCutover:
         if source is None:
             return _skip(_GONE)
 
-        # A previous attempt already stopped it on the source: the money side is
-        # committed, so the only safe move is to finish, not re-run the checks
-        # against the cancellation we made ourselves.
+        # We cancelled it ourselves, in an attempt that died before it committed.
+        # The checks below would read that as the customer churning and skip for
+        # good, leaving them cancelled on the source and paused here.
         already_stopped = source.stopped_for_migration
         if not already_stopped:
+            # The renewal scheduler filters on this, so taking the subscription
+            # over would cancel it on the source and then never bill it.
+            if not subscription.organization.can_renew_subscriptions:
+                return _skip(_RENEWALS_DISABLED)
             reason = self._source_reason(source, record)
             if reason is not None:
                 return _skip(reason)
 
-        # Stays behind the source gate above: resolving writes, because it
-        # upserts the copied methods and may set the customer's default.
+        # Behind the gate above because resolving writes: it upserts the copied
+        # methods and may set the customer's default.
         payment_method = await self._resolve_payment_method(
             subscription, customer, source.payment_method
         )
         if already_stopped:
-            # Declining to finish now would leave the customer billed by nobody.
-            # A card we can't prove is still better than that: an unpaid first
-            # renewal goes to dunning, which is recoverable. Only having no
-            # method at all blocks us, and that's a failure to chase rather than
-            # a deliberate skip.
+            # An unproven card beats no biller at all: a failed first renewal
+            # goes to dunning, which is recoverable.
             if payment_method is None:
                 log.error(
                     "merchant_migration.cutover.stranded",
@@ -202,41 +210,59 @@ class SubscriptionCutover:
                     source_id=record.source_id,
                 )
                 return _fail(_STRANDED)
-        else:
-            if payment_method is None:
-                return _skip(_NO_CARD)
-            card_reason = await self._card_reason(customer, payment_method)
-            if card_reason is not None:
-                return _skip(card_reason)
+            if subscription.is_period_lapsed(self._period_end(source, subscription)):
+                return _fail(_LAPSED)
+        elif payment_method is None:
+            return _skip(_NO_CARD)
+
+        # Locked only now: the portal takes this same row lock, and everything
+        # above spends seconds in Stripe. Bailing here is still free.
+        await self.session.refresh(subscription, _LOCKED_COLUMNS, with_for_update=True)
+        if subscription.status != SubscriptionStatus.paused:
+            return _skip(_NOT_PAUSED)
+
+        if not already_stopped:
             await self.adapter.stop_source_subscription(
                 record.source_id, reference=str(self.migration.id)
             )
 
         current_period_start, current_period_end = self._period(source, subscription)
-        await subscription_service.activate_imported(
-            self.session,
-            subscription,
-            current_period_start=current_period_start,
-            current_period_end=current_period_end,
-            trial_end=self._trial_end(source),
-            payment_method=payment_method,
-        )
+        try:
+            await subscription_service.activate_imported(
+                self.session,
+                subscription,
+                current_period_start=current_period_start,
+                current_period_end=current_period_end,
+                trial_end=self._trial_end(source),
+                anchor_day=source.anchor_day,
+                payment_method=payment_method,
+            )
+        except Exception:
+            # The source is stopped and this rolls back, ledger row included, so
+            # the log is the only trace of a customer nobody is billing.
+            log.error(
+                "merchant_migration.cutover.stopped_but_unfinished",
+                migration_id=self.migration.id,
+                record_id=record.id,
+                source_id=record.source_id,
+                exc_info=True,
+            )
+            raise
         log.info(
             "merchant_migration.cutover.moved",
             migration_id=self.migration.id,
             subscription_id=subscription.id,
             source_id=record.source_id,
         )
-        return _MOVED
+        return _moved(self._card_note(payment_method))
 
     async def _reconcile_active(
         self, record: MerchantMigrationRecord
     ) -> CutoverOutcome:
-        """The Polar subscription is already live, so make sure the source isn't.
+        """Already live on Polar, so make sure it isn't live on the source too.
 
-        Usually a previous run finishing twice. But a paused subscription can
-        also be resumed by hand — by the customer, from their portal — and then
-        both sides are billing the same person.
+        Usually a previous run finishing twice, but a customer can also resume
+        from their portal, and then both sides bill them.
         """
         source = await self.adapter.get_subscription(record.source_id)
         if source is not None and source.status != CanonicalSubscriptionStatus.canceled:
@@ -248,18 +274,17 @@ class SubscriptionCutover:
             await self.adapter.stop_source_subscription(
                 record.source_id, reference=str(self.migration.id)
             )
-        return _MOVED
+        return _moved()
 
-    async def _load_subscription(
-        self, record: MerchantMigrationRecord
-    ) -> Subscription | None:
-        if record.target_id is None:
-            return None
-        # Only the customer: `activate_imported` re-reads the product for the
-        # benefit grants, and the webhook re-loads the whole graph itself, so
-        # the repository's eager options would be fetched and thrown away.
+    async def _load_subscription(self, subscription_id: UUID) -> Subscription | None:
         return await self.subscription_repository.get_by_id(
-            record.target_id, options=(joinedload(Subscription.customer),)
+            subscription_id,
+            options=(
+                joinedload(Subscription.customer).noload(Customer.owner),
+                joinedload(Subscription.organization),
+                noload(Subscription.meters),
+                noload(Subscription.subscription_product_prices),
+            ),
         )
 
     def _source_reason(
@@ -271,8 +296,8 @@ class SubscriptionCutover:
         migratable = source.status in MIGRATABLE_SOURCE_STATUSES
         if migratable and source.cancel_at_period_end:
             return _ENDING
-        # Everything the import refused to take, re-applied: the source has had
-        # weeks to grow a second line item, a coupon or a manual invoice.
+        # The import's own bar, re-applied: the source has had weeks to grow a
+        # second line item, a coupon or a manual invoice.
         reason = subscription_import_reason(source)
         if reason is not None:
             return reason.message
@@ -281,9 +306,7 @@ class SubscriptionCutover:
         try:
             staged = deserialize(record.type, record.canonical)
         except (KeyError, TypeError, ValueError):
-            # A blob staged before a canonical change, or half-written. Stopping
-            # this one record beats letting it raise: the run is one subscription
-            # per job, so an escaping error would stall the whole chain on it.
+            # Raising would stall the chain, so it stops at this record instead.
             return _UNREADABLE
         if (
             isinstance(staged, CanonicalSubscription)
@@ -314,13 +337,8 @@ class SubscriptionCutover:
         customer: Customer,
         source_method: CanonicalPaymentMethod | None,
     ) -> PaymentMethod | None:
-        """The card the first Polar renewal will charge.
-
-        A card linked by the `verify_cards` step wins; otherwise we look again,
-        because cards keep landing while the merchant walks the checklist. Read
-        from the source now, not from the staged copy: the customer may have
-        changed which card the subscription charges since the import.
-        """
+        """The card the first Polar renewal will charge. A card the `verify_cards`
+        step linked wins; otherwise look again, because cards keep landing."""
         if subscription.payment_method_id is not None:
             payment_method = await PaymentMethodRepository.from_session(
                 self.session
@@ -331,58 +349,44 @@ class SubscriptionCutover:
             self.session, customer, source_method=source_method
         )
 
-    async def _card_reason(
-        self, customer: Customer, payment_method: PaymentMethod
-    ) -> str | None:
-        """Prove the card can be charged before anything is cancelled.
+    def _card_note(self, payment_method: PaymentMethod) -> str | None:
+        """What the merchant should chase, not a reason to hold the switch back.
 
-        Only cards: a zero-amount confirmation says nothing useful about a bank
-        debit, and confirming one needs a mandate the copy doesn't carry.
+        A card only proves itself on a real charge, and a first renewal that
+        fails already goes to dunning. Leaving the subscription on the provider
+        the merchant is closing helps nobody, so the checks here stay free and
+        the answer travels with a subscription that moved.
         """
-        if payment_method.type != CARD_TYPE or customer.stripe_customer_id is None:
+        expires_at = payment_method.expires_at
+        if expires_at is None or expires_at > utc_now():
             return None
-        try:
-            setup_intent = await stripe_service.create_setup_intent(
-                customer=customer.stripe_customer_id,
-                payment_method=payment_method.processor_id,
-                payment_method_types=[CARD_TYPE],
-                usage="off_session",
-                confirm=True,
-                metadata={"merchant_migration_id": str(self.migration.id)},
-            )
-        except stripe_lib.CardError as e:
-            return f"The copied card was declined by the bank: {e.user_message}."
-        if setup_intent.status != "succeeded":
-            return (
-                "The copied card can't be charged without the customer "
-                "confirming it, so Polar can't bill it unattended. Ask them to "
-                "re-enter their billing details."
-            )
-        return None
+        return _CARD_EXPIRED
 
     def _period(
         self, source: CanonicalSubscription, subscription: Subscription
     ) -> tuple[datetime, datetime]:
-        """Where the source left the billing cycle.
-
-        Read at cutover, not at import: the source has kept renewing in between,
-        so the staged period is stale. The subscription's own period is the
-        fallback for a source that no longer reports one.
-        """
-        end = source.current_period_end or subscription.current_period_end
-        start = source.current_period_start or subscription.current_period_start
-        if start >= end:
-            # An inverted or empty period would feed the renewal maths, and the
-            # subscription's own start can be just as late as the source's. Keep
-            # the cycle length Polar already knows and land it before the end.
+        """Where the source left the billing cycle. Read now, not at import: it
+        has kept renewing in between, so the staged period is stale."""
+        end = self._period_end(source, subscription)
+        start = source.current_period_start
+        if start is None or start >= end:
+            # Polar's own start belongs to whichever period the import caught,
+            # which can be renewals behind this end. Reuse its length, not it.
             length = subscription.current_period_end - subscription.current_period_start
             start = end - max(length, _MINIMUM_PERIOD)
         return start, end
 
+    def _period_end(
+        self, source: CanonicalSubscription, subscription: Subscription
+    ) -> datetime:
+        return source.current_period_end or subscription.current_period_end
+
     def _trial_end(self, source: CanonicalSubscription) -> datetime | None:
-        """Keep a running trial running: Polar bills at its end, not today."""
-        if source.status != CanonicalSubscriptionStatus.trialing:
-            return None
+        """Keep a running trial running: Polar bills at its end, not today.
+
+        Off the date, not the status: a retry reads the source we cancelled
+        ourselves, which says `canceled` while the trial is still running.
+        """
         if source.trial_end is None or source.trial_end <= utc_now():
             return None
         return source.trial_end

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -1,0 +1,349 @@
+"""The cutover: Polar takes over billing for the imported subscriptions.
+
+Imported subscriptions sit paused so nothing bills while the cards move. Cutting
+over switches one on, and stops it on the old provider, in that order of checks:
+
+1. the subscription is still live on the source, on the same plan;
+2. its renewal is far enough out that the source can't bill the period first;
+3. the copied card is on Polar and can actually be charged;
+4. only then: stop it on the source, and unpause it on Polar.
+
+Everything before step 4 is read-only, so a subscription that fails any check is
+left exactly where it is — still billing on the source, still paused on Polar —
+with a reason the merchant can act on. The one irreversible act is fenced by all
+of them.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import stripe as stripe_lib
+import structlog
+
+from polar.integrations.stripe.service import stripe as stripe_service
+from polar.kit.utils import utc_now
+from polar.logging import Logger
+from polar.models import (
+    Customer,
+    MerchantMigration,
+    MerchantMigrationRecord,
+    PaymentMethod,
+    Subscription,
+)
+from polar.models.merchant_migration_record import MerchantMigrationCutoverStatus
+from polar.models.subscription import SubscriptionStatus
+from polar.payment_method.repository import PaymentMethodRepository
+from polar.postgres import AsyncSession
+from polar.subscription.repository import SubscriptionRepository
+from polar.subscription.service import subscription as subscription_service
+
+from .adapters import SourceAdapter
+from .canonical import (
+    CanonicalPaymentMethod,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+    deserialize,
+)
+from .cards import CARD_TYPE, AmbiguousCopiedCard, link_payment_method
+from .precheck import subscription_import_reason
+
+log: Logger = structlog.get_logger()
+
+# The source must not get the chance to bill the period we're taking over. A
+# renewal landing inside this window stays where it is: once the source has
+# charged it, the next period opens up and the cutover can be retried.
+RENEWAL_SAFETY_WINDOW = timedelta(hours=24)
+
+# Source states we can hand over. Anything else means the customer isn't cleanly
+# subscribed there, so there is no healthy billing relationship to take on.
+MIGRATABLE_SOURCE_STATUSES = frozenset(
+    {CanonicalSubscriptionStatus.active, CanonicalSubscriptionStatus.trialing}
+)
+
+_GONE = "It no longer exists on the source, so there is nothing to take over."
+_SOURCE_CANCELED = (
+    "It was cancelled on the source after the import, so Polar won't start billing it."
+)
+_SOURCE_NOT_LIVE = (
+    "The source reports it as `{status}`, which isn't a healthy subscription "
+    "Polar can take billing over from."
+)
+_ENDING = (
+    "It's set to cancel at the end of the period on the source, so there is no "
+    "renewal for Polar to take over. It stays there until it ends."
+)
+_PLAN_CHANGED = (
+    "The plan changed on the source since the import, so the imported "
+    "subscription no longer matches. Re-run the import for this customer."
+)
+_NO_CARD = (
+    "No copied card has landed on Polar for this customer yet. They need to "
+    "enter their billing details again, or the copy has to pick them up."
+)
+_NOT_PAUSED = "It isn't paused in Polar any more, so it was left alone."
+_CUSTOMER_DELETED = "The Polar customer was deleted, so it can't be billed."
+_SUBSCRIPTION_GONE = "The imported Polar subscription no longer exists."
+
+
+@dataclass(frozen=True)
+class CutoverOutcome:
+    status: MerchantMigrationCutoverStatus
+    reason: str | None = None
+
+
+_MOVED = CutoverOutcome(MerchantMigrationCutoverStatus.moved)
+
+
+def _skip(reason: str) -> CutoverOutcome:
+    return CutoverOutcome(MerchantMigrationCutoverStatus.skipped, reason)
+
+
+def _fail(reason: str) -> CutoverOutcome:
+    return CutoverOutcome(MerchantMigrationCutoverStatus.failed, reason)
+
+
+class SubscriptionCutover:
+    """Cuts one imported subscription over, or explains why it didn't."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        adapter: SourceAdapter,
+    ) -> None:
+        self.session = session
+        self.migration = migration
+        self.adapter = adapter
+        self.subscription_repository = SubscriptionRepository.from_session(session)
+
+    async def run(self, record: MerchantMigrationRecord) -> CutoverOutcome:
+        try:
+            return await self._run(record)
+        except AmbiguousCopiedCard as e:
+            # One customer nobody can pick a card for must not stop the run for
+            # everyone else. Recorded so it surfaces, and retryable once someone
+            # has removed the duplicate.
+            log.warning(
+                "merchant_migration.cutover.ambiguous_card",
+                migration_id=self.migration.id,
+                record_id=record.id,
+                customer_id=e.customer_id,
+            )
+            return _fail(str(e))
+        except stripe_lib.StripeError as e:
+            # Reaching Stripe is the one thing that fails for reasons that have
+            # nothing to do with this subscription, so it's recorded as failed
+            # (retryable) rather than skipped, and the run moves on.
+            log.warning(
+                "merchant_migration.cutover.stripe_error",
+                migration_id=self.migration.id,
+                record_id=record.id,
+                source_id=record.source_id,
+                error=str(e),
+            )
+            return _fail(e.user_message or str(e))
+
+    async def _run(self, record: MerchantMigrationRecord) -> CutoverOutcome:
+        subscription = await self._load_subscription(record)
+        if subscription is None:
+            return _fail(_SUBSCRIPTION_GONE)
+        if SubscriptionStatus.is_active(subscription.status):
+            return await self._reconcile_active(record)
+        if subscription.status != SubscriptionStatus.paused:
+            return _skip(_NOT_PAUSED)
+
+        customer = subscription.customer
+        if customer.is_deleted:
+            return _skip(_CUSTOMER_DELETED)
+
+        source = await self.adapter.get_subscription(record.source_id)
+        if source is None:
+            return _skip(_GONE)
+
+        # A previous attempt already stopped it on the source: the money side is
+        # committed, so the only safe move is to finish, not re-run the checks
+        # against the cancellation we made ourselves.
+        if not source.stopped_for_migration:
+            reason = self._source_reason(source, record)
+            if reason is not None:
+                return _skip(reason)
+
+        payment_method = await self._resolve_payment_method(
+            subscription, customer, source.payment_method
+        )
+        if payment_method is None:
+            return _skip(_NO_CARD)
+        card_reason = await self._card_reason(customer, payment_method)
+        if card_reason is not None:
+            return _skip(card_reason)
+
+        if not source.stopped_for_migration:
+            await self.adapter.stop_source_subscription(
+                record.source_id, reference=str(self.migration.id)
+            )
+
+        current_period_start, current_period_end = self._period(source, subscription)
+        await subscription_service.activate_imported(
+            self.session,
+            subscription,
+            current_period_start=current_period_start,
+            current_period_end=current_period_end,
+            trial_end=self._trial_end(source),
+            payment_method=payment_method,
+        )
+        log.info(
+            "merchant_migration.cutover.moved",
+            migration_id=self.migration.id,
+            subscription_id=subscription.id,
+            source_id=record.source_id,
+        )
+        return _MOVED
+
+    async def _reconcile_active(
+        self, record: MerchantMigrationRecord
+    ) -> CutoverOutcome:
+        """The Polar subscription is already live, so make sure the source isn't.
+
+        Usually a previous run finishing twice. But a paused subscription can
+        also be resumed by hand — by the customer, from their portal — and then
+        both sides are billing the same person.
+        """
+        source = await self.adapter.get_subscription(record.source_id)
+        if source is not None and source.status != CanonicalSubscriptionStatus.canceled:
+            log.warning(
+                "merchant_migration.cutover.source_still_live",
+                migration_id=self.migration.id,
+                source_id=record.source_id,
+            )
+            await self.adapter.stop_source_subscription(
+                record.source_id, reference=str(self.migration.id)
+            )
+        return _MOVED
+
+    async def _load_subscription(
+        self, record: MerchantMigrationRecord
+    ) -> Subscription | None:
+        if record.target_id is None:
+            return None
+        return await self.subscription_repository.get_by_id(
+            record.target_id,
+            options=self.subscription_repository.get_eager_options(),
+        )
+
+    def _source_reason(
+        self, source: CanonicalSubscription, record: MerchantMigrationRecord
+    ) -> str | None:
+        """Why the source says this subscription shouldn't move today."""
+        if source.status not in MIGRATABLE_SOURCE_STATUSES:
+            if source.status == CanonicalSubscriptionStatus.canceled:
+                return _SOURCE_CANCELED
+            reason = subscription_import_reason(source)
+            if reason is not None:
+                return reason.message
+            return _SOURCE_NOT_LIVE.format(status=source.status.value)
+        if source.cancel_at_period_end:
+            return _ENDING
+        # Everything the import refused to take, re-applied: the source has had
+        # weeks to grow a second line item, a coupon or a manual invoice.
+        reason = subscription_import_reason(source)
+        if reason is not None:
+            return reason.message
+        staged = deserialize(record.type, record.canonical)
+        if (
+            isinstance(staged, CanonicalSubscription)
+            and staged.price_source_id != source.price_source_id
+        ):
+            return _PLAN_CHANGED
+        return self._renewal_reason(source)
+
+    def _renewal_reason(self, source: CanonicalSubscription) -> str | None:
+        renewal = source.current_period_end
+        if renewal is None:
+            return (
+                "The source doesn't report a renewal date, so we can't tell "
+                "whether it's about to bill this subscription."
+            )
+        deadline = utc_now() + RENEWAL_SAFETY_WINDOW
+        if renewal > deadline:
+            return None
+        return (
+            f"It renews on the source at {renewal.isoformat()}, too soon to hand "
+            "over without risking a double charge. Retry once that renewal has "
+            "gone through."
+        )
+
+    async def _resolve_payment_method(
+        self,
+        subscription: Subscription,
+        customer: Customer,
+        source_method: CanonicalPaymentMethod | None,
+    ) -> PaymentMethod | None:
+        """The card the first Polar renewal will charge.
+
+        A card linked by the `verify_cards` step wins; otherwise we look again,
+        because cards keep landing while the merchant walks the checklist. Read
+        from the source now, not from the staged copy: the customer may have
+        changed which card the subscription charges since the import.
+        """
+        if subscription.payment_method_id is not None:
+            payment_method = await PaymentMethodRepository.from_session(
+                self.session
+            ).get_by_id(subscription.payment_method_id)
+            if payment_method is not None:
+                return payment_method
+        return await link_payment_method(
+            self.session, customer, source_method=source_method
+        )
+
+    async def _card_reason(
+        self, customer: Customer, payment_method: PaymentMethod
+    ) -> str | None:
+        """Prove the card can be charged before anything is cancelled.
+
+        Only cards: a zero-amount confirmation says nothing useful about a bank
+        debit, and confirming one needs a mandate the copy doesn't carry.
+        """
+        if payment_method.type != CARD_TYPE or customer.stripe_customer_id is None:
+            return None
+        try:
+            setup_intent = await stripe_service.create_setup_intent(
+                customer=customer.stripe_customer_id,
+                payment_method=payment_method.processor_id,
+                payment_method_types=[CARD_TYPE],
+                usage="off_session",
+                confirm=True,
+                metadata={"merchant_migration_id": str(self.migration.id)},
+            )
+        except stripe_lib.CardError as e:
+            return f"The copied card was declined by the bank: {e.user_message}."
+        if setup_intent.status != "succeeded":
+            return (
+                "The copied card can't be charged without the customer "
+                "confirming it, so Polar can't bill it unattended. Ask them to "
+                "re-enter their billing details."
+            )
+        return None
+
+    def _period(
+        self, source: CanonicalSubscription, subscription: Subscription
+    ) -> tuple[datetime, datetime]:
+        """Where the source left the billing cycle.
+
+        Read at cutover, not at import: the source has kept renewing in between,
+        so the staged period is stale. The subscription's own period is the
+        fallback for a source that no longer reports one.
+        """
+        end = source.current_period_end or subscription.current_period_end
+        start = source.current_period_start or subscription.current_period_start
+        if start >= end:
+            # An inverted period would feed the renewal maths.
+            start = min(subscription.current_period_start, end)
+        return start, end
+
+    def _trial_end(self, source: CanonicalSubscription) -> datetime | None:
+        """Keep a running trial running: Polar bills at its end, not today."""
+        if source.status != CanonicalSubscriptionStatus.trialing:
+            return None
+        if source.trial_end is None or source.trial_end <= utc_now():
+            return None
+        return source.trial_end

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -60,6 +60,10 @@ MIGRATABLE_SOURCE_STATUSES = frozenset(
     {CanonicalSubscriptionStatus.active, CanonicalSubscriptionStatus.trialing}
 )
 
+# Floor for a period we have to reconstruct, so an activated subscription never
+# starts on a cycle of zero length.
+_MINIMUM_PERIOD = timedelta(days=1)
+
 _GONE = "It no longer exists on the source, so there is nothing to take over."
 _SOURCE_CANCELED = (
     "It was cancelled on the source after the import, so Polar won't start billing it."
@@ -81,6 +85,15 @@ _NO_CARD = (
     "enter their billing details again, or the copy has to pick them up."
 )
 _NOT_PAUSED = "It isn't paused in Polar any more, so it was left alone."
+_STRANDED = (
+    "It was already stopped on the source, but no payment method has landed on "
+    "Polar for this customer, so nobody is billing them. They need to enter "
+    "their billing details, then run this again."
+)
+_UNREADABLE = (
+    "We can't read what was imported for this subscription, so we can't tell "
+    "whether it still matches the source. Re-run the import for this customer."
+)
 _CUSTOMER_DELETED = "The Polar customer was deleted, so it can't be billed."
 _SUBSCRIPTION_GONE = "The imported Polar subscription no longer exists."
 
@@ -171,11 +184,26 @@ class SubscriptionCutover:
         payment_method = await self._resolve_payment_method(
             subscription, customer, source.payment_method
         )
-        if payment_method is None:
-            return _skip(_NO_CARD)
-        card_reason = await self._card_reason(customer, payment_method)
-        if card_reason is not None:
-            return _skip(card_reason)
+        if source.stopped_for_migration:
+            # The source is already stopped, so declining to finish here would
+            # leave the customer billed by nobody. A card we can't prove is
+            # still better than that: an unpaid first renewal goes to dunning,
+            # which is recoverable. Only having no method at all blocks us, and
+            # that's a failure to chase rather than a deliberate skip.
+            if payment_method is None:
+                log.error(
+                    "merchant_migration.cutover.stranded",
+                    migration_id=self.migration.id,
+                    record_id=record.id,
+                    source_id=record.source_id,
+                )
+                return _fail(_STRANDED)
+        else:
+            if payment_method is None:
+                return _skip(_NO_CARD)
+            card_reason = await self._card_reason(customer, payment_method)
+            if card_reason is not None:
+                return _skip(card_reason)
 
         if not source.stopped_for_migration:
             await self.adapter.stop_source_subscription(
@@ -248,7 +276,13 @@ class SubscriptionCutover:
         reason = subscription_import_reason(source)
         if reason is not None:
             return reason.message
-        staged = deserialize(record.type, record.canonical)
+        try:
+            staged = deserialize(record.type, record.canonical)
+        except (KeyError, TypeError, ValueError):
+            # A blob staged before a canonical change, or half-written. Stopping
+            # this one record beats letting it raise: the run is one subscription
+            # per job, so an escaping error would stall the whole chain on it.
+            return _UNREADABLE
         if (
             isinstance(staged, CanonicalSubscription)
             and staged.price_source_id != source.price_source_id
@@ -336,8 +370,11 @@ class SubscriptionCutover:
         end = source.current_period_end or subscription.current_period_end
         start = source.current_period_start or subscription.current_period_start
         if start >= end:
-            # An inverted period would feed the renewal maths.
-            start = min(subscription.current_period_start, end)
+            # An inverted or empty period would feed the renewal maths, and the
+            # subscription's own start can be just as late as the source's. Keep
+            # the cycle length Polar already knows and land it before the end.
+            length = subscription.current_period_end - subscription.current_period_start
+            start = end - max(length, _MINIMUM_PERIOD)
         return start, end
 
     def _trial_end(self, source: CanonicalSubscription) -> datetime | None:

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -449,6 +449,7 @@ class CatalogImporter:
             customer=customer,
             current_period_start=subscription.current_period_start,
             current_period_end=subscription.current_period_end,
+            anchor_day=subscription.anchor_day,
             user_metadata={"stripe_subscription_id": subscription.source_id},
         )
 

--- a/server/polar/models/payment_method.py
+++ b/server/polar/models/payment_method.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
@@ -11,6 +12,11 @@ from polar.kit.extensions.sqlalchemy.types import StringEnum
 
 if TYPE_CHECKING:
     from .customer import Customer
+
+
+def card_expiration(year: int, month: int) -> datetime:
+    """Cards stay valid through the end of their expiration month."""
+    return datetime(year + month // 12, month % 12 + 1, 1, tzinfo=UTC)
 
 
 class PaymentMethod(RecordModel):
@@ -45,3 +51,14 @@ class PaymentMethod(RecordModel):
     @property
     def fingerprint(self) -> str | None:
         return self.method_metadata.get("fingerprint")
+
+    @property
+    def expires_at(self) -> datetime | None:
+        """None for a method that carries no expiry, such as a bank debit."""
+        year, month = (
+            self.method_metadata.get("exp_year"),
+            self.method_metadata.get("exp_month"),
+        )
+        if year is None or month is None:
+            return None
+        return card_expiration(year, month)

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -572,17 +572,22 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
         ):
             return False
 
-        now = utc_now()
-        if self.current_period_end <= now:
-            new_period_end = self.recurring_interval.get_next_period(
-                self.current_period_end,
-                self.anchor_day,
-                self.recurring_interval_count,
-            )
-            if new_period_end <= now:
-                return False
+        return not self.is_period_lapsed()
 
-        return True
+    def is_period_lapsed(self, period_end: datetime | None = None) -> bool:
+        """More than one renewal has gone by unbilled.
+
+        The scheduler catches a subscription up one period at a time, so past
+        this point it would issue an order per period nobody billed.
+        """
+        end = period_end if period_end is not None else self.current_period_end
+        now = utc_now()
+        if end > now:
+            return False
+        next_end = self.recurring_interval.get_next_period(
+            end, self.anchor_day, self.recurring_interval_count
+        )
+        return next_end <= now
 
     def update_amount_and_currency(
         self, prices: Sequence["SubscriptionProductPrice"], discount: "Discount | None"

--- a/server/polar/payment_method/repository.py
+++ b/server/polar/payment_method/repository.py
@@ -15,14 +15,14 @@ from polar.kit.repository import (
 )
 from polar.models import Customer, PaymentMethod, Subscription
 from polar.models.email_log import EmailLog, EmailLogStatus
-from polar.models.payment_method import card_expiration as _expiration_datetime
+from polar.models.payment_method import card_expiration
 
 
 def expiring_periods(now: datetime, window_end: datetime) -> list[tuple[int, int]]:
     """(year, month) pairs whose expiration falls within (now, window_end]."""
     periods: list[tuple[int, int]] = []
     year, month = now.year, now.month
-    while _expiration_datetime(year, month) <= window_end:
+    while card_expiration(year, month) <= window_end:
         periods.append((year, month))
         year, month = (year + 1, 1) if month == 12 else (year, month + 1)
     return periods

--- a/server/polar/payment_method/repository.py
+++ b/server/polar/payment_method/repository.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from datetime import UTC, datetime
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import Select, and_, or_, select, update
@@ -15,11 +15,7 @@ from polar.kit.repository import (
 )
 from polar.models import Customer, PaymentMethod, Subscription
 from polar.models.email_log import EmailLog, EmailLogStatus
-
-
-def _expiration_datetime(year: int, month: int) -> datetime:
-    """Cards stay valid through the end of their expiration month."""
-    return datetime(year + month // 12, month % 12 + 1, 1, tzinfo=UTC)
+from polar.models.payment_method import card_expiration as _expiration_datetime
 
 
 def expiring_periods(now: datetime, window_end: datetime) -> list[tuple[int, int]]:

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -731,6 +731,60 @@ class SubscriptionService:
         repository = SubscriptionRepository.from_session(session)
         return await repository.create(subscription, flush=True)
 
+    async def activate_imported(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        *,
+        current_period_start: datetime,
+        current_period_end: datetime,
+        trial_end: datetime | None,
+        payment_method: PaymentMethod,
+    ) -> Subscription:
+        """Hand billing of an imported subscription over to Polar (the cutover).
+
+        Unlike ``resume``, this doesn't start a fresh period or charge anything:
+        the customer already paid the old provider through ``current_period_end``,
+        so Polar picks the cycle up exactly there and first bills at the renewal
+        the customer is already expecting.
+
+        No resumed email either — from the customer's side nothing paused, and
+        nothing about their subscription is changing today.
+        """
+        assert subscription.status == SubscriptionStatus.paused
+
+        subscription.status = (
+            SubscriptionStatus.trialing if trial_end else SubscriptionStatus.active
+        )
+        subscription.paused_at = None
+        subscription.resumes_at = None
+        subscription.scheduler_locked_at = None
+        subscription.trial_start = current_period_start if trial_end else None
+        subscription.trial_end = trial_end
+        subscription.current_period_start = current_period_start
+        subscription.anchor_day = current_period_start.day
+        subscription.current_period_end = current_period_end
+        subscription.payment_method = payment_method
+        subscription.initialize_meter_period(
+            None if trial_end else current_period_start
+        )
+
+        repository = SubscriptionRepository.from_session(session)
+        # Flushed: the cutover settles its ledger and counts what moved in the
+        # same transaction, off the columns this writes.
+        subscription = await repository.update(subscription, flush=True)
+
+        await self.enqueue_benefits_grants(session, subscription)
+        await self._on_subscription_updated(session, subscription)
+        enqueue_job("customer.state_changed", subscription.customer_id)
+
+        log.info(
+            "subscription.imported_activated",
+            id=subscription.id,
+            current_period_end=subscription.current_period_end,
+        )
+        return subscription
+
     async def create_or_update_from_checkout(
         self,
         session: AsyncSession,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -700,8 +700,9 @@ class SubscriptionService:
         recurring_interval = product.recurring_interval
         recurring_interval_count = product.recurring_interval_count or 1
         start = current_period_start or utc_now()
+        anchor = anchor_day or start.day
         next_period = recurring_interval.get_next_period(
-            start, start.day, recurring_interval_count
+            start, anchor, recurring_interval_count
         )
         # A source end that predates the start would invert the period, which
         # would then feed the renewal maths at cutover.
@@ -715,7 +716,7 @@ class SubscriptionService:
             status=SubscriptionStatus.paused,
             paused_at=utc_now(),
             started_at=start,
-            anchor_day=anchor_day or start.day,
+            anchor_day=anchor,
             current_period_start=start,
             current_period_end=end,
             cancel_at_period_end=False,
@@ -768,7 +769,9 @@ class SubscriptionService:
         # the anchor is corrected on the way through.
         if anchor_day is not None:
             subscription.anchor_day = anchor_day
-        subscription.current_period_end = current_period_end
+        # The scheduler converts a trial at `current_period_end`, so while
+        # trialing the two have to agree or the customer is billed late.
+        subscription.current_period_end = trial_end or current_period_end
         subscription.payment_method = payment_method
         subscription.initialize_meter_period(
             None if trial_end else current_period_start

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -687,10 +687,15 @@ class SubscriptionService:
         customer: Customer,
         current_period_start: datetime | None,
         current_period_end: datetime | None,
+        anchor_day: int | None = None,
         user_metadata: dict[str, Any],
     ) -> Subscription:
         """Create a subscription migrated from another provider. It starts paused
-        so nothing bills until the merchant cuts over, and grants no benefits."""
+        so nothing bills until the merchant cuts over, and grants no benefits.
+
+        Without an ``anchor_day`` we fall back to the period start, which reads
+        as 28 for a 31st anchor caught during a February period.
+        """
         assert product.recurring_interval is not None
         recurring_interval = product.recurring_interval
         recurring_interval_count = product.recurring_interval_count or 1
@@ -710,7 +715,7 @@ class SubscriptionService:
             status=SubscriptionStatus.paused,
             paused_at=utc_now(),
             started_at=start,
-            anchor_day=start.day,
+            anchor_day=anchor_day or start.day,
             current_period_start=start,
             current_period_end=end,
             cancel_at_period_end=False,
@@ -739,17 +744,14 @@ class SubscriptionService:
         current_period_start: datetime,
         current_period_end: datetime,
         trial_end: datetime | None,
+        anchor_day: int | None = None,
         payment_method: PaymentMethod,
     ) -> Subscription:
         """Hand billing of an imported subscription over to Polar (the cutover).
 
-        Unlike ``resume``, this doesn't start a fresh period or charge anything:
-        the customer already paid the old provider through ``current_period_end``,
-        so Polar picks the cycle up exactly there and first bills at the renewal
-        the customer is already expecting.
-
-        No resumed email either — from the customer's side nothing paused, and
-        nothing about their subscription is changing today.
+        Unlike ``resume``, this starts no fresh period and charges nothing: the
+        customer already paid the old provider through ``current_period_end``. It
+        skips the resumed side effects too, since nothing paused for them.
         """
         assert subscription.status == SubscriptionStatus.paused
 
@@ -762,7 +764,10 @@ class SubscriptionService:
         subscription.trial_start = current_period_start if trial_end else None
         subscription.trial_end = trial_end
         subscription.current_period_start = current_period_start
-        subscription.anchor_day = current_period_start.day
+        # Re-read from the source, so a subscription imported before we asked for
+        # the anchor is corrected on the way through.
+        if anchor_day is not None:
+            subscription.anchor_day = anchor_day
         subscription.current_period_end = current_period_end
         subscription.payment_method = payment_method
         subscription.initialize_meter_period(
@@ -770,8 +775,8 @@ class SubscriptionService:
         )
 
         repository = SubscriptionRepository.from_session(session)
-        # Flushed: the cutover settles its ledger and counts what moved in the
-        # same transaction, off the columns this writes.
+        # Flushed so the returned subscription carries `payment_method_id`, which
+        # the cutover records, and not just the relationship.
         subscription = await repository.update(subscription, flush=True)
 
         await self.enqueue_benefits_grants(session, subscription)

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -1,5 +1,15 @@
+from datetime import datetime, timedelta
+
 from polar.kit.encryption import EncryptedString
+from polar.kit.utils import utc_now
 from polar.merchant_migration import pan_transfer
+from polar.merchant_migration.canonical import (
+    CanonicalCollectionMethod,
+    CanonicalPaymentMethod,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+    serialize,
+)
 from polar.merchant_migration.pan_transfer import (
     PanStepActor,
     PanStepOwner,
@@ -11,10 +21,19 @@ from polar.merchant_migration.service import (
     SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT,
     StripeSourceCredentials,
 )
-from polar.models import MerchantMigration, Organization
+from polar.models import (
+    MerchantMigration,
+    MerchantMigrationRecord,
+    Organization,
+    Subscription,
+)
 from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
+)
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
 )
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
@@ -94,3 +113,70 @@ def pan_steps_until(
         steps = pan_transfer.complete(
             method, steps, current.key, actor=_STEP_ACTORS[current.owner], inputs={}
         )
+
+
+def canonical_subscription(
+    *,
+    source_id: str = "sub_1",
+    customer_source_id: str = "cus_1",
+    price_source_id: str = "price_1",
+    status: CanonicalSubscriptionStatus = CanonicalSubscriptionStatus.active,
+    collection_method: CanonicalCollectionMethod = (
+        CanonicalCollectionMethod.charge_automatically
+    ),
+    current_period_start: datetime | None = None,
+    current_period_end: datetime | None = None,
+    line_item_count: int = 1,
+    quantity: int = 1,
+    has_discount: bool = False,
+    cancel_at_period_end: bool = False,
+    trial_end: datetime | None = None,
+    stopped_for_migration: bool = False,
+    payment_method: CanonicalPaymentMethod | None = None,
+) -> CanonicalSubscription:
+    """A source subscription that renews comfortably outside the safety window,
+    so a test only states the field it's actually about."""
+    return CanonicalSubscription(
+        source_id=source_id,
+        customer_source_id=customer_source_id,
+        price_source_id=price_source_id,
+        status=status,
+        collection_method=collection_method,
+        current_period_start=current_period_start or utc_now() - timedelta(days=10),
+        current_period_end=current_period_end or utc_now() + timedelta(days=20),
+        trialing=status == CanonicalSubscriptionStatus.trialing,
+        paused_collection=status == CanonicalSubscriptionStatus.paused,
+        line_item_count=line_item_count,
+        quantity=quantity,
+        payment_method=payment_method,
+        has_discount=has_discount,
+        cancel_at_period_end=cancel_at_period_end,
+        trial_end=trial_end,
+        stopped_for_migration=stopped_for_migration,
+    )
+
+
+async def stage_subscription_record(
+    save_fixture: SaveFixture,
+    migration: MerchantMigration,
+    organization: Organization,
+    subscription: Subscription,
+    *,
+    source_id: str = "sub_1",
+    price_source_id: str = "price_1",
+) -> MerchantMigrationRecord:
+    """An imported subscription in the ledger, pointing at its Polar row: what
+    the cutover reads."""
+    record = MerchantMigrationRecord(
+        merchant_migration=migration,
+        organization=organization,
+        type=MerchantMigrationRecordType.subscription,
+        status=MerchantMigrationRecordStatus.imported,
+        source_id=source_id,
+        target_id=subscription.id,
+        canonical=serialize(
+            canonical_subscription(source_id=source_id, price_source_id=price_source_id)
+        ),
+    )
+    await save_fixture(record)
+    return record

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -1,4 +1,8 @@
+from collections.abc import AsyncIterator
 from datetime import datetime, timedelta
+from typing import Any
+
+from pytest_mock import MockerFixture
 
 from polar.kit.encryption import EncryptedString
 from polar.kit.utils import utc_now
@@ -132,10 +136,10 @@ def canonical_subscription(
     cancel_at_period_end: bool = False,
     trial_end: datetime | None = None,
     stopped_for_migration: bool = False,
+    anchor_day: int | None = None,
     payment_method: CanonicalPaymentMethod | None = None,
 ) -> CanonicalSubscription:
-    """A source subscription that renews comfortably outside the safety window,
-    so a test only states the field it's actually about."""
+    """Renews outside the safety window, so a test only states its own field."""
     return CanonicalSubscription(
         source_id=source_id,
         customer_source_id=customer_source_id,
@@ -153,6 +157,7 @@ def canonical_subscription(
         cancel_at_period_end=cancel_at_period_end,
         trial_end=trial_end,
         stopped_for_migration=stopped_for_migration,
+        anchor_day=anchor_day,
     )
 
 
@@ -165,8 +170,7 @@ async def stage_subscription_record(
     source_id: str = "sub_1",
     price_source_id: str = "price_1",
 ) -> MerchantMigrationRecord:
-    """An imported subscription in the ledger, pointing at its Polar row: what
-    the cutover reads."""
+    """An imported subscription in the ledger: what the cutover reads."""
     record = MerchantMigrationRecord(
         merchant_migration=migration,
         organization=organization,
@@ -180,3 +184,16 @@ async def stage_subscription_record(
     )
     await save_fixture(record)
     return record
+
+
+def copied_cards(mocker: MockerFixture, *cards: Any) -> None:
+    """What `list_payment_methods` finds on Polar's Stripe account."""
+
+    async def listed(customer: str) -> AsyncIterator[Any]:
+        for card in cards:
+            yield card
+
+    mocker.patch(
+        "polar.merchant_migration.cards.stripe_service.list_payment_methods",
+        new=listed,
+    )

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -1,6 +1,7 @@
-from collections.abc import AsyncIterator
-from datetime import timedelta
+from collections.abc import AsyncIterator, Awaitable, Callable
+from datetime import UTC, datetime, timedelta
 from typing import Any
+from uuid import uuid4
 
 import pytest
 import pytest_asyncio
@@ -17,7 +18,7 @@ from polar.merchant_migration.canonical import (
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
 )
-from polar.merchant_migration.cutover import SubscriptionCutover
+from polar.merchant_migration.cutover import CutoverOutcome, SubscriptionCutover
 from polar.models import (
     Customer,
     MerchantMigration,
@@ -28,6 +29,7 @@ from polar.models import (
     Subscription,
 )
 from polar.models.merchant_migration_record import MerchantMigrationCutoverStatus
+from polar.models.organization import OrganizationStatus
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
@@ -40,19 +42,20 @@ from tests.fixtures.stripe import build_stripe_payment_method
 from tests.merchant_migration._helpers import (
     build_connected_migration,
     canonical_subscription,
+    copied_cards,
     stage_subscription_record,
 )
 
+RunCutover = Callable[["_FakeSourceAdapter"], Awaitable[CutoverOutcome]]
 
-async def _no_payment_methods() -> AsyncIterator[Any]:
-    """Nothing has landed on Polar's Stripe account for this customer yet."""
-    return
-    yield
+STOPPED_BY_US = {
+    "status": CanonicalSubscriptionStatus.canceled,
+    "stopped_for_migration": True,
+}
 
 
 class _FakeSourceAdapter:
-    """Stands in for the merchant's Stripe account: what it reports back, and
-    whether anyone actually stopped a subscription on it."""
+    """The merchant's Stripe account: what it reports, and what got stopped."""
 
     def __init__(
         self,
@@ -72,8 +75,7 @@ class _FakeSourceAdapter:
     async def stop_source_subscription(self, source_id: str, *, reference: str) -> None:
         self.stopped.append(source_id)
 
-    # The cutover never reads the catalog, but the protocol covers the whole
-    # adapter and a fake that only satisfies half of it isn't one.
+    # Unused by the cutover, but a fake that satisfies half a protocol isn't one.
     async def extract(self) -> AsyncIterator[CanonicalRecord]:
         return
         yield
@@ -82,24 +84,13 @@ class _FakeSourceAdapter:
         return CanonicalAccount(country="US", has_connected_accounts=False)
 
 
-def _succeeded_setup_intent(mocker: MockerFixture, status: str = "succeeded") -> Any:
-    return mocker.patch(
-        "polar.merchant_migration.cutover.stripe_service.create_setup_intent",
-        new=mocker.AsyncMock(return_value=mocker.MagicMock(status=status)),
-    )
+def _source(**fields: Any) -> _FakeSourceAdapter:
+    return _FakeSourceAdapter(canonical_subscription(**fields))
 
 
-async def _card_on(
-    save_fixture: SaveFixture, subscription: Subscription, customer: Customer
-) -> PaymentMethod:
-    """A copied card, already attached to the subscription: what the card check
-    leaves behind when the copy landed."""
-    payment_method = await create_payment_method(
-        save_fixture, customer, processor_id="pm_copied"
-    )
-    subscription.payment_method = payment_method
-    await save_fixture(subscription)
-    return payment_method
+def _assert_left_alone(adapter: _FakeSourceAdapter, subscription: Subscription) -> None:
+    assert adapter.stopped == []
+    assert subscription.status == SubscriptionStatus.paused
 
 
 @pytest_asyncio.fixture
@@ -148,224 +139,271 @@ async def record(
     )
 
 
+@pytest_asyncio.fixture
+async def copied_card(
+    save_fixture: SaveFixture,
+    imported_customer: Customer,
+    paused_subscription: Subscription,
+) -> PaymentMethod:
+    """A copied card already attached to the subscription."""
+    payment_method = await create_payment_method(
+        save_fixture, imported_customer, processor_id="pm_copied"
+    )
+    paused_subscription.payment_method = payment_method
+    await save_fixture(paused_subscription)
+    return payment_method
+
+
+@pytest.fixture
+def cutover(
+    session: AsyncSession,
+    migration: MerchantMigration,
+    record: MerchantMigrationRecord,
+) -> RunCutover:
+    async def run(adapter: _FakeSourceAdapter) -> CutoverOutcome:
+        return await SubscriptionCutover(session, migration, adapter).run(record)
+
+    return run
+
+
 @pytest.mark.asyncio
 class TestRun:
     async def test_moves_and_stops_the_source(
         self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        imported_customer: Customer,
+        cutover: RunCutover,
+        copied_card: PaymentMethod,
         paused_subscription: Subscription,
     ) -> None:
-        payment_method = await _card_on(
-            save_fixture, paused_subscription, imported_customer
-        )
         renewal = utc_now() + timedelta(days=20)
-        adapter = _FakeSourceAdapter(canonical_subscription(current_period_end=renewal))
-        _succeeded_setup_intent(mocker)
+        adapter = _source(current_period_end=renewal)
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.moved
         assert adapter.stopped == ["sub_1"]
         assert paused_subscription.status == SubscriptionStatus.active
         assert paused_subscription.paused_at is None
-        # Polar picks the cycle up where the source left it, so the customer's
-        # first Polar charge lands on the date they already expect.
+        # The first Polar charge lands on the date the customer already expects.
         assert paused_subscription.current_period_end == renewal
-        assert paused_subscription.payment_method_id == payment_method.id
+        assert paused_subscription.payment_method_id == copied_card.id
+
+    async def test_charges_a_card_that_landed_after_the_card_check(
+        self,
+        mocker: MockerFixture,
+        cutover: RunCutover,
+        paused_subscription: Subscription,
+    ) -> None:
+        copied_cards(mocker, build_stripe_payment_method(customer="cus_1"))
+
+        outcome = await cutover(_source())
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert paused_subscription.payment_method_id is not None
 
     async def test_keeps_a_running_trial_running(
         self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        imported_customer: Customer,
+        cutover: RunCutover,
+        copied_card: PaymentMethod,
         paused_subscription: Subscription,
     ) -> None:
-        await _card_on(save_fixture, paused_subscription, imported_customer)
         trial_end = utc_now() + timedelta(days=10)
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(
+
+        outcome = await cutover(
+            _source(
                 status=CanonicalSubscriptionStatus.trialing,
                 current_period_end=trial_end,
                 trial_end=trial_end,
             )
         )
-        _succeeded_setup_intent(mocker)
-
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
 
         assert outcome.status == MerchantMigrationCutoverStatus.moved
         assert paused_subscription.status == SubscriptionStatus.trialing
         assert paused_subscription.trial_end == trial_end
         assert paused_subscription.current_period_end == trial_end
 
-    async def test_finishes_a_move_that_already_stopped_the_source(
+    async def test_rebuilds_a_period_the_source_reports_backwards(
         self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        imported_customer: Customer,
+        cutover: RunCutover,
+        copied_card: PaymentMethod,
         paused_subscription: Subscription,
     ) -> None:
-        """A crash between the Stripe cancellation and the commit must not read
-        our own cancellation as the customer having churned."""
-        await _card_on(save_fixture, paused_subscription, imported_customer)
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(
-                status=CanonicalSubscriptionStatus.canceled,
-                # Cancelled, and its period has since lapsed: Polar takes over
-                # anyway, and bills on the next scheduler pass.
-                current_period_end=utc_now() - timedelta(days=1),
-                stopped_for_migration=True,
+        """An inverted period would feed the renewal maths."""
+        known_length = (
+            paused_subscription.current_period_end
+            - paused_subscription.current_period_start
+        )
+        renewal = utc_now() + timedelta(days=20)
+
+        outcome = await cutover(
+            _source(
+                current_period_start=renewal + timedelta(days=10),
+                current_period_end=renewal,
             )
         )
-        _succeeded_setup_intent(mocker)
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert paused_subscription.current_period_end == renewal
+        assert paused_subscription.current_period_start == renewal - known_length
+
+    async def test_finishes_a_move_that_already_stopped_the_source(
+        self,
+        cutover: RunCutover,
+        copied_card: PaymentMethod,
+        paused_subscription: Subscription,
+    ) -> None:
+        """A crash between the cancellation and the commit must not read our own
+        cancellation as the customer having churned."""
+        # Lapsed by a day: Polar takes over and bills on the next scheduler pass.
+        adapter = _source(**STOPPED_BY_US, current_period_end=utc_now() - timedelta(1))
+
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.moved
         assert adapter.stopped == []
         assert paused_subscription.status == SubscriptionStatus.active
 
-    async def test_finishes_a_stopped_move_even_when_the_card_now_declines(
+    async def test_keeps_a_trial_the_source_no_longer_reports_as_running(
         self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        imported_customer: Customer,
+        cutover: RunCutover,
+        copied_card: PaymentMethod,
         paused_subscription: Subscription,
     ) -> None:
-        """The source is already stopped, so refusing here would leave the
-        customer billed by nobody. An unpaid first renewal goes to dunning,
-        which is recoverable; a subscription nobody bills is not."""
-        await _card_on(save_fixture, paused_subscription, imported_customer)
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(
-                status=CanonicalSubscriptionStatus.canceled,
-                stopped_for_migration=True,
-            )
-        )
-        # Would have been a skip on the normal path.
-        _succeeded_setup_intent(mocker, status="requires_action")
+        """The source says `canceled` because we cancelled it, not the customer."""
+        trial_end = utc_now() + timedelta(days=10)
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(
+            _source(**STOPPED_BY_US, current_period_end=trial_end, trial_end=trial_end)
+        )
 
         assert outcome.status == MerchantMigrationCutoverStatus.moved
-        assert paused_subscription.status == SubscriptionStatus.active
+        assert paused_subscription.status == SubscriptionStatus.trialing
+        assert paused_subscription.trial_end == trial_end
+
+    async def test_takes_the_renewal_day_from_the_source_anchor(
+        self,
+        cutover: RunCutover,
+        copied_card: PaymentMethod,
+        paused_subscription: Subscription,
+    ) -> None:
+        """A 31st anchor reports a clamped Feb 28 period start."""
+        outcome = await cutover(
+            _source(
+                current_period_start=datetime(2027, 2, 28, tzinfo=UTC),
+                current_period_end=datetime(2027, 3, 31, tzinfo=UTC),
+                anchor_day=31,
+            )
+        )
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert paused_subscription.anchor_day == 31
 
     async def test_a_stopped_move_with_no_card_at_all_fails_loudly(
         self,
         mocker: MockerFixture,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
+        cutover: RunCutover,
         paused_subscription: Subscription,
     ) -> None:
-        """Nothing to charge and nothing billing on the source either. Failed,
-        not skipped: it needs chasing, and a retry can still finish it."""
-        mocker.patch(
-            "polar.merchant_migration.cards.stripe_service.list_payment_methods",
-            return_value=_no_payment_methods(),
-        )
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(
-                status=CanonicalSubscriptionStatus.canceled,
-                stopped_for_migration=True,
-            )
-        )
+        """Failed, not skipped: it needs chasing, and a retry can still finish."""
+        copied_cards(mocker)
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(_source(**STOPPED_BY_US))
 
         assert outcome.status == MerchantMigrationCutoverStatus.failed
-        assert outcome.reason is not None
+        assert outcome.message is not None
+        assert paused_subscription.status == SubscriptionStatus.paused
+
+    async def test_moves_an_expired_card_and_says_so(
+        self,
+        save_fixture: SaveFixture,
+        cutover: RunCutover,
+        copied_card: PaymentMethod,
+        paused_subscription: Subscription,
+    ) -> None:
+        """A card only proves itself on a real charge, so an expired one still
+        moves and the merchant is told to chase it."""
+        copied_card.method_metadata = {
+            **copied_card.method_metadata,
+            "exp_month": 6,
+            "exp_year": 2020,
+        }
+        await save_fixture(copied_card)
+
+        outcome = await cutover(_source())
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert "has expired" in (outcome.message or "")
+        assert paused_subscription.status == SubscriptionStatus.active
+
+    async def test_a_stopped_move_left_lapsed_for_months_fails(
+        self,
+        cutover: RunCutover,
+        copied_card: PaymentMethod,
+        paused_subscription: Subscription,
+    ) -> None:
+        """The scheduler cycles once per period behind, so this would charge the
+        customer for every period nobody billed."""
+        outcome = await cutover(
+            _source(**STOPPED_BY_US, current_period_end=utc_now() - timedelta(days=70))
+        )
+
+        assert outcome.status == MerchantMigrationCutoverStatus.failed
+        assert "every period missed since" in (outcome.message or "")
         assert paused_subscription.status == SubscriptionStatus.paused
 
     async def test_an_unreadable_staged_record_stops_at_that_record(
         self,
-        mocker: MockerFixture,
-        session: AsyncSession,
         save_fixture: SaveFixture,
-        migration: MerchantMigration,
+        cutover: RunCutover,
         record: MerchantMigrationRecord,
         paused_subscription: Subscription,
     ) -> None:
-        """One bad ledger row must not raise: the run is one subscription per
-        job, so an escaping error would stall the whole chain on it."""
+        """One bad ledger row must not raise and stall the chain."""
         record.canonical = {}
         await save_fixture(record)
-        adapter = _FakeSourceAdapter(canonical_subscription())
+        adapter = _source()
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        assert adapter.stopped == []
-        assert paused_subscription.status == SubscriptionStatus.paused
+        _assert_left_alone(adapter, paused_subscription)
 
-    async def test_a_second_run_stops_nothing_twice(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
+
+@pytest.mark.asyncio
+class TestAlreadyLiveOnPolar:
+    """Reconciling: whatever activated it, the source must not still be billing."""
+
+    @pytest_asyncio.fixture(autouse=True)
+    async def live(
+        self, save_fixture: SaveFixture, paused_subscription: Subscription
     ) -> None:
         paused_subscription.status = SubscriptionStatus.active
         await save_fixture(paused_subscription)
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(
-                status=CanonicalSubscriptionStatus.canceled,
-                stopped_for_migration=True,
-            )
-        )
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+    async def test_a_second_run_stops_nothing_twice(self, cutover: RunCutover) -> None:
+        adapter = _source(**STOPPED_BY_US)
+
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.moved
         assert adapter.stopped == []
 
     async def test_resumed_by_hand_still_stops_the_source(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
+        self, cutover: RunCutover
     ) -> None:
-        """A customer can resume a paused subscription from their portal. Taking
-        "active on Polar" as proof the source stopped would bill them twice."""
-        paused_subscription.status = SubscriptionStatus.active
-        await save_fixture(paused_subscription)
-        adapter = _FakeSourceAdapter(canonical_subscription())
+        """Taking "active on Polar" as proof the source stopped bills them twice."""
+        adapter = _source()
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.moved
         assert adapter.stopped == ["sub_1"]
 
     async def test_source_already_gone_needs_no_reconciling(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
+        self, cutover: RunCutover
     ) -> None:
-        paused_subscription.status = SubscriptionStatus.active
-        await save_fixture(paused_subscription)
         adapter = _FakeSourceAdapter(None)
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.moved
         assert adapter.stopped == []
@@ -373,277 +411,156 @@ class TestRun:
 
 @pytest.mark.asyncio
 class TestSkips:
-    """Every skip must leave the source billing: nothing is cancelled, and the
-    Polar subscription stays paused."""
+    """Every skip leaves the source billing and Polar paused."""
 
-    def _assert_left_alone(
+    @pytest.mark.parametrize(
+        ("source_fields", "expected_reason"),
+        [
+            pytest.param(
+                {"status": CanonicalSubscriptionStatus.canceled},
+                "cancelled on the source",
+                id="canceled-after-the-import",
+            ),
+            pytest.param(
+                {"status": CanonicalSubscriptionStatus.past_due},
+                None,
+                id="payment-failing",
+            ),
+            pytest.param(
+                {"cancel_at_period_end": True},
+                "cancel at the end of the period",
+                id="already-ending",
+            ),
+            pytest.param(
+                {"current_period_end": utc_now() + timedelta(hours=6)},
+                "too soon to hand over",
+                id="renewal-inside-the-safety-window",
+            ),
+            pytest.param(
+                {"current_period_end": utc_now() - timedelta(days=2)},
+                "too soon to hand over",
+                id="renewal-already-past",
+            ),
+            pytest.param(
+                {"price_source_id": "price_upgraded"},
+                "plan changed on the source",
+                id="plan-changed",
+            ),
+            pytest.param({"line_item_count": 2}, None, id="second-line-item"),
+            pytest.param(
+                {"collection_method": CanonicalCollectionMethod.send_invoice},
+                None,
+                id="manual-invoicing",
+            ),
+        ],
+    )
+    async def test_source_is_no_longer_handable(
         self,
-        adapter: _FakeSourceAdapter,
-        subscription: Subscription,
+        cutover: RunCutover,
+        paused_subscription: Subscription,
+        source_fields: dict[str, Any],
+        expected_reason: str | None,
     ) -> None:
-        assert adapter.stopped == []
-        assert subscription.status == SubscriptionStatus.paused
+        adapter = _source(**source_fields)
+
+        outcome = await cutover(adapter)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        if expected_reason is not None:
+            assert expected_reason in (outcome.message or "")
+        _assert_left_alone(adapter, paused_subscription)
 
     async def test_source_subscription_gone(
-        self,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
+        self, cutover: RunCutover, paused_subscription: Subscription
     ) -> None:
         adapter = _FakeSourceAdapter(None)
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        assert "no longer exists on the source" in (outcome.reason or "")
-        self._assert_left_alone(adapter, paused_subscription)
+        assert "no longer exists on the source" in (outcome.message or "")
+        _assert_left_alone(adapter, paused_subscription)
 
-    async def test_source_canceled_after_the_import(
+    async def test_organization_cannot_renew_subscriptions(
         self,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
+        save_fixture: SaveFixture,
+        cutover: RunCutover,
+        copied_card: PaymentMethod,
+        organization: Organization,
         paused_subscription: Subscription,
     ) -> None:
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(status=CanonicalSubscriptionStatus.canceled)
-        )
+        """The renewal scheduler skips these organizations, so it would never bill."""
+        organization.status = OrganizationStatus.CREATED
+        organization.capabilities = {
+            **organization.capabilities,
+            "subscription_renewals": False,
+        }
+        await save_fixture(organization)
+        adapter = _source()
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
-
-        assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        assert "cancelled on the source" in (outcome.reason or "")
-        self._assert_left_alone(adapter, paused_subscription)
-
-    async def test_source_payment_failing(
-        self,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
-    ) -> None:
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(status=CanonicalSubscriptionStatus.past_due)
-        )
-
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        self._assert_left_alone(adapter, paused_subscription)
-
-    async def test_source_already_ending(
-        self,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
-    ) -> None:
-        adapter = _FakeSourceAdapter(canonical_subscription(cancel_at_period_end=True))
-
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
-
-        assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        assert "cancel at the end of the period" in (outcome.reason or "")
-        self._assert_left_alone(adapter, paused_subscription)
-
-    async def test_renewal_inside_the_safety_window(
-        self,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
-    ) -> None:
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(current_period_end=utc_now() + timedelta(hours=6))
-        )
-
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
-
-        assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        assert "too soon to hand over" in (outcome.reason or "")
-        self._assert_left_alone(adapter, paused_subscription)
-
-    async def test_renewal_already_past(
-        self,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
-    ) -> None:
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(current_period_end=utc_now() - timedelta(days=2))
-        )
-
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
-
-        assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        self._assert_left_alone(adapter, paused_subscription)
-
-    async def test_plan_changed_on_the_source(
-        self,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
-    ) -> None:
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(price_source_id="price_upgraded")
-        )
-
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
-
-        assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        assert "plan changed on the source" in (outcome.reason or "")
-        self._assert_left_alone(adapter, paused_subscription)
-
-    async def test_source_grew_a_second_line_item(
-        self,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
-    ) -> None:
-        adapter = _FakeSourceAdapter(canonical_subscription(line_item_count=2))
-
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
-
-        assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        self._assert_left_alone(adapter, paused_subscription)
-
-    async def test_source_switched_to_manual_invoicing(
-        self,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
-    ) -> None:
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(
-                collection_method=CanonicalCollectionMethod.send_invoice
-            )
-        )
-
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
-
-        assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        self._assert_left_alone(adapter, paused_subscription)
+        assert "can't renew subscriptions" in (outcome.message or "")
+        _assert_left_alone(adapter, paused_subscription)
 
     async def test_no_card_landed_on_polar(
         self,
         mocker: MockerFixture,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
+        cutover: RunCutover,
         paused_subscription: Subscription,
     ) -> None:
-        mocker.patch(
-            "polar.merchant_migration.cards.stripe_service.list_payment_methods",
-            return_value=_no_payment_methods(),
-        )
-        adapter = _FakeSourceAdapter(canonical_subscription())
+        copied_cards(mocker)
+        adapter = _source()
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        assert "No copied card" in (outcome.reason or "")
-        self._assert_left_alone(adapter, paused_subscription)
-
-    async def test_card_declined_when_validated(
-        self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        imported_customer: Customer,
-        paused_subscription: Subscription,
-    ) -> None:
-        await _card_on(save_fixture, paused_subscription, imported_customer)
-        mocker.patch(
-            "polar.merchant_migration.cutover.stripe_service.create_setup_intent",
-            new=mocker.AsyncMock(
-                side_effect=stripe_lib.CardError("Your card was declined.", None, None)
-            ),
-        )
-        adapter = _FakeSourceAdapter(canonical_subscription())
-
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
-
-        assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        assert "declined by the bank" in (outcome.reason or "")
-        self._assert_left_alone(adapter, paused_subscription)
-
-    async def test_card_needs_authentication(
-        self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        imported_customer: Customer,
-        paused_subscription: Subscription,
-    ) -> None:
-        await _card_on(save_fixture, paused_subscription, imported_customer)
-        _succeeded_setup_intent(mocker, status="requires_action")
-        adapter = _FakeSourceAdapter(canonical_subscription())
-
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
-
-        assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        assert "without the customer confirming" in (outcome.reason or "")
-        self._assert_left_alone(adapter, paused_subscription)
+        assert "No copied card" in (outcome.message or "")
+        _assert_left_alone(adapter, paused_subscription)
 
     async def test_polar_subscription_canceled_by_the_merchant(
         self,
-        session: AsyncSession,
         save_fixture: SaveFixture,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
+        cutover: RunCutover,
         paused_subscription: Subscription,
     ) -> None:
         paused_subscription.status = SubscriptionStatus.canceled
         await save_fixture(paused_subscription)
-        adapter = _FakeSourceAdapter(canonical_subscription())
+        adapter = _source()
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.skipped
         assert adapter.stopped == []
 
     async def test_customer_deleted_on_polar(
         self,
-        session: AsyncSession,
         save_fixture: SaveFixture,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
+        cutover: RunCutover,
         imported_customer: Customer,
         paused_subscription: Subscription,
     ) -> None:
         imported_customer.deleted_at = utc_now()
         await save_fixture(imported_customer)
-        adapter = _FakeSourceAdapter(canonical_subscription())
+        adapter = _source()
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        self._assert_left_alone(adapter, paused_subscription)
+        _assert_left_alone(adapter, paused_subscription)
 
 
 @pytest.mark.asyncio
 class TestFailures:
     async def test_stripe_error_is_retryable(
-        self,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
-        paused_subscription: Subscription,
+        self, cutover: RunCutover, paused_subscription: Subscription
     ) -> None:
         adapter = _FakeSourceAdapter(
             None, error=stripe_lib.APIConnectionError("Stripe is down")
         )
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.failed
         assert paused_subscription.status == SubscriptionStatus.paused
@@ -651,52 +568,50 @@ class TestFailures:
     async def test_two_indistinguishable_cards_are_retryable(
         self,
         mocker: MockerFixture,
-        session: AsyncSession,
-        migration: MerchantMigration,
-        record: MerchantMigrationRecord,
+        cutover: RunCutover,
         paused_subscription: Subscription,
     ) -> None:
-        """One customer nobody can pick a card for must not stop the run for
-        everyone else, and must never be resolved by guessing."""
+        """Never resolved by guessing, and never at the cost of the whole run."""
         identical = {"last4": "4242", "brand": "visa", "exp_month": 4, "exp_year": 2030}
-
-        async def _two_copies(customer: str) -> AsyncIterator[Any]:
-            for id in ("pm_copy_a", "pm_copy_b"):
-                copy = build_stripe_payment_method(details=identical, customer=customer)
-                copy.id = id
-                yield copy
-
-        mocker.patch(
-            "polar.merchant_migration.cards.stripe_service.list_payment_methods",
-            new=_two_copies,
-        )
-        adapter = _FakeSourceAdapter(
-            canonical_subscription(
-                payment_method=CanonicalPaymentMethod(
-                    source_id="pm_on_the_source",
-                    type=CanonicalPaymentMethodType.card,
-                    **identical,  # type: ignore[arg-type]
-                )
+        copies = []
+        for id in ("pm_copy_a", "pm_copy_b"):
+            copy = build_stripe_payment_method(details=identical, customer="cus_1")
+            copy.id = id
+            copies.append(copy)
+        copied_cards(mocker, *copies)
+        adapter = _source(
+            payment_method=CanonicalPaymentMethod(
+                source_id="pm_on_the_source",
+                type=CanonicalPaymentMethodType.card,
+                **identical,  # type: ignore[arg-type]
             )
         )
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.failed
-        assert "can't tell which is which" in (outcome.reason or "")
-        assert adapter.stopped == []
-        assert paused_subscription.status == SubscriptionStatus.paused
+        assert "can't tell which is which" in (outcome.message or "")
+        _assert_left_alone(adapter, paused_subscription)
 
-    async def test_missing_polar_subscription(
+    @pytest.mark.parametrize(
+        ("target_id", "expected_reason"),
+        [
+            pytest.param(None, "never imported into Polar", id="never-imported"),
+            pytest.param(uuid4(), "no longer exists", id="row-deleted"),
+        ],
+    )
+    async def test_no_polar_subscription_to_switch_on(
         self,
-        session: AsyncSession,
-        migration: MerchantMigration,
+        cutover: RunCutover,
         record: MerchantMigrationRecord,
+        target_id: Any,
+        expected_reason: str,
     ) -> None:
-        record.target_id = None
-        adapter = _FakeSourceAdapter(canonical_subscription())
+        record.target_id = target_id
+        adapter = _source()
 
-        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+        outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.failed
+        assert expected_reason in (outcome.message or "")
         assert adapter.stopped == []

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -236,6 +236,84 @@ class TestRun:
         assert adapter.stopped == []
         assert paused_subscription.status == SubscriptionStatus.active
 
+    async def test_finishes_a_stopped_move_even_when_the_card_now_declines(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        """The source is already stopped, so refusing here would leave the
+        customer billed by nobody. An unpaid first renewal goes to dunning,
+        which is recoverable; a subscription nobody bills is not."""
+        payment_method = await _linked_card(save_fixture, imported_customer)
+        paused_subscription.payment_method = payment_method
+        await save_fixture(paused_subscription)
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                status=CanonicalSubscriptionStatus.canceled,
+                stopped_for_migration=True,
+            )
+        )
+        # Would have been a skip on the normal path.
+        _succeeded_setup_intent(mocker, status="requires_action")
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert paused_subscription.status == SubscriptionStatus.active
+
+    async def test_a_stopped_move_with_no_card_at_all_fails_loudly(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        """Nothing to charge and nothing billing on the source either. Failed,
+        not skipped: it needs chasing, and a retry can still finish it."""
+        mocker.patch(
+            "polar.merchant_migration.cards.stripe_service.list_payment_methods",
+            return_value=_no_payment_methods(),
+        )
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                status=CanonicalSubscriptionStatus.canceled,
+                stopped_for_migration=True,
+            )
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.failed
+        assert outcome.reason is not None
+        assert paused_subscription.status == SubscriptionStatus.paused
+
+    async def test_an_unreadable_staged_record_stops_at_that_record(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        """One bad ledger row must not raise: the run is one subscription per
+        job, so an escaping error would stall the whole chain on it."""
+        record.canonical = {}
+        await save_fixture(record)
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert adapter.stopped == []
+        assert paused_subscription.status == SubscriptionStatus.paused
+
     async def test_a_second_run_stops_nothing_twice(
         self,
         session: AsyncSession,

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -1,0 +1,630 @@
+from collections.abc import AsyncIterator
+from datetime import timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+import stripe as stripe_lib
+from pytest_mock import MockerFixture
+
+from polar.enums import PaymentProcessor
+from polar.kit.utils import utc_now
+from polar.merchant_migration.canonical import (
+    CanonicalAccount,
+    CanonicalCollectionMethod,
+    CanonicalPaymentMethod,
+    CanonicalPaymentMethodType,
+    CanonicalRecord,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+)
+from polar.merchant_migration.cutover import SubscriptionCutover
+from polar.models import (
+    Customer,
+    MerchantMigration,
+    MerchantMigrationRecord,
+    Organization,
+    PaymentMethod,
+    Product,
+    Subscription,
+)
+from polar.models.merchant_migration_record import MerchantMigrationCutoverStatus
+from polar.models.subscription import SubscriptionStatus
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_customer, create_subscription
+from tests.fixtures.stripe import build_stripe_payment_method
+from tests.merchant_migration._helpers import (
+    build_connected_migration,
+    canonical_subscription,
+    stage_subscription_record,
+)
+
+
+async def _no_payment_methods() -> AsyncIterator[Any]:
+    """Nothing has landed on Polar's Stripe account for this customer yet."""
+    return
+    yield
+
+
+class _FakeSourceAdapter:
+    """Stands in for the merchant's Stripe account: what it reports back, and
+    whether anyone actually stopped a subscription on it."""
+
+    def __init__(
+        self,
+        subscription: CanonicalSubscription | None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self._subscription = subscription
+        self._error = error
+        self.stopped: list[str] = []
+
+    async def get_subscription(self, source_id: str) -> CanonicalSubscription | None:
+        if self._error is not None:
+            raise self._error
+        return self._subscription
+
+    async def stop_source_subscription(self, source_id: str, *, reference: str) -> None:
+        self.stopped.append(source_id)
+
+    # The cutover never reads the catalog, but the protocol covers the whole
+    # adapter and a fake that only satisfies half of it isn't one.
+    async def extract(self) -> AsyncIterator[CanonicalRecord]:
+        return
+        yield
+
+    async def get_source_account(self) -> CanonicalAccount:
+        return CanonicalAccount(country="US", has_connected_accounts=False)
+
+
+def _succeeded_setup_intent(mocker: MockerFixture, status: str = "succeeded") -> Any:
+    return mocker.patch(
+        "polar.merchant_migration.cutover.stripe_service.create_setup_intent",
+        new=mocker.AsyncMock(return_value=mocker.MagicMock(status=status)),
+    )
+
+
+async def _linked_card(save_fixture: SaveFixture, customer: Customer) -> PaymentMethod:
+    payment_method = PaymentMethod(
+        processor=PaymentProcessor.stripe,
+        processor_id="pm_copied",
+        type="card",
+        method_metadata={},
+        customer=customer,
+    )
+    await save_fixture(payment_method)
+    return payment_method
+
+
+@pytest_asyncio.fixture
+async def migration(
+    save_fixture: SaveFixture, organization: Organization
+) -> MerchantMigration:
+    return await build_connected_migration(save_fixture, organization)
+
+
+@pytest_asyncio.fixture
+async def imported_customer(
+    save_fixture: SaveFixture, organization: Organization
+) -> Customer:
+    return await create_customer(
+        save_fixture,
+        organization=organization,
+        email="imported@example.com",
+        stripe_customer_id="cus_1",
+    )
+
+
+@pytest_asyncio.fixture
+async def paused_subscription(
+    save_fixture: SaveFixture, product: Product, imported_customer: Customer
+) -> Subscription:
+    return await create_subscription(
+        save_fixture,
+        product=product,
+        customer=imported_customer,
+        status=SubscriptionStatus.paused,
+        current_period_start=utc_now() - timedelta(days=40),
+        current_period_end=utc_now() - timedelta(days=10),
+        user_metadata={"stripe_subscription_id": "sub_1"},
+    )
+
+
+@pytest_asyncio.fixture
+async def record(
+    save_fixture: SaveFixture,
+    migration: MerchantMigration,
+    organization: Organization,
+    paused_subscription: Subscription,
+) -> MerchantMigrationRecord:
+    return await stage_subscription_record(
+        save_fixture, migration, organization, paused_subscription
+    )
+
+
+@pytest.mark.asyncio
+class TestRun:
+    async def test_moves_and_stops_the_source(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        payment_method = await _linked_card(save_fixture, imported_customer)
+        paused_subscription.payment_method = payment_method
+        await save_fixture(paused_subscription)
+        renewal = utc_now() + timedelta(days=20)
+        adapter = _FakeSourceAdapter(canonical_subscription(current_period_end=renewal))
+        _succeeded_setup_intent(mocker)
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert adapter.stopped == ["sub_1"]
+        assert paused_subscription.status == SubscriptionStatus.active
+        assert paused_subscription.paused_at is None
+        # Polar picks the cycle up where the source left it, so the customer's
+        # first Polar charge lands on the date they already expect.
+        assert paused_subscription.current_period_end == renewal
+        assert paused_subscription.payment_method_id == payment_method.id
+
+    async def test_keeps_a_running_trial_running(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        payment_method = await _linked_card(save_fixture, imported_customer)
+        paused_subscription.payment_method = payment_method
+        await save_fixture(paused_subscription)
+        trial_end = utc_now() + timedelta(days=10)
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                status=CanonicalSubscriptionStatus.trialing,
+                current_period_end=trial_end,
+                trial_end=trial_end,
+            )
+        )
+        _succeeded_setup_intent(mocker)
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert paused_subscription.status == SubscriptionStatus.trialing
+        assert paused_subscription.trial_end == trial_end
+        assert paused_subscription.current_period_end == trial_end
+
+    async def test_finishes_a_move_that_already_stopped_the_source(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        """A crash between the Stripe cancellation and the commit must not read
+        our own cancellation as the customer having churned."""
+        payment_method = await _linked_card(save_fixture, imported_customer)
+        paused_subscription.payment_method = payment_method
+        await save_fixture(paused_subscription)
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                status=CanonicalSubscriptionStatus.canceled,
+                # Cancelled, and its period has since lapsed: Polar takes over
+                # anyway, and bills on the next scheduler pass.
+                current_period_end=utc_now() - timedelta(days=1),
+                stopped_for_migration=True,
+            )
+        )
+        _succeeded_setup_intent(mocker)
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert adapter.stopped == []
+        assert paused_subscription.status == SubscriptionStatus.active
+
+    async def test_a_second_run_stops_nothing_twice(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        paused_subscription.status = SubscriptionStatus.active
+        await save_fixture(paused_subscription)
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                status=CanonicalSubscriptionStatus.canceled,
+                stopped_for_migration=True,
+            )
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert adapter.stopped == []
+
+    async def test_resumed_by_hand_still_stops_the_source(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        """A customer can resume a paused subscription from their portal. Taking
+        "active on Polar" as proof the source stopped would bill them twice."""
+        paused_subscription.status = SubscriptionStatus.active
+        await save_fixture(paused_subscription)
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert adapter.stopped == ["sub_1"]
+
+    async def test_source_already_gone_needs_no_reconciling(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        paused_subscription.status = SubscriptionStatus.active
+        await save_fixture(paused_subscription)
+        adapter = _FakeSourceAdapter(None)
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert adapter.stopped == []
+
+
+@pytest.mark.asyncio
+class TestSkips:
+    """Every skip must leave the source billing: nothing is cancelled, and the
+    Polar subscription stays paused."""
+
+    def _assert_left_alone(
+        self,
+        adapter: _FakeSourceAdapter,
+        subscription: Subscription,
+    ) -> None:
+        assert adapter.stopped == []
+        assert subscription.status == SubscriptionStatus.paused
+
+    async def test_source_subscription_gone(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(None)
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "no longer exists on the source" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_source_canceled_after_the_import(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(status=CanonicalSubscriptionStatus.canceled)
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "cancelled on the source" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_source_payment_failing(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(status=CanonicalSubscriptionStatus.past_due)
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_source_already_ending(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(canonical_subscription(cancel_at_period_end=True))
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "cancel at the end of the period" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_renewal_inside_the_safety_window(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(current_period_end=utc_now() + timedelta(hours=6))
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "too soon to hand over" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_renewal_already_past(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(current_period_end=utc_now() - timedelta(days=2))
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_plan_changed_on_the_source(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(price_source_id="price_upgraded")
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "plan changed on the source" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_source_grew_a_second_line_item(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(canonical_subscription(line_item_count=2))
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_source_switched_to_manual_invoicing(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                collection_method=CanonicalCollectionMethod.send_invoice
+            )
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_no_card_landed_on_polar(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        mocker.patch(
+            "polar.merchant_migration.cards.stripe_service.list_payment_methods",
+            return_value=_no_payment_methods(),
+        )
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "No copied card" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_card_declined_when_validated(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        payment_method = await _linked_card(save_fixture, imported_customer)
+        paused_subscription.payment_method = payment_method
+        await save_fixture(paused_subscription)
+        mocker.patch(
+            "polar.merchant_migration.cutover.stripe_service.create_setup_intent",
+            new=mocker.AsyncMock(
+                side_effect=stripe_lib.CardError("Your card was declined.", None, None)
+            ),
+        )
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "declined by the bank" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_card_needs_authentication(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        payment_method = await _linked_card(save_fixture, imported_customer)
+        paused_subscription.payment_method = payment_method
+        await save_fixture(paused_subscription)
+        _succeeded_setup_intent(mocker, status="requires_action")
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "without the customer confirming" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_polar_subscription_canceled_by_the_merchant(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        paused_subscription.status = SubscriptionStatus.canceled
+        await save_fixture(paused_subscription)
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert adapter.stopped == []
+
+    async def test_customer_deleted_on_polar(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        imported_customer.deleted_at = utc_now()
+        await save_fixture(imported_customer)
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        self._assert_left_alone(adapter, paused_subscription)
+
+
+@pytest.mark.asyncio
+class TestFailures:
+    async def test_stripe_error_is_retryable(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            None, error=stripe_lib.APIConnectionError("Stripe is down")
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.failed
+        assert paused_subscription.status == SubscriptionStatus.paused
+
+    async def test_two_indistinguishable_cards_are_retryable(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        """One customer nobody can pick a card for must not stop the run for
+        everyone else, and must never be resolved by guessing."""
+        identical = {"last4": "4242", "brand": "visa", "exp_month": 4, "exp_year": 2030}
+
+        async def _two_copies(customer: str) -> AsyncIterator[Any]:
+            for id in ("pm_copy_a", "pm_copy_b"):
+                copy = build_stripe_payment_method(details=identical, customer=customer)
+                copy.id = id
+                yield copy
+
+        mocker.patch(
+            "polar.merchant_migration.cards.stripe_service.list_payment_methods",
+            new=_two_copies,
+        )
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                payment_method=CanonicalPaymentMethod(
+                    source_id="pm_on_the_source",
+                    type=CanonicalPaymentMethodType.card,
+                    **identical,  # type: ignore[arg-type]
+                )
+            )
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.failed
+        assert "can't tell which is which" in (outcome.reason or "")
+        assert adapter.stopped == []
+        assert paused_subscription.status == SubscriptionStatus.paused
+
+    async def test_missing_polar_subscription(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+    ) -> None:
+        record.target_id = None
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.failed
+        assert adapter.stopped == []

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -221,6 +221,29 @@ class TestRun:
         assert paused_subscription.trial_end == trial_end
         assert paused_subscription.current_period_end == trial_end
 
+    async def test_bills_a_trial_at_its_end_not_the_period_end(
+        self,
+        cutover: RunCutover,
+        copied_card: PaymentMethod,
+        paused_subscription: Subscription,
+    ) -> None:
+        """The scheduler converts a trial at `current_period_end`, so a source
+        reporting a later period end would convert it weeks late."""
+        trial_end = utc_now() + timedelta(days=10)
+
+        outcome = await cutover(
+            _source(
+                status=CanonicalSubscriptionStatus.trialing,
+                current_period_end=utc_now() + timedelta(days=45),
+                trial_end=trial_end,
+            )
+        )
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert paused_subscription.status == SubscriptionStatus.trialing
+        assert paused_subscription.trial_end == trial_end
+        assert paused_subscription.current_period_end == trial_end
+
     async def test_rebuilds_a_period_the_source_reports_backwards(
         self,
         cutover: RunCutover,

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -7,7 +7,6 @@ import pytest_asyncio
 import stripe as stripe_lib
 from pytest_mock import MockerFixture
 
-from polar.enums import PaymentProcessor
 from polar.kit.utils import utc_now
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
@@ -32,7 +31,11 @@ from polar.models.merchant_migration_record import MerchantMigrationCutoverStatu
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_customer, create_subscription
+from tests.fixtures.random_objects import (
+    create_customer,
+    create_payment_method,
+    create_subscription,
+)
 from tests.fixtures.stripe import build_stripe_payment_method
 from tests.merchant_migration._helpers import (
     build_connected_migration,
@@ -86,15 +89,16 @@ def _succeeded_setup_intent(mocker: MockerFixture, status: str = "succeeded") ->
     )
 
 
-async def _linked_card(save_fixture: SaveFixture, customer: Customer) -> PaymentMethod:
-    payment_method = PaymentMethod(
-        processor=PaymentProcessor.stripe,
-        processor_id="pm_copied",
-        type="card",
-        method_metadata={},
-        customer=customer,
+async def _card_on(
+    save_fixture: SaveFixture, subscription: Subscription, customer: Customer
+) -> PaymentMethod:
+    """A copied card, already attached to the subscription: what the card check
+    leaves behind when the copy landed."""
+    payment_method = await create_payment_method(
+        save_fixture, customer, processor_id="pm_copied"
     )
-    await save_fixture(payment_method)
+    subscription.payment_method = payment_method
+    await save_fixture(subscription)
     return payment_method
 
 
@@ -156,9 +160,9 @@ class TestRun:
         imported_customer: Customer,
         paused_subscription: Subscription,
     ) -> None:
-        payment_method = await _linked_card(save_fixture, imported_customer)
-        paused_subscription.payment_method = payment_method
-        await save_fixture(paused_subscription)
+        payment_method = await _card_on(
+            save_fixture, paused_subscription, imported_customer
+        )
         renewal = utc_now() + timedelta(days=20)
         adapter = _FakeSourceAdapter(canonical_subscription(current_period_end=renewal))
         _succeeded_setup_intent(mocker)
@@ -184,9 +188,7 @@ class TestRun:
         imported_customer: Customer,
         paused_subscription: Subscription,
     ) -> None:
-        payment_method = await _linked_card(save_fixture, imported_customer)
-        paused_subscription.payment_method = payment_method
-        await save_fixture(paused_subscription)
+        await _card_on(save_fixture, paused_subscription, imported_customer)
         trial_end = utc_now() + timedelta(days=10)
         adapter = _FakeSourceAdapter(
             canonical_subscription(
@@ -216,9 +218,7 @@ class TestRun:
     ) -> None:
         """A crash between the Stripe cancellation and the commit must not read
         our own cancellation as the customer having churned."""
-        payment_method = await _linked_card(save_fixture, imported_customer)
-        paused_subscription.payment_method = payment_method
-        await save_fixture(paused_subscription)
+        await _card_on(save_fixture, paused_subscription, imported_customer)
         adapter = _FakeSourceAdapter(
             canonical_subscription(
                 status=CanonicalSubscriptionStatus.canceled,
@@ -249,9 +249,7 @@ class TestRun:
         """The source is already stopped, so refusing here would leave the
         customer billed by nobody. An unpaid first renewal goes to dunning,
         which is recoverable; a subscription nobody bills is not."""
-        payment_method = await _linked_card(save_fixture, imported_customer)
-        paused_subscription.payment_method = payment_method
-        await save_fixture(paused_subscription)
+        await _card_on(save_fixture, paused_subscription, imported_customer)
         adapter = _FakeSourceAdapter(
             canonical_subscription(
                 status=CanonicalSubscriptionStatus.canceled,
@@ -561,9 +559,7 @@ class TestSkips:
         imported_customer: Customer,
         paused_subscription: Subscription,
     ) -> None:
-        payment_method = await _linked_card(save_fixture, imported_customer)
-        paused_subscription.payment_method = payment_method
-        await save_fixture(paused_subscription)
+        await _card_on(save_fixture, paused_subscription, imported_customer)
         mocker.patch(
             "polar.merchant_migration.cutover.stripe_service.create_setup_intent",
             new=mocker.AsyncMock(
@@ -588,9 +584,7 @@ class TestSkips:
         imported_customer: Customer,
         paused_subscription: Subscription,
     ) -> None:
-        payment_method = await _linked_card(save_fixture, imported_customer)
-        paused_subscription.payment_method = payment_method
-        await save_fixture(paused_subscription)
+        await _card_on(save_fixture, paused_subscription, imported_customer)
         _succeeded_setup_intent(mocker, status="requires_action")
         adapter = _FakeSourceAdapter(canonical_subscription())
 

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -208,6 +208,7 @@ def _stripe_subscription(
     status: str = "active",
     cancel_at_period_end: bool = False,
     trial_end: int | None = None,
+    billing_cycle_anchor: int | None = 1_700_000_000,
     cancellation_comment: str | None = None,
     items: list[dict[str, Any]] | None = None,
     payment_method: dict[str, Any] | None = None,
@@ -221,6 +222,7 @@ def _stripe_subscription(
             "cancel_at_period_end": cancel_at_period_end,
             "pause_collection": None,
             "trial_end": trial_end,
+            "billing_cycle_anchor": billing_cycle_anchor,
             "default_payment_method": payment_method,
             "discounts": [],
             "cancellation_details": (

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -3835,8 +3835,7 @@ class TestActivateImported:
         customer: Customer,
         payment_method: PaymentMethod,
     ) -> None:
-        """Unlike a resume, the cutover keeps the period the customer already
-        paid the old provider for, and bills nothing today."""
+        """The customer already paid the old provider for this period."""
         subscription = await create_subscription(
             save_fixture,
             product=product,
@@ -3864,7 +3863,7 @@ class TestActivateImported:
         assert updated.current_period_end == period_end
         assert updated.payment_method_id == payment_method.id
         enqueue_benefits_grants_mock.assert_called_once_with(session, updated)
-        # No order: the customer is not charged for a period they already paid.
+        # No order: they already paid for this period.
         enqueued = [call.args[0] for call in enqueue_job_mock.call_args_list]
         assert "order.create_subscription_order" not in enqueued
 
@@ -3878,8 +3877,8 @@ class TestActivateImported:
         customer: Customer,
         payment_method: PaymentMethod,
     ) -> None:
-        """Nothing paused from the customer's side, so a resumed email would be
-        the first they hear of a migration they shouldn't notice."""
+        """Nothing paused for them, so a resumed email is the first they'd hear
+        of a migration they shouldn't notice."""
         subscription = await create_subscription(
             save_fixture,
             product=product,
@@ -3898,6 +3897,38 @@ class TestActivateImported:
         )
 
         assert_hooks_called_once(subscription_hooks, {"updated"})
+
+    async def test_keeps_the_billing_anchor_the_import_captured(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_benefits_grants_mock: MagicMock,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+        payment_method: PaymentMethod,
+    ) -> None:
+        """A month-end schedule reports a clamped period start."""
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        subscription.anchor_day = 31
+        await save_fixture(subscription)
+        reset_hooks(subscription_hooks)
+
+        updated = await subscription_service.activate_imported(
+            session,
+            subscription,
+            current_period_start=datetime(2026, 2, 28, tzinfo=UTC),
+            current_period_end=datetime(2026, 3, 31, tzinfo=UTC),
+            trial_end=None,
+            payment_method=payment_method,
+        )
+
+        assert updated.anchor_day == 31
 
 
 async def create_event_billing_entry(

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -3821,6 +3821,85 @@ class TestResume:
         assert cycle_entries[0].discount is None
 
 
+@pytest.mark.asyncio
+class TestActivateImported:
+    async def test_takes_over_the_cycle_without_charging(
+        self,
+        frozen_time: datetime,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_job_mock: MagicMock,
+        enqueue_benefits_grants_mock: MagicMock,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+        payment_method: PaymentMethod,
+    ) -> None:
+        """Unlike a resume, the cutover keeps the period the customer already
+        paid the old provider for, and bills nothing today."""
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        subscription.paused_at = frozen_time - timedelta(days=10)
+        await save_fixture(subscription)
+        reset_hooks(subscription_hooks)
+        period_start = frozen_time - timedelta(days=10)
+        period_end = frozen_time + timedelta(days=20)
+
+        updated = await subscription_service.activate_imported(
+            session,
+            subscription,
+            current_period_start=period_start,
+            current_period_end=period_end,
+            trial_end=None,
+            payment_method=payment_method,
+        )
+
+        assert updated.status == SubscriptionStatus.active
+        assert updated.paused_at is None
+        assert updated.current_period_start == period_start
+        assert updated.current_period_end == period_end
+        assert updated.payment_method_id == payment_method.id
+        enqueue_benefits_grants_mock.assert_called_once_with(session, updated)
+        # No order: the customer is not charged for a period they already paid.
+        enqueued = [call.args[0] for call in enqueue_job_mock.call_args_list]
+        assert "order.create_subscription_order" not in enqueued
+
+    async def test_does_not_tell_the_customer_anything_resumed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_benefits_grants_mock: MagicMock,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+        payment_method: PaymentMethod,
+    ) -> None:
+        """Nothing paused from the customer's side, so a resumed email would be
+        the first they hear of a migration they shouldn't notice."""
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        reset_hooks(subscription_hooks)
+
+        await subscription_service.activate_imported(
+            session,
+            subscription,
+            current_period_start=utc_now(),
+            current_period_end=utc_now() + timedelta(days=30),
+            trial_end=None,
+            payment_method=payment_method,
+        )
+
+        assert_hooks_called_once(subscription_hooks, {"updated"})
+
+
 async def create_event_billing_entry(
     save_fixture: SaveFixture,
     *,


### PR DESCRIPTION
## Summary

Adds the engine that switches one imported subscription over to Polar. Nothing calls it yet; the API and the UI come in follow-ups.

In a follow-up PR, I plan to make sure that we only import subscriptions at cutover, will make things easier to read and will reduce some edge cases. 

## What

- `SubscriptionCutover` runs the checks for one subscription and switches it over.
- `subscription.activate_imported` takes over the billing cycle without charging.
- `CanonicalSubscription.anchor_day`, read from Stripe's `billing_cycle_anchor`.
- `PaymentMethod.expires_at` and `Subscription.is_period_lapsed`, two rules that already existed here and were about to get a third copy each.

## Why

Imported subscriptions arrive paused, so nothing bills while the saved cards move. This is the part that turns one of them on and stops it on the old provider.

Weeks can pass between the import and the switch, so every check reads the source again rather than trusting what was staged.

## How

```mermaid
flowchart TD
    Start([Imported subscription<br/>paused on Polar]) --> Stopped{Did we already cancel<br/>it on the source?}

    Stopped -->|no| Checks{Org can renew?<br/>Source healthy, same plan?<br/>Renewal more than 24h out?}
    Checks -->|any fails| Skip([skipped<br/>still billing on the source])
    Checks -->|all pass| Card[Resolve the copied card]

    Stopped -->|yes, an earlier<br/>attempt died| Card

    Card --> HasCard{Card found?}
    HasCard -->|no| NoCard([skipped, or failed if<br/>the source is already stopped])
    HasCard -->|yes| Lapsed{Source stopped more<br/>than one renewal ago?}
    Lapsed -->|yes| Lapse([failed, needs a human])
    Lapsed -->|no| Lock[Take the row lock<br/>re-check it is still paused]
    Lock --> Cancel[Cancel on the source<br/>the one irreversible step]
    Cancel --> Activate[Activate on Polar<br/>same period end, no charge]
    Activate --> Moved([moved<br/>plus a note if the card looks weak])
```


### Surviving a crash mid-switch

The cancellation on Stripe is not part of our transaction, so a run can cancel and then lose everything it was about to write. The cancellation is stamped with a marker, which is the only durable trace of what happened.

```mermaid
sequenceDiagram
    participant W as Worker
    participant S as Stripe (merchant account)
    participant DB as Polar DB

    Note over W: attempt 1
    W->>S: cancel, comment "Migrated to Polar (migration …)"
    S-->>W: ok
    W--xDB: crash before commit
    Note over DB: rolls back,<br/>cutover_status still NULL

    Note over W: attempt 2
    W->>S: retrieve subscription
    S-->>W: canceled, and the comment is ours
    Note over W: stopped_for_migration = true<br/>skip the checks, finish the move
    W->>DB: activate, commit
```

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
