### PR TITLE
Add Resend tags (category + tenant_id) to outgoing emails

### DIFF
--- a/server/polar/email/repository.py
+++ b/server/polar/email/repository.py
@@ -14,7 +14,7 @@ from polar.models.email_log import (
 log: Logger = structlog.get_logger()
 
 
-def _extract_organization_id(
+def extract_organization_id(
     email_props: dict[str, Any],
 ) -> UUID | None:
     org = email_props.get("organization")
@@ -76,6 +76,6 @@ class EmailLogRepository(RepositoryBase[EmailLog], RepositoryIDMixin[EmailLog, U
                 processor_id=processor_id,
                 error=error,
                 deduplication_key=deduplication_key,
-                organization_id=_extract_organization_id(props),
+                organization_id=extract_organization_id(props),
             )
         )

--- a/server/polar/email/sender.py
+++ b/server/polar/email/sender.py
@@ -66,6 +66,7 @@ class EmailSender(ABC):
         reply_to_name: str | None = DEFAULT_REPLY_TO_NAME,
         reply_to_email_addr: str | None = DEFAULT_REPLY_TO_EMAIL_ADDRESS,
         attachments: Iterable[Attachment] | None = None,
+        tags: dict[str, str] | None = None,
     ) -> str | None:
         pass
 
@@ -83,6 +84,7 @@ class LoggingEmailSender(EmailSender):
         reply_to_name: str | None = DEFAULT_REPLY_TO_NAME,
         reply_to_email_addr: str | None = DEFAULT_REPLY_TO_EMAIL_ADDRESS,
         attachments: Iterable[Attachment] | None = None,
+        tags: dict[str, str] | None = None,
     ) -> str | None:
         log.info(
             "Sending an email",
@@ -90,6 +92,7 @@ class LoggingEmailSender(EmailSender):
             subject=subject,
             from_name=from_name,
             from_email_addr=to_ascii_email(from_email_addr),
+            tags=tags,
         )
         return None
 
@@ -113,6 +116,7 @@ class ResendEmailSender(EmailSender):
         reply_to_name: str | None = DEFAULT_REPLY_TO_NAME,
         reply_to_email_addr: str | None = DEFAULT_REPLY_TO_EMAIL_ADDRESS,
         attachments: Iterable[Attachment] | None = None,
+        tags: dict[str, str] | None = None,
     ) -> str | None:
         to_email_addr_ascii = to_ascii_email(to_email_addr)
         payload: dict[str, Any] = {
@@ -129,6 +133,9 @@ class ResendEmailSender(EmailSender):
                 for attachment in attachments
             ]
             if attachments
+            else [],
+            "tags": [{"name": name, "value": value} for name, value in tags.items()]
+            if tags
             else [],
         }
         if reply_to_name and reply_to_email_addr:

--- a/server/polar/email/tasks.py
+++ b/server/polar/email/tasks.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 import structlog
 
@@ -8,10 +9,20 @@ from polar.models.email_log import EmailLogStatus
 from polar.worker import AsyncSessionMaker, TaskPriority, actor
 
 from .react import render_from_json
-from .repository import EmailLogRepository
+from .repository import EmailLogRepository, extract_organization_id
 from .sender import Attachment, email_sender
 
 log: Logger = structlog.get_logger()
+
+
+def _build_tags(template: str | None, email_props: dict[str, Any]) -> dict[str, str]:
+    tags: dict[str, str] = {}
+    if template is not None:
+        tags["category"] = template
+    organization_id = extract_organization_id(email_props)
+    if organization_id is not None:
+        tags["tenant_id"] = str(organization_id)
+    return tags
 
 
 @actor(actor_name="email.send", priority=TaskPriority.HIGH)
@@ -34,6 +45,9 @@ async def email_send(
         assert props_json is not None
         html_content = await render_from_json(template, props_json)
 
+    email_props = json.loads(props_json) if props_json else {}
+    tags = _build_tags(template, email_props)
+
     processor_id: str | None = None
     status = EmailLogStatus.sent
     error: str | None = None
@@ -49,6 +63,7 @@ async def email_send(
             reply_to_name=reply_to_name,
             reply_to_email_addr=reply_to_email_addr,
             attachments=attachments,
+            tags=tags,
         )
     except Exception as e:
         status = EmailLogStatus.failed
@@ -56,8 +71,6 @@ async def email_send(
         raise
     finally:
         try:
-            email_props = json.loads(props_json) if props_json else {}
-
             async with AsyncSessionMaker() as session:
                 repository = EmailLogRepository.from_session(session)
                 await repository.create_log(

--- a/server/tests/e2e/infra/email_capture.py
+++ b/server/tests/e2e/infra/email_capture.py
@@ -48,6 +48,7 @@ def create_email_sender_mock(capture: EmailCapture) -> MagicMock:
         reply_to_name: str | None = None,
         reply_to_email_addr: str | None = None,
         attachments: Any = None,
+        tags: dict[str, str] | None = None,
     ) -> str:
         capture.emails.append(CapturedEmail(to=to_email_addr, subject=subject))
         return f"mock-email-{uuid.uuid4()}"

--- a/server/tests/email/test_tasks.py
+++ b/server/tests/email/test_tasks.py
@@ -135,6 +135,73 @@ class TestEmailSend:
         assert str(log.organization_id) == org_id
         assert log.email_props["organization"]["name"] == "Test Org"
 
+    async def test_send_includes_category_and_tenant_tags(
+        self,
+        session: AsyncSession,
+        mocker: MockerFixture,
+    ) -> None:
+        mock_send = mocker.patch(
+            "polar.email.tasks.email_sender.send",
+            return_value=None,
+        )
+        mocker.patch(
+            "polar.email.tasks.render_from_json",
+            return_value="<p>Rendered</p>",
+        )
+
+        org_id = "01942f38-d81f-7cd7-a40e-a80ae5e3cecd"
+        props_json = (
+            '{"email": "test@example.com",'
+            f' "organization": {{"id": "{org_id}", "name": "Test Org"}}}}'
+        )
+
+        await email_send(
+            to_email_addr="test@example.com",
+            subject="Test Subject",
+            html_content=None,
+            from_name="Polar",
+            from_email_addr="noreply@polar.sh",
+            email_headers=None,
+            reply_to_name=None,
+            reply_to_email_addr=None,
+            template="order_confirmation",
+            props_json=props_json,
+        )
+
+        assert mock_send.call_args.kwargs["tags"] == {
+            "category": "order_confirmation",
+            "tenant_id": org_id,
+        }
+
+    async def test_send_tags_omit_tenant_without_organization(
+        self,
+        session: AsyncSession,
+        mocker: MockerFixture,
+    ) -> None:
+        mock_send = mocker.patch(
+            "polar.email.tasks.email_sender.send",
+            return_value=None,
+        )
+        mocker.patch(
+            "polar.email.tasks.render_from_json",
+            return_value="<p>Rendered</p>",
+        )
+
+        await email_send(
+            to_email_addr="test@example.com",
+            subject="Test Subject",
+            html_content=None,
+            from_name="Polar",
+            from_email_addr="noreply@polar.sh",
+            email_headers=None,
+            reply_to_name=None,
+            reply_to_email_addr=None,
+            template="login_code",
+            props_json='{"email": "test@example.com"}',
+        )
+
+        assert mock_send.call_args.kwargs["tags"] == {"category": "login_code"}
+
     async def test_processor_reflects_settings(
         self,
         session: AsyncSession,


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

Attach two Resend tags to every email we send, so emails can be filtered and attributed in the Resend dashboard and webhooks:

- `category` — the email template name (e.g. `order_confirmation`, `login_code`)
- `tenant_id` — the organization id, for organization-scoped emails

## What

- `polar/email/sender.py`: added an optional `tags: dict[str, str]` argument to `EmailSender.send()` (abstract + `LoggingEmailSender` + `ResendEmailSender`). `ResendEmailSender` serializes it into Resend's payload shape: `"tags": [{"name": ..., "value": ...}, ...]`.
- `polar/email/tasks.py`: the `email.send` task derives the tags and passes them to the sender — `category` from `template`, `tenant_id` from the organization id in the props.
- `polar/email/repository.py`: made the existing `_extract_organization_id` helper public (`extract_organization_id`) and reused it for the `tenant_id` tag.
- `tests/email/test_tasks.py`: added tests asserting the tags passed to the sender for an org-scoped email and a non-org email.

## Why

We want per-tenant and per-template observability/filtering of transactional email in Resend (deliverability, volume, debugging) without threading extra context through every call site.

## How

All outgoing mail funnels through the `email.send` Dramatiq task → `email_sender.send()`. Deriving the tags there means:

- **No call-site changes** — the task already receives `template` and `props_json`, which is everything needed to build both tags.
- `tenant_id` reuses `extract_organization_id`, the same derivation that already populates `EmailLog.organization_id`, so the tag and the log row stay consistent.
- Tag values are UUIDs / snake_case template names, which already satisfy Resend's tag charset (ASCII letters, numbers, `_`, `-`).

## Follow-up (separate PR)

`tenant_id` is only emitted for templates whose props embed the full `Organization` object (orders, subscriptions, payment-method reminders, webhook-disabled, seat invitations, customer sessions, etc.). A handful of organization-related templates currently carry only `organization_name` (a string, no id) and therefore get `category` but **not** `tenant_id`:

- `organization_invite`
- `organization_offboarded`
- `support_case_organization_new_message`
- the maintainer `notification_*` emails

A follow-up PR should plumb the organization id into those props (and their call sites) so they also carry `tenant_id`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`) — could not be run in the ephemeral web session (no Python 3.14.6 available); files compile and logic is verified, please confirm in CI
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jJqvAiamwfGwNnBWHF2xr

---
_Generated by [Claude Code](https://claude.ai/code/session_011jJqvAiamwfGwNnBWHF2xr)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

