### PR TITLE
backoffice/subscriptions: Add ability to set a past_due subscription to active

### DIFF
--- a/server/polar/backoffice/subscriptions/endpoints.py
+++ b/server/polar/backoffice/subscriptions/endpoints.py
@@ -21,6 +21,7 @@ from polar.models import (
 )
 from polar.models.subscription import SubscriptionStatus
 from polar.order.repository import OrderRepository
+from polar.order.service import order as order_service
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from polar.subscription import sorting
 from polar.subscription.repository import SubscriptionRepository
@@ -40,9 +41,13 @@ from ..layout import layout
 from ..orders.components import orders_datatable
 from ..responses import HXRedirectResponse
 from ..toast import add_toast
-from .forms import CancelForm, UpdateBillingPeriodEndForm
+from .forms import CancelForm, UpdateBillingPeriodEndForm, build_update_status_form
 
 router = APIRouter()
+
+STATUS_TRANSITIONS: dict[SubscriptionStatus, set[SubscriptionStatus]] = {
+    SubscriptionStatus.past_due: {SubscriptionStatus.active},
+}
 
 
 # Description List Items
@@ -304,6 +309,16 @@ async def get(
                             hx_target="#modal",
                         ):
                             text("Update Billing Period End")
+                    if subscription.status in STATUS_TRANSITIONS:
+                        with button(
+                            hx_get=str(
+                                request.url_for(
+                                    "subscriptions:update_status", id=subscription.id
+                                )
+                            ),
+                            hx_target="#modal",
+                        ):
+                            text("Update Status")
 
             with tag.div(classes="grid grid-cols-1 lg:grid-cols-2 gap-4"):
                 # Subscription Details
@@ -658,3 +673,81 @@ async def update_billing_period_end(
                         text("Cancel")
                 with button(type="submit", variant="primary"):
                     text("Submit")
+
+
+@router.api_route(
+    "/{id}/update_status", name="subscriptions:update_status", methods=["GET", "POST"]
+)
+async def update_status(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    subscription_repository = SubscriptionRepository.from_session(session)
+    subscription = await subscription_repository.get_by_id(
+        id, options=subscription_repository.get_eager_options()
+    )
+
+    if subscription is None:
+        raise HTTPException(status_code=404)
+
+    targets = STATUS_TRANSITIONS.get(subscription.status, set())
+    if not targets:
+        await add_toast(
+            request, "This subscription's status cannot be updated.", "error"
+        )
+        return
+
+    update_status_form = build_update_status_form(
+        sorted(targets), subscription.status == SubscriptionStatus.past_due
+    )
+
+    validation_error: ValidationError | None = None
+
+    if request.method == "POST":
+        data = await request.form()
+        try:
+            form = update_status_form.model_validate_form(data)
+            if form.status not in targets:
+                await add_toast(
+                    request,
+                    f"Cannot update this subscription to {form.status.value}.",
+                    "error",
+                )
+                return
+            if (subscription.status, form.status) == (
+                SubscriptionStatus.past_due,
+                SubscriptionStatus.active,
+            ):
+                await subscription_service.mark_active(session, subscription)
+                if form.void_pending_orders:
+                    await order_service.void_pending_orders_for_subscription(
+                        session, subscription
+                    )
+            await add_toast(request, "Subscription status updated.", "success")
+            return HXRedirectResponse(
+                request, str(request.url_for("subscriptions:get", id=id)), 303
+            )
+        except ValidationError as e:
+            validation_error = e
+
+    with modal("Update subscription status", open=True):
+        with tag.div(classes="flex flex-col gap-4"):
+            with alert("warning", soft=True):
+                with tag.p():
+                    text(
+                        "This triggers the full lifecycle side effects: "
+                        "webhooks, customer emails and benefit grants or revokes."
+                    )
+            with update_status_form.render(
+                hx_post=str(request.url_for("subscriptions:update_status", id=id)),
+                hx_target="#modal",
+                classes="flex flex-col",
+                validation_error=validation_error,
+            ):
+                with tag.div(classes="modal-action"):
+                    with tag.form(method="dialog"):
+                        with button(ghost=True):
+                            text("Cancel")
+                    with button(type="submit", variant="primary"):
+                        text("Submit")

--- a/server/polar/backoffice/subscriptions/forms.py
+++ b/server/polar/backoffice/subscriptions/forms.py
@@ -1,10 +1,11 @@
+from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import Annotated
+from typing import Annotated, Any
 
-from pydantic import Field, field_validator
+from pydantic import Field, create_model, field_validator
 
 from polar.kit.schemas import EmptyStrToNone
-from polar.models.subscription import CustomerCancellationReason
+from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
 
 from .. import forms
 
@@ -17,6 +18,44 @@ class CancelForm(forms.BaseForm):
         EmptyStrToNone, Field(default=None, title="Customer cancellation comment")
     ]
     revoke: Annotated[bool, Field(default=False, title="Cancel immediately")]
+
+
+class UpdateStatusForm(forms.BaseForm):
+    status: Annotated[SubscriptionStatus, Field(title="New status")]
+    void_pending_orders: Annotated[
+        bool,
+        Field(
+            default=False,
+            title="Void pending orders",
+            description=(
+                "Stops dunning retries so the subscription "
+                "doesn't fall back to past due."
+            ),
+        ),
+    ]
+
+
+def build_update_status_form(
+    targets: Sequence[SubscriptionStatus], include_void_pending_orders: bool
+) -> type[UpdateStatusForm]:
+    fields: dict[str, Any] = {
+        "status": (
+            Annotated[
+                SubscriptionStatus,
+                forms.SelectField(
+                    [
+                        (target.value, target.value.replace("_", " ").title())
+                        for target in targets
+                    ]
+                ),
+                Field(title="New status"),
+            ],
+            ...,
+        )
+    }
+    if not include_void_pending_orders:
+        fields["void_pending_orders"] = (Annotated[bool, forms.SkipField()], False)
+    return create_model("UpdateStatusForm", __base__=UpdateStatusForm, **fields)
 
 
 class UpdateBillingPeriodEndForm(forms.BaseForm):

--- a/server/tests/backoffice/subscriptions/test_endpoints.py
+++ b/server/tests/backoffice/subscriptions/test_endpoints.py
@@ -1,0 +1,197 @@
+import uuid
+from collections.abc import AsyncGenerator
+
+import httpx
+import pytest
+import pytest_asyncio
+from pytest_mock import MockerFixture
+
+from polar.backoffice import app as backoffice_app
+from polar.backoffice.dependencies import get_admin
+from polar.kit.utils import utc_now
+from polar.models import Customer, Product, User
+from polar.models.order import OrderStatus
+from polar.models.subscription import SubscriptionStatus
+from polar.models.user_session import UserSession
+from polar.postgres import AsyncSession, get_db_read_session, get_db_session
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_active_subscription,
+    create_order,
+    create_subscription,
+)
+
+
+@pytest_asyncio.fixture
+async def backoffice_client(
+    session: AsyncSession, user: User
+) -> AsyncGenerator[httpx.AsyncClient, None]:
+    user_session = UserSession(token="0" * 64, user_agent="tests", user=user)
+    backoffice_app.dependency_overrides[get_db_session] = lambda: session
+    backoffice_app.dependency_overrides[get_db_read_session] = lambda: session
+    backoffice_app.dependency_overrides[get_admin] = lambda: user_session
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=backoffice_app),
+            base_url="http://test",
+        ) as client:
+            yield client
+    finally:
+        backoffice_app.dependency_overrides.pop(get_db_session, None)
+        backoffice_app.dependency_overrides.pop(get_db_read_session, None)
+        backoffice_app.dependency_overrides.pop(get_admin, None)
+
+
+@pytest.mark.asyncio
+class TestUpdateStatus:
+    async def test_returns_404_for_unknown_subscription(
+        self, backoffice_client: httpx.AsyncClient
+    ) -> None:
+        response = await backoffice_client.get(
+            f"/subscriptions/{uuid.uuid4()}/update_status"
+        )
+
+        assert response.status_code == 404
+
+    async def test_get_renders_modal_for_past_due_subscription(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+            started_at=utc_now(),
+            past_due_at=utc_now(),
+        )
+
+        response = await backoffice_client.get(
+            f"/subscriptions/{subscription.id}/update_status"
+        )
+
+        assert response.status_code == 200
+        assert "Update subscription status" in response.text
+        assert 'value="active"' in response.text
+        assert "Void pending orders" in response.text
+
+    async def test_no_valid_targets(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        response = await backoffice_client.get(
+            f"/subscriptions/{subscription.id}/update_status"
+        )
+
+        assert response.status_code == 200
+        assert "cannot be updated" in response.text
+        assert "Update subscription status" not in response.text
+
+    async def test_post_past_due_to_active(
+        self,
+        mocker: MockerFixture,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.subscription.service.enqueue_job")
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+            started_at=utc_now(),
+            past_due_at=utc_now(),
+        )
+
+        response = await backoffice_client.post(
+            f"/subscriptions/{subscription.id}/update_status",
+            data={"status": "active"},
+        )
+
+        assert response.status_code == 303
+        await session.refresh(subscription)
+        assert subscription.status == SubscriptionStatus.active
+        assert subscription.past_due_at is None
+        enqueue_job_mock.assert_any_call(
+            "customer.state_changed", subscription.customer_id
+        )
+
+    async def test_post_past_due_to_active_voids_pending_orders(
+        self,
+        mocker: MockerFixture,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        mocker.patch("polar.subscription.service.enqueue_job")
+        mocker.patch("polar.order.service.enqueue_job")
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+            started_at=utc_now(),
+            past_due_at=utc_now(),
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+            subscription=subscription,
+            status=OrderStatus.pending,
+            next_payment_attempt_at=utc_now(),
+        )
+
+        response = await backoffice_client.post(
+            f"/subscriptions/{subscription.id}/update_status",
+            data={"status": "active", "void_pending_orders": "on"},
+        )
+
+        assert response.status_code == 303
+        await session.refresh(subscription)
+        assert subscription.status == SubscriptionStatus.active
+        await session.refresh(order)
+        assert order.status == OrderStatus.void
+        assert order.next_payment_attempt_at is None
+
+    async def test_post_invalid_target(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+            started_at=utc_now(),
+            past_due_at=utc_now(),
+        )
+
+        response = await backoffice_client.post(
+            f"/subscriptions/{subscription.id}/update_status",
+            data={"status": "canceled"},
+        )
+
+        assert response.status_code == 200
+        assert "Cannot update this subscription to canceled." in response.text
+        await session.refresh(subscription)
+        assert subscription.status == SubscriptionStatus.past_due


### PR DESCRIPTION
Adds a somewhat generic status transition on subscriptions in the backoffice, but only allow past_due to active for now

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

