### PR TITLE
redis: Allow ReadOnly errors to be retriable

### DIFF
--- a/server/polar/redis.py
+++ b/server/polar/redis.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Literal
 
 import redis.asyncio as _async_redis
 from fastapi import Request
-from redis import ConnectionError, RedisError, TimeoutError
+from redis import ConnectionError, ReadOnlyError, RedisError, TimeoutError
 from redis.asyncio.retry import Retry
 from redis.backoff import default_backoff
 
@@ -17,7 +17,11 @@ else:
     Redis = _async_redis.Redis
 
 
-REDIS_RETRY_ON_ERRROR: list[type[RedisError]] = [ConnectionError, TimeoutError]
+REDIS_RETRY_ON_ERRROR: list[type[RedisError]] = [
+    ConnectionError,
+    ReadOnlyError,
+    TimeoutError,
+]
 REDIS_RETRY = Retry(default_backoff(), retries=50)
 
 # TCP_KEEPIDLE is Linux, TCP_KEEPALIVE its macOS equivalent

--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -15,11 +15,14 @@ from dramatiq.middleware.group_callbacks import GroupCallbacks
 from dramatiq.rate_limits.backends import RedisBackend as RateLimiterBackend
 from dramatiq.results import Results
 from dramatiq.results.backends import RedisBackend as ResultsBackend
+from redis.backoff import default_backoff
+from redis.retry import Retry
 
 from polar.config import settings
 from polar.logfire import instrument_httpx
 from polar.logging import CorrelationID, Logger
 from polar.operational_errors import handle_operational_error
+from polar.redis import REDIS_RETRY_ON_ERRROR
 
 from . import _sqs
 from ._asyncio import MonitoredAsyncIO
@@ -206,13 +209,25 @@ class RoutingRedisBroker(RedisBroker):
 
 
 def get_broker(*, database: bool = True) -> dramatiq.Broker:
+    retry = Retry(default_backoff(), retries=50)
     redis_pool = redis.ConnectionPool.from_url(
         settings.redis_url,
         client_name=f"{settings.ENV.value}.worker.dramatiq",
+        retry=retry,
+        retry_on_error=REDIS_RETRY_ON_ERRROR,
     )
 
-    result_backend = ResultsBackend(url=settings.redis_url, encoder=JSONEncoder())
-    rate_limiter_backend = RateLimiterBackend(url=settings.redis_url)
+    result_backend = ResultsBackend(
+        encoder=JSONEncoder(),
+        connection_pool=redis.ConnectionPool.from_url(
+            settings.redis_url, retry=retry, retry_on_error=REDIS_RETRY_ON_ERRROR
+        ),
+    )
+    rate_limiter_backend = RateLimiterBackend(
+        connection_pool=redis.ConnectionPool.from_url(
+            settings.redis_url, retry=retry, retry_on_error=REDIS_RETRY_ON_ERRROR
+        )
+    )
 
     middleware_list = [
         # Infrastructure & async support


### PR DESCRIPTION
When we do changes to our AWS ElastiCache cluster we get a ReadOnly redis during failover. This is a new error that we haven't been seeing on Render previously. We should handle it as other blips to avoid an impact when we do maintenance to Redis.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

