### PR TITLE
tf/aws: Split sandbox and test into their own subnets

### DIFF
--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -30,6 +30,25 @@ resource "aws_subnet" "private" {
   tags = merge(var.tags, { Name = "${var.name}-private-${var.availability_zones[count.index]}" })
 }
 
+resource "aws_vpc_ipv4_cidr_block_association" "secondary" {
+  count = var.secondary_cidr_block == null ? 0 : 1
+
+  vpc_id     = aws_vpc.this.id
+  cidr_block = var.secondary_cidr_block
+}
+
+resource "aws_subnet" "private_secondary" {
+  count = var.secondary_cidr_block == null ? 0 : length(var.availability_zones)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.secondary_cidr_block, 4, count.index + 1)
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(var.tags, { Name = "${var.name}-private-secondary-${var.availability_zones[count.index]}" })
+
+  depends_on = [aws_vpc_ipv4_cidr_block_association.secondary]
+}
+
 resource "aws_nat_gateway" "this" {
   allocation_id = var.eip_allocation_id
   subnet_id     = aws_subnet.public.id
@@ -72,5 +91,12 @@ resource "aws_route_table_association" "private" {
   count = length(aws_subnet.private)
 
   subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "private_secondary" {
+  count = length(aws_subnet.private_secondary)
+
+  subnet_id      = aws_subnet.private_secondary[count.index].id
   route_table_id = aws_route_table.private.id
 }

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -12,3 +12,8 @@ output "public_subnet_id" {
   description = "ID of the public subnet."
   value       = aws_subnet.public.id
 }
+
+output "secondary_private_subnet_ids" {
+  description = "IDs of the private subnets in the secondary CIDR block."
+  value       = aws_subnet.private_secondary[*].id
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -9,6 +9,12 @@ variable "cidr_block" {
   default     = "10.20.0.0/16"
 }
 
+variable "secondary_cidr_block" {
+  description = "Optional secondary CIDR block, with parallel private subnets in each availability zone."
+  type        = string
+  default     = null
+}
+
 variable "availability_zones" {
   description = "Availability zones for the private subnets. The first also hosts the NAT gateway's public subnet."
   type        = list(string)

--- a/terraform/sandbox/network.tf
+++ b/terraform/sandbox/network.tf
@@ -11,9 +11,10 @@ module "egress_ip" {
 module "vpc" {
   source = "../modules/vpc"
 
-  name               = "polar-sandbox"
-  availability_zones = ["us-east-2a", "us-east-2b", "us-east-2c"]
-  eip_allocation_id  = module.egress_ip.allocation_id
+  name                 = "polar-sandbox"
+  availability_zones   = ["us-east-2a", "us-east-2b", "us-east-2c"]
+  eip_allocation_id    = module.egress_ip.allocation_id
+  secondary_cidr_block = "10.21.0.0/16"
 }
 
 resource "aws_security_group" "lambda" {

--- a/terraform/test/network.tf
+++ b/terraform/test/network.tf
@@ -13,9 +13,10 @@ module "vpc" {
   count  = local.test_enabled ? 1 : 0
   source = "../modules/vpc"
 
-  name               = "polar-test"
-  availability_zones = ["us-east-2a", "us-east-2b", "us-east-2c"]
-  eip_allocation_id  = module.egress_ip[0].allocation_id
+  name                 = "polar-test"
+  secondary_cidr_block = "10.22.0.0/16"
+  availability_zones   = ["us-east-2a", "us-east-2b", "us-east-2c"]
+  eip_allocation_id    = module.egress_ip[0].allocation_id
 }
 
 resource "aws_security_group" "lambda" {


### PR DESCRIPTION
An oversight when we applied the TF for the respective environment was that they ended up with the same IP addresses in their subnets.

To be able to support intra-account linking and things like Tailscale route forwarding in different environments we need to split these cleanly.

This adds new subnets to sandbox and test accounts, giving us a chance to start using them before deprecating the old overlapping subnets.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

