### PR TITLE
tinybird: Ensure that wildcards in search are treated as literal

### DIFF
--- a/server/polar/integrations/tinybird/service.py
+++ b/server/polar/integrations/tinybird/service.py
@@ -14,6 +14,7 @@ from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
 from sqlalchemy import (
     Column,
     ColumnClause,
+    ColumnElement,
     DateTime,
     Float,
     MetaData,
@@ -44,6 +45,16 @@ from .schemas import TinybirdEvent
 log: Logger = structlog.get_logger()
 
 clickhouse_dialect = ClickHouseDialect()
+
+
+def _contains(column: Any, value: str) -> ColumnElement[bool]:
+    return func.position(column, value) > 0
+
+
+def _icontains(column: Any, value: str) -> ColumnElement[bool]:
+    return func.positionCaseInsensitiveUTF8(column, value) > 0
+
+
 metadata = MetaData()
 
 events_table = Table(
@@ -541,7 +552,7 @@ class TinybirdEventsQuery:
         return self
 
     def filter_name_query(self, query: str) -> Self:
-        self._filters.append(events_table.c.name.ilike(f"%{query}%"))
+        self._filters.append(_icontains(events_table.c.name, query))
         return self
 
     def filter_timestamp_range(
@@ -598,9 +609,9 @@ class TinybirdEventsQuery:
         matching_external_customer_ids: Sequence[str] | None = None,
     ) -> Self:
         conditions: list[Any] = [
-            events_table.c.name.ilike(f"%{query}%"),
-            events_table.c.source.ilike(f"%{query}%"),
-            events_table.c.user_metadata.ilike(f"%{query}%"),
+            _icontains(events_table.c.name, query),
+            _icontains(events_table.c.source, query),
+            _icontains(events_table.c.user_metadata, query),
         ]
         if matching_customer_ids:
             conditions.append(
@@ -686,7 +697,11 @@ class TinybirdEventsQuery:
     def _ch_comparison(attr: Any, clause: FilterClause) -> Any:
         v = clause.value
         if clause.operator in (FilterOperator.like, FilterOperator.not_like):
-            v = str(v) if not isinstance(v, bool) else ("t" if v else "f")
+            needle = str(v) if not isinstance(v, bool) else ("t" if v else "f")
+            haystack = func.toString(attr)
+            if clause.operator == FilterOperator.like:
+                return _contains(haystack, needle)
+            return ~_contains(haystack, needle)
         op = clause.operator
         if op == FilterOperator.eq:
             return attr == v
@@ -700,10 +715,6 @@ class TinybirdEventsQuery:
             return attr < v
         if op == FilterOperator.lte:
             return attr <= v
-        if op == FilterOperator.like:
-            return attr.like(f"%{v}%")
-        if op == FilterOperator.not_like:
-            return attr.notlike(f"%{v}%")
         return false()
 
     _SORT_COLUMN_MAP = {

--- a/server/tests/integrations/tinybird/test_service.py
+++ b/server/tests/integrations/tinybird/test_service.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import httpx
 import pytest
@@ -18,8 +19,11 @@ from polar.integrations.tinybird.service import (
     TinybirdEventsQuery,
     TinybirdEventTypesQuery,
     _event_to_tinybird,
+    clickhouse_dialect,
     count_user_events_by_organization,
+    events_table,
 )
+from polar.meter.filter import FilterClause, FilterOperator
 from polar.models import Event
 from polar.models.event import EventSource
 from tests.fixtures.tinybird import tinybird_available
@@ -130,6 +134,69 @@ class TestEventToTinybird:
         assert result["parent_id"] is None
         assert result["meter_id"] is None
         assert result["amount"] is None
+
+
+def compile_clause(clause: Any) -> str:
+    return str(
+        clause.compile(
+            dialect=clickhouse_dialect, compile_kwargs={"literal_binds": True}
+        )
+    )
+
+
+class TestQueryWildcardsAreLiteral:
+    def test_filter_name_query(self) -> None:
+        query = TinybirdEventsQuery([uuid.uuid4()]).filter_name_query("ai_gen%")
+        compiled = compile_clause(query._filters[-1])
+        assert (
+            compiled
+            == "positionCaseInsensitiveUTF8(`events_by_timestamp`.`name`, 'ai_gen%') > 0"
+        )
+
+    def test_filter_by_query(self) -> None:
+        query = TinybirdEventsQuery([uuid.uuid4()]).filter_by_query("100%_x")
+        compiled = compile_clause(query._filters[-1])
+        for column in ("name", "source", "user_metadata"):
+            assert (
+                f"positionCaseInsensitiveUTF8(`events_by_timestamp`.`{column}`, '100%_x') > 0"
+                in compiled
+            )
+
+    def test_like_operator(self) -> None:
+        clause = FilterClause(
+            property="name", operator=FilterOperator.like, value="api_test"
+        )
+        compiled = compile_clause(
+            TinybirdEventsQuery._ch_comparison(events_table.c.name, clause)
+        )
+        assert (
+            compiled
+            == "position(toString(`events_by_timestamp`.`name`), 'api_test') > 0"
+        )
+
+    def test_not_like_operator(self) -> None:
+        clause = FilterClause(
+            property="name", operator=FilterOperator.not_like, value="api_test"
+        )
+        compiled = compile_clause(
+            TinybirdEventsQuery._ch_comparison(events_table.c.name, clause)
+        )
+        assert (
+            compiled
+            == "position(toString(`events_by_timestamp`.`name`), 'api_test') <= 0"
+        )
+
+    def test_like_operator_numeric_column(self) -> None:
+        clause = FilterClause(
+            property="_cost.amount", operator=FilterOperator.like, value=10
+        )
+        compiled = compile_clause(
+            TinybirdEventsQuery._ch_comparison(events_table.c.cost_amount, clause)
+        )
+        assert (
+            compiled
+            == "position(toString(`events_by_timestamp`.`cost_amount`), '10') > 0"
+        )
 
 
 @pytest.mark.skipif(not tinybird_available(), reason="Tinybird not running")


### PR DESCRIPTION
We don't want the input to the search containing wildqueries to be treated as such, rather we want them to be treated as literals in the search

Fixes https://github.com/polarsource/feedback/issues/371

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

