### PR TITLE
Add support for Uruguay RUT tax ID validation

### DIFF
--- a/server/polar/tax/tax_id.py
+++ b/server/polar/tax/tax_id.py
@@ -14,6 +14,7 @@ import stdnum.in_.gstin
 import stdnum.mk.edb
 import stdnum.tr.vkn
 import stdnum.tw.ubn
+import stdnum.uy.rut
 import stdnum.vn.mst
 from pydantic import Field
 from sqlalchemy.dialects.postgresql import JSONB
@@ -370,6 +371,15 @@ class TWVATValidator(ValidatorProtocol):
             raise InvalidTaxID(number, country) from e
 
 
+class UYRUCValidator(ValidatorProtocol):
+    def validate(self, number: str, country: str) -> str:
+        number = stdnum.uy.rut.compact(number)
+        try:
+            return stdnum.uy.rut.validate(number)
+        except stdnum.exceptions.ValidationError as e:
+            raise InvalidTaxID(number, country) from e
+
+
 class INGSTValidator(ValidatorProtocol):
     def validate(self, number: str, country: str) -> str:
         number = stdnum.in_.gstin.compact(number)
@@ -463,6 +473,8 @@ def _get_validator(tax_id_type: TaxIDFormat) -> ValidatorProtocol:
             return TRTINValidator()
         case TaxIDFormat.tw_vat:
             return TWVATValidator()
+        case TaxIDFormat.uy_ruc:
+            return UYRUCValidator()
         case TaxIDFormat.in_gst:
             return INGSTValidator()
         case TaxIDFormat.vn_tin:

--- a/server/tests/tax/test_tax_id.py
+++ b/server/tests/tax/test_tax_id.py
@@ -79,6 +79,10 @@ from polar.tax.tax_id import InvalidTaxID, TaxID, TaxIDFormat, validate_tax_id
         # CR TIN: cédula jurídica (business)
         ("3-101-356876", "CR", ("3101356876", TaxIDFormat.cr_tin)),
         ("3101356876", "CR", ("3101356876", TaxIDFormat.cr_tin)),
+        # UY RUT (Stripe calls it uy_ruc, stdnum module is uy.rut)
+        ("211003420017", "UY", ("211003420017", TaxIDFormat.uy_ruc)),
+        ("21-100342-001-7", "UY", ("211003420017", TaxIDFormat.uy_ruc)),
+        ("UY 21 140634 001 1", "UY", ("211406340011", TaxIDFormat.uy_ruc)),
     ],
 )
 def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> None:
@@ -115,6 +119,7 @@ def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> No
         ("62140098", "TW"),  # Wrong check digit under both rules
         ("9999999999", "CR"),  # Invalid CR TIN
         ("1-1000-0001", "CR"),  # cédula física (individual), not accepted
+        ("210303670014", "UY"),  # Wrong check digit
     ],
 )
 def test_validate_tax_id_invalid(number: str, country: str) -> None:


### PR DESCRIPTION
## Summary

Adds validation support for Uruguay's RUT (Registro Único Tributario) tax identification numbers.

## What

- Added `UYRUCValidator` class to validate Uruguay RUT numbers using the `stdnum.uy.rut` module
- Imported `stdnum.uy.rut` module
- Added `TaxIDFormat.uy_ruc` case to the `_get_validator()` function
- Added test cases for valid RUT formats (with and without formatting)
- Added test case for invalid RUT (wrong check digit)

## Why

This enables the tax ID validation system to support Uruguay's RUT tax identification format, allowing proper validation and normalization of Uruguayan tax IDs.

## How

Implemented a new validator following the existing pattern used by other country validators (e.g., `TRTINValidator`, `TWVATValidator`). The validator:
1. Compacts the input number to remove formatting characters
2. Validates using the stdnum library's built-in validation
3. Raises `InvalidTaxID` on validation failure

## Checklist

- [x] This PR addresses a single concern (one feature: UY RUT support)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (3 valid cases, 1 invalid case)
- [ ] Linting and type checking pass (assumed, standard pattern)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_01YZcei7XDcJEEoRMPPB2e8P

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

