### PR TITLE
Fix order voiding race with payment processing

### DIFF
--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -360,6 +360,20 @@ class OrderRepository(
         result = cast(CursorResult[Order], await self.session.execute(statement))
         return result.rowcount > 0
 
+    async def void_if_pending_and_unlocked(self, order_id: UUID) -> bool:
+        statement = (
+            update(Order)
+            .where(
+                Order.id == order_id,
+                Order.status == OrderStatus.pending,
+                Order.payment_lock_acquired_at.is_(None),
+            )
+            .values(status=OrderStatus.void, next_payment_attempt_at=None)
+            .execution_options(synchronize_session=False)
+        )
+        result = cast(CursorResult[Order], await self.session.execute(statement))
+        return result.rowcount > 0
+
     async def release_payment_lock(self, order: Order, *, flush: bool = False) -> Order:
         """Release a payment lock for an order."""
         return await self.update(

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -2673,18 +2673,20 @@ class OrderService:
 
     async def void(self, session: AsyncSession, order: Order) -> Order:
         """Mark an order as void, indicating payment cannot be recovered."""
-        if order.payment_lock_acquired_at is not None:
-            raise PaymentAlreadyInProgress(order)
-        if order.status != OrderStatus.pending:
-            raise OrderNotPending(order)
-
-        previous_status = order.status
-
         repository = OrderRepository.from_session(session)
-        order = await repository.update(
-            order,
-            update_dict={"status": OrderStatus.void, "next_payment_attempt_at": None},
-        )
+        while True:
+            if await repository.void_if_pending_and_unlocked(order.id):
+                order.status = OrderStatus.void
+                order.next_payment_attempt_at = None
+                break
+
+            await session.refresh(order, {"status", "payment_lock_acquired_at"})
+            if order.payment_lock_acquired_at is not None:
+                raise PaymentAlreadyInProgress(order)
+            if order.status != OrderStatus.pending:
+                raise OrderNotPending(order)
+
+        previous_status = OrderStatus.pending
 
         # Reduce positive customer balance
         customer_balance = await wallet_service.get_billing_wallet_balance(

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -10,6 +10,7 @@ import stripe as stripe_lib
 from freezegun import freeze_time
 from pydantic import BaseModel
 from pytest_mock import MockerFixture
+from sqlalchemy import update
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
@@ -5742,6 +5743,35 @@ class TestVoidOrder:
             await order_service.void(session, order)
 
         assert exc_info.value.order == order
+
+    @pytest.mark.asyncio
+    async def test_void_order_with_stale_payment_lock(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+        )
+        await session.execute(
+            update(Order)
+            .where(Order.id == order.id)
+            .values(payment_lock_acquired_at=utc_now())
+            .execution_options(synchronize_session=False)
+        )
+
+        assert order.payment_lock_acquired_at is None
+
+        with pytest.raises(PaymentAlreadyInProgress) as exc_info:
+            await order_service.void(session, order)
+
+        assert exc_info.value.order == order
+        assert order.status == OrderStatus.pending
 
     @pytest.mark.asyncio
     async def test_void_non_pending_order(


### PR DESCRIPTION
## Summary

- atomically void pending orders only when no payment lock is held
- refresh payment state after a failed transition to report the correct conflict
- preserve loaded order relationships while synchronizing the successful state change
- add regression coverage for a stale in-memory payment lock

## Root cause

`OrderService.void` checked `payment_lock_acquired_at` on an already-loaded ORM object, then updated the order without a database predicate. A concurrent payment worker could acquire the lock between those operations, allowing the order to become void while Stripe was charging it.

The new repository update guards both `status = pending` and `payment_lock_acquired_at IS NULL` in the same SQL statement. If it loses the race, the service refreshes the current state and raises `PaymentAlreadyInProgress` or `OrderNotPending` without performing void side effects.

## Validation

- `POLAR_ENV=testing uv run python -m pytest tests/order/test_repository.py tests/order/test_service.py::TestVoidOrder tests/order/test_service.py::TestVoidPendingOrdersForSubscription` (11 passed)
- `uv run task lint`
- `uv run task lint_types`
- ADR check: no violations

Fixes polarsource/feedback#370

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

