### PR TITLE
Redis failover pool reset

### DIFF
--- a/server/polar/redis.py
+++ b/server/polar/redis.py
@@ -101,6 +101,8 @@ def create_redis(process_name: ProcessName) -> Redis:
         retry_on_error=REDIS_RETRY_ON_ERRROR,
         retry=REDIS_RETRY,
         client_name=f"{settings.ENV.value}.{process_name}",
+        socket_timeout=10,
+        socket_connect_timeout=3,
         socket_keepalive=True,
         socket_keepalive_options=REDIS_KEEPALIVE_OPTIONS,
         health_check_interval=30,

--- a/server/polar/redis.py
+++ b/server/polar/redis.py
@@ -1,6 +1,8 @@
 import socket
-from typing import TYPE_CHECKING, Literal
+import sys
+from typing import TYPE_CHECKING, Any, Literal
 
+import redis as _sync_redis
 import redis.asyncio as _async_redis
 from fastapi import Request
 from redis import ConnectionError, ReadOnlyError, RedisError, TimeoutError
@@ -13,8 +15,61 @@ from polar.config import settings
 # Redis is generic at type checking, but not at runtime...
 if TYPE_CHECKING:
     Redis = _async_redis.Redis[str]
+    _Pipeline = _async_redis.client.Pipeline[str]
+    _SyncRedis = _sync_redis.Redis[bytes]
+    _SyncPipeline = _sync_redis.client.Pipeline[bytes]
 else:
     Redis = _async_redis.Redis
+    _Pipeline = _async_redis.client.Pipeline
+    _SyncRedis = _sync_redis.Redis
+    _SyncPipeline = _sync_redis.client.Pipeline
+
+
+# A demoted primary answers READONLY until DNS flips; dropping idle connections on
+# the first one (via redis-py's per-attempt failure hooks) makes the whole pool
+# re-resolve while the command keeps retrying, without surfacing an error.
+
+
+class FailoverPipeline(_Pipeline):
+    async def _disconnect_raise_on_watching(self, conn: Any, error: Exception) -> None:
+        if isinstance(error, ReadOnlyError):
+            await self.connection_pool.disconnect(inuse_connections=False)
+        await super()._disconnect_raise_on_watching(conn, error)  # type: ignore[misc]
+
+
+class FailoverRedis(Redis):
+    async def _close_connection(self, conn: Any) -> None:
+        if isinstance(sys.exc_info()[1], ReadOnlyError):
+            await self.connection_pool.disconnect(inuse_connections=False)
+        await super()._close_connection(conn)  # type: ignore[misc]
+
+    def pipeline(
+        self, transaction: bool = True, shard_hint: str | None = None
+    ) -> "_Pipeline":
+        return FailoverPipeline(
+            self.connection_pool, self.response_callbacks, transaction, shard_hint
+        )
+
+
+class SyncFailoverPipeline(_SyncPipeline):
+    def _disconnect_raise_on_watching(self, conn: Any, error: Exception) -> None:
+        if isinstance(error, ReadOnlyError):
+            self.connection_pool.disconnect(inuse_connections=False)
+        super()._disconnect_raise_on_watching(conn, error)  # type: ignore[misc]
+
+
+class SyncFailoverRedis(_SyncRedis):
+    def _close_connection(self, conn: Any) -> None:
+        if isinstance(sys.exc_info()[1], ReadOnlyError):
+            self.connection_pool.disconnect(inuse_connections=False)
+        super()._close_connection(conn)  # type: ignore[misc]
+
+    def pipeline(
+        self, transaction: bool = True, shard_hint: str | None = None
+    ) -> "_SyncPipeline":
+        return SyncFailoverPipeline(
+            self.connection_pool, self.response_callbacks, transaction, shard_hint
+        )
 
 
 REDIS_RETRY_ON_ERRROR: list[type[RedisError]] = [
@@ -40,7 +95,7 @@ type ProcessName = Literal["app", "rate-limit", "worker", "script"]
 
 
 def create_redis(process_name: ProcessName) -> Redis:
-    return _async_redis.Redis.from_url(
+    return FailoverRedis.from_url(
         settings.redis_url,
         decode_responses=True,
         retry_on_error=REDIS_RETRY_ON_ERRROR,
@@ -59,7 +114,9 @@ async def get_redis(request: Request) -> Redis:
 __all__ = [
     "REDIS_RETRY",
     "REDIS_RETRY_ON_ERRROR",
+    "FailoverRedis",
     "Redis",
+    "SyncFailoverRedis",
     "create_redis",
     "get_redis",
 ]

--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -22,7 +22,7 @@ from polar.config import settings
 from polar.logfire import instrument_httpx
 from polar.logging import CorrelationID, Logger
 from polar.operational_errors import handle_operational_error
-from polar.redis import REDIS_RETRY_ON_ERRROR
+from polar.redis import REDIS_RETRY_ON_ERRROR, SyncFailoverRedis
 
 from . import _sqs
 from ._asyncio import MonitoredAsyncIO
@@ -219,13 +219,17 @@ def get_broker(*, database: bool = True) -> dramatiq.Broker:
 
     result_backend = ResultsBackend(
         encoder=JSONEncoder(),
-        connection_pool=redis.ConnectionPool.from_url(
-            settings.redis_url, retry=retry, retry_on_error=REDIS_RETRY_ON_ERRROR
+        client=SyncFailoverRedis(
+            connection_pool=redis.ConnectionPool.from_url(
+                settings.redis_url, retry=retry, retry_on_error=REDIS_RETRY_ON_ERRROR
+            )
         ),
     )
     rate_limiter_backend = RateLimiterBackend(
-        connection_pool=redis.ConnectionPool.from_url(
-            settings.redis_url, retry=retry, retry_on_error=REDIS_RETRY_ON_ERRROR
+        client=SyncFailoverRedis(
+            connection_pool=redis.ConnectionPool.from_url(
+                settings.redis_url, retry=retry, retry_on_error=REDIS_RETRY_ON_ERRROR
+            )
         )
     )
 
@@ -263,6 +267,7 @@ def get_broker(*, database: bool = True) -> dramatiq.Broker:
 
     broker = RoutingRedisBroker(
         connection_pool=redis_pool,
+        client=SyncFailoverRedis(connection_pool=redis_pool),
         middleware=middleware_list,
         dead_message_ttl=3600 * 1000,  # 1 hour in milliseconds
     )

--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -215,20 +215,30 @@ def get_broker(*, database: bool = True) -> dramatiq.Broker:
         client_name=f"{settings.ENV.value}.worker.dramatiq",
         retry=retry,
         retry_on_error=REDIS_RETRY_ON_ERRROR,
+        socket_timeout=10,
+        socket_connect_timeout=3,
     )
 
     result_backend = ResultsBackend(
         encoder=JSONEncoder(),
         client=SyncFailoverRedis(
             connection_pool=redis.ConnectionPool.from_url(
-                settings.redis_url, retry=retry, retry_on_error=REDIS_RETRY_ON_ERRROR
+                settings.redis_url,
+                retry=retry,
+                retry_on_error=REDIS_RETRY_ON_ERRROR,
+                socket_timeout=10,
+                socket_connect_timeout=3,
             )
         ),
     )
     rate_limiter_backend = RateLimiterBackend(
         client=SyncFailoverRedis(
             connection_pool=redis.ConnectionPool.from_url(
-                settings.redis_url, retry=retry, retry_on_error=REDIS_RETRY_ON_ERRROR
+                settings.redis_url,
+                retry=retry,
+                retry_on_error=REDIS_RETRY_ON_ERRROR,
+                socket_timeout=10,
+                socket_connect_timeout=3,
             )
         )
     )

--- a/server/polar/worker/_debounce.py
+++ b/server/polar/worker/_debounce.py
@@ -10,6 +10,7 @@ import structlog
 from polar.config import settings
 from polar.logging import Logger
 from polar.observability import TASK_DEBOUNCE_DELAY, TASK_DEBOUNCED
+from polar.redis import SyncFailoverRedis
 
 if TYPE_CHECKING:
     from ._enqueue import JSONSerializable
@@ -83,7 +84,9 @@ class DebounceMiddleware(dramatiq.Middleware):
     """
 
     def __init__(self, redis_pool: redis.ConnectionPool) -> None:
-        self._redis = redis.Redis(connection_pool=redis_pool, decode_responses=False)
+        self._redis = SyncFailoverRedis(
+            connection_pool=redis_pool, decode_responses=False
+        )
 
     @property
     def actor_options(self) -> set[str]:

--- a/server/polar/worker/_health.py
+++ b/server/polar/worker/_health.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from typing import Any
 
 import logfire
+import redis.asyncio as async_redis
 import structlog
 import uvicorn
 from dramatiq.middleware import Middleware
@@ -18,6 +19,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
+from polar.config import settings
 from polar.external_event.repository import ExternalEventRepository
 from polar.kit.db.postgres import AsyncSessionMaker, create_async_sessionmaker
 from polar.kit.utils import utc_now
@@ -25,7 +27,7 @@ from polar.logfire import configure_logfire
 from polar.logging import Logger
 from polar.logging import configure as configure_logging
 from polar.postgres import AsyncEngine, create_async_engine
-from polar.redis import Redis, create_redis
+from polar.redis import Redis
 from polar.webhook.repository import WebhookEventRepository
 
 log: Logger = structlog.get_logger()
@@ -129,7 +131,13 @@ def _create_lifespan(
 ) -> Callable[[Starlette], contextlib.AbstractAsyncContextManager[Mapping[str, Any]]]:
     @contextlib.asynccontextmanager
     async def lifespan(app: Starlette) -> AsyncGenerator[Mapping[str, Any]]:
-        redis = create_redis("worker")
+        redis: Redis = async_redis.Redis.from_url(
+            settings.redis_url,
+            decode_responses=True,
+            client_name=f"{settings.ENV.value}.worker.health",
+            socket_timeout=2,
+            socket_connect_timeout=2,
+        )
         state: dict[str, Any] = {"redis": redis}
 
         async_engine: AsyncEngine | None = None

--- a/server/tests/test_redis.py
+++ b/server/tests/test_redis.py
@@ -1,0 +1,102 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from redis import ConnectionError, ReadOnlyError
+
+from polar.redis import (
+    FailoverPipeline,
+    FailoverRedis,
+    SyncFailoverPipeline,
+    SyncFailoverRedis,
+)
+
+
+def create_async_client() -> FailoverRedis:
+    client = FailoverRedis()
+    client.connection_pool = AsyncMock()
+    return client
+
+
+def create_sync_client() -> SyncFailoverRedis:
+    client = SyncFailoverRedis()
+    client.connection_pool = MagicMock()
+    return client
+
+
+@pytest.mark.asyncio
+class TestFailoverRedis:
+    async def test_readonly_drops_idle_connections(self) -> None:
+        client = create_async_client()
+        try:
+            raise ReadOnlyError("READONLY")
+        except ReadOnlyError:
+            await client._close_connection(AsyncMock())
+
+        client.connection_pool.disconnect.assert_awaited_once_with(
+            inuse_connections=False
+        )
+
+    async def test_other_errors_leave_pool_alone(self) -> None:
+        client = create_async_client()
+        try:
+            raise ConnectionError("connection lost")
+        except ConnectionError:
+            await client._close_connection(AsyncMock())
+
+        client.connection_pool.disconnect.assert_not_awaited()
+
+    async def test_pipeline_returns_failover_pipeline(self) -> None:
+        client = create_async_client()
+        assert isinstance(client.pipeline(), FailoverPipeline)
+
+    async def test_pipeline_readonly_drops_idle_connections(self) -> None:
+        client = create_async_client()
+        pipeline = client.pipeline()
+        assert isinstance(pipeline, FailoverPipeline)
+        pipeline.watching = False
+
+        await pipeline._disconnect_raise_on_watching(
+            AsyncMock(), ReadOnlyError("READONLY")
+        )
+
+        client.connection_pool.disconnect.assert_awaited_once_with(
+            inuse_connections=False
+        )
+
+
+class TestSyncFailoverRedis:
+    def test_readonly_drops_idle_connections(self) -> None:
+        client = create_sync_client()
+        try:
+            raise ReadOnlyError("READONLY")
+        except ReadOnlyError:
+            client._close_connection(MagicMock())
+
+        client.connection_pool.disconnect.assert_called_once_with(
+            inuse_connections=False
+        )
+
+    def test_other_errors_leave_pool_alone(self) -> None:
+        client = create_sync_client()
+        try:
+            raise ConnectionError("connection lost")
+        except ConnectionError:
+            client._close_connection(MagicMock())
+
+        client.connection_pool.disconnect.assert_not_called()
+
+    def test_pipeline_returns_failover_pipeline(self) -> None:
+        client = create_sync_client()
+        assert isinstance(client.pipeline(), SyncFailoverPipeline)
+
+    def test_pipeline_readonly_drops_idle_connections(self) -> None:
+        client = create_sync_client()
+        pipeline = client.pipeline()
+        assert isinstance(pipeline, SyncFailoverPipeline)
+        pipeline.watching = False
+
+        pipeline._disconnect_raise_on_watching(MagicMock(), ReadOnlyError("READONLY"))
+
+        client.connection_pool.disconnect.assert_called_once_with(
+            inuse_connections=False
+        )

--- a/server/tests/worker/test_health.py
+++ b/server/tests/worker/test_health.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import redis.asyncio as async_redis
 from httpx import ASGITransport, AsyncClient
 from pytest_mock import MockerFixture
 from redis import RedisError
@@ -302,7 +303,9 @@ class TestLifespan:
     ) -> None:
         create_engine = mocker.patch.object(health_module, "create_async_engine")
         mocker.patch.object(
-            health_module, "create_redis", return_value=MagicMock(close=AsyncMock())
+            async_redis.Redis,
+            "from_url",
+            return_value=MagicMock(close=AsyncMock()),
         )
 
         async with _create_lifespan(database=False)(MagicMock()) as state:
@@ -322,7 +325,9 @@ class TestLifespan:
             health_module, "create_async_sessionmaker", return_value="sessionmaker"
         )
         mocker.patch.object(
-            health_module, "create_redis", return_value=MagicMock(close=AsyncMock())
+            async_redis.Redis,
+            "from_url",
+            return_value=MagicMock(close=AsyncMock()),
         )
 
         async with _create_lifespan(database=True)(MagicMock()) as state:


### PR DESCRIPTION
- Reset the full pool on ReadOnly errors, to trigger a reconnect instead of letting each connection retry until they reconnect
- Bind socket read and connects
- Let health check toward Redis not retry so we get instant feedback

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

