### PR TITLE
fix(checkout): preserve locked seat count when switching products

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2373,11 +2373,20 @@ class CheckoutService:
         seat_price = price_set.get_seat_price()
         seats: int | None = None
         if seat_price is not None:
-            seats = (
-                checkout_update.seats
-                or previous_seats
-                or seat_price.get_minimum_seats()
+            is_seat_count_locked = (
+                checkout.min_seats is not None or checkout.max_seats is not None
             )
+            if checkout_update.seats is not None:
+                seats = checkout_update.seats
+            elif previous_seats is not None and not is_seat_count_locked:
+                # Preserve the existing seat count across a product switch,
+                # clamped to the new product's own bounds.
+                seats = max(previous_seats, seat_price.get_minimum_seats())
+                maximum_seats = seat_price.get_maximum_seats()
+                if maximum_seats is not None:
+                    seats = min(seats, maximum_seats)
+            else:
+                seats = previous_seats or seat_price.get_minimum_seats()
             self._validate_seat_limits(
                 seat_price,
                 seats,

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2368,12 +2368,22 @@ class CheckoutService:
         price_set: PriceSet,
     ) -> Checkout:
         checkout.product_price = price_set.get_default_price()
+        previous_seats = checkout.seats
         checkout.seats = None
         seat_price = price_set.get_seat_price()
         seats: int | None = None
         if seat_price is not None:
-            seats = checkout_update.seats or seat_price.get_minimum_seats()
-            self._validate_seat_limits(seat_price, seats)
+            seats = (
+                checkout_update.seats
+                or previous_seats
+                or seat_price.get_minimum_seats()
+            )
+            self._validate_seat_limits(
+                seat_price,
+                seats,
+                checkout_min_seats=checkout.min_seats,
+                checkout_max_seats=checkout.max_seats,
+            )
             checkout.seats = seats
         checkout.amount = calculate_upfront_amount(
             price_set.get_static_prices(), custom_amount=None, seats=seats

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -4251,6 +4251,60 @@ class TestUpdate:
         assert updated_checkout.product == product_one_time
         assert updated_checkout.seats is None
 
+    async def test_switching_products_preserves_seats(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_seat_based: Product,
+        product_seat_based_with_min_max: Product,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product_seat_based, product_seat_based_with_min_max],
+            product=product_seat_based,
+            seats=5,
+        )
+
+        assert checkout.seats == 5
+
+        updated_checkout = await checkout_service.update(
+            session,
+            checkout,
+            CheckoutUpdate(product_id=product_seat_based_with_min_max.id),
+        )
+
+        assert updated_checkout.product == product_seat_based_with_min_max
+        assert updated_checkout.seats == 5
+
+    async def test_switching_products_respects_locked_seats(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_seat_based: Product,
+        product_seat_based_with_min_max: Product,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product_seat_based, product_seat_based_with_min_max],
+            product=product_seat_based,
+            seats=5,
+            min_seats=5,
+            max_seats=5,
+        )
+
+        assert checkout.seats == 5
+        assert checkout.min_seats == 5
+        assert checkout.max_seats == 5
+
+        updated_checkout = await checkout_service.update(
+            session,
+            checkout,
+            CheckoutUpdate(product_id=product_seat_based_with_min_max.id),
+        )
+
+        assert updated_checkout.product == product_seat_based_with_min_max
+        assert updated_checkout.seats == 5
+
     async def test_update_seats_below_minimum(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -4352,9 +4352,7 @@ class TestUpdate:
             await checkout_service.update(
                 session,
                 checkout,
-                CheckoutUpdate(
-                    product_id=product_seat_based_with_min_max.id, seats=10
-                ),
+                CheckoutUpdate(product_id=product_seat_based_with_min_max.id, seats=10),
             )
 
     async def test_update_seats_below_minimum(

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -4276,7 +4276,32 @@ class TestUpdate:
         assert updated_checkout.product == product_seat_based_with_min_max
         assert updated_checkout.seats == 5
 
-    async def test_switching_products_respects_locked_seats(
+    async def test_switching_products_clamps_seats_to_new_bounds(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_seat_based: Product,
+        product_seat_based_with_max: Product,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product_seat_based, product_seat_based_with_max],
+            product=product_seat_based,
+            seats=15,
+        )
+
+        assert checkout.seats == 15
+
+        updated_checkout = await checkout_service.update(
+            session,
+            checkout,
+            CheckoutUpdate(product_id=product_seat_based_with_max.id),
+        )
+
+        assert updated_checkout.product == product_seat_based_with_max
+        assert updated_checkout.seats == 10
+
+    async def test_switching_products_preserves_locked_seats(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -4304,6 +4329,33 @@ class TestUpdate:
 
         assert updated_checkout.product == product_seat_based_with_min_max
         assert updated_checkout.seats == 5
+        assert updated_checkout.min_seats == 5
+        assert updated_checkout.max_seats == 5
+
+    async def test_switching_products_enforces_locked_seats_on_override(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_seat_based: Product,
+        product_seat_based_with_min_max: Product,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product_seat_based, product_seat_based_with_min_max],
+            product=product_seat_based,
+            seats=5,
+            min_seats=5,
+            max_seats=5,
+        )
+
+        with pytest.raises(PolarRequestValidationError):
+            await checkout_service.update(
+                session,
+                checkout,
+                CheckoutUpdate(
+                    product_id=product_seat_based_with_min_max.id, seats=10
+                ),
+            )
 
     async def test_update_seats_below_minimum(
         self,


### PR DESCRIPTION
Fixes https://github.com/polarsource/feedback/issues/332, currently causing stripe webhooks to fail in sandbox


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the existing seat count when switching seat‑based products and enforces checkout‑level locked seats. Previously, switching reset seats to the new product minimum and ignored locked min/max, letting customers bypass a merchant’s seat lock.

- Seat selection priority: `checkout_update.seats` > previous `checkout.seats` when not locked (clamped to the new product’s bounds) > product minimum; switching to a fixed‑price product still clears seats.
- Validation now checks product limits and checkout‑level `min_seats`/`max_seats`; overriding a locked seat count fails validation.
- Tests cover preserving and clamping seats across product switches and strict enforcement for locked seats.
- No migrations or config changes.

<sup>Written for commit 0d3c8b6a9d1ea3aa8d41a64506f7f7c0a6c0547b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



