### PR TITLE
meter: Exclude boolean properties from property aggregation

### DIFF
--- a/server/polar/meter/aggregation.py
+++ b/server/polar/meter/aggregation.py
@@ -109,7 +109,7 @@ class PropertyAggregation(BaseModel):
         if self.property in ("name", "source", "timestamp"):
             return True
         value = get_nested_metadata_value(event.user_metadata, self.property)
-        return isinstance(value, int | float)
+        return isinstance(value, int | float) and not isinstance(value, bool)
 
 
 class UniqueAggregation(BaseModel):

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -583,9 +583,13 @@ class MeterService:
         meter: Meter,
         events_statement: Select[tuple[Event]],
     ) -> float:
-        statement = events_statement.with_only_columns(
-            func.coalesce(meter.aggregation.get_sql_column(Event), 0)
-        ).order_by(None)
+        statement = (
+            events_statement.where(meter.aggregation.get_sql_clause(Event))
+            .with_only_columns(
+                func.coalesce(meter.aggregation.get_sql_column(Event), 0)
+            )
+            .order_by(None)
+        )
         result = await session.scalar(statement)
         return result or 0.0
 

--- a/server/tests/meter/test_aggregation.py
+++ b/server/tests/meter/test_aggregation.py
@@ -251,6 +251,16 @@ class TestAggregationMatches:
         )
         assert agg.matches(event) is False
 
+    def test_property_not_matches_boolean(self, organization: Organization) -> None:
+        agg = PropertyAggregation(func=AggregationFunction.sum, property="amount")
+        event = Event(
+            name="test",
+            organization_id=organization.id,
+            source=EventSource.user,
+            user_metadata={"amount": True},
+        )
+        assert agg.matches(event) is False
+
     def test_property_not_matches_missing(self, organization: Organization) -> None:
         agg = PropertyAggregation(func=AggregationFunction.sum, property="amount")
         event = Event(

--- a/server/tests/meter/test_service.py
+++ b/server/tests/meter/test_service.py
@@ -13,6 +13,7 @@ from pytest_mock import MockerFixture
 
 from polar.auth.models import AuthSubject
 from polar.enums import SubscriptionRecurringInterval
+from polar.event.repository import EventRepository
 from polar.event.service import event as event_service
 from polar.event.system import SystemEvent
 from polar.exceptions import PolarRequestValidationError
@@ -1107,6 +1108,57 @@ class TestGetQuantities:
         quantity = result.quantities[0]
         assert quantity.quantity == expected_value
         assert result.total == expected_value
+
+
+@pytest.mark.asyncio
+class TestGetQuantity:
+    async def test_excludes_non_numeric_values(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+    ) -> None:
+        await create_event(
+            save_fixture,
+            organization=customer.organization,
+            customer=customer,
+            metadata={"tokens": 20},
+        )
+        await create_event(
+            save_fixture,
+            organization=customer.organization,
+            customer=customer,
+            metadata={"tokens": 10},
+        )
+        await create_event(
+            save_fixture,
+            organization=customer.organization,
+            customer=customer,
+            metadata={"tokens": True},
+        )
+        await create_event(
+            save_fixture,
+            organization=customer.organization,
+            customer=customer,
+            metadata={"tokens": "invalid"},
+        )
+
+        meter = await create_meter(
+            save_fixture,
+            aggregation=PropertyAggregation(
+                func=AggregationFunction.sum, property="tokens"
+            ),
+            organization=customer.organization,
+        )
+
+        event_repository = EventRepository.from_session(session)
+        events_statement = event_repository.get_base_statement().where(
+            Event.organization_id == customer.organization_id
+        )
+
+        quantity = await meter_service.get_quantity(session, meter, events_statement)
+
+        assert quantity == 30.0
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
Otherwise we overcount meters in python where they would not count in SQL

Solves https://github.com/polarsource/feedback/issues/376

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

