### PR TITLE
tf/redis: Migrate to Valkey 9.1

### DIFF
--- a/terraform/modules/aws_redis/main.tf
+++ b/terraform/modules/aws_redis/main.tf
@@ -24,7 +24,7 @@ resource "aws_elasticache_parameter_group" "this" {
 
 resource "aws_elasticache_replication_group" "this" {
   replication_group_id       = var.name
-  description                = "${var.name} Redis"
+  description                = "${var.name} cache"
   engine                     = "valkey"
   engine_version             = var.engine_version
   parameter_group_name       = aws_elasticache_parameter_group.this.name

--- a/terraform/modules/aws_redis/main.tf
+++ b/terraform/modules/aws_redis/main.tf
@@ -11,11 +11,23 @@ resource "aws_security_group" "this" {
   tags        = var.tags
 }
 
+resource "aws_elasticache_parameter_group" "this" {
+  name   = var.name
+  family = var.parameter_group_family
+  tags   = var.tags
+
+  parameter {
+    name  = "maxmemory-policy"
+    value = "noeviction"
+  }
+}
+
 resource "aws_elasticache_replication_group" "this" {
   replication_group_id       = var.name
   description                = "${var.name} Redis"
   engine                     = "valkey"
   engine_version             = var.engine_version
+  parameter_group_name       = aws_elasticache_parameter_group.this.name
   node_type                  = var.node_type
   num_cache_clusters         = var.node_count
   multi_az_enabled           = var.node_count > 1

--- a/terraform/modules/aws_redis/main.tf
+++ b/terraform/modules/aws_redis/main.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "this" {
 resource "aws_elasticache_replication_group" "this" {
   replication_group_id       = var.name
   description                = "${var.name} Redis"
-  engine                     = "redis"
+  engine                     = "valkey"
   engine_version             = var.engine_version
   node_type                  = var.node_type
   num_cache_clusters         = var.node_count

--- a/terraform/modules/aws_redis/variables.tf
+++ b/terraform/modules/aws_redis/variables.tf
@@ -32,9 +32,9 @@ variable "node_type" {
 }
 
 variable "engine_version" {
-  description = "Redis engine version."
+  description = "Valkey engine version."
   type        = string
-  default     = "7.1"
+  default     = "9.1"
 }
 
 variable "port" {

--- a/terraform/modules/aws_redis/variables.tf
+++ b/terraform/modules/aws_redis/variables.tf
@@ -37,6 +37,12 @@ variable "engine_version" {
   default     = "9.1"
 }
 
+variable "parameter_group_family" {
+  description = "Parameter group family matching the engine version."
+  type        = string
+  default     = "valkey9"
+}
+
 variable "port" {
   description = "Redis port."
   type        = number


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Migrates the `aws_redis` Terraform module from Redis 7.1 to Valkey 9.1, adds a managed parameter group, and generalizes the replication group description. Old behavior used `engine = "redis"` with no parameter group and description "<name> Redis"; new behavior uses `engine = "valkey"` (default `engine_version = "9.1"`), attaches an `aws_elasticache_parameter_group` with `maxmemory-policy = noeviction`, and sets description to "<name> cache".

- Terraform will recreate `aws_elasticache_replication_group` and create `aws_elasticache_parameter_group`; plan a cutover window or blue/green.
- Required: take a snapshot/backup, apply to create the Valkey group, restore data if needed, and update client endpoints or DNS aliases.
- Required: confirm `maxmemory-policy = noeviction` suits the workload or override it. If you override `engine_version`, set a matching `parameter_group_family` (default `valkey9`) and verify client/library compatibility with Valkey 9.1.

<sup>Written for commit e87ea5993c60d3aad22c309972fd41a7d2070a26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

