### PR TITLE
fix(script): keep domains under a two-level registry suffix

### DIFF
--- a/server/scripts/set_organization_embed_hosts.py
+++ b/server/scripts/set_organization_embed_hosts.py
@@ -169,12 +169,13 @@ def _is_preview_host(host: str) -> bool:
     written. `*.vercel.app` would cover it and admit every other tenant too, so
     the merchant has to weigh that themselves.
 
-    What is left after the first label has to be a suffix someone else operates,
-    which takes at least two labels: `vercel.app` is one, `com` is every ordinary
-    domain in the world.
+    What is left after the first label has to be a suffix a company operates for
+    its tenants: `vercel.app`, `pages.dev`. A registry suffix does not count,
+    however many labels it carries — `acme.co.uk` is a merchant's own domain,
+    not one tenant of `co.uk`.
     """
     _, _, parent = host.partition(".")
-    return "." in parent and is_tld(parent)
+    return is_tld(parent) and not is_tld(parent, search_private=False)
 
 
 def _owned_domains(candidate: Candidate) -> dict[str, str]:


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes preview-host detection so only hosts under private suffixes (e.g., *.vercel.app, *.pages.dev) are treated as preview; domains under multi-label registry suffixes (e.g., acme.co.uk) are now kept as merchant-owned. Previously, any multi-label public suffix like co.uk could be misclassified as preview.

- Changes _is_preview_host to require a private suffix: returns true when the parent is a suffix and not an ICANN/registry suffix.
- Impact: domains like acme.co.uk and shop.com.au are retained; foo.vercel.app remains preview.
- No config or migrations. Re-running the script will keep more owned domains under two-level registries.

<sup>Written for commit 83f3f19e6779c19e9995585539396a21bb6af6fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

