### PR TITLE
server/refund: assert payment transaction exists before issuing a refund

### DIFF
--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -39,6 +39,7 @@ from polar.order.service import order as order_service
 from polar.payment.repository import PaymentRepository
 from polar.tax.calculation import tax_calculation as tax_calculation_service
 from polar.tax.calculation.base import AlreadyRevertedError
+from polar.transaction.repository import PaymentTransactionRepository
 from polar.transaction.service.refund import (
     RefundTransactionAlreadyExistsError,
     RefundTransactionDoesNotExistError,
@@ -236,6 +237,15 @@ class RefundService:
         payment = await payment_repository.get_succeeded_by_order(order.id)
         if payment is None:
             raise RefundUnknownPayment(order.id, payment_type="order")
+
+        payment_transaction_repository = PaymentTransactionRepository.from_session(
+            session
+        )
+        payment_transaction = await payment_transaction_repository.get_by_payment_id(
+            payment.id
+        )
+        if payment_transaction is None:
+            raise RefundUnknownPayment(payment.id, payment_type="order")
 
         if payment.processor == PaymentProcessor.stripe:
             refund_total = refund_amount + refund_tax_amount

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -70,6 +70,13 @@ class RefundUnknownPayment(ResourceNotFound):
         super().__init__(message, 404)
 
 
+class RefundPaymentTransactionNotFound(ResourceNotFound):
+    def __init__(self, payment_id: UUID) -> None:
+        self.payment_id = payment_id
+        message = f"Payment transaction not found for payment: {payment_id}"
+        super().__init__(message, 404)
+
+
 class RefundedAlready(RefundError):
     def __init__(self, order: Order) -> None:
         self.order = order
@@ -245,7 +252,7 @@ class RefundService:
             payment.id
         )
         if payment_transaction is None:
-            raise RefundUnknownPayment(payment.id, payment_type="order")
+            raise RefundPaymentTransactionNotFound(payment.id)
 
         if payment.processor == PaymentProcessor.stripe:
             refund_total = refund_amount + refund_tax_amount

--- a/server/tests/refund/test_service.py
+++ b/server/tests/refund/test_service.py
@@ -27,7 +27,7 @@ from polar.refund.schemas import RefundCreate
 from polar.refund.service import (
     MissingRelatedDispute,
     RefundedAlready,
-    RefundUnknownPayment,
+    RefundPaymentTransactionNotFound,
 )
 from polar.refund.service import refund as refund_service
 from polar.tax.calculation import TaxCalculationService
@@ -219,7 +219,7 @@ class TestCreate(StripeRefund):
         )
         await session.delete(transaction)
 
-        with pytest.raises(RefundUnknownPayment):
+        with pytest.raises(RefundPaymentTransactionNotFound) as exc_info:
             await refund_service.create(
                 session,
                 order,
@@ -231,6 +231,11 @@ class TestCreate(StripeRefund):
                     revoke_benefits=False,
                 ),
             )
+
+        assert exc_info.value.payment_id == payment.id
+        assert exc_info.value.message == (
+            f"Payment transaction not found for payment: {payment.id}"
+        )
 
     async def test_create_repeatedly(
         self,

--- a/server/tests/refund/test_service.py
+++ b/server/tests/refund/test_service.py
@@ -24,7 +24,11 @@ from polar.order.repository import OrderRepository
 from polar.order.service import order as order_service
 from polar.postgres import AsyncSession
 from polar.refund.schemas import RefundCreate
-from polar.refund.service import MissingRelatedDispute, RefundedAlready
+from polar.refund.service import (
+    MissingRelatedDispute,
+    RefundedAlready,
+    RefundUnknownPayment,
+)
 from polar.refund.service import refund as refund_service
 from polar.tax.calculation import TaxCalculationService
 from polar.tax.calculation.base import AlreadyRevertedError
@@ -199,6 +203,35 @@ class StripeRefund:
 
 @pytest.mark.asyncio
 class TestCreate(StripeRefund):
+    async def test_missing_payment_transaction(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order, payment, transaction = await create_order_and_payment(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subtotal_amount=1000,
+            tax_amount=250,
+        )
+        await session.delete(transaction)
+
+        with pytest.raises(RefundUnknownPayment):
+            await refund_service.create(
+                session,
+                order,
+                RefundCreate(
+                    order_id=order.id,
+                    reason=RefundReason.service_disruption,
+                    amount=1000,
+                    comment=None,
+                    revoke_benefits=False,
+                ),
+            )
+
     async def test_create_repeatedly(
         self,
         session: AsyncSession,


### PR DESCRIPTION

In the case where a merchant issues a refund very quickly (<2 seconds) after a successful payment, the payment transaction may not yet be available in the database. Since the refund transaction service assumes this transaction exists, we hit an assertion error after having issued the refund on Stripe; which led to an inconsistent state where we try to reconcile a refund from a Stripe webhook we didn't save in our database.

This fix ensures the payment transaction exists before proceeding with the refund, and raise an error if it doesn't.

Fixes https://github.com/polarsource/feedback/issues/383


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

