### PR TITLE
seed: Speed up event insertion in seed

### DIFF
--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -88,7 +88,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         return float(value) if value is not None else None
 
     async def insert_batch(
-        self, events: Sequence[dict[str, Any]]
+        self, events: Sequence[dict[str, Any]], *, render_nulls: bool = False
     ) -> tuple[Sequence[UUID], int]:
         if not events:
             return [], 0
@@ -104,6 +104,8 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             .on_conflict_do_nothing(index_elements=["organization_id", "external_id"])
             .returning(Event.id)
         )
+        if render_nulls:
+            statement = statement.execution_options(render_nulls=True)
         result = await self.session.execute(statement, events)
         inserted_ids = [row[0] for row in result.all()]
 

--- a/server/polar/event_type/repository.py
+++ b/server/polar/event_type/repository.py
@@ -2,6 +2,7 @@ from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import Select, select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 
 from polar.authz.types import AccessibleOrganizationID
@@ -31,7 +32,11 @@ class EventTypeRepository(
         return result.scalar_one_or_none()
 
     async def get_by_names_and_organization(
-        self, names: list[str], organization_id: UUID | Sequence[UUID]
+        self,
+        names: list[str],
+        organization_id: UUID | Sequence[UUID],
+        *,
+        include_deleted: bool = False,
     ) -> dict[tuple[UUID, str], EventType]:
         if not names:
             return {}
@@ -40,11 +45,9 @@ class EventTypeRepository(
             if isinstance(organization_id, Sequence)
             else EventType.organization_id == organization_id
         )
-        statement = select(EventType).where(
-            EventType.name.in_(names),
-            org_filter,
-            ~EventType.is_deleted,
-        )
+        statement = select(EventType).where(EventType.name.in_(names), org_filter)
+        if not include_deleted:
+            statement = statement.where(~EventType.is_deleted)
         result = await self.session.execute(statement)
         return {(et.organization_id, et.name): et for et in result.scalars().all()}
 
@@ -65,3 +68,37 @@ class EventTypeRepository(
                 return existing
             raise
         return event_type
+
+    async def ensure_by_names(
+        self, names: Sequence[str], organization_id: UUID
+    ) -> dict[str, EventType]:
+        unique_names = sorted(set(names))
+        existing = await self.get_by_names_and_organization(
+            unique_names, organization_id, include_deleted=True
+        )
+        for event_type in existing.values():
+            if event_type.is_deleted:
+                event_type.deleted_at = None
+        missing_names = [
+            name for name in unique_names if (organization_id, name) not in existing
+        ]
+        if missing_names:
+            statement = insert(EventType).values(
+                [
+                    {
+                        "name": name,
+                        "label": name,
+                        "organization_id": organization_id,
+                    }
+                    for name in missing_names
+                ]
+            )
+            statement = statement.on_conflict_do_update(
+                constraint="event_types_name_organization_id_key",
+                set_={"deleted_at": None},
+            )
+            await self.session.execute(statement)
+            existing = await self.get_by_names_and_organization(
+                unique_names, organization_id
+            )
+        return {name: existing[(organization_id, name)] for name in unique_names}

--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -4,11 +4,13 @@ from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
+from time import monotonic
 from typing import Any, Literal, NotRequired, TypedDict
 from uuid import UUID
 
 import dramatiq
 import typer
+from sqlalchemy import event as sqlalchemy_event
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload, selectinload
 
@@ -287,17 +289,37 @@ async def _stamp_event_type_ids(
 ) -> None:
     """Stamp event_type_id on each event dict, mirroring the real ingest path."""
     event_type_repository = EventTypeRepository.from_session(session)
-    cache: dict[tuple[str, Any], Any] = {}
+    names_by_organization: dict[UUID, set[str]] = {}
     for event in events:
         name = event.get("name")
-        org_id = event.get("organization_id")
-        if not name or not org_id:
+        organization_id = event.get("organization_id")
+        if not name or not organization_id:
             continue
-        key = (name, org_id)
-        if key not in cache:
-            event_type = await event_type_repository.get_or_create(name, org_id)
-            cache[key] = event_type.id
-        event["event_type_id"] = cache[key]
+        names_by_organization.setdefault(organization_id, set()).add(name)
+
+    event_type_ids: dict[tuple[UUID, str], UUID] = {}
+    for organization_id, names in names_by_organization.items():
+        ensured = await event_type_repository.ensure_by_names(
+            sorted(names), organization_id
+        )
+        event_type_ids.update(
+            {
+                (organization_id, name): event_type.id
+                for name, event_type in ensured.items()
+            }
+        )
+
+    for event in events:
+        name = event.get("name")
+        event_organization_id = event.get("organization_id")
+        if name and event_organization_id:
+            event["event_type_id"] = event_type_ids[(event_organization_id, name)]
+
+
+def _normalize_seed_event_batch(events: list[dict[str, Any]]) -> None:
+    for event in events:
+        event.setdefault("external_id", None)
+        event.setdefault("parent_id", None)
 
 
 def _build_customer_timeline_events(
@@ -1245,6 +1267,9 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
     if existing:
         raise typer.Exit(2)
 
+    seed_started_at = monotonic()
+    print("seed.load status=pending")
+
     # Organizations data
     orgs_data: list[OrganizationDict] = [
         {
@@ -1714,6 +1739,7 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
 
     # Create organizations with users and sample data
     for org_data in orgs_data:
+        organization_started_at = monotonic()
         # Get or create user (allows multiple orgs to share the same user)
         user, _created = await user_service.get_by_email_or_create(
             session=session,
@@ -2030,8 +2056,7 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
         # Accumulate events across all customers in this org, then flush to
         # Tinybird in a single batched call at the end. The per-customer
         # synchronous ingest (with wait=true) used to dominate seed runtime.
-        pending_tinybird_events: list[EventModel] = []
-        pending_tinybird_ancestors: dict[UUID, list[str]] = {}
+        pending_events: list[dict[str, Any]] = []
 
         num_customers = (
             random.randint(3, 8) if not org_data.get("seat_based_customers") else 0
@@ -2058,8 +2083,6 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
                 customer_name=f"Customer {i + 1}",
                 products=org_products,
             )
-
-            event_repository = EventRepository.from_session(session)
 
             # Create meter events for ColdMail customers
             if org_data["slug"] == "coldmail" and coldmail_meter and i == 0:
@@ -2102,24 +2125,25 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
             )
             timeline_events.extend(cost_spans)
 
-            # Insert events in batch; defer Tinybird ingest until all of the
-            # org's customers are processed so we can send one batched call.
-            if timeline_events:
-                await _stamp_event_type_ids(session, timeline_events)
-                event_ids, _ = await event_repository.insert_batch(timeline_events)
-                if event_ids:
-                    inserted = await event_repository.get_all(
-                        select(EventModel).where(EventModel.id.in_(event_ids))
-                    )
-                    ancestors_by_event = await event_repository.get_ancestors_batch(
-                        event_ids
-                    )
-                    pending_tinybird_events.extend(inserted)
-                    pending_tinybird_ancestors.update(ancestors_by_event)
+            pending_events.extend(timeline_events)
 
-        await _flush_tinybird_events(
-            pending_tinybird_events, pending_tinybird_ancestors
-        )
+        inserted_event_count = 0
+        if pending_events:
+            event_repository = EventRepository.from_session(session)
+            _normalize_seed_event_batch(pending_events)
+            await _stamp_event_type_ids(session, pending_events)
+            event_ids, _ = await event_repository.insert_batch(
+                pending_events, render_nulls=True
+            )
+            inserted_event_count = len(event_ids)
+            if event_ids:
+                inserted = await event_repository.get_all(
+                    select(EventModel).where(EventModel.id.in_(event_ids))
+                )
+                ancestors_by_event = await event_repository.get_ancestors_batch(
+                    event_ids
+                )
+                await _flush_tinybird_events(inserted, ancestors_by_event)
 
         # Create real Subscription rows for acme-corp customers so that PG-based
         # metrics (MRR, Trial MRR, Active Subscriptions) have data to display.
@@ -2482,6 +2506,12 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
             user,
             update_dict={"is_admin": user.is_admin or org_data.get("is_admin", False)},
         )
+        print(
+            "seed.organization status=processed "
+            f"slug={organization.slug} events={inserted_event_count} "
+            f"event_insert_batches={int(bool(pending_events))} "
+            f"elapsed_seconds={monotonic() - organization_started_at:.2f}"
+        )
 
     subscribed = await _subscribe_seeded_orgs_to_polar_self(session)
     if subscribed:
@@ -2490,8 +2520,15 @@ async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
     await create_support_cases_seed(session)
 
     await session.commit()
+    print(
+        "seed.load status=success "
+        f"organizations={len(orgs_data)} "
+        f"elapsed_seconds={monotonic() - seed_started_at:.2f}"
+    )
     print("✅ Sample data created successfully!")
-    print("Created 3 organizations with users, products, benefits, and customers")
+    print(
+        f"Created {len(orgs_data)} organizations with users, products, benefits, and customers"
+    )
 
 
 POLAR_ORG_SLUG = "polar"
@@ -2669,8 +2706,7 @@ async def create_single_org_seed(
     # Create customers with timeline events. Accumulate events across
     # customers and flush to Tinybird once at the end to avoid per-customer
     # synchronous HTTP round-trips (wait=true is ~4s each).
-    pending_tinybird_events: list[EventModel] = []
-    pending_tinybird_ancestors: dict[UUID, list[str]] = {}
+    pending_events: list[dict[str, Any]] = []
 
     num_customers = random.randint(5, 10)
     for i in range(num_customers):
@@ -2693,26 +2729,29 @@ async def create_single_org_seed(
             products=org_products,
         )
 
-        if timeline_events:
-            event_repository = EventRepository.from_session(session)
-            await _stamp_event_type_ids(session, timeline_events)
-            event_ids, _ = await event_repository.insert_batch(timeline_events)
-            if event_ids:
-                inserted = await event_repository.get_all(
-                    select(EventModel).where(EventModel.id.in_(event_ids))
-                )
-                ancestors_by_event = await event_repository.get_ancestors_batch(
-                    event_ids
-                )
-                pending_tinybird_events.extend(inserted)
-                pending_tinybird_ancestors.update(ancestors_by_event)
+        pending_events.extend(timeline_events)
 
-    await _flush_tinybird_events(pending_tinybird_events, pending_tinybird_ancestors)
+    inserted_event_count = 0
+    if pending_events:
+        event_repository = EventRepository.from_session(session)
+        _normalize_seed_event_batch(pending_events)
+        await _stamp_event_type_ids(session, pending_events)
+        event_ids, _ = await event_repository.insert_batch(
+            pending_events, render_nulls=True
+        )
+        inserted_event_count = len(event_ids)
+        if event_ids:
+            inserted = await event_repository.get_all(
+                select(EventModel).where(EventModel.id.in_(event_ids))
+            )
+            ancestors_by_event = await event_repository.get_ancestors_batch(event_ids)
+            await _flush_tinybird_events(inserted, ancestors_by_event)
 
     await session.commit()
     print(f"✅ Created organization '{name}' ({slug})")
     print(
-        f"   {len(org_products)} products, {num_customers} customers with timeline events"
+        f"   {len(org_products)} products, {num_customers} customers, "
+        f"{inserted_event_count} timeline events"
     )
 
 
@@ -2734,11 +2773,26 @@ def seeds_load(
         async with JobQueueManager.open(dramatiq.get_broker(), redis):
             engine = create_async_engine("script")
             sessionmaker = create_async_sessionmaker(engine)
-            async with sessionmaker() as session:
-                if new_org:
-                    await create_single_org_seed(session, redis, new_org)
-                else:
-                    await create_seed_data(session, redis)
+            sql_executions = 0
+
+            def count_sql_executions(*args: Any) -> None:
+                nonlocal sql_executions
+                sql_executions += 1
+
+            sqlalchemy_event.listen(
+                engine.sync_engine, "before_cursor_execute", count_sql_executions
+            )
+            try:
+                async with sessionmaker() as session:
+                    if new_org:
+                        await create_single_org_seed(session, redis, new_org)
+                    else:
+                        await create_seed_data(session, redis)
+            finally:
+                sqlalchemy_event.remove(
+                    engine.sync_engine, "before_cursor_execute", count_sql_executions
+                )
+                print(f"seed.sql executions={sql_executions}")
 
     asyncio.run(run())
 

--- a/server/tests/event/test_resolve_pending_parents.py
+++ b/server/tests/event/test_resolve_pending_parents.py
@@ -4,6 +4,7 @@ from typing import Any
 from uuid import UUID
 
 import pytest
+from sqlalchemy import event as sqlalchemy_event
 from sqlalchemy import select
 
 from polar.event.repository import EventRepository
@@ -49,6 +50,55 @@ async def _resolve(
 
 @pytest.mark.asyncio
 class TestResolvePendingParents:
+    async def test_render_nulls_uses_single_insert(
+        self, save_fixture: SaveFixture, session: AsyncSession, account: Account
+    ) -> None:
+        organization = await create_organization(save_fixture, account)
+        repository = EventRepository.from_session(session)
+        parent_id = uuid.uuid4()
+        events = [
+            {
+                "id": parent_id,
+                "name": "root",
+                "source": EventSource.user,
+                "organization_id": organization.id,
+                "external_id": "root",
+                "parent_id": None,
+            },
+            {
+                "name": "child",
+                "source": EventSource.user,
+                "organization_id": organization.id,
+                "external_id": None,
+                "parent_id": parent_id,
+            },
+            {
+                "name": "standalone",
+                "source": EventSource.system,
+                "organization_id": organization.id,
+                "external_id": None,
+                "parent_id": None,
+            },
+        ]
+        insert_count = 0
+
+        def count_event_inserts(*args: Any) -> None:
+            nonlocal insert_count
+            statement = args[2]
+            if statement.startswith("INSERT INTO events"):
+                insert_count += 1
+
+        bind = session.sync_session.bind
+        assert bind is not None
+        sqlalchemy_event.listen(bind, "before_cursor_execute", count_event_inserts)
+        try:
+            inserted_ids, _ = await repository.insert_batch(events, render_nulls=True)
+        finally:
+            sqlalchemy_event.remove(bind, "before_cursor_execute", count_event_inserts)
+
+        assert len(inserted_ids) == 3
+        assert insert_count == 1
+
     async def test_no_pending_events(
         self, save_fixture: SaveFixture, session: AsyncSession, account: Account
     ) -> None:

--- a/server/tests/event_type/test_repository.py
+++ b/server/tests/event_type/test_repository.py
@@ -1,0 +1,64 @@
+import pytest
+from sqlalchemy import func, select
+
+from polar.event_type.repository import EventTypeRepository
+from polar.kit.utils import utc_now
+from polar.models import EventType, Organization
+from polar.postgres import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_ensure_by_names_is_idempotent(
+    session: AsyncSession, organization: Organization
+) -> None:
+    repository = EventTypeRepository.from_session(session)
+
+    first = await repository.ensure_by_names(
+        ["subscription.created", "checkout.created", "subscription.created"],
+        organization.id,
+    )
+    second = await repository.ensure_by_names(
+        ["checkout.created", "subscription.created"], organization.id
+    )
+
+    assert set(first) == {"checkout.created", "subscription.created"}
+    assert {name: event_type.id for name, event_type in first.items()} == {
+        name: event_type.id for name, event_type in second.items()
+    }
+    assert (
+        await session.scalar(
+            select(func.count(EventType.id)).where(
+                EventType.organization_id == organization.id
+            )
+        )
+        == 2
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_by_names_restores_soft_deleted_type(
+    session: AsyncSession, organization: Organization
+) -> None:
+    repository = EventTypeRepository.from_session(session)
+    created = await repository.ensure_by_names(
+        ["subscription.created"], organization.id
+    )
+    event_type = created["subscription.created"]
+    event_type.label = "Subscription started"
+    event_type.deleted_at = utc_now()
+    await session.flush()
+
+    restored = await repository.ensure_by_names(
+        ["subscription.created"], organization.id
+    )
+
+    restored_event_type = restored["subscription.created"]
+    assert restored_event_type.id == event_type.id
+    assert restored_event_type.label == "Subscription started"
+    assert restored_event_type.deleted_at is None
+    assert (
+        await session.scalar(
+            select(EventType.deleted_at).where(EventType.id == event_type.id)
+        )
+        is None
+    )

--- a/server/tests/scripts/test_seeds_load.py
+++ b/server/tests/scripts/test_seeds_load.py
@@ -1,6 +1,18 @@
-import pytest
+import random
+from collections import Counter
+from collections.abc import Sequence
+from typing import Any
+from uuid import UUID
 
+import pytest
+import typer
+from pytest_mock import MockerFixture
+from sqlalchemy import event as sqlalchemy_event
+from sqlalchemy import select
+
+from polar.event.repository import EventRepository
 from polar.kit.db.postgres import AsyncSession
+from polar.models import Organization
 from polar.redis import Redis
 from scripts.seeds_load import create_seed_data
 
@@ -11,5 +23,85 @@ class TestSeedsLoad:
         self,
         session: AsyncSession,
         redis: Redis,
+        mocker: MockerFixture,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
-        await create_seed_data(session, redis)
+        sql_count = 0
+        event_insert_count = 0
+        render_nulls_batch_count = 0
+        render_nulls_inserted_ids: list[UUID] = []
+        original_insert_batch = EventRepository.insert_batch
+        original_randint = random.randint
+
+        def max_seed_customer_count(start: int, end: int) -> int:
+            if (start, end) == (3, 8):
+                return end
+            return original_randint(start, end)
+
+        async def track_insert_batch(
+            repository: EventRepository,
+            events: Sequence[dict[str, Any]],
+            *,
+            render_nulls: bool = False,
+        ) -> tuple[Sequence[UUID], int]:
+            nonlocal render_nulls_batch_count
+            result = await original_insert_batch(
+                repository, events, render_nulls=render_nulls
+            )
+            if render_nulls:
+                render_nulls_batch_count += 1
+                render_nulls_inserted_ids.extend(result[0])
+            return result
+
+        def count_queries(*args: Any) -> None:
+            nonlocal sql_count, event_insert_count
+            sql_count += 1
+            if args[2].startswith("INSERT INTO events"):
+                event_insert_count += 1
+
+        bind = session.sync_session.bind
+        assert bind is not None
+        tinybird_ingest_mock = mocker.patch("scripts.seeds_load.tinybird_ingest_events")
+        mocker.patch(
+            "scripts.seeds_load.random.randint", side_effect=max_seed_customer_count
+        )
+        mocker.patch.object(EventRepository, "insert_batch", track_insert_batch)
+        sqlalchemy_event.listen(bind, "before_cursor_execute", count_queries)
+        try:
+            await create_seed_data(session, redis)
+        finally:
+            sqlalchemy_event.remove(bind, "before_cursor_execute", count_queries)
+
+        organizations = (
+            (await session.execute(select(Organization.slug))).scalars().all()
+        )
+        assert set(organizations) == {
+            "acme-corp",
+            "admin-org",
+            "coldmail",
+            "example-news-inc",
+            "melted-sql",
+            "polar",
+            "seatbased-only-corp",
+            "seatbased-members-corp",
+            "widget-industries",
+        }
+        assert render_nulls_batch_count <= len(organizations), render_nulls_batch_count
+        assert event_insert_count <= render_nulls_batch_count * 2, event_insert_count
+        assert sql_count <= 1800, sql_count
+        tinybird_event_ids = [
+            event.id
+            for call in tinybird_ingest_mock.await_args_list
+            for event in call.args[0]
+        ]
+        assert Counter(tinybird_event_ids) == Counter(render_nulls_inserted_ids)
+        assert all(
+            len(call.args[0]) <= 2500 for call in tinybird_ingest_mock.await_args_list
+        )
+        output = capsys.readouterr().out
+        assert output.count("seed.organization status=processed") == len(organizations)
+        assert "seed.organization status=success" not in output
+        assert "seed.load status=success" in output
+        with pytest.raises(typer.Exit) as exception_info:
+            await create_seed_data(session, redis)
+        assert exception_info.value.exit_code == 2


### PR DESCRIPTION
With a higher latency to the DB, we want to ensure that we can batch SQL as cleanly as possible. This can be done with rendering nulls so that SQLAlchemy batches them in the same query, reducing the overhead and number of roundtrips


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

