### PR TITLE
fix(typescript-sdk): serialize nested query arrays

### DIFF
--- a/sdk/generator/typescript/template/src/base.test.ts
+++ b/sdk/generator/typescript/template/src/base.test.ts
@@ -62,6 +62,15 @@ describe("buildRequest", () => {
     );
   });
 
+  test("deep object array query params", () => {
+    const [url] = client.buildRequest("GET", "/v1/items/", undefined, {
+      metadata: { reference_id: ["ABC", "DEF"] },
+    });
+    expect(url).toBe(
+      "https://api.polar.sh/v1/items/?metadata%5Breference_id%5D=ABC&metadata%5Breference_id%5D=DEF",
+    );
+  });
+
   test("null and undefined values are ignored", () => {
     const [url] = client.buildRequest(
       "GET",

--- a/sdk/generator/typescript/template/src/base.ts
+++ b/sdk/generator/typescript/template/src/base.ts
@@ -80,7 +80,13 @@ const buildUrl = (
           // Handle deepObject style parameters (e.g., metadata)
           for (const [subKey, subValue] of Object.entries(value)) {
             if (subValue !== null && subValue !== undefined) {
-              searchParams.append(`${key}[${subKey}]`, String(subValue));
+              if (Array.isArray(subValue)) {
+                for (const item of subValue) {
+                  searchParams.append(`${key}[${subKey}]`, String(item));
+                }
+              } else {
+                searchParams.append(`${key}[${subKey}]`, String(subValue));
+              }
             }
           }
         } else {

--- a/sdk/typescript/src/base.test.ts
+++ b/sdk/typescript/src/base.test.ts
@@ -55,6 +55,15 @@ describe("buildRequest", () => {
     );
   });
 
+  test("deep object array query params", () => {
+    const [url] = client.buildRequest("GET", "/v1/items/", undefined, {
+      metadata: { reference_id: ["ABC", "DEF"] },
+    });
+    expect(url).toBe(
+      "https://api.polar.sh/v1/items/?metadata%5Breference_id%5D=ABC&metadata%5Breference_id%5D=DEF",
+    );
+  });
+
   test("null and undefined values are ignored", () => {
     const [url] = client.buildRequest(
       "GET",

--- a/sdk/typescript/src/base.ts
+++ b/sdk/typescript/src/base.ts
@@ -71,7 +71,13 @@ const buildUrl = (url: string, pathParams?: PathParams, queryParams?: QueryParam
           // Handle deepObject style parameters (e.g., metadata)
           for (const [subKey, subValue] of Object.entries(value)) {
             if (subValue !== null && subValue !== undefined) {
-              searchParams.append(`${key}[${subKey}]`, String(subValue));
+              if (Array.isArray(subValue)) {
+                for (const item of subValue) {
+                  searchParams.append(`${key}[${subKey}]`, String(item));
+                }
+              } else {
+                searchParams.append(`${key}[${subKey}]`, String(subValue));
+              }
             }
           }
         } else {


### PR DESCRIPTION
## Summary

- serialize array values inside deep-object query parameters as repeated keys
- keep the generated TypeScript SDK and generator template in sync
- add regression coverage for metadata filters with multiple values

## Root cause

Nested query values were converted with `String(subValue)`, which joins arrays with commas. The API expects repeated deep-object keys so it can apply OR matching across metadata values.

## Validation

- `just test` (20 tests passed)
- `just lint`
- `just typecheck`
- ADR compliance check: no violations

Closes polarsource/feedback#361

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

