### PR TITLE
Add metadata update support to subscription PATCH endpoint

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -34838,6 +34838,23 @@ export interface components {
     /** SubscriptionUpdateBase */
     SubscriptionUpdateBase: {
       /**
+       * Metadata
+       * @description Key-value object allowing you to store additional information.
+       *
+       *     The key must be a string with a maximum length of **40 characters**.
+       *     The value must be either:
+       *
+       *     * A string with a maximum length of **500 characters**
+       *     * An integer
+       *     * A floating-point number
+       *     * A boolean
+       *
+       *     You can store up to **50 key-value pairs**.
+       */
+      metadata?: {
+        [key: string]: string | number | boolean
+      }
+      /**
        * Product Id
        * @description Update subscription to another product.
        * @example d8dd2de1-21b7-4a41-8bc3-ce909c0cfe23

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -308,7 +308,7 @@ class SubscriptionCreateExternalCustomer(SubscriptionCreateBase):
 SubscriptionCreate = SubscriptionCreateCustomer | SubscriptionCreateExternalCustomer
 
 
-class SubscriptionUpdateBase(Schema):
+class SubscriptionUpdateBase(MetadataInputMixin, Schema):
     model_config = ConfigDict(extra="forbid")
 
     product_id: UUID4 | None = Field(
@@ -346,6 +346,10 @@ class SubscriptionUpdateBase(Schema):
     @property
     def has_trial_end(self) -> bool:
         return self.trial_end is not None
+
+    @property
+    def has_metadata(self) -> bool:
+        return "metadata" in self.model_fields_set
 
     @property
     def discount(self) -> UUID4 | Literal["unset"] | None:

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1236,6 +1236,11 @@ class SubscriptionService:
                     session, ctx, subscription, trial_end=update.trial_end
                 )
 
+            if update.has_metadata:
+                subscription = await self.update_metadata(
+                    session, ctx, subscription, metadata=update.metadata
+                )
+
         if isinstance(update, SubscriptionUpdateSeats):
             subscription = await self.update_seats(
                 session,
@@ -1807,6 +1812,19 @@ class SubscriptionService:
         )
 
         return subscription
+
+    async def update_metadata(
+        self,
+        session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
+        subscription: Subscription,
+        *,
+        metadata: dict[str, Any],
+    ) -> Subscription:
+        repository = SubscriptionRepository.from_session(session)
+        return await repository.update(
+            subscription, update_dict={"user_metadata": metadata}, flush=True
+        )
 
     async def update_seats(
         self,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1237,9 +1237,7 @@ class SubscriptionService:
                 )
 
             if update.has_metadata:
-                subscription = await self.update_metadata(
-                    session, ctx, subscription, metadata=update.metadata
-                )
+                subscription.user_metadata = update.metadata
 
         if isinstance(update, SubscriptionUpdateSeats):
             subscription = await self.update_seats(
@@ -1812,19 +1810,6 @@ class SubscriptionService:
         )
 
         return subscription
-
-    async def update_metadata(
-        self,
-        session: AsyncSession,
-        ctx: SubscriptionUpdateContext,
-        subscription: Subscription,
-        *,
-        metadata: dict[str, Any],
-    ) -> Subscription:
-        repository = SubscriptionRepository.from_session(session)
-        return await repository.update(
-            subscription, update_dict={"user_metadata": metadata}, flush=True
-        )
 
     async def update_seats(
         self,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1237,7 +1237,9 @@ class SubscriptionService:
                 )
 
             if update.has_metadata:
-                subscription.user_metadata = update.metadata
+                subscription = await self.update_metadata(
+                    session, ctx, subscription, metadata=update.metadata
+                )
 
         if isinstance(update, SubscriptionUpdateSeats):
             subscription = await self.update_seats(
@@ -1810,6 +1812,19 @@ class SubscriptionService:
         )
 
         return subscription
+
+    async def update_metadata(
+        self,
+        session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
+        subscription: Subscription,
+        *,
+        metadata: dict[str, Any],
+    ) -> Subscription:
+        repository = SubscriptionRepository.from_session(session)
+        return await repository.update(
+            subscription, update_dict={"user_metadata": metadata}
+        )
 
     async def update_seats(
         self,

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -550,6 +550,59 @@ class TestSubscriptionProductUpdate:
 
 
 @pytest.mark.asyncio
+class TestSubscriptionUpdateMetadata:
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            user_metadata={"reference_id": "ABC", "keep": "no"},
+        )
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"metadata": {"reference_id": "DEF"}},
+        )
+        assert response.status_code == 200
+        updated_subscription = response.json()
+        # Setting metadata replaces the whole object, it doesn't merge with the existing one
+        assert updated_subscription["metadata"] == {"reference_id": "DEF"}
+
+    @pytest.mark.auth
+    async def test_not_provided_leaves_metadata_untouched(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user_organization: UserOrganization,
+        product: Product,
+        product_second: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            user_metadata={"reference_id": "ABC"},
+        )
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"product_id": str(product_second.id)},
+        )
+        assert response.status_code == 200
+        updated_subscription = response.json()
+        assert updated_subscription["metadata"] == {"reference_id": "ABC"}
+
+
+@pytest.mark.asyncio
 class TestSubscriptionUpdateMixedFields:
     @pytest.mark.auth
     async def test_mixed_seats_and_discount_returns_422(


### PR DESCRIPTION
## Summary

Adds support for updating subscription metadata through the PATCH `/v1/subscriptions/{id}` endpoint.

## What

- Added `MetadataInputMixin` to `SubscriptionUpdateBase` schema to enable metadata field in update requests
- Implemented `update_metadata()` method in `SubscriptionService` to handle metadata updates
- Added logic to call `update_metadata()` when metadata is provided in the update request
- Added `has_metadata` property to detect when metadata is explicitly set in the request
- Added comprehensive tests covering metadata replacement and preservation when not provided

## Why

Users need the ability to update subscription metadata (e.g., custom reference IDs) without modifying other subscription properties. This is a common use case for integrations that need to track external identifiers.

## How

The implementation follows the existing pattern used for other subscription update operations:
1. Extended the schema with metadata support via `MetadataInputMixin`
2. Added a dedicated `update_metadata()` method in the service layer
3. Integrated the metadata update into the main `update()` flow with a conditional check
4. Metadata replacement is complete (not merged) with existing metadata, consistent with API design

The tests verify:
- Metadata is correctly replaced when provided
- Metadata is preserved when not included in the update request
- HTTP 200 response is returned on success

## Checklist

- [x] This PR addresses a single concern (metadata update feature)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (`TestSubscriptionUpdateMetadata`)
- [x] No unrelated changes included

https://claude.ai/code/session_01BfbGArfSwn7Dfh3KmPVYPX

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

