### PR TITLE
Fix deterministic order status sorting

### DIFF
--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -457,10 +457,12 @@ class OrderRepository(
                 return Order.created_at
             case OrderSortProperty.status:
                 return case(
-                    (Order.status == OrderStatus.pending, 1),
-                    (Order.status == OrderStatus.paid, 2),
-                    (Order.status == OrderStatus.refunded, 3),
+                    (Order.status == OrderStatus.draft, 1),
+                    (Order.status == OrderStatus.pending, 2),
+                    (Order.status == OrderStatus.paid, 3),
                     (Order.status == OrderStatus.partially_refunded, 4),
+                    (Order.status == OrderStatus.refunded, 5),
+                    (Order.status == OrderStatus.void, 6),
                 )
             case OrderSortProperty.invoice_number:
                 return Order.invoice_number

--- a/server/tests/order/test_repository.py
+++ b/server/tests/order/test_repository.py
@@ -5,9 +5,42 @@ from pytest_mock import MockerFixture
 from sqlalchemy import Select
 from sqlalchemy.dialects import postgresql
 
-from polar.models import Order
+from polar.models import Customer, Order
+from polar.models.order import OrderStatus
 from polar.order.repository import OrderRepository
+from polar.order.sorting import OrderSortProperty
 from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_order
+
+
+@pytest.mark.asyncio
+class TestGetSortingClause:
+    async def test_status(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+    ) -> None:
+        expected_statuses = [
+            OrderStatus.draft,
+            OrderStatus.pending,
+            OrderStatus.paid,
+            OrderStatus.partially_refunded,
+            OrderStatus.refunded,
+            OrderStatus.void,
+        ]
+        for status in reversed(expected_statuses):
+            await create_order(save_fixture, customer=customer, status=status)
+
+        repository = OrderRepository.from_session(session)
+        statement = repository.apply_sorting(
+            repository.get_base_statement(),
+            [(OrderSortProperty.status, False)],
+        )
+        orders = await repository.get_all(statement)
+
+        assert [order.status for order in orders] == expected_statuses
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- assign every `OrderStatus` a distinct status sort value
- order statuses by lifecycle from draft through void
- add a database-backed regression test covering all six statuses

## Why

The status `CASE` expression omitted `draft` and `void`, so both produced `NULL` sort keys. Their relative ordering was therefore undefined, which could make backoffice results and pagination unstable when sorting by status.

Closes polarsource/feedback#369.

## Validation

- `POLAR_ENV=testing uv run python -m pytest tests/order/test_repository.py -q`
- `uv run task lint`
- `uv run task lint_types`
- ADR compliance: no violations

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

