### PR TITLE
login: Fix 401 on login in preview env

### DIFF
--- a/clients/apps/web/src/app/(main)/auth/backup-codes/VerifyPage.tsx
+++ b/clients/apps/web/src/app/(main)/auth/backup-codes/VerifyPage.tsx
@@ -13,7 +13,6 @@ import {
   FormItem,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
@@ -21,7 +20,6 @@ const VerifyPage = () => {
   const form = useForm<{ code: string }>()
   const { control, handleSubmit, setError } = form
   const backupCodesVerify = useBackupCodesVerify()
-  const router = useRouter()
 
   const [loading, setLoading] = useState(false)
   const onSubmit: SubmitHandler<{ code: string }> = async ({ code }) => {
@@ -36,7 +34,7 @@ const VerifyPage = () => {
         }
         return
       }
-      router.push('/auth')
+      window.location.href = `${CONFIG.FRONTEND_BASE_URL}/auth`
     } catch {
       setError('code', {
         message: 'An unexpected error occurred. Please try again.',

--- a/clients/apps/web/src/app/(main)/auth/email-otp/VerifyPage.tsx
+++ b/clients/apps/web/src/app/(main)/auth/email-otp/VerifyPage.tsx
@@ -17,7 +17,6 @@ import {
   FormItem,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import { useRouter } from 'next/navigation'
 import { useRef, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
@@ -25,7 +24,6 @@ const VerifyPage = ({ intent = 'login' }: { intent?: 'login' | 'signup' }) => {
   const form = useForm<{ code: string }>()
   const { control, handleSubmit, setError } = form
   const emailOTPVerify = useEmailOTPVerify()
-  const router = useRouter()
 
   const [loading, setLoading] = useState(false)
   const submittingRef = useRef(false)
@@ -43,7 +41,7 @@ const VerifyPage = ({ intent = 'login' }: { intent?: 'login' | 'signup' }) => {
         }
         return
       }
-      router.push('/auth')
+      window.location.href = `${CONFIG.FRONTEND_BASE_URL}/auth`
     } catch {
       setError('code', {
         message: 'An unexpected error occurred. Please try again.',

--- a/clients/apps/web/src/app/(main)/auth/totp/VerifyPage.tsx
+++ b/clients/apps/web/src/app/(main)/auth/totp/VerifyPage.tsx
@@ -18,7 +18,6 @@ import {
   FormItem,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import { useRouter } from 'next/navigation'
 import { useRef, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
@@ -26,7 +25,6 @@ const VerifyPage = () => {
   const form = useForm<{ code: string }>()
   const { control, handleSubmit, setError } = form
   const totpVerify = useTOTPVerify()
-  const router = useRouter()
 
   const [loading, setLoading] = useState(false)
   const submittingRef = useRef(false)
@@ -44,7 +42,7 @@ const VerifyPage = () => {
         }
         return
       }
-      router.push('/auth')
+      window.location.href = `${CONFIG.FRONTEND_BASE_URL}/auth`
     } catch {
       setError('code', {
         message: 'An unexpected error occurred. Please try again.',

--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -20,18 +20,20 @@ from reauth.factors.totp import (
     NotEnrolledTOTPException,
 )
 
+from polar.auth.dependencies import WebUserOrAnonymous
 from polar.auth.exceptions import (
     PolarAuthError,
     PolarAuthRedirectionError,
     SessionNotFreshError,
     UnavailableFactorError,
 )
+from polar.auth.models import is_user
 from polar.auth.oauth2.github import get_github_factor
 from polar.auth.oauth2.google import get_google_factor
 from polar.authz.dependencies import AuthorizeWebUserRead, AuthorizeWebUserWriteFresh
 from polar.config import settings
 from polar.exceptions import NotPermitted, ResourceNotFound
-from polar.kit.http import get_ip_address
+from polar.kit.http import get_ip_address, get_safe_return_url
 from polar.models import UserSession as UserSession
 from polar.openapi import APITag
 from polar.postgres import AsyncSession, get_db_session
@@ -45,6 +47,7 @@ from .authentication_session import (
     InvalidAuthenticationSession,
     get_authentication_session,
     get_authentication_session_service,
+    get_optional_authentication_session,
 )
 from .factors import (
     BackupCodesFactor,
@@ -135,12 +138,20 @@ async def status(
 @router.get("/complete", include_in_schema=False)
 async def complete(
     request: Request,
-    authentication_session: AuthenticationSession = Depends(get_authentication_session),
+    auth_subject: WebUserOrAnonymous,
+    authentication_session: AuthenticationSession | None = Depends(
+        get_optional_authentication_session
+    ),
     authentication_session_service: AuthenticationSessionService = Depends(
         get_authentication_session_service
     ),
     session: AsyncSession = Depends(get_db_session),
 ) -> RedirectResponse:
+    if authentication_session is None:
+        if is_user(auth_subject):
+            return RedirectResponse(get_safe_return_url(None), 303)
+        raise InvalidAuthenticationSession()
+
     try:
         identity_id, _ = await authentication_session_service.complete(
             authentication_session

--- a/server/tests/auth/test_endpoints.py
+++ b/server/tests/auth/test_endpoints.py
@@ -1,9 +1,99 @@
-import pytest
-from httpx import AsyncClient
+from collections.abc import AsyncIterator
 
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import AsyncClient
+from reauth.amr import AuthenticationMethodReference
+from reauth.crypto import generate_token_hash_pair
+
+from polar.auth.authentication_session import TOKEN_PREFIX
 from polar.auth.models import AuthSubject
-from polar.models import User
+from polar.config import settings
+from polar.kit.utils import utc_now
+from polar.models import AuthenticationSession, User
+from polar.postgres import AsyncSession
 from tests.fixtures.auth import make_session_stale
+from tests.fixtures.base import IsolatedSessionTestClient
+from tests.fixtures.database import SaveFixture
+
+
+@pytest_asyncio.fixture
+async def cookie_client(
+    app: FastAPI, session: AsyncSession
+) -> AsyncIterator[httpx.AsyncClient]:
+    # https://test matches the Secure session cookies' domain
+    async with IsolatedSessionTestClient(
+        session=session,
+        auto_expunge=False,
+        transport=httpx.ASGITransport(app=app),
+        base_url="https://test",
+    ) as client:
+        yield client
+
+
+async def create_completable_authentication_session(
+    save_fixture: SaveFixture, user: User
+) -> str:
+    token, token_hash = generate_token_hash_pair(
+        secret=settings.SECRET, prefix=TOKEN_PREFIX
+    )
+    authentication_session = AuthenticationSession(
+        token_hash=token_hash,
+        expires_at=int(utc_now().timestamp()) + 900,
+        step=1,
+        authentication_method_references=[AuthenticationMethodReference.EMAIL],
+        used_factors=["email_otp"],
+        context=None,
+        identity_id=user.id,
+    )
+    await save_fixture(authentication_session)
+    return token
+
+
+@pytest.mark.asyncio
+class TestComplete:
+    async def test_anonymous(self, cookie_client: httpx.AsyncClient) -> None:
+        response = await cookie_client.get("/v1/auth/complete")
+
+        assert response.status_code == 401
+        assert response.json()["error"] == "InvalidAuthenticationSession"
+
+    async def test_valid(
+        self,
+        cookie_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        user: User,
+    ) -> None:
+        token = await create_completable_authentication_session(save_fixture, user)
+        cookie_client.cookies.set(settings.AUTHENTICATION_SESSION_COOKIE_KEY, token)
+
+        response = await cookie_client.get("/v1/auth/complete")
+
+        assert response.status_code == 303
+        assert settings.USER_SESSION_COOKIE_KEY in response.cookies
+
+    @pytest.mark.auth
+    async def test_replay_with_user_session(
+        self,
+        cookie_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        user: User,
+    ) -> None:
+        token = await create_completable_authentication_session(save_fixture, user)
+        cookie_client.cookies.set(settings.AUTHENTICATION_SESSION_COOKIE_KEY, token)
+
+        first = await cookie_client.get("/v1/auth/complete")
+        assert first.status_code == 303
+
+        cookie_client.cookies.clear()
+        replay = await cookie_client.get("/v1/auth/complete")
+
+        assert replay.status_code == 303
+        assert replay.headers["location"] == settings.generate_frontend_url(
+            settings.FRONTEND_DEFAULT_RETURN_PATH
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Allow login with successful token
- Prevent accidental double requests with same origin

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

