### PR TITLE
checkout: show the discount redemption limit error when the code input is hidden

### DIFF
--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.test.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.test.tsx
@@ -122,6 +122,68 @@ describe('CheckoutFormProvider', () => {
       )
     })
 
+    it('sets discount_code error for DiscountRedemptionLimitReached when the code input is shown', async () => {
+      const getCtx = renderWithCheckout({
+        checkout: { allow_discount_codes: true, is_discount_applicable: true },
+        update: vi.fn<CheckoutContextProps['update']>(async () =>
+          updateErrorResult({
+            error: 'DiscountRedemptionLimitReached',
+            detail: 'limit reached',
+          }),
+        ),
+      })
+
+      await act(async () => {
+        await expect(
+          getCtx().update({ discount_code: 'CODE' }),
+        ).rejects.toBeDefined()
+      })
+
+      expect(getCtx().form.formState.errors.discount_code?.message).toBe(
+        'limit reached',
+      )
+    })
+
+    it('sets root error for DiscountRedemptionLimitReached when discount codes are disabled', async () => {
+      const getCtx = renderWithCheckout({
+        checkout: { allow_discount_codes: false, is_discount_applicable: true },
+        update: vi.fn<CheckoutContextProps['update']>(async () =>
+          updateErrorResult({
+            error: 'DiscountRedemptionLimitReached',
+            detail: 'limit reached',
+          }),
+        ),
+      })
+
+      await act(async () => {
+        await expect(
+          getCtx().update({ customer_email: 'a@b.com' }),
+        ).rejects.toBeDefined()
+      })
+
+      expect(getCtx().form.formState.errors.root?.message).toBe('limit reached')
+    })
+
+    it('sets root error for DiscountRedemptionLimitReached when no discount applies', async () => {
+      const getCtx = renderWithCheckout({
+        checkout: { allow_discount_codes: true, is_discount_applicable: false },
+        update: vi.fn<CheckoutContextProps['update']>(async () =>
+          updateErrorResult({
+            error: 'DiscountRedemptionLimitReached',
+            detail: 'limit reached',
+          }),
+        ),
+      })
+
+      await act(async () => {
+        await expect(
+          getCtx().update({ customer_email: 'a@b.com' }),
+        ).rejects.toBeDefined()
+      })
+
+      expect(getCtx().form.formState.errors.root?.message).toBe('limit reached')
+    })
+
     it.each(['ResourceNotFound', 'ExpiredCheckoutError'] as const)(
       'does not set a form error for %s',
       async (errorCode) => {
@@ -238,6 +300,58 @@ describe('CheckoutFormProvider', () => {
       expect(getCtx().form.formState.errors.root?.message).toBe(
         `${errorCode} detail`,
       )
+    })
+
+    it('sets discount_code error for DiscountRedemptionLimitReached when the code input is shown', async () => {
+      const getCtx = renderWithCheckout({
+        checkout: {
+          ...freeCheckout,
+          allow_discount_codes: true,
+          is_discount_applicable: true,
+        },
+        update: vi.fn(),
+        confirm: vi.fn<CheckoutContextProps['confirm']>(async () =>
+          confirmErrorResult({
+            error: 'DiscountRedemptionLimitReached',
+            detail: 'limit reached',
+          }),
+        ),
+      })
+
+      await act(async () => {
+        await expect(
+          getCtx().confirm({ customer_email: 'a@b.com' }, null, null),
+        ).rejects.toBeDefined()
+      })
+
+      expect(getCtx().form.formState.errors.discount_code?.message).toBe(
+        'limit reached',
+      )
+    })
+
+    it('sets root error for DiscountRedemptionLimitReached when discount codes are disabled', async () => {
+      const getCtx = renderWithCheckout({
+        checkout: {
+          ...freeCheckout,
+          allow_discount_codes: false,
+          is_discount_applicable: true,
+        },
+        update: vi.fn(),
+        confirm: vi.fn<CheckoutContextProps['confirm']>(async () =>
+          confirmErrorResult({
+            error: 'DiscountRedemptionLimitReached',
+            detail: 'limit reached',
+          }),
+        ),
+      })
+
+      await act(async () => {
+        await expect(
+          getCtx().confirm({ customer_email: 'a@b.com' }, null, null),
+        ).rejects.toBeDefined()
+      })
+
+      expect(getCtx().form.formState.errors.root?.message).toBe('limit reached')
     })
 
     it.each(['ResourceNotFound', 'ExpiredCheckoutError'] as const)(

--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
@@ -69,6 +69,17 @@ export const CheckoutFormProvider = ({
   })
   const { setError } = form
 
+  const setDiscountError = useCallback(
+    (message: string) => {
+      const field =
+        checkout.allow_discount_codes && checkout.is_discount_applicable
+          ? 'discount_code'
+          : 'root'
+      setError(field, { message })
+    },
+    [checkout, setError],
+  )
+
   const update = useCallback(
     async (
       checkoutUpdatePublic: schemas['CheckoutUpdatePublic'],
@@ -89,7 +100,7 @@ export const CheckoutFormProvider = ({
               setValidationErrors(error.detail, setError)
               break
             case 'DiscountRedemptionLimitReached':
-              setError('discount_code', { message: error.detail })
+              setDiscountError(error.detail)
               break
             case 'AlreadyActiveSubscriptionError':
             case 'NotOpenCheckout':
@@ -104,7 +115,7 @@ export const CheckoutFormProvider = ({
         throw error
       }
     },
-    [updateOuter, setError],
+    [updateOuter, setError, setDiscountError],
   )
 
   const _confirm = useCallback(
@@ -130,7 +141,7 @@ export const CheckoutFormProvider = ({
             setError('root', { message: error.detail })
             break
           case 'DiscountRedemptionLimitReached':
-            setError('discount_code', { message: error.detail })
+            setDiscountError(error.detail)
             break
           case 'TrialAlreadyRedeemed':
             setTrialUnavailable(true)
@@ -144,7 +155,7 @@ export const CheckoutFormProvider = ({
 
       throw error
     },
-    [confirmOuter, setError, update, setTrialUnavailable],
+    [confirmOuter, setError, setDiscountError, update, setTrialUnavailable],
   )
 
   const confirm = useCallback(

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -420,11 +420,19 @@
             }
           },
           "403": {
-            "description": "You don't have the permission to update this organization.",
+            "description": "You don't have the permission to update this organization, or dispute auto-accept isn't enabled for it.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/NotPermitted"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/NotPermitted"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DisputeAutoAcceptNotEnabled"
+                    }
+                  ],
+                  "title": "Response 403 Organizations:Update"
                 }
               }
             }
@@ -633,14 +641,14 @@
                 {
                   "type": "string",
                   "format": "uuid4",
-                  "description": "The product ID."
+                  "description": "The discount ID."
                 },
                 {
                   "type": "array",
                   "items": {
                     "type": "string",
                     "format": "uuid4",
-                    "description": "The product ID."
+                    "description": "The discount ID."
                   }
                 },
                 {
@@ -775,6 +783,44 @@
               "title": "Canceled At Before"
             },
             "description": "Filter by cancellation date (before or equal to)."
+          },
+          {
+            "name": "started_after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only include subscriptions started after this date.",
+              "title": "Started After"
+            },
+            "description": "Only include subscriptions started after this date."
+          },
+          {
+            "name": "started_before",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only include subscriptions started before this date.",
+              "title": "Started Before"
+            },
+            "description": "Only include subscriptions started before this date."
           },
           {
             "name": "page",
@@ -1043,10 +1089,154 @@
                   "type": "null"
                 }
               ],
-              "description": "Filter by organization ID.",
-              "title": "Organization Id"
+              "title": "OrganizationID Filter",
+              "description": "Filter by organization ID."
             },
             "description": "Filter by organization ID."
+          },
+          {
+            "name": "product_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid4",
+                  "description": "The product ID."
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uuid4",
+                    "description": "The product ID."
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "ProductID Filter",
+              "description": "Filter by product ID."
+            },
+            "description": "Filter by product ID."
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SubscriptionStatus"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SubscriptionStatus"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status Filter",
+              "description": "Filter by subscription status."
+            },
+            "description": "Filter by subscription status."
+          },
+          {
+            "name": "cancel_at_period_end",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by subscriptions that are set to cancel at period end.",
+              "title": "Cancel At Period End"
+            },
+            "description": "Filter by subscriptions that are set to cancel at period end."
+          },
+          {
+            "name": "started_after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only include subscriptions started after this date. Must include a UTC offset.",
+              "title": "Started After"
+            },
+            "description": "Only include subscriptions started after this date. Must include a UTC offset."
+          },
+          {
+            "name": "started_before",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only include subscriptions started before this date. Must include a UTC offset.",
+              "title": "Started Before"
+            },
+            "description": "Only include subscriptions started before this date. Must include a UTC offset."
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Time zone used to render dates in the CSV.",
+              "default": "UTC",
+              "title": "Timezone"
+            },
+            "description": "Time zone used to render dates in the CSV."
+          },
+          {
+            "name": "columns",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SubscriptionExportColumn"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SubscriptionExportColumn"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Columns to include in the CSV, in order. Defaults to email, started_at, product, amount, currency, status and recurring_interval.",
+              "title": "Columns"
+            },
+            "description": "Columns to include in the CSV, in order. Defaults to email, started_at, product, amount, currency, status and recurring_interval."
           }
         ],
         "responses": {
@@ -1080,11 +1270,11 @@
         "x-codeSamples": [
           {
             "lang": "Python (New SDK)",
-            "source": "from polar.v2026_04 import Polar\n\npolar = Polar(\"polar_oat_xxx\")\n\nresponse = polar.subscriptions.export()\nprint(response)\n"
+            "source": "from polar.v2026_04 import Polar\n\npolar = Polar(\"polar_oat_xxx\")\n\nresponse = polar.subscriptions.export(\n    timezone='UTC',\n)\nprint(response)\n"
           },
           {
             "lang": "TypeScript (New SDK)",
-            "source": "import { createPolar } from \"@polar-sh/sdk/2026-04\";\n\nconst polar = createPolar({\n  accessToken: \"polar_oat_xxx\",\n});\n\nconst response = await polar.subscriptions.export();\nconsole.log(response);\n"
+            "source": "import { createPolar } from \"@polar-sh/sdk/2026-04\";\n\nconst polar = createPolar({\n  accessToken: \"polar_oat_xxx\",\n});\n\nconst response = await polar.subscriptions.export(\n  {\n    \"timezone\": \"UTC\"\n  },\n);\nconsole.log(response);\n"
           }
         ]
       }
@@ -1252,11 +1442,19 @@
             }
           },
           "403": {
-            "description": "Subscription is already canceled or will be at the end of the period.",
+            "description": "Subscription is already canceled or will be at the end of the period, or is not active.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AlreadyCanceledSubscription"
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/AlreadyCanceledSubscription"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InactiveSubscription"
+                    }
+                  ],
+                  "title": "Response 403 Subscriptions:Update"
                 }
               }
             }
@@ -2606,6 +2804,149 @@
           {
             "lang": "TypeScript (New SDK)",
             "source": "import { createPolar } from \"@polar-sh/sdk/2026-04\";\n\nconst polar = createPolar({\n  accessToken: \"polar_oat_xxx\",\n});\n\nawait polar.benefits.delete(\n  \"00000000-0000-4000-8000-000000000000\",\n);\n"
+          }
+        ]
+      }
+    },
+    "/v1/benefits/{id}/files": {
+      "get": {
+        "tags": [
+          "benefits",
+          "public"
+        ],
+        "summary": "List Benefit Files",
+        "description": "List the downloadable files for a benefit with their download statistics.\n\n**Scopes**: `benefits:read` `benefits:write`",
+        "operationId": "benefits:files",
+        "security": [
+          {
+            "oidc": [
+              "benefits:read",
+              "benefits:write"
+            ]
+          },
+          {
+            "pat": [
+              "benefits:read",
+              "benefits:write"
+            ]
+          },
+          {
+            "oat": [
+              "benefits:read",
+              "benefits:write"
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid4",
+              "description": "The benefit ID.",
+              "title": "Id"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "description": "Page number, defaults to 1.",
+              "default": 1,
+              "title": "Page"
+            },
+            "description": "Page number, defaults to 1."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "description": "Size of a page, defaults to 10. Maximum is 100.",
+              "default": 10,
+              "title": "Limit"
+            },
+            "description": "Size of a page, defaults to 10. Maximum is 100."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListResource_BenefitDownloadableFile_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Benefit not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceNotFound"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-polar-allowed-subjects": [
+          "Organization",
+          "User"
+        ],
+        "x-speakeasy-pagination": {
+          "type": "offsetLimit",
+          "inputs": [
+            {
+              "name": "page",
+              "in": "parameters",
+              "type": "page"
+            },
+            {
+              "name": "limit",
+              "in": "parameters",
+              "type": "limit"
+            }
+          ],
+          "outputs": {
+            "results": "$.items",
+            "numPages": "$.pagination.max_page"
+          }
+        },
+        "x-speakeasy-group": "benefits",
+        "x-speakeasy-name-override": "files",
+        "x-polar-pagination": {
+          "type": "page_limit",
+          "item_schema": {
+            "$ref": "#/components/schemas/BenefitDownloadableFile"
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "Python (New SDK)",
+            "source": "from polar.v2026_04 import Polar\n\npolar = Polar(\"polar_oat_xxx\")\n\nfor item in polar.benefits.iter_files(\n    '00000000-0000-4000-8000-000000000000',\n    page=1,\n    limit=10,\n):\n    print(item)\n"
+          },
+          {
+            "lang": "TypeScript (New SDK)",
+            "source": "import { createPolar } from \"@polar-sh/sdk/2026-04\";\n\nconst polar = createPolar({\n  accessToken: \"polar_oat_xxx\",\n});\n\nfor await (const item of polar.benefits.iterFiles(\n  \"00000000-0000-4000-8000-000000000000\",\n  {\n    \"page\": 1,\n    \"limit\": 10\n  },\n)) {\n  console.log(item);\n}\n"
           }
         ]
       }
@@ -4978,6 +5319,68 @@
             "description": "Filter by subscription ID."
           },
           {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OrderStatus"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OrderStatus"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status Filter",
+              "description": "Filter by order status."
+            },
+            "description": "Filter by order status."
+          },
+          {
+            "name": "created_after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only include orders created after this date",
+              "title": "Created After"
+            },
+            "description": "Only include orders created after this date"
+          },
+          {
+            "name": "created_before",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only include orders created before this date",
+              "title": "Created Before"
+            },
+            "description": "Only include orders created before this date"
+          },
+          {
             "name": "page",
             "in": "query",
             "required": false,
@@ -5265,6 +5668,104 @@
               "description": "Filter by product ID."
             },
             "description": "Filter by product ID."
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OrderStatus"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OrderStatus"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status Filter",
+              "description": "Filter by order status."
+            },
+            "description": "Filter by order status."
+          },
+          {
+            "name": "created_after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only include orders created after this date. Must include a UTC offset.",
+              "title": "Created After"
+            },
+            "description": "Only include orders created after this date. Must include a UTC offset."
+          },
+          {
+            "name": "created_before",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only include orders created before this date. Must include a UTC offset.",
+              "title": "Created Before"
+            },
+            "description": "Only include orders created before this date. Must include a UTC offset."
+          },
+          {
+            "name": "timezone",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Time zone used to render dates in the CSV.",
+              "default": "UTC",
+              "title": "Timezone"
+            },
+            "description": "Time zone used to render dates in the CSV."
+          },
+          {
+            "name": "columns",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/OrderExportColumn"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OrderExportColumn"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Columns to include in the CSV, in order. Defaults to email, created_at, product, net_amount, currency, status and invoice_number.",
+              "title": "Columns"
+            },
+            "description": "Columns to include in the CSV, in order. Defaults to email, created_at, product, net_amount, currency, status and invoice_number."
           }
         ],
         "responses": {
@@ -5298,11 +5799,11 @@
         "x-codeSamples": [
           {
             "lang": "Python (New SDK)",
-            "source": "from polar.v2026_04 import Polar\n\npolar = Polar(\"polar_oat_xxx\")\n\nresponse = polar.orders.export()\nprint(response)\n"
+            "source": "from polar.v2026_04 import Polar\n\npolar = Polar(\"polar_oat_xxx\")\n\nresponse = polar.orders.export(\n    timezone='UTC',\n)\nprint(response)\n"
           },
           {
             "lang": "TypeScript (New SDK)",
-            "source": "import { createPolar } from \"@polar-sh/sdk/2026-04\";\n\nconst polar = createPolar({\n  accessToken: \"polar_oat_xxx\",\n});\n\nconst response = await polar.orders.export();\nconsole.log(response);\n"
+            "source": "import { createPolar } from \"@polar-sh/sdk/2026-04\";\n\nconst polar = createPolar({\n  accessToken: \"polar_oat_xxx\",\n});\n\nconst response = await polar.orders.export(\n  {\n    \"timezone\": \"UTC\"\n  },\n);\nconsole.log(response);\n"
           }
         ]
       }
@@ -16342,7 +16843,7 @@
             "description": "Payment method deleted."
           },
           "400": {
-            "description": "Payment method is used by active subscription(s).",
+            "description": "Payment method is still needed to bill a subscription.",
             "content": {
               "application/json": {
                 "schema": {
@@ -19661,6 +20162,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ResourceNotFound"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The subscription has no payment method to charge.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodRequired"
                 }
               }
             }
@@ -27221,6 +27732,76 @@
         ],
         "title": "AppealNotRejectedError"
       },
+      "AssistantBlockPart": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "block",
+            "title": "Kind",
+            "default": "block"
+          },
+          "block": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TextBlock"
+              },
+              {
+                "$ref": "#/components/schemas/MetricChartBlock"
+              },
+              {
+                "$ref": "#/components/schemas/InsightCardsBlock"
+              },
+              {
+                "$ref": "#/components/schemas/EntityListBlock"
+              },
+              {
+                "$ref": "#/components/schemas/DataTableBlock"
+              },
+              {
+                "$ref": "#/components/schemas/CustomerCardBlock"
+              }
+            ],
+            "title": "Block",
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "customer_card": "#/components/schemas/CustomerCardBlock",
+                "data_table": "#/components/schemas/DataTableBlock",
+                "entity_list": "#/components/schemas/EntityListBlock",
+                "insight_cards": "#/components/schemas/InsightCardsBlock",
+                "metric_chart": "#/components/schemas/MetricChartBlock",
+                "text": "#/components/schemas/TextBlock"
+              }
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "block"
+        ],
+        "title": "AssistantBlockPart",
+        "description": "A renderable block, at the position the model placed it."
+      },
+      "AssistantTextPart": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "text",
+            "title": "Kind",
+            "default": "text"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "title": "AssistantTextPart",
+        "description": "A run of assistant prose, as it was streamed."
+      },
       "AttachedCustomField": {
         "properties": {
           "custom_field_id": {
@@ -30008,6 +30589,168 @@
           "type"
         ],
         "title": "BenefitDiscordUpdate"
+      },
+      "BenefitDownloadableFile": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid4",
+            "title": "Id",
+            "description": "The ID of the object."
+          },
+          "organization_id": {
+            "type": "string",
+            "format": "uuid4",
+            "title": "Organization Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "mime_type": {
+            "type": "string",
+            "title": "Mime Type"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "storage_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Version"
+          },
+          "checksum_etag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Checksum Etag"
+          },
+          "checksum_sha256_base64": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Checksum Sha256 Base64"
+          },
+          "checksum_sha256_hex": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Checksum Sha256 Hex"
+          },
+          "last_modified_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Modified At"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version"
+          },
+          "service": {
+            "type": "string",
+            "const": "downloadable",
+            "title": "Service"
+          },
+          "is_uploaded": {
+            "type": "boolean",
+            "title": "Is Uploaded"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "flagged_malicious_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Flagged Malicious At"
+          },
+          "downloaders": {
+            "type": "integer",
+            "title": "Downloaders",
+            "description": "Number of distinct customers or members who downloaded the file."
+          },
+          "downloads": {
+            "type": "integer",
+            "title": "Downloads",
+            "description": "Total number of downloads for the file."
+          },
+          "size_readable": {
+            "type": "string",
+            "title": "Size Readable",
+            "readOnly": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "organization_id",
+          "name",
+          "path",
+          "mime_type",
+          "size",
+          "storage_version",
+          "checksum_etag",
+          "checksum_sha256_base64",
+          "checksum_sha256_hex",
+          "last_modified_at",
+          "version",
+          "service",
+          "is_uploaded",
+          "created_at",
+          "flagged_malicious_at",
+          "downloaders",
+          "downloads",
+          "size_readable"
+        ],
+        "title": "BenefitDownloadableFile"
       },
       "BenefitDownloadables": {
         "properties": {
@@ -35354,6 +36097,50 @@
         ],
         "title": "CaseRepliesNotSupportedError"
       },
+      "CatalogImportBlocked": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "CatalogImportBlocked",
+            "title": "Error",
+            "examples": [
+              "CatalogImportBlocked"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "CatalogImportBlocked"
+      },
+      "CatalogImportNotReady": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "CatalogImportNotReady",
+            "title": "Error",
+            "examples": [
+              "CatalogImportNotReady"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "CatalogImportNotReady"
+      },
       "ChannelNamePreviewRequest": {
         "properties": {
           "organization_id": {
@@ -36818,6 +37605,9 @@
           },
           {
             "$ref": "#/components/schemas/TrialAlreadyRedeemed"
+          },
+          {
+            "$ref": "#/components/schemas/DiscountRedemptionLimitReached"
           }
         ]
       },
@@ -41221,6 +42011,148 @@
         "title": "CheckoutUpdatePublic",
         "description": "Update an existing checkout session using the client secret."
       },
+      "ColumnFormat": {
+        "type": "string",
+        "enum": [
+          "text",
+          "currency",
+          "datetime",
+          "badge",
+          "avatar"
+        ],
+        "title": "ColumnFormat"
+      },
+      "CompassThreadMessageSchema": {
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Creation timestamp of the object."
+          },
+          "modified_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Modified At",
+            "description": "Last modification timestamp of the object."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid4",
+            "title": "Id",
+            "description": "The ID of the object."
+          },
+          "prompt": {
+            "type": "string",
+            "title": "Prompt"
+          },
+          "parts": {
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssistantTextPart"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantBlockPart"
+                }
+              ],
+              "discriminator": {
+                "propertyName": "kind",
+                "mapping": {
+                  "block": "#/components/schemas/AssistantBlockPart",
+                  "text": "#/components/schemas/AssistantTextPart"
+                }
+              }
+            },
+            "type": "array",
+            "title": "Parts"
+          }
+        },
+        "type": "object",
+        "required": [
+          "created_at",
+          "modified_at",
+          "id",
+          "prompt",
+          "parts"
+        ],
+        "title": "CompassThreadMessageSchema",
+        "description": "One completed turn: the user's prompt and the rendered answer."
+      },
+      "CompassThreadSchema": {
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Creation timestamp of the object."
+          },
+          "modified_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Modified At",
+            "description": "Last modification timestamp of the object."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid4",
+            "title": "Id",
+            "description": "The ID of the object."
+          },
+          "organization_id": {
+            "type": "string",
+            "format": "uuid4",
+            "title": "Organization Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          }
+        },
+        "type": "object",
+        "required": [
+          "created_at",
+          "modified_at",
+          "id",
+          "organization_id",
+          "title"
+        ],
+        "title": "CompassThreadSchema",
+        "description": "An assistant conversation thread."
+      },
+      "CompassThreadUpdate": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 80,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          }
+        },
+        "type": "object",
+        "title": "CompassThreadUpdate"
+      },
       "ConfidenceLevel": {
         "type": "string",
         "enum": [
@@ -44704,6 +45636,56 @@
         ],
         "title": "CustomerCancellationReason"
       },
+      "CustomerCardBlock": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "customer_card",
+            "title": "Type",
+            "default": "customer_card"
+          },
+          "email": {
+            "type": "string",
+            "title": "Email"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "name",
+          "avatar_url",
+          "created_at"
+        ],
+        "title": "CustomerCardBlock",
+        "description": "A single customer's identity header, above their orders/subscriptions."
+      },
       "CustomerCreate": {
         "oneOf": [
           {
@@ -45307,6 +46289,33 @@
         ],
         "title": "CustomerEmailUpdateVerifyResponse"
       },
+      "CustomerGrowthPeriod": {
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp",
+            "description": "The start of the period."
+          },
+          "new_customers": {
+            "type": "integer",
+            "title": "New Customers",
+            "description": "The number of customers created during the period."
+          },
+          "total_customers": {
+            "type": "integer",
+            "title": "Total Customers",
+            "description": "The cumulative number of customers at the end of the period."
+          }
+        },
+        "type": "object",
+        "required": [
+          "timestamp",
+          "new_customers",
+          "total_customers"
+        ],
+        "title": "CustomerGrowthPeriod"
+      },
       "CustomerIndividual": {
         "properties": {
           "id": {
@@ -45497,6 +46506,19 @@
             "title": "Deleted At",
             "description": "Timestamp for when the customer was soft deleted."
           },
+          "first_user_event_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First User Event At",
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+          },
           "avatar_url": {
             "anyOf": [
               {
@@ -45527,6 +46549,7 @@
           "tax_id",
           "organization_id",
           "deleted_at",
+          "first_user_event_at",
           "avatar_url"
         ],
         "title": "CustomerIndividual",
@@ -48909,6 +49932,19 @@
             "title": "Deleted At",
             "description": "Timestamp for when the customer was soft deleted."
           },
+          "first_user_event_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First User Event At",
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+          },
           "avatar_url": {
             "anyOf": [
               {
@@ -48963,6 +49999,7 @@
           "tax_id",
           "organization_id",
           "deleted_at",
+          "first_user_event_at",
           "avatar_url",
           "active_subscriptions",
           "granted_benefits",
@@ -49571,6 +50608,19 @@
             "title": "Deleted At",
             "description": "Timestamp for when the customer was soft deleted."
           },
+          "first_user_event_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First User Event At",
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+          },
           "avatar_url": {
             "anyOf": [
               {
@@ -49624,6 +50674,7 @@
           "tax_id",
           "organization_id",
           "deleted_at",
+          "first_user_event_at",
           "avatar_url",
           "active_subscriptions",
           "granted_benefits",
@@ -50756,6 +51807,19 @@
             "title": "Deleted At",
             "description": "Timestamp for when the customer was soft deleted."
           },
+          "first_user_event_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First User Event At",
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+          },
           "avatar_url": {
             "anyOf": [
               {
@@ -50785,6 +51849,7 @@
           "tax_id",
           "organization_id",
           "deleted_at",
+          "first_user_event_at",
           "avatar_url"
         ],
         "title": "CustomerTeam",
@@ -51545,6 +52610,99 @@
         ],
         "title": "CustomerWalletSortProperty"
       },
+      "DataTableBlock": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "data_table",
+            "title": "Type",
+            "default": "data_table"
+          },
+          "entity": {
+            "type": "string",
+            "title": "Entity",
+            "description": "What the rows are, e.g. `subscriptions`."
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title",
+            "description": "Heading rendered above the table."
+          },
+          "columns": {
+            "items": {
+              "$ref": "#/components/schemas/DataTableColumn"
+            },
+            "type": "array",
+            "title": "Columns"
+          },
+          "rows": {
+            "items": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Rows"
+          },
+          "total_count": {
+            "type": "integer",
+            "title": "Total Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "entity",
+          "title",
+          "columns",
+          "rows",
+          "total_count"
+        ],
+        "title": "DataTableBlock",
+        "description": "Tabular entities (orders, subscriptions, customers, ...)."
+      },
+      "DataTableColumn": {
+        "properties": {
+          "key": {
+            "type": "string",
+            "title": "Key"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "format": {
+            "$ref": "#/components/schemas/ColumnFormat",
+            "default": "text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "key",
+          "label"
+        ],
+        "title": "DataTableColumn"
+      },
       "DiscordGuild": {
         "properties": {
           "name": {
@@ -51729,6 +52887,20 @@
             ],
             "title": "Max Redemptions",
             "description": "Optional maximum number of times the discount can be redeemed."
+          },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 2147483647.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Optional maximum number of times the discount can be redeemed by a single customer."
           },
           "products": {
             "anyOf": [
@@ -51967,6 +53139,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -52005,6 +53189,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id",
           "products"
@@ -52133,6 +53318,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -52164,6 +53361,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id"
         ],
@@ -52294,6 +53492,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -52333,6 +53543,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id",
           "products"
@@ -52465,6 +53676,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -52497,6 +53720,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id"
         ],
@@ -52589,6 +53813,20 @@
             ],
             "title": "Max Redemptions",
             "description": "Optional maximum number of times the discount can be redeemed."
+          },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 2147483647.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Optional maximum number of times the discount can be redeemed by a single customer."
           },
           "products": {
             "anyOf": [
@@ -52763,6 +54001,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -52799,6 +54049,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id",
           "products"
@@ -52905,6 +54156,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -52934,6 +54197,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id"
         ],
@@ -53042,6 +54306,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -53079,6 +54355,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id",
           "products"
@@ -53189,6 +54466,18 @@
             "title": "Max Redemptions",
             "description": "Maximum number of times the discount can be redeemed."
           },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Maximum number of times the discount can be redeemed by a single customer."
+          },
           "redemptions_count": {
             "type": "integer",
             "title": "Redemptions Count",
@@ -53219,6 +54508,7 @@
           "starts_at",
           "ends_at",
           "max_redemptions",
+          "max_redemptions_per_customer",
           "redemptions_count",
           "organization_id"
         ],
@@ -53383,6 +54673,28 @@
         "title": "DiscountProduct",
         "description": "A product that a discount can be applied to."
       },
+      "DiscountRedemptionLimitReached": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "DiscountRedemptionLimitReached",
+            "title": "Error",
+            "examples": [
+              "DiscountRedemptionLimitReached"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "DiscountRedemptionLimitReached"
+      },
       "DiscountSortProperty": {
         "type": "string",
         "enum": [
@@ -53501,6 +54813,20 @@
             ],
             "title": "Max Redemptions",
             "description": "Optional maximum number of times the discount can be redeemed."
+          },
+          "max_redemptions_per_customer": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 2147483647.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Redemptions Per Customer",
+            "description": "Optional maximum number of times the discount can be redeemed by a single customer."
           },
           "duration": {
             "anyOf": [
@@ -53789,6 +55115,28 @@
         "title": "Dispute",
         "description": "Schema representing a dispute.\n\nA dispute is a challenge raised by a customer or their bank regarding a payment."
       },
+      "DisputeAutoAcceptNotEnabled": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "DisputeAutoAcceptNotEnabled",
+            "title": "Error",
+            "examples": [
+              "DisputeAutoAcceptNotEnabled"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "DisputeAutoAcceptNotEnabled"
+      },
       "DisputeCustomer": {
         "properties": {
           "id": {
@@ -53984,6 +55332,19 @@
             "title": "Deleted At",
             "description": "Timestamp for when the customer was soft deleted."
           },
+          "first_user_event_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First User Event At",
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+          },
           "avatar_url": {
             "anyOf": [
               {
@@ -54013,6 +55374,7 @@
           "tax_id",
           "organization_id",
           "deleted_at",
+          "first_user_event_at",
           "avatar_url"
         ],
         "title": "DisputeCustomer"
@@ -54363,6 +55725,18 @@
             "format": "date-time",
             "title": "Created At"
           },
+          "flagged_malicious_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Flagged Malicious At"
+          },
           "size_readable": {
             "type": "string",
             "title": "Size Readable",
@@ -54386,6 +55760,7 @@
           "service",
           "is_uploaded",
           "created_at",
+          "flagged_malicious_at",
           "size_readable"
         ],
         "title": "DownloadableFileRead",
@@ -54471,6 +55846,77 @@
           "email"
         ],
         "title": "EmailUpdateRequest"
+      },
+      "EntityListBlock": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "entity_list",
+            "title": "Type",
+            "default": "entity_list"
+          },
+          "entity": {
+            "type": "string",
+            "title": "Entity",
+            "description": "What the items are, e.g. `orders`."
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title",
+            "description": "Heading rendered above the list."
+          },
+          "columns": {
+            "items": {
+              "$ref": "#/components/schemas/DataTableColumn"
+            },
+            "type": "array",
+            "title": "Columns"
+          },
+          "rows": {
+            "items": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Rows"
+          },
+          "total_count": {
+            "type": "integer",
+            "title": "Total Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "entity",
+          "title",
+          "columns",
+          "rows",
+          "total_count"
+        ],
+        "title": "EntityListBlock",
+        "description": "A few entities as a compact list; same shape as the table so the\nclient formats values (currency, dates) identically in both."
       },
       "Event": {
         "oneOf": [
@@ -56054,6 +57500,28 @@
         ],
         "title": "IdentityVerificationStatus"
       },
+      "InactiveSubscription": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "InactiveSubscription",
+            "title": "Error",
+            "examples": [
+              "InactiveSubscription"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "InactiveSubscription"
+      },
       "Insight": {
         "properties": {
           "id": {
@@ -56169,6 +57637,29 @@
         ],
         "title": "Insight",
         "description": "A computed, narrated reading of the business with a drill-down."
+      },
+      "InsightCardsBlock": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "insight_cards",
+            "title": "Type",
+            "default": "insight_cards"
+          },
+          "insights": {
+            "items": {
+              "$ref": "#/components/schemas/Insight"
+            },
+            "type": "array",
+            "title": "Insights"
+          }
+        },
+        "type": "object",
+        "required": [
+          "insights"
+        ],
+        "title": "InsightCardsBlock",
+        "description": "Compass insights, rendered with the same card as the feed."
       },
       "InsightCategory": {
         "type": "string",
@@ -57122,6 +58613,19 @@
             "title": "Deleted At",
             "description": "Timestamp for when the customer was soft deleted."
           },
+          "first_user_event_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First User Event At",
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+          },
           "avatar_url": {
             "anyOf": [
               {
@@ -57151,6 +58655,7 @@
           "tax_id",
           "organization_id",
           "deleted_at",
+          "first_user_event_at",
           "avatar_url"
         ],
         "title": "LicenseKeyCustomer"
@@ -57719,6 +59224,26 @@
         ],
         "title": "ListResourceWithCursorPagination[Event]"
       },
+      "ListResource_BenefitDownloadableFile_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/BenefitDownloadableFile"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "pagination"
+        ],
+        "title": "ListResource[BenefitDownloadableFile]"
+      },
       "ListResource_BenefitGrant_": {
         "properties": {
           "items": {
@@ -57799,6 +59324,46 @@
           "pagination"
         ],
         "title": "ListResource[Checkout]"
+      },
+      "ListResource_CompassThreadMessageSchema_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CompassThreadMessageSchema"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "pagination"
+        ],
+        "title": "ListResource[CompassThreadMessageSchema]"
+      },
+      "ListResource_CompassThreadSchema_": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/CompassThreadSchema"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "pagination"
+        ],
+        "title": "ListResource[CompassThreadSchema]"
       },
       "ListResource_CustomField_": {
         "properties": {
@@ -58836,6 +60401,65 @@
         ],
         "title": "MaintainerAccountCreditsGrantedNotificationPayload"
       },
+      "MaintainerFileFlaggedMaliciousNotification": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid4",
+            "title": "Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "type": {
+            "type": "string",
+            "const": "MaintainerFileFlaggedMaliciousNotification",
+            "title": "Type"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/MaintainerFileFlaggedMaliciousNotificationPayload"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "created_at",
+          "type",
+          "payload"
+        ],
+        "title": "MaintainerFileFlaggedMaliciousNotification"
+      },
+      "MaintainerFileFlaggedMaliciousNotificationPayload": {
+        "properties": {
+          "file_name": {
+            "type": "string",
+            "title": "File Name"
+          },
+          "organization_name": {
+            "type": "string",
+            "title": "Organization Name"
+          },
+          "organization_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organization Slug"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file_name",
+          "organization_name"
+        ],
+        "title": "MaintainerFileFlaggedMaliciousNotificationPayload"
+      },
       "MaintainerNewPaidSubscriptionNotification": {
         "properties": {
           "id": {
@@ -59166,6 +60790,119 @@
           "order_url"
         ],
         "title": "MaintainerNewProductSaleNotificationPayload"
+      },
+      "MaintainerSubscriptionRenewalNotification": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid4",
+            "title": "Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "type": {
+            "type": "string",
+            "const": "MaintainerSubscriptionRenewalNotification",
+            "title": "Type"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/MaintainerSubscriptionRenewalNotificationPayload"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "created_at",
+          "type",
+          "payload"
+        ],
+        "title": "MaintainerSubscriptionRenewalNotification"
+      },
+      "MaintainerSubscriptionRenewalNotificationPayload": {
+        "properties": {
+          "product_name": {
+            "type": "string",
+            "title": "Product Name"
+          },
+          "product_price_amount": {
+            "type": "integer",
+            "title": "Product Price Amount"
+          },
+          "customer_name": {
+            "type": "string",
+            "title": "Customer Name",
+            "default": ""
+          },
+          "customer_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Customer Email"
+          },
+          "organization_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Organization Slug"
+          },
+          "subscription_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subscription Id"
+          },
+          "recurring_interval": {
+            "type": "string",
+            "title": "Recurring Interval"
+          },
+          "recurring_interval_count": {
+            "type": "integer",
+            "title": "Recurring Interval Count",
+            "default": 1
+          },
+          "currency": {
+            "type": "string",
+            "title": "Currency",
+            "default": "usd"
+          },
+          "formatted_price_amount": {
+            "type": "string",
+            "title": "Formatted Price Amount",
+            "readOnly": true
+          },
+          "formatted_recurring_interval": {
+            "type": "string",
+            "title": "Formatted Recurring Interval",
+            "readOnly": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "product_name",
+          "product_price_amount",
+          "recurring_interval",
+          "formatted_price_amount",
+          "formatted_recurring_interval"
+        ],
+        "title": "MaintainerSubscriptionRenewalNotificationPayload"
       },
       "ManualRetryLimitExceeded": {
         "properties": {
@@ -59673,6 +61410,91 @@
         ],
         "title": "MerchantMigrationCreate"
       },
+      "MerchantMigrationImportReport": {
+        "properties": {
+          "step": {
+            "$ref": "#/components/schemas/MerchantMigrationStep",
+            "description": "The migration step after the import."
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/MerchantMigrationImportResult"
+            },
+            "type": "array",
+            "title": "Results",
+            "description": "Per-entity counts of what was imported vs skipped."
+          }
+        },
+        "type": "object",
+        "required": [
+          "step",
+          "results"
+        ],
+        "title": "MerchantMigrationImportReport"
+      },
+      "MerchantMigrationImportRequest": {
+        "properties": {
+          "record_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "uuid4"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Record Ids",
+            "description": "The ledger record ids to import (from the records listing). When omitted, every importable record is imported (subject to `exclude_record_ids`). Records not selected stay pending."
+          },
+          "exclude_record_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "uuid4"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exclude Record Ids",
+            "description": "Import every importable record except these \u2014 the opt-out selection for large catalogs. Ignored when `record_ids` is set."
+          }
+        },
+        "type": "object",
+        "title": "MerchantMigrationImportRequest"
+      },
+      "MerchantMigrationImportResult": {
+        "properties": {
+          "entity": {
+            "$ref": "#/components/schemas/PrecheckEntity",
+            "description": "The source entity type."
+          },
+          "imported": {
+            "type": "integer",
+            "title": "Imported",
+            "description": "How many were created or reused in Polar."
+          },
+          "skipped": {
+            "type": "integer",
+            "title": "Skipped",
+            "description": "How many were left on the source (not importable)."
+          }
+        },
+        "type": "object",
+        "required": [
+          "entity",
+          "imported",
+          "skipped"
+        ],
+        "title": "MerchantMigrationImportResult"
+      },
       "MerchantMigrationNotEnabled": {
         "properties": {
           "error": {
@@ -59719,6 +61541,19 @@
       },
       "MerchantMigrationRecordItem": {
         "properties": {
+          "record_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid4"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Record Id",
+            "description": "The ledger record id, used to select this row for import. Null for price rows, which are imported together with their product."
+          },
           "entity": {
             "$ref": "#/components/schemas/PrecheckEntity",
             "description": "The source entity type."
@@ -59743,11 +61578,58 @@
               }
             ],
             "title": "Subtitle",
-            "description": "Secondary detail (interval, amount, country, status)."
+            "description": "Secondary detail (lifecycle status, country)."
+          },
+          "amount": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Amount",
+            "description": "Recurring price in the currency's smallest unit (cents for USD), for priced rows."
+          },
+          "currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Currency",
+            "description": "ISO currency for `amount`."
+          },
+          "recurring_interval": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recurring Interval",
+            "description": "Billing interval for `amount` (e.g. `month`, `year`)."
           },
           "status": {
             "$ref": "#/components/schemas/PrecheckRecordStatus",
             "description": "Whether this record will be imported or stays on the source."
+          },
+          "import_status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MerchantMigrationRecordStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The ledger status of this record: `pending` (not imported yet), `imported`, `skipped` or `failed`. Null for price rows, which import with their product."
           },
           "reason": {
             "anyOf": [
@@ -59759,7 +61641,7 @@
               }
             ],
             "title": "Reason",
-            "description": "Why the record is skipped, if it is."
+            "description": "Why the record is skipped, or what to know about it if it isn't."
           },
           "reason_code": {
             "anyOf": [
@@ -59771,20 +61653,115 @@
               }
             ],
             "title": "Reason Code",
-            "description": "Stable code for the skip reason, if any."
+            "description": "Stable code for `reason`, if any."
+          },
+          "reason_level": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PrecheckReasonLevel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "How urgent `reason` is: `action_required` when the merchant has to fix something, `info` when there is nothing to fix. Null without a reason."
+          }
+        },
+        "type": "object",
+        "required": [
+          "record_id",
+          "entity",
+          "source_id",
+          "title",
+          "subtitle",
+          "amount",
+          "currency",
+          "recurring_interval",
+          "status",
+          "import_status",
+          "reason",
+          "reason_code",
+          "reason_level"
+        ],
+        "title": "MerchantMigrationRecordItem"
+      },
+      "MerchantMigrationRecordStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "imported",
+          "skipped",
+          "failed"
+        ],
+        "title": "MerchantMigrationRecordStatus"
+      },
+      "MerchantMigrationRecordSummary": {
+        "properties": {
+          "entities": {
+            "items": {
+              "$ref": "#/components/schemas/MerchantMigrationRecordSummaryEntity"
+            },
+            "type": "array",
+            "title": "Entities",
+            "description": "Per-entity counts, for the listable entities only."
+          },
+          "action_required": {
+            "type": "integer",
+            "title": "Action Required",
+            "description": "How many records the pre-check flagged for the merchant to fix, across entities. Classification only, so a flagged record that has since been imported still counts."
+          }
+        },
+        "type": "object",
+        "required": [
+          "entities",
+          "action_required"
+        ],
+        "title": "MerchantMigrationRecordSummary",
+        "description": "Every count the review UI needs, from one classification pass."
+      },
+      "MerchantMigrationRecordSummaryEntity": {
+        "properties": {
+          "entity": {
+            "$ref": "#/components/schemas/PrecheckEntity",
+            "description": "The source entity type."
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total",
+            "description": "How many were read from the source."
+          },
+          "importable": {
+            "type": "integer",
+            "title": "Importable",
+            "description": "How many will be imported into Polar."
+          },
+          "skipped": {
+            "type": "integer",
+            "title": "Skipped",
+            "description": "How many won't be imported and stay on the source."
+          },
+          "imported": {
+            "type": "integer",
+            "title": "Imported",
+            "description": "How many are already in Polar."
+          },
+          "selectable": {
+            "type": "integer",
+            "title": "Selectable",
+            "description": "How many an import would actually move: importable by the pre-check and still pending in the ledger."
           }
         },
         "type": "object",
         "required": [
           "entity",
-          "source_id",
-          "title",
-          "subtitle",
-          "status",
-          "reason",
-          "reason_code"
+          "total",
+          "importable",
+          "skipped",
+          "imported",
+          "selectable"
         ],
-        "title": "MerchantMigrationRecordItem"
+        "title": "MerchantMigrationRecordSummaryEntity",
+        "description": "The pre-check's per-entity counts, plus where the ledger has got to."
       },
       "MerchantMigrationSourcePlatform": {
         "type": "string",
@@ -60625,6 +62602,66 @@
         ],
         "title": "Metric",
         "description": "Information about a metric."
+      },
+      "MetricChartBlock": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "metric_chart",
+            "title": "Type",
+            "default": "metric_chart"
+          },
+          "metric": {
+            "type": "string",
+            "title": "Metric",
+            "description": "Metric slug, e.g. `monthly_recurring_revenue`."
+          },
+          "label": {
+            "type": "string",
+            "title": "Label",
+            "description": "Human-readable metric name."
+          },
+          "unit": {
+            "type": "string",
+            "title": "Unit",
+            "description": "Metric unit type, e.g. `currency` or `scalar`."
+          },
+          "points": {
+            "items": {
+              "$ref": "#/components/schemas/MetricChartPoint"
+            },
+            "type": "array",
+            "title": "Points"
+          }
+        },
+        "type": "object",
+        "required": [
+          "metric",
+          "label",
+          "unit",
+          "points"
+        ],
+        "title": "MetricChartBlock",
+        "description": "A single metric's series over the requested window."
+      },
+      "MetricChartPoint": {
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timestamp"
+          },
+          "value": {
+            "type": "number",
+            "title": "Value"
+          }
+        },
+        "type": "object",
+        "required": [
+          "timestamp",
+          "value"
+        ],
+        "title": "MetricChartPoint"
       },
       "MetricDashboardCreate": {
         "properties": {
@@ -63218,15 +65255,23 @@
                   "$ref": "#/components/schemas/MaintainerNewProductSaleNotification"
                 },
                 {
+                  "$ref": "#/components/schemas/MaintainerSubscriptionRenewalNotification"
+                },
+                {
                   "$ref": "#/components/schemas/MaintainerAccountCreditsGrantedNotification"
+                },
+                {
+                  "$ref": "#/components/schemas/MaintainerFileFlaggedMaliciousNotification"
                 }
               ],
               "discriminator": {
                 "propertyName": "type",
                 "mapping": {
                   "MaintainerAccountCreditsGrantedNotification": "#/components/schemas/MaintainerAccountCreditsGrantedNotification",
+                  "MaintainerFileFlaggedMaliciousNotification": "#/components/schemas/MaintainerFileFlaggedMaliciousNotification",
                   "MaintainerNewPaidSubscriptionNotification": "#/components/schemas/MaintainerNewPaidSubscriptionNotification",
-                  "MaintainerNewProductSaleNotification": "#/components/schemas/MaintainerNewProductSaleNotification"
+                  "MaintainerNewProductSaleNotification": "#/components/schemas/MaintainerNewProductSaleNotification",
+                  "MaintainerSubscriptionRenewalNotification": "#/components/schemas/MaintainerSubscriptionRenewalNotification"
                 }
               }
             },
@@ -64426,7 +66471,8 @@
           "purchase",
           "subscription_create",
           "subscription_cycle",
-          "subscription_update"
+          "subscription_update",
+          "subscription_meter_cycle"
         ],
         "title": "OrderBillingReason"
       },
@@ -64438,7 +66484,8 @@
           "subscription_cycle",
           "subscription_cycle_after_trial",
           "subscription_cancel",
-          "subscription_update"
+          "subscription_update",
+          "subscription_meter_cycle"
         ],
         "title": "OrderBillingReasonInternal",
         "description": "Internal billing reasons with additional granularity."
@@ -64769,6 +66816,19 @@
             "title": "Deleted At",
             "description": "Timestamp for when the customer was soft deleted."
           },
+          "first_user_event_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First User Event At",
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+          },
           "avatar_url": {
             "anyOf": [
               {
@@ -64798,9 +66858,32 @@
           "tax_id",
           "organization_id",
           "deleted_at",
+          "first_user_event_at",
           "avatar_url"
         ],
         "title": "OrderCustomer"
+      },
+      "OrderExportColumn": {
+        "type": "string",
+        "enum": [
+          "email",
+          "created_at",
+          "product",
+          "net_amount",
+          "currency",
+          "status",
+          "invoice_number",
+          "customer_name",
+          "billing_name",
+          "billing_country",
+          "subtotal_amount",
+          "discount_amount",
+          "tax_amount",
+          "total_amount",
+          "refunded_amount",
+          "billing_reason"
+        ],
+        "title": "OrderExportColumn"
       },
       "OrderFinalize": {
         "properties": {
@@ -66418,6 +68501,19 @@
             "title": "Details Submitted At",
             "description": "When the business details were submitted for review."
           },
+          "onboarding_resubmission_requested_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onboarding Resubmission Requested At",
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable."
+          },
           "sso_enforced": {
             "type": "boolean",
             "title": "Sso Enforced",
@@ -66454,6 +68550,23 @@
           "customer_portal_settings": {
             "$ref": "#/components/schemas/OrganizationCustomerPortalSettings",
             "description": "Settings related to the customer portal"
+          },
+          "dispute_settings": {
+            "$ref": "#/components/schemas/OrganizationDisputeSettings",
+            "description": "Settings related to disputes"
+          },
+          "embed_hosts": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Embed Hosts",
+            "description": "Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts \u2014 `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on."
+          },
+          "embed_hosts_enforced": {
+            "type": "boolean",
+            "title": "Embed Hosts Enforced",
+            "description": "Whether an embedding page's origin must match `embed_hosts`. Organizations that have not configured a list yet embed unchecked until the allowlist is enforced for everyone."
           },
           "country": {
             "anyOf": [
@@ -67015,6 +69128,7 @@
           "socials",
           "status",
           "details_submitted_at",
+          "onboarding_resubmission_requested_at",
           "sso_enforced",
           "default_presentment_currency",
           "default_tax_behavior",
@@ -67022,6 +69136,9 @@
           "subscription_settings",
           "customer_email_settings",
           "customer_portal_settings",
+          "dispute_settings",
+          "embed_hosts",
+          "embed_hosts_enforced",
           "account_id",
           "payout_account_id",
           "capabilities"
@@ -68461,6 +70578,10 @@
             "type": "boolean",
             "title": "Order Confirmation"
           },
+          "payment_method_expiration_reminder": {
+            "type": "boolean",
+            "title": "Payment Method Expiration Reminder"
+          },
           "subscription_cancellation": {
             "type": "boolean",
             "title": "Subscription Cancellation"
@@ -68513,6 +70634,7 @@
         "type": "object",
         "required": [
           "order_confirmation",
+          "payment_method_expiration_reminder",
           "subscription_cancellation",
           "subscription_confirmation",
           "subscription_cycled",
@@ -68722,6 +70844,94 @@
         "type": "object",
         "title": "OrganizationDetails"
       },
+      "OrganizationDisputeSettings": {
+        "properties": {
+          "auto_accept_below_amount": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auto Accept Below Amount"
+          }
+        },
+        "type": "object",
+        "required": [
+          "auto_accept_below_amount"
+        ],
+        "title": "OrganizationDisputeSettings",
+        "description": "`auto_accept_below_amount` is in Polar's settlement currency (USD)."
+      },
+      "OrganizationDisputeSettingsUpdate": {
+        "properties": {
+          "auto_accept_below_amount": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 10000.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auto Accept Below Amount",
+            "description": "Concede disputes below this amount, in USD cents, without asking the organization. A dispute charged in another currency converts at the rate its payment settled at. `null` turns it off. The disputed amount and the processor's dispute fee are still deducted."
+          }
+        },
+        "type": "object",
+        "title": "OrganizationDisputeSettingsUpdate"
+      },
+      "OrganizationEmbedStatus": {
+        "properties": {
+          "has_embedded": {
+            "type": "boolean",
+            "title": "Has Embedded",
+            "description": "Whether this organization has ever opened an embedded checkout."
+          },
+          "embed_hosts": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Embed Hosts",
+            "description": "Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts \u2014 `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on."
+          },
+          "embed_hosts_enforced": {
+            "type": "boolean",
+            "title": "Embed Hosts Enforced",
+            "description": "Whether an embedding page's origin must match `embed_hosts`."
+          },
+          "shared_hosts": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Shared Hosts",
+            "description": "Entries of `embed_hosts` admitting every tenant of a platform, such as `*.vercel.app`."
+          },
+          "uncovered_hosts": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationUncoveredHost"
+            },
+            "type": "array",
+            "title": "Uncovered Hosts",
+            "description": "Hosts seen embedding this organization's checkout that `embed_hosts` would refuse. Anyone can name an origin when they create a checkout, so these are observations, not hosts we vouch for."
+          }
+        },
+        "type": "object",
+        "required": [
+          "has_embedded",
+          "embed_hosts",
+          "embed_hosts_enforced",
+          "shared_hosts",
+          "uncovered_hosts"
+        ],
+        "title": "OrganizationEmbedStatus"
+      },
       "OrganizationFeatureSettings": {
         "properties": {
           "issue_funding_enabled": {
@@ -68803,6 +71013,12 @@
             "type": "boolean",
             "title": "Sso Enabled",
             "description": "If this organization has single sign-on configuration enabled",
+            "default": false
+          },
+          "dispute_auto_accept_enabled": {
+            "type": "boolean",
+            "title": "Dispute Auto Accept Enabled",
+            "description": "If this organization can set a threshold below which Polar concedes disputes on its behalf. Requires `disputes_enabled`.",
             "default": false
           },
           "compass_enabled": {
@@ -68982,6 +71198,19 @@
             "title": "Details Submitted At",
             "description": "When the business details were submitted for review."
           },
+          "onboarding_resubmission_requested_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onboarding Resubmission Requested At",
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable."
+          },
           "sso_enforced": {
             "type": "boolean",
             "title": "Sso Enforced",
@@ -69018,6 +71247,23 @@
           "customer_portal_settings": {
             "$ref": "#/components/schemas/OrganizationCustomerPortalSettings",
             "description": "Settings related to the customer portal"
+          },
+          "dispute_settings": {
+            "$ref": "#/components/schemas/OrganizationDisputeSettings",
+            "description": "Settings related to disputes"
+          },
+          "embed_hosts": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Embed Hosts",
+            "description": "Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts \u2014 `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on."
+          },
+          "embed_hosts_enforced": {
+            "type": "boolean",
+            "title": "Embed Hosts Enforced",
+            "description": "Whether an embedding page's origin must match `embed_hosts`. Organizations that have not configured a list yet embed unchecked until the allowlist is enforced for everyone."
           },
           "country": {
             "anyOf": [
@@ -69590,6 +71836,7 @@
           "socials",
           "status",
           "details_submitted_at",
+          "onboarding_resubmission_requested_at",
           "sso_enforced",
           "default_presentment_currency",
           "default_tax_behavior",
@@ -69597,6 +71844,9 @@
           "subscription_settings",
           "customer_email_settings",
           "customer_portal_settings",
+          "dispute_settings",
+          "embed_hosts",
+          "embed_hosts_enforced",
           "account_id",
           "payout_account_id",
           "capabilities"
@@ -69716,13 +71966,18 @@
           "chargeback_prevention": {
             "type": "boolean",
             "title": "Chargeback Prevention"
+          },
+          "subscription_renewal": {
+            "type": "boolean",
+            "title": "Subscription Renewal"
           }
         },
         "type": "object",
         "required": [
           "new_order",
           "new_subscription",
-          "chargeback_prevention"
+          "chargeback_prevention",
+          "subscription_renewal"
         ],
         "title": "OrganizationNotificationSettings"
       },
@@ -69901,12 +72156,26 @@
           "organization_status": {
             "$ref": "#/components/schemas/OrganizationStatus",
             "description": "Current organization status"
+          },
+          "onboarding_resubmission_requested_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onboarding Resubmission Requested At",
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable. Null for organizations that have never been reset for review."
           }
         },
         "type": "object",
         "required": [
           "payment_ready",
-          "organization_status"
+          "organization_status",
+          "onboarding_resubmission_requested_at"
         ],
         "title": "OrganizationPaymentStatus"
       },
@@ -71115,6 +73384,39 @@
         ],
         "title": "OrganizationSubscriptionUpdate"
       },
+      "OrganizationUncoveredHost": {
+        "properties": {
+          "host": {
+            "type": "string",
+            "title": "Host",
+            "description": "The entry that would admit this origin."
+          },
+          "origin": {
+            "type": "string",
+            "title": "Origin",
+            "description": "The origin seen embedding the checkout."
+          },
+          "checkouts": {
+            "type": "integer",
+            "title": "Checkouts",
+            "description": "Embedded checkouts opened from this origin."
+          },
+          "last_seen_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Seen At",
+            "description": "When it last opened one."
+          }
+        },
+        "type": "object",
+        "required": [
+          "host",
+          "origin",
+          "checkouts",
+          "last_seen_at"
+        ],
+        "title": "OrganizationUncoveredHost"
+      },
       "OrganizationUpdate": {
         "properties": {
           "name": {
@@ -71741,6 +74043,38 @@
               }
             ]
           },
+          "dispute_settings": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OrganizationDisputeSettingsUpdate"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "embed_hosts": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts \u2014 `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on.",
+                "examples": [
+                  [
+                    "example.com",
+                    "*.example.com",
+                    "localhost:3000"
+                  ]
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Embed Hosts"
+          },
           "default_presentment_currency": {
             "anyOf": [
               {
@@ -71941,6 +74275,19 @@
             "title": "Details Submitted At",
             "description": "When the business details were submitted for review."
           },
+          "onboarding_resubmission_requested_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onboarding Resubmission Requested At",
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable."
+          },
           "sso_enforced": {
             "type": "boolean",
             "title": "Sso Enforced",
@@ -71977,6 +74324,23 @@
           "customer_portal_settings": {
             "$ref": "#/components/schemas/OrganizationCustomerPortalSettings",
             "description": "Settings related to the customer portal"
+          },
+          "dispute_settings": {
+            "$ref": "#/components/schemas/OrganizationDisputeSettings",
+            "description": "Settings related to disputes"
+          },
+          "embed_hosts": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Embed Hosts",
+            "description": "Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts \u2014 `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on."
+          },
+          "embed_hosts_enforced": {
+            "type": "boolean",
+            "title": "Embed Hosts Enforced",
+            "description": "Whether an embedding page's origin must match `embed_hosts`. Organizations that have not configured a list yet embed unchecked until the allowlist is enforced for everyone."
           },
           "country": {
             "anyOf": [
@@ -72550,6 +74914,7 @@
           "socials",
           "status",
           "details_submitted_at",
+          "onboarding_resubmission_requested_at",
           "sso_enforced",
           "default_presentment_currency",
           "default_tax_behavior",
@@ -72557,6 +74922,9 @@
           "subscription_settings",
           "customer_email_settings",
           "customer_portal_settings",
+          "dispute_settings",
+          "embed_hosts",
+          "embed_hosts_enforced",
           "account_id",
           "payout_account_id",
           "capabilities",
@@ -72583,6 +74951,385 @@
           "max_page"
         ],
         "title": "Pagination"
+      },
+      "PanStepActor": {
+        "type": "string",
+        "enum": [
+          "merchant",
+          "ops",
+          "system"
+        ],
+        "title": "PanStepActor",
+        "description": "Who is asking to move a step, which decides what they're allowed to move."
+      },
+      "PanStepKind": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "input",
+          "confirm"
+        ],
+        "title": "PanStepKind",
+        "description": "What the owner has to do, which is what the frontend renders."
+      },
+      "PanStepNotActionable": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "PanStepNotActionable",
+            "title": "Error",
+            "examples": [
+              "PanStepNotActionable"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "PanStepNotActionable"
+      },
+      "PanStepNotFound": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "PanStepNotFound",
+            "title": "Error",
+            "examples": [
+              "PanStepNotFound"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "PanStepNotFound"
+      },
+      "PanStepNotOwned": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "PanStepNotOwned",
+            "title": "Error",
+            "examples": [
+              "PanStepNotOwned"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "PanStepNotOwned"
+      },
+      "PanStepOwner": {
+        "type": "string",
+        "enum": [
+          "merchant",
+          "polar_ops",
+          "polar_app",
+          "stripe",
+          "provider"
+        ],
+        "title": "PanStepOwner",
+        "description": "Who moves a step forward."
+      },
+      "PanStepStatus": {
+        "type": "string",
+        "enum": [
+          "blocked",
+          "pending",
+          "in_progress",
+          "completed"
+        ],
+        "title": "PanStepStatus"
+      },
+      "PanTransferAlreadyStarted": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "PanTransferAlreadyStarted",
+            "title": "Error",
+            "examples": [
+              "PanTransferAlreadyStarted"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "PanTransferAlreadyStarted"
+      },
+      "PanTransferChecklist": {
+        "properties": {
+          "method": {
+            "$ref": "#/components/schemas/PanTransferMethod",
+            "description": "How the cards move: `pan_copy` for a Stripe source (account to account), `pan_import` for any other vault."
+          },
+          "started": {
+            "type": "boolean",
+            "title": "Started",
+            "description": "Whether the card transfer has been started. Steps are empty until it is."
+          },
+          "current_step_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Step Key",
+            "description": "The one step that can be acted on now. Null once every step is done."
+          },
+          "destination_account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Destination Account Id",
+            "description": "The Stripe account the cards move into. The merchant needs it to address the copy or import to Polar."
+          },
+          "steps": {
+            "items": {
+              "$ref": "#/components/schemas/PanTransferStep"
+            },
+            "type": "array",
+            "title": "Steps",
+            "description": "The ordered checklist. Titles and guidance live in the client, keyed by `key`."
+          }
+        },
+        "type": "object",
+        "required": [
+          "method",
+          "started",
+          "current_step_key",
+          "destination_account_id",
+          "steps"
+        ],
+        "title": "PanTransferChecklist"
+      },
+      "PanTransferMethod": {
+        "type": "string",
+        "enum": [
+          "pan_copy",
+          "pan_import"
+        ],
+        "title": "PanTransferMethod",
+        "description": "How the cards reach Polar's Stripe account."
+      },
+      "PanTransferNotReady": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "PanTransferNotReady",
+            "title": "Error",
+            "examples": [
+              "PanTransferNotReady"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "PanTransferNotReady"
+      },
+      "PanTransferNotStarted": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "PanTransferNotStarted",
+            "title": "Error",
+            "examples": [
+              "PanTransferNotStarted"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "PanTransferNotStarted"
+      },
+      "PanTransferStep": {
+        "properties": {
+          "key": {
+            "type": "string",
+            "title": "Key",
+            "description": "Stable identifier. The client keys its copy off it."
+          },
+          "owner": {
+            "$ref": "#/components/schemas/PanStepOwner",
+            "description": "Who moves this step forward."
+          },
+          "kind": {
+            "$ref": "#/components/schemas/PanStepKind",
+            "description": "What the owner does, so the client knows what to render."
+          },
+          "status": {
+            "$ref": "#/components/schemas/PanStepStatus",
+            "description": "Where the step is. Only one step is actionable at a time."
+          },
+          "inputs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Inputs",
+            "description": "Values collected on this step."
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note",
+            "description": "Free text from Polar Ops, shown to the merchant. How a weeks-long wait on Stripe or the provider gets explained without a support thread."
+          },
+          "expected_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected At",
+            "description": "When Ops expects this step to land."
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At",
+            "description": "When the step became actionable."
+          },
+          "completed_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completed At",
+            "description": "When the step was completed."
+          },
+          "completed_by": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PanStepActor"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Who completed the step."
+          }
+        },
+        "type": "object",
+        "required": [
+          "key",
+          "owner",
+          "kind",
+          "status",
+          "inputs",
+          "note",
+          "expected_at",
+          "started_at",
+          "completed_at",
+          "completed_by"
+        ],
+        "title": "PanTransferStep",
+        "description": "One checklist step, as persisted on `MerchantMigration.pan_transfer_steps`.\n\nThe row is self-contained: owner and kind are copied off the template so both\nthe stored JSONB and the API response can be read without resolving a\ntemplate. The template stays authoritative for the rules that gate a\ntransition (`auto_complete`, the accepted inputs), so a step whose key no\nlonger has a template can't be completed."
+      },
+      "PanTransferStepComplete": {
+        "properties": {
+          "inputs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Inputs",
+            "description": "Values the step collects. Which keys it accepts depends on the step; unknown keys are rejected."
+          }
+        },
+        "type": "object",
+        "title": "PanTransferStepComplete"
+      },
+      "PanTransferUnavailable": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "PanTransferUnavailable",
+            "title": "Error",
+            "examples": [
+              "PanTransferUnavailable"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "PanTransferUnavailable"
       },
       "PauseResumeNotAllowed": {
         "properties": {
@@ -72903,6 +75650,28 @@
           "detail"
         ],
         "title": "PaymentMethodInUseByActiveSubscription"
+      },
+      "PaymentMethodRequired": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "PaymentMethodRequired",
+            "title": "Error",
+            "examples": [
+              "PaymentMethodRequired"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "PaymentMethodRequired"
       },
       "PaymentMethodSetupFailed": {
         "properties": {
@@ -73895,6 +76664,14 @@
           "warning"
         ],
         "title": "PrecheckIssueLevel"
+      },
+      "PrecheckReasonLevel": {
+        "type": "string",
+        "enum": [
+          "action_required",
+          "info"
+        ],
+        "title": "PrecheckReasonLevel"
       },
       "PrecheckRecordStatus": {
         "type": "string",
@@ -77722,6 +80499,28 @@
         ],
         "title": "SlackWorkspaceUsersResponse"
       },
+      "SourceAccountNotMigratable": {
+        "properties": {
+          "error": {
+            "type": "string",
+            "const": "SourceAccountNotMigratable",
+            "title": "Error",
+            "examples": [
+              "SourceAccountNotMigratable"
+            ]
+          },
+          "detail": {
+            "type": "string",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "required": [
+          "error",
+          "detail"
+        ],
+        "title": "SourceAccountNotMigratable"
+      },
       "SourceKeyModeMismatch": {
         "properties": {
           "error": {
@@ -79473,6 +82272,19 @@
             "title": "Deleted At",
             "description": "Timestamp for when the customer was soft deleted."
           },
+          "first_user_event_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First User Event At",
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+          },
           "avatar_url": {
             "anyOf": [
               {
@@ -79502,6 +82314,7 @@
           "tax_id",
           "organization_id",
           "deleted_at",
+          "first_user_event_at",
           "avatar_url"
         ],
         "title": "SubscriptionCustomer"
@@ -79678,6 +82491,34 @@
           "subscription_id"
         ],
         "title": "SubscriptionCycledMetadata"
+      },
+      "SubscriptionExportColumn": {
+        "type": "string",
+        "enum": [
+          "email",
+          "started_at",
+          "product",
+          "amount",
+          "currency",
+          "status",
+          "recurring_interval",
+          "customer_name",
+          "billing_name",
+          "billing_country",
+          "net_amount",
+          "discount",
+          "seats",
+          "current_period_start",
+          "current_period_end",
+          "cancel_at_period_end",
+          "canceled_at",
+          "ends_at",
+          "ended_at",
+          "cancellation_reason",
+          "trial_start",
+          "trial_end"
+        ],
+        "title": "SubscriptionExportColumn"
       },
       "SubscriptionLocked": {
         "properties": {
@@ -82456,7 +85297,10 @@
           "dispute_won",
           "dispute_lost",
           "dispute_prevented",
-          "merchant_accepted"
+          "merchant_accepted",
+          "dispute_auto_accept_scheduled",
+          "dispute_auto_accept_canceled",
+          "dispute_auto_accepted"
         ],
         "title": "SupportCaseMessageType",
         "description": "Known message types. Stored as a plain string column (not a DB enum):\n``chat`` and lifecycle values are generic, while action values are\ndomain-specific and grow per case type. Validated at the app boundary."
@@ -82939,6 +85783,26 @@
         "title": "TaxSummary",
         "description": "Aggregated tax remitted by Polar across all jurisdictions.\n\nTotals span the full filtered dataset, independent of the pagination\napplied to the jurisdiction breakdown."
       },
+      "TextBlock": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "text",
+            "title": "Type",
+            "default": "text"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "title": "TextBlock",
+        "description": "Plain narrated text."
+      },
       "TimeInterval": {
         "type": "string",
         "enum": [
@@ -83000,6 +85864,83 @@
           "scope"
         ],
         "title": "TokenResponse"
+      },
+      "TopCustomer": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid4",
+            "title": "Id",
+            "description": "The ID of the customer.",
+            "examples": [
+              "992fae2a-2a17-4b7a-8d9e-e287cf90131b"
+            ]
+          },
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email",
+            "description": "The email address of the customer. This must be unique within the organization.",
+            "examples": [
+              "customer@example.com"
+            ]
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "The name of the customer.",
+            "examples": [
+              "John Doe"
+            ]
+          },
+          "avatar_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar Url",
+            "examples": [
+              "https://www.gravatar.com/avatar/xxx?d=404"
+            ]
+          },
+          "order_count": {
+            "type": "integer",
+            "title": "Order Count",
+            "description": "The number of paid orders in the period."
+          },
+          "net_revenue": {
+            "type": "integer",
+            "title": "Net Revenue",
+            "description": "The net revenue from this customer in the period, in cents, with refunded amounts subtracted."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "name",
+          "avatar_url",
+          "order_count",
+          "net_revenue"
+        ],
+        "title": "TopCustomer"
       },
       "Transaction": {
         "properties": {

--- a/sdk/python/polar/v2026_04/errors.py
+++ b/sdk/python/polar/v2026_04/errors.py
@@ -17,6 +17,9 @@ from polar.v2026_04.outputs import (
     CustomerNotReady as CustomerNotReadyModel,
 )
 from polar.v2026_04.outputs import (
+    DisputeAutoAcceptNotEnabled as DisputeAutoAcceptNotEnabledModel,
+)
+from polar.v2026_04.outputs import (
     DisputeNotOpenError as DisputeNotOpenErrorModel,
 )
 from polar.v2026_04.outputs import (
@@ -24,6 +27,9 @@ from polar.v2026_04.outputs import (
 )
 from polar.v2026_04.outputs import (
     HTTPValidationError as HTTPValidationErrorModel,
+)
+from polar.v2026_04.outputs import (
+    InactiveSubscription as InactiveSubscriptionModel,
 )
 from polar.v2026_04.outputs import (
     ManualRetryLimitExceeded as ManualRetryLimitExceededModel,
@@ -66,6 +72,9 @@ from polar.v2026_04.outputs import (
 )
 from polar.v2026_04.outputs import (
     PaymentMethodInUseByActiveSubscription as PaymentMethodInUseByActiveSubscriptionModel,
+)
+from polar.v2026_04.outputs import (
+    PaymentMethodRequired as PaymentMethodRequiredModel,
 )
 from polar.v2026_04.outputs import (
     PaymentMethodSetupFailed as PaymentMethodSetupFailedModel,
@@ -116,11 +125,15 @@ class ResourceNotFound(PolarClientError):
         super().__init__(status_code, error)
 
 
-class NotPermitted(PolarClientError):
-    error_type = NotPermittedModel
-    error: NotPermittedModel
+class OrganizationsUpdate403Error(PolarClientError):
+    error_type = NotPermittedModel | DisputeAutoAcceptNotEnabledModel
+    error: NotPermittedModel | DisputeAutoAcceptNotEnabledModel
 
-    def __init__(self, status_code: int, error: NotPermittedModel) -> None:
+    def __init__(
+        self,
+        status_code: int,
+        error: NotPermittedModel | DisputeAutoAcceptNotEnabledModel,
+    ) -> None:
         self.error = error
         super().__init__(status_code, error)
 
@@ -161,6 +174,28 @@ class PaymentFailed(PolarClientError):
     error: PaymentFailedModel
 
     def __init__(self, status_code: int, error: PaymentFailedModel) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class SubscriptionsUpdate403Error(PolarClientError):
+    error_type = AlreadyCanceledSubscriptionModel | InactiveSubscriptionModel
+    error: AlreadyCanceledSubscriptionModel | InactiveSubscriptionModel
+
+    def __init__(
+        self,
+        status_code: int,
+        error: AlreadyCanceledSubscriptionModel | InactiveSubscriptionModel,
+    ) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class NotPermitted(PolarClientError):
+    error_type = NotPermittedModel
+    error: NotPermittedModel
+
+    def __init__(self, status_code: int, error: NotPermittedModel) -> None:
         self.error = error
         super().__init__(status_code, error)
 
@@ -647,6 +682,15 @@ class CustomerPortalSubscriptionsUpdate403Error(PolarClientError):
         status_code: int,
         error: AlreadyCanceledSubscriptionModel | PauseResumeNotAllowedModel,
     ) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class PaymentMethodRequired(PolarClientError):
+    error_type = PaymentMethodRequiredModel
+    error: PaymentMethodRequiredModel
+
+    def __init__(self, status_code: int, error: PaymentMethodRequiredModel) -> None:
         self.error = error
         super().__init__(status_code, error)
 

--- a/sdk/python/polar/v2026_04/inputs.py
+++ b/sdk/python/polar/v2026_04/inputs.py
@@ -1841,6 +1841,9 @@ You can store up to **50 key-value pairs**."""
     max_redemptions: typing.NotRequired[int | None]
     """Optional maximum number of times the discount can be redeemed."""
 
+    max_redemptions_per_customer: typing.NotRequired[int | None]
+    """Optional maximum number of times the discount can be redeemed by a single customer."""
+
     products: typing.NotRequired[list[str] | None]
 
     organization_id: typing.NotRequired[str | None]
@@ -1896,6 +1899,9 @@ You can store up to **50 key-value pairs**."""
     max_redemptions: typing.NotRequired[int | None]
     """Optional maximum number of times the discount can be redeemed."""
 
+    max_redemptions_per_customer: typing.NotRequired[int | None]
+    """Optional maximum number of times the discount can be redeemed by a single customer."""
+
     products: typing.NotRequired[list[str] | None]
 
     organization_id: typing.NotRequired[str | None]
@@ -1949,6 +1955,9 @@ You can store up to **50 key-value pairs**."""
 
     max_redemptions: typing.NotRequired[int | None]
     """Optional maximum number of times the discount can be redeemed."""
+
+    max_redemptions_per_customer: typing.NotRequired[int | None]
+    """Optional maximum number of times the discount can be redeemed by a single customer."""
 
     duration: typing.NotRequired[DiscountDuration | None]
 
@@ -2523,6 +2532,8 @@ class OrganizationCreate(typing.TypedDict):
 class OrganizationCustomerEmailSettings(typing.TypedDict):
     order_confirmation: bool
 
+    payment_method_expiration_reminder: bool
+
     subscription_cancellation: bool
 
     subscription_confirmation: bool
@@ -2588,6 +2599,11 @@ class OrganizationDetails(typing.TypedDict):
 
     previous_annual_revenue: typing.NotRequired[int | None]
     """Revenue from last year if applicable."""
+
+
+class OrganizationDisputeSettingsUpdate(typing.TypedDict):
+    auto_accept_below_amount: typing.NotRequired[int | None]
+    """Concede disputes below this amount, in USD cents, without asking the organization. A dispute charged in another currency converts at the rate its payment settled at. `null` turns it off. The disputed amount and the processor's dispute fee are still deducted."""
 
 
 class OrganizationFeatureSettingsUpdate(typing.TypedDict):
@@ -2663,6 +2679,10 @@ class OrganizationUpdate(typing.TypedDict):
     customer_portal_settings: typing.NotRequired[
         OrganizationCustomerPortalSettings | None
     ]
+
+    dispute_settings: typing.NotRequired[OrganizationDisputeSettingsUpdate | None]
+
+    embed_hosts: typing.NotRequired[list[str] | None]
 
     default_presentment_currency: typing.NotRequired[PresentmentCurrency | None]
     """Default presentment currency for the organization"""

--- a/sdk/python/polar/v2026_04/literals.py
+++ b/sdk/python/polar/v2026_04/literals.py
@@ -704,7 +704,29 @@ MetricType: typing.TypeAlias = typing.Literal[
     "scalar", "currency", "currency_sub_cent", "percentage"
 ]
 OrderBillingReason: typing.TypeAlias = typing.Literal[
-    "purchase", "subscription_create", "subscription_cycle", "subscription_update"
+    "purchase",
+    "subscription_create",
+    "subscription_cycle",
+    "subscription_update",
+    "subscription_meter_cycle",
+]
+OrderExportColumn: typing.TypeAlias = typing.Literal[
+    "email",
+    "created_at",
+    "product",
+    "net_amount",
+    "currency",
+    "status",
+    "invoice_number",
+    "customer_name",
+    "billing_name",
+    "billing_country",
+    "subtotal_amount",
+    "discount_amount",
+    "tax_amount",
+    "total_amount",
+    "refunded_amount",
+    "billing_reason",
 ]
 OrderSortProperty: typing.TypeAlias = typing.Literal[
     "created_at",
@@ -1026,6 +1048,30 @@ SeatStatus: typing.TypeAlias = typing.Literal["pending", "claimed", "revoked"]
 SeatTierType: typing.TypeAlias = typing.Literal["volume", "graduated"]
 Status: typing.TypeAlias = typing.Literal["active", "trialing"]
 SubType: typing.TypeAlias = typing.Literal["user", "organization"]
+SubscriptionExportColumn: typing.TypeAlias = typing.Literal[
+    "email",
+    "started_at",
+    "product",
+    "amount",
+    "currency",
+    "status",
+    "recurring_interval",
+    "customer_name",
+    "billing_name",
+    "billing_country",
+    "net_amount",
+    "discount",
+    "seats",
+    "current_period_start",
+    "current_period_end",
+    "cancel_at_period_end",
+    "canceled_at",
+    "ends_at",
+    "ended_at",
+    "cancellation_reason",
+    "trial_start",
+    "trial_end",
+]
 SubscriptionProrationBehavior: typing.TypeAlias = typing.Literal[
     "invoice", "prorate", "next_period", "reset"
 ]
@@ -1694,6 +1740,7 @@ WebhookEventType: typing.TypeAlias = typing.Literal[
     "subscription.active",
     "subscription.canceled",
     "subscription.uncanceled",
+    "subscription.cycled",
     "subscription.revoked",
     "subscription.past_due",
     "subscription.paused",
@@ -1702,6 +1749,9 @@ WebhookEventType: typing.TypeAlias = typing.Literal[
     "refund.updated",
     "product.created",
     "product.updated",
+    "discount.created",
+    "discount.updated",
+    "discount.deleted",
     "benefit.created",
     "benefit.updated",
     "benefit_grant.created",

--- a/sdk/python/polar/v2026_04/outputs.py
+++ b/sdk/python/polar/v2026_04/outputs.py
@@ -936,6 +936,50 @@ class BenefitDiscordSubscriberProperties:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
+class BenefitDownloadableFile:
+    id: str
+    """The ID of the object."""
+
+    organization_id: str
+
+    name: str
+
+    path: str
+
+    mime_type: str
+
+    size: int
+
+    storage_version: str | None
+
+    checksum_etag: str | None
+
+    checksum_sha256_base64: str | None
+
+    checksum_sha256_hex: str | None
+
+    last_modified_at: str | None
+
+    version: str | None
+
+    service: typing.Literal["downloadable"]
+
+    is_uploaded: bool
+
+    created_at: str
+
+    flagged_malicious_at: str | None
+
+    downloaders: int
+    """Number of distinct customers or members who downloaded the file."""
+
+    downloads: int
+    """Total number of downloads for the file."""
+
+    size_readable: str
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
 class BenefitDownloadables:
     id: str
     """The ID of the benefit."""
@@ -3966,6 +4010,9 @@ class CustomerIndividual:
     deleted_at: str | None
     """Timestamp for when the customer was soft deleted."""
 
+    first_user_event_at: str | None
+    """Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."""
+
     avatar_url: str | None
 
 
@@ -4705,6 +4752,9 @@ class CustomerStateIndividual:
     deleted_at: str | None
     """Timestamp for when the customer was soft deleted."""
 
+    first_user_event_at: str | None
+    """Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."""
+
     avatar_url: str | None
 
     active_subscriptions: list[CustomerStateSubscription]
@@ -4882,6 +4932,9 @@ class CustomerStateTeam:
 
     deleted_at: str | None
     """Timestamp for when the customer was soft deleted."""
+
+    first_user_event_at: str | None
+    """Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."""
 
     avatar_url: str | None
 
@@ -5141,6 +5194,9 @@ class CustomerTeam:
     deleted_at: str | None
     """Timestamp for when the customer was soft deleted."""
 
+    first_user_event_at: str | None
+    """Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."""
+
     avatar_url: str | None
 
 
@@ -5284,6 +5340,9 @@ class DiscountFixedOnceForeverDuration:
     max_redemptions: int | None
     """Maximum number of times the discount can be redeemed."""
 
+    max_redemptions_per_customer: int | None
+    """Maximum number of times the discount can be redeemed by a single customer."""
+
     redemptions_count: int
     """Number of times the discount has been redeemed."""
 
@@ -5331,6 +5390,9 @@ class DiscountFixedOnceForeverDurationBase:
 
     max_redemptions: int | None
     """Maximum number of times the discount can be redeemed."""
+
+    max_redemptions_per_customer: int | None
+    """Maximum number of times the discount can be redeemed by a single customer."""
 
     redemptions_count: int
     """Number of times the discount has been redeemed."""
@@ -5383,6 +5445,9 @@ class DiscountFixedRepeatDuration:
     max_redemptions: int | None
     """Maximum number of times the discount can be redeemed."""
 
+    max_redemptions_per_customer: int | None
+    """Maximum number of times the discount can be redeemed by a single customer."""
+
     redemptions_count: int
     """Number of times the discount has been redeemed."""
 
@@ -5433,6 +5498,9 @@ class DiscountFixedRepeatDurationBase:
     max_redemptions: int | None
     """Maximum number of times the discount can be redeemed."""
 
+    max_redemptions_per_customer: int | None
+    """Maximum number of times the discount can be redeemed by a single customer."""
+
     redemptions_count: int
     """Number of times the discount has been redeemed."""
 
@@ -5477,6 +5545,9 @@ class DiscountPercentageOnceForeverDuration:
     max_redemptions: int | None
     """Maximum number of times the discount can be redeemed."""
 
+    max_redemptions_per_customer: int | None
+    """Maximum number of times the discount can be redeemed by a single customer."""
+
     redemptions_count: int
     """Number of times the discount has been redeemed."""
 
@@ -5520,6 +5591,9 @@ class DiscountPercentageOnceForeverDurationBase:
 
     max_redemptions: int | None
     """Maximum number of times the discount can be redeemed."""
+
+    max_redemptions_per_customer: int | None
+    """Maximum number of times the discount can be redeemed by a single customer."""
 
     redemptions_count: int
     """Number of times the discount has been redeemed."""
@@ -5568,6 +5642,9 @@ class DiscountPercentageRepeatDuration:
     max_redemptions: int | None
     """Maximum number of times the discount can be redeemed."""
 
+    max_redemptions_per_customer: int | None
+    """Maximum number of times the discount can be redeemed by a single customer."""
+
     redemptions_count: int
     """Number of times the discount has been redeemed."""
 
@@ -5613,6 +5690,9 @@ class DiscountPercentageRepeatDurationBase:
 
     max_redemptions: int | None
     """Maximum number of times the discount can be redeemed."""
+
+    max_redemptions_per_customer: int | None
+    """Maximum number of times the discount can be redeemed by a single customer."""
 
     redemptions_count: int
     """Number of times the discount has been redeemed."""
@@ -5673,6 +5753,13 @@ class DiscountProduct:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
+class DiscountRedemptionLimitReached:
+    error: typing.Literal["DiscountRedemptionLimitReached"]
+
+    detail: str
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
 class Dispute:
     """Schema representing a dispute.
 
@@ -5726,6 +5813,13 @@ class Dispute:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
+class DisputeAutoAcceptNotEnabled:
+    error: typing.Literal["DisputeAutoAcceptNotEnabled"]
+
+    detail: str
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
 class DisputeCustomer:
     id: str
     """The ID of the customer."""
@@ -5769,6 +5863,9 @@ class DisputeCustomer:
 
     deleted_at: str | None
     """Timestamp for when the customer was soft deleted."""
+
+    first_user_event_at: str | None
+    """Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."""
 
     avatar_url: str | None
 
@@ -5814,6 +5911,8 @@ class DownloadableFileRead:
     is_uploaded: bool
 
     created_at: str
+
+    flagged_malicious_at: str | None
 
     size_readable: str
 
@@ -6071,6 +6170,13 @@ class HTTPValidationError:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
+class InactiveSubscription:
+    error: typing.Literal["InactiveSubscription"]
+
+    detail: str
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
 class IntrospectTokenResponse:
     active: bool
 
@@ -6289,6 +6395,9 @@ class LicenseKeyCustomer:
     deleted_at: str | None
     """Timestamp for when the customer was soft deleted."""
 
+    first_user_event_at: str | None
+    """Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."""
+
     avatar_url: str | None
 
 
@@ -6375,6 +6484,13 @@ class LicenseKeyWithActivations:
 @dataclasses.dataclass(kw_only=True, slots=True)
 class ListResourceBenefit:
     items: list[Benefit]
+
+    pagination: Pagination
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class ListResourceBenefitDownloadableFile:
+    items: list[BenefitDownloadableFile]
 
     pagination: Pagination
 
@@ -7442,6 +7558,9 @@ class OrderCustomer:
     deleted_at: str | None
     """Timestamp for when the customer was soft deleted."""
 
+    first_user_event_at: str | None
+    """Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."""
+
     avatar_url: str | None
 
 
@@ -7931,6 +8050,9 @@ class Organization:
     details_submitted_at: str | None
     """When the business details were submitted for review."""
 
+    onboarding_resubmission_requested_at: str | None
+    """When Polar requested that the organization review and resubmit its onboarding information, if applicable."""
+
     sso_enforced: bool
     """Whether members must access this organization through its SSO connection."""
 
@@ -7947,6 +8069,14 @@ class Organization:
     customer_email_settings: OrganizationCustomerEmailSettings
 
     customer_portal_settings: OrganizationCustomerPortalSettings
+
+    dispute_settings: OrganizationDisputeSettings
+
+    embed_hosts: list[str]
+    """Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts — `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on."""
+
+    embed_hosts_enforced: bool
+    """Whether an embedding page's origin must match `embed_hosts`. Organizations that have not configured a list yet embed unchecked until the allowlist is enforced for everyone."""
 
     country: CountryAlpha2 | None = None
     """Two-letter country code (ISO 3166-1 alpha-2)."""
@@ -8025,6 +8155,8 @@ class OrganizationCapabilities:
 class OrganizationCustomerEmailSettings:
     order_confirmation: bool
 
+    payment_method_expiration_reminder: bool
+
     subscription_cancellation: bool
 
     subscription_confirmation: bool
@@ -8057,6 +8189,13 @@ class OrganizationCustomerPortalSettings:
     subscription: CustomerPortalSubscriptionSettings
 
     customer: CustomerPortalCustomerSettings | None = None
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class OrganizationDisputeSettings:
+    """`auto_accept_below_amount` is in Polar's settlement currency (USD)."""
+
+    auto_accept_below_amount: int | None
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -8096,6 +8235,9 @@ class OrganizationFeatureSettings:
 
     sso_enabled: bool = False
     """If this organization has single sign-on configuration enabled"""
+
+    dispute_auto_accept_enabled: bool = False
+    """If this organization can set a threshold below which Polar concedes disputes on its behalf. Requires `disputes_enabled`."""
 
     compass_enabled: bool = False
     """If this organization has the split product navigation (Billing / Compass / Customers) enabled in the dashboard"""
@@ -8228,6 +8370,13 @@ class PaymentMethodGeneric:
 @dataclasses.dataclass(kw_only=True, slots=True)
 class PaymentMethodInUseByActiveSubscription:
     error: typing.Literal["PaymentMethodInUseByActiveSubscription"]
+
+    detail: str
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class PaymentMethodRequired:
+    error: typing.Literal["PaymentMethodRequired"]
 
     detail: str
 
@@ -9126,6 +9275,9 @@ class SubscriptionCustomer:
 
     deleted_at: str | None
     """Timestamp for when the customer was soft deleted."""
+
+    first_user_event_at: str | None
+    """Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."""
 
     avatar_url: str | None
 
@@ -10200,6 +10352,7 @@ CheckoutForbiddenError: typing.TypeAlias = (
     | NotOpenCheckout
     | PaymentNotReady
     | TrialAlreadyRedeemed
+    | DiscountRedemptionLimitReached
 )
 
 CustomField: typing.TypeAlias = (

--- a/sdk/python/polar/v2026_04/services/benefits.py
+++ b/sdk/python/polar/v2026_04/services/benefits.py
@@ -39,8 +39,10 @@ from polar.v2026_04.literals import (
 )
 from polar.v2026_04.outputs import (
     Benefit,
+    BenefitDownloadableFile,
     BenefitGrant,
     ListResourceBenefit,
+    ListResourceBenefitDownloadableFile,
     ListResourceBenefitGrant,
 )
 
@@ -403,6 +405,88 @@ class BenefitsSync(SyncServiceBase):
             422: HTTPValidationError,
         }
         return parse_response_json(response, Benefit, method_errors)
+
+    def files(
+        self,
+        id: str,
+        *,
+        page: int = 1,
+        limit: int = 10,
+    ) -> ListResourceBenefitDownloadableFile:
+        """
+        List the downloadable files for a benefit with their download statistics.
+
+        **Scopes**: `benefits:read` `benefits:write`
+
+        Args:
+            id:
+            page: Page number, defaults to 1.
+            limit: Size of a page, defaults to 10. Maximum is 100.
+
+        Raises:
+            ResourceNotFound: Benefit not found.
+            HTTPValidationError: Validation Error
+            PolarNetworkError: Raised when a network error occurs while making the request.
+            PolarRateLimitError: Raised when the rate limit is exceeded.
+            PolarServerError: Raised when the server returns a 5xx error response.
+        """
+        request = self.client.build_request(
+            method="GET",
+            url="/v1/benefits/{id}/files",
+            path_params={
+                "id": id,
+            },
+            query_params={
+                "page": page,
+                "limit": limit,
+            },
+        )
+        response = self.client.send_request(request)
+        method_errors = {
+            404: ResourceNotFound,
+            422: HTTPValidationError,
+        }
+        return parse_response_json(
+            response, ListResourceBenefitDownloadableFile, method_errors
+        )
+
+    def iter_files(
+        self,
+        id: str,
+        *,
+        page: int = 1,
+        limit: int = 10,
+    ) -> typing.Generator[BenefitDownloadableFile, None, None]:
+        """
+        List the downloadable files for a benefit with their download statistics.
+
+        **Scopes**: `benefits:read` `benefits:write`
+
+        Args:
+            id:
+            page: Page number, defaults to 1.
+            limit: Size of a page, defaults to 10. Maximum is 100.
+
+        Returns:
+            A generator that yields items of type BenefitDownloadableFile.
+
+        Raises:
+            ResourceNotFound: Benefit not found.
+            HTTPValidationError: Validation Error
+            PolarNetworkError: Raised when a network error occurs while making the request.
+            PolarRateLimitError: Raised when the rate limit is exceeded.
+            PolarServerError: Raised when the server returns a 5xx error response.
+        """
+        while True:
+            response = self.files(
+                id=id,
+                page=page,
+                limit=limit,
+            )
+            yield from response.items
+            if page >= response.pagination.max_page:
+                break
+            page += 1
 
     def grants(
         self,
@@ -866,6 +950,89 @@ class BenefitsAsync(AsyncServiceBase):
             422: HTTPValidationError,
         }
         return parse_response_json(response, Benefit, method_errors)
+
+    async def files(
+        self,
+        id: str,
+        *,
+        page: int = 1,
+        limit: int = 10,
+    ) -> ListResourceBenefitDownloadableFile:
+        """
+        List the downloadable files for a benefit with their download statistics.
+
+        **Scopes**: `benefits:read` `benefits:write`
+
+        Args:
+            id:
+            page: Page number, defaults to 1.
+            limit: Size of a page, defaults to 10. Maximum is 100.
+
+        Raises:
+            ResourceNotFound: Benefit not found.
+            HTTPValidationError: Validation Error
+            PolarNetworkError: Raised when a network error occurs while making the request.
+            PolarRateLimitError: Raised when the rate limit is exceeded.
+            PolarServerError: Raised when the server returns a 5xx error response.
+        """
+        request = self.client.build_request(
+            method="GET",
+            url="/v1/benefits/{id}/files",
+            path_params={
+                "id": id,
+            },
+            query_params={
+                "page": page,
+                "limit": limit,
+            },
+        )
+        response = await self.client.send_request(request)
+        method_errors = {
+            404: ResourceNotFound,
+            422: HTTPValidationError,
+        }
+        return parse_response_json(
+            response, ListResourceBenefitDownloadableFile, method_errors
+        )
+
+    async def iter_files(
+        self,
+        id: str,
+        *,
+        page: int = 1,
+        limit: int = 10,
+    ) -> typing.AsyncGenerator[BenefitDownloadableFile, None]:
+        """
+        List the downloadable files for a benefit with their download statistics.
+
+        **Scopes**: `benefits:read` `benefits:write`
+
+        Args:
+            id:
+            page: Page number, defaults to 1.
+            limit: Size of a page, defaults to 10. Maximum is 100.
+
+        Returns:
+            An async generator that yields items of type BenefitDownloadableFile.
+
+        Raises:
+            ResourceNotFound: Benefit not found.
+            HTTPValidationError: Validation Error
+            PolarNetworkError: Raised when a network error occurs while making the request.
+            PolarRateLimitError: Raised when the rate limit is exceeded.
+            PolarServerError: Raised when the server returns a 5xx error response.
+        """
+        while True:
+            response = await self.files(
+                id=id,
+                page=page,
+                limit=limit,
+            )
+            for item in response.items:
+                yield item
+            if page >= response.pagination.max_page:
+                break
+            page += 1
 
     async def grants(
         self,

--- a/sdk/python/polar/v2026_04/services/customer_portal/customers.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/customers.py
@@ -233,7 +233,7 @@ class CustomersSync(SyncServiceBase):
             id:
 
         Raises:
-            PaymentMethodInUseByActiveSubscription: Payment method is used by active subscription(s).
+            PaymentMethodInUseByActiveSubscription: Payment method is still needed to bill a subscription.
             ResourceNotFound: Payment method not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
@@ -552,7 +552,7 @@ class CustomersAsync(AsyncServiceBase):
             id:
 
         Raises:
-            PaymentMethodInUseByActiveSubscription: Payment method is used by active subscription(s).
+            PaymentMethodInUseByActiveSubscription: Payment method is still needed to bill a subscription.
             ResourceNotFound: Payment method not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.

--- a/sdk/python/polar/v2026_04/services/customer_portal/subscriptions.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/subscriptions.py
@@ -9,6 +9,7 @@ from polar.v2026_04.errors import (
     CustomerPortalSubscriptionsUpdate403Error,
     HTTPValidationError,
     PaymentFailed,
+    PaymentMethodRequired,
     ResourceNotFound,
 )
 from polar.v2026_04.inputs import (
@@ -251,6 +252,7 @@ class SubscriptionsSync(SyncServiceBase):
             PaymentFailed: Payment required to apply the subscription update.
             CustomerPortalSubscriptionsUpdate403Error: Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
             ResourceNotFound: Customer subscription was not found.
+            PaymentMethodRequired: The subscription has no payment method to charge.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -270,6 +272,7 @@ class SubscriptionsSync(SyncServiceBase):
             402: PaymentFailed,
             403: CustomerPortalSubscriptionsUpdate403Error,
             404: ResourceNotFound,
+            409: PaymentMethodRequired,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSubscription, method_errors)
@@ -499,6 +502,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             PaymentFailed: Payment required to apply the subscription update.
             CustomerPortalSubscriptionsUpdate403Error: Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
             ResourceNotFound: Customer subscription was not found.
+            PaymentMethodRequired: The subscription has no payment method to charge.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -518,6 +522,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             402: PaymentFailed,
             403: CustomerPortalSubscriptionsUpdate403Error,
             404: ResourceNotFound,
+            409: PaymentMethodRequired,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSubscription, method_errors)

--- a/sdk/python/polar/v2026_04/services/orders.py
+++ b/sdk/python/polar/v2026_04/services/orders.py
@@ -25,7 +25,9 @@ from polar.v2026_04.inputs import (
     OrderUpdate,
 )
 from polar.v2026_04.literals import (
+    OrderExportColumn,
     OrderSortProperty,
+    OrderStatus,
     ProductBillingType,
 )
 from polar.v2026_04.outputs import (
@@ -50,6 +52,9 @@ class OrdersSync(SyncServiceBase):
         external_customer_id: str | builtins.list[str] | None = None,
         checkout_id: str | builtins.list[str] | None = None,
         subscription_id: str | builtins.list[str] | None = None,
+        status: OrderStatus | builtins.list[OrderStatus] | None = None,
+        created_after: str | None = None,
+        created_before: str | None = None,
         page: int = 1,
         limit: int = 10,
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
@@ -69,6 +74,9 @@ class OrdersSync(SyncServiceBase):
             external_customer_id: Filter by customer external ID.
             checkout_id: Filter by checkout ID.
             subscription_id: Filter by subscription ID.
+            status: Filter by order status.
+            created_after: Only include orders created after this date
+            created_before: Only include orders created before this date
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
@@ -93,6 +101,9 @@ class OrdersSync(SyncServiceBase):
                 "external_customer_id": external_customer_id,
                 "checkout_id": checkout_id,
                 "subscription_id": subscription_id,
+                "status": status,
+                "created_after": created_after,
+                "created_before": created_before,
                 "page": page,
                 "limit": limit,
                 "sorting": sorting,
@@ -118,6 +129,9 @@ class OrdersSync(SyncServiceBase):
         external_customer_id: str | builtins.list[str] | None = None,
         checkout_id: str | builtins.list[str] | None = None,
         subscription_id: str | builtins.list[str] | None = None,
+        status: OrderStatus | builtins.list[OrderStatus] | None = None,
+        created_after: str | None = None,
+        created_before: str | None = None,
         page: int = 1,
         limit: int = 10,
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
@@ -137,6 +151,9 @@ class OrdersSync(SyncServiceBase):
             external_customer_id: Filter by customer external ID.
             checkout_id: Filter by checkout ID.
             subscription_id: Filter by subscription ID.
+            status: Filter by order status.
+            created_after: Only include orders created after this date
+            created_before: Only include orders created before this date
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
@@ -161,6 +178,9 @@ class OrdersSync(SyncServiceBase):
                 external_customer_id=external_customer_id,
                 checkout_id=checkout_id,
                 subscription_id=subscription_id,
+                status=status,
+                created_after=created_after,
+                created_before=created_before,
                 page=page,
                 limit=limit,
                 sorting=sorting,
@@ -211,6 +231,11 @@ class OrdersSync(SyncServiceBase):
         *,
         organization_id: str | builtins.list[str] | None = None,
         product_id: str | builtins.list[str] | None = None,
+        status: OrderStatus | builtins.list[OrderStatus] | None = None,
+        created_after: str | None = None,
+        created_before: str | None = None,
+        timezone: str = "UTC",
+        columns: OrderExportColumn | builtins.list[OrderExportColumn] | None = None,
     ) -> str:
         """
         Export orders as a CSV file.
@@ -220,6 +245,11 @@ class OrdersSync(SyncServiceBase):
         Args:
             organization_id: Filter by organization ID.
             product_id: Filter by product ID.
+            status: Filter by order status.
+            created_after: Only include orders created after this date. Must include a UTC offset.
+            created_before: Only include orders created before this date. Must include a UTC offset.
+            timezone: Time zone used to render dates in the CSV.
+            columns: Columns to include in the CSV, in order. Defaults to email, created_at, product, net_amount, currency, status and invoice_number.
 
         Raises:
             HTTPValidationError: Validation Error
@@ -234,6 +264,11 @@ class OrdersSync(SyncServiceBase):
             query_params={
                 "organization_id": organization_id,
                 "product_id": product_id,
+                "status": status,
+                "created_after": created_after,
+                "created_before": created_before,
+                "timezone": timezone,
+                "columns": columns,
             },
         )
         response = self.client.send_request(request)
@@ -481,6 +516,9 @@ class OrdersAsync(AsyncServiceBase):
         external_customer_id: str | builtins.list[str] | None = None,
         checkout_id: str | builtins.list[str] | None = None,
         subscription_id: str | builtins.list[str] | None = None,
+        status: OrderStatus | builtins.list[OrderStatus] | None = None,
+        created_after: str | None = None,
+        created_before: str | None = None,
         page: int = 1,
         limit: int = 10,
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
@@ -500,6 +538,9 @@ class OrdersAsync(AsyncServiceBase):
             external_customer_id: Filter by customer external ID.
             checkout_id: Filter by checkout ID.
             subscription_id: Filter by subscription ID.
+            status: Filter by order status.
+            created_after: Only include orders created after this date
+            created_before: Only include orders created before this date
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
@@ -524,6 +565,9 @@ class OrdersAsync(AsyncServiceBase):
                 "external_customer_id": external_customer_id,
                 "checkout_id": checkout_id,
                 "subscription_id": subscription_id,
+                "status": status,
+                "created_after": created_after,
+                "created_before": created_before,
                 "page": page,
                 "limit": limit,
                 "sorting": sorting,
@@ -549,6 +593,9 @@ class OrdersAsync(AsyncServiceBase):
         external_customer_id: str | builtins.list[str] | None = None,
         checkout_id: str | builtins.list[str] | None = None,
         subscription_id: str | builtins.list[str] | None = None,
+        status: OrderStatus | builtins.list[OrderStatus] | None = None,
+        created_after: str | None = None,
+        created_before: str | None = None,
         page: int = 1,
         limit: int = 10,
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
@@ -568,6 +615,9 @@ class OrdersAsync(AsyncServiceBase):
             external_customer_id: Filter by customer external ID.
             checkout_id: Filter by checkout ID.
             subscription_id: Filter by subscription ID.
+            status: Filter by order status.
+            created_after: Only include orders created after this date
+            created_before: Only include orders created before this date
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
@@ -592,6 +642,9 @@ class OrdersAsync(AsyncServiceBase):
                 external_customer_id=external_customer_id,
                 checkout_id=checkout_id,
                 subscription_id=subscription_id,
+                status=status,
+                created_after=created_after,
+                created_before=created_before,
                 page=page,
                 limit=limit,
                 sorting=sorting,
@@ -643,6 +696,11 @@ class OrdersAsync(AsyncServiceBase):
         *,
         organization_id: str | builtins.list[str] | None = None,
         product_id: str | builtins.list[str] | None = None,
+        status: OrderStatus | builtins.list[OrderStatus] | None = None,
+        created_after: str | None = None,
+        created_before: str | None = None,
+        timezone: str = "UTC",
+        columns: OrderExportColumn | builtins.list[OrderExportColumn] | None = None,
     ) -> str:
         """
         Export orders as a CSV file.
@@ -652,6 +710,11 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             organization_id: Filter by organization ID.
             product_id: Filter by product ID.
+            status: Filter by order status.
+            created_after: Only include orders created after this date. Must include a UTC offset.
+            created_before: Only include orders created before this date. Must include a UTC offset.
+            timezone: Time zone used to render dates in the CSV.
+            columns: Columns to include in the CSV, in order. Defaults to email, created_at, product, net_amount, currency, status and invoice_number.
 
         Raises:
             HTTPValidationError: Validation Error
@@ -666,6 +729,11 @@ class OrdersAsync(AsyncServiceBase):
             query_params={
                 "organization_id": organization_id,
                 "product_id": product_id,
+                "status": status,
+                "created_after": created_after,
+                "created_before": created_before,
+                "timezone": timezone,
+                "columns": columns,
             },
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/organizations.py
+++ b/sdk/python/polar/v2026_04/services/organizations.py
@@ -7,7 +7,7 @@ from polar.base import AsyncServiceBase, SyncServiceBase, parse_response_json
 from polar.v2026_04.errors import (
     CannotCreateOrganizationError,
     HTTPValidationError,
-    NotPermitted,
+    OrganizationsUpdate403Error,
     ResourceNotFound,
     SSOEnforcementRequiresConnection,
 )
@@ -189,7 +189,7 @@ class OrganizationsSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            NotPermitted: You don't have the permission to update this organization.
+            OrganizationsUpdate403Error: You don't have the permission to update this organization, or dispute auto-accept isn't enabled for it.
             ResourceNotFound: Organization not found.
             SSOEnforcementRequiresConnection: Cannot enforce SSO without an enabled connection.
             HTTPValidationError: Validation Error
@@ -208,7 +208,7 @@ class OrganizationsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            403: NotPermitted,
+            403: OrganizationsUpdate403Error,
             404: ResourceNotFound,
             409: SSOEnforcementRequiresConnection,
             422: HTTPValidationError,
@@ -382,7 +382,7 @@ class OrganizationsAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            NotPermitted: You don't have the permission to update this organization.
+            OrganizationsUpdate403Error: You don't have the permission to update this organization, or dispute auto-accept isn't enabled for it.
             ResourceNotFound: Organization not found.
             SSOEnforcementRequiresConnection: Cannot enforce SSO without an enabled connection.
             HTTPValidationError: Validation Error
@@ -401,7 +401,7 @@ class OrganizationsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            403: NotPermitted,
+            403: OrganizationsUpdate403Error,
             404: ResourceNotFound,
             409: SSOEnforcementRequiresConnection,
             422: HTTPValidationError,

--- a/sdk/python/polar/v2026_04/services/subscriptions.py
+++ b/sdk/python/polar/v2026_04/services/subscriptions.py
@@ -15,6 +15,7 @@ from polar.v2026_04.errors import (
     PaymentFailed,
     ResourceNotFound,
     SubscriptionLocked,
+    SubscriptionsUpdate403Error,
 )
 from polar.v2026_04.inputs import (
     MetadataQuery,
@@ -31,6 +32,7 @@ from polar.v2026_04.inputs import (
 )
 from polar.v2026_04.literals import (
     CustomerCancellationReason,
+    SubscriptionExportColumn,
     SubscriptionSortProperty,
     SubscriptionStatus,
 )
@@ -57,6 +59,8 @@ class SubscriptionsSync(SyncServiceBase):
         | None = None,
         canceled_at_after: str | None = None,
         canceled_at_before: str | None = None,
+        started_after: str | None = None,
+        started_before: str | None = None,
         page: int = 1,
         limit: int = 10,
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
@@ -79,6 +83,8 @@ class SubscriptionsSync(SyncServiceBase):
             customer_cancellation_reason: Filter by customer cancellation reason.
             canceled_at_after: Filter by cancellation date (after or equal to).
             canceled_at_before: Filter by cancellation date (before or equal to).
+            started_after: Only include subscriptions started after this date.
+            started_before: Only include subscriptions started before this date.
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
@@ -106,6 +112,8 @@ class SubscriptionsSync(SyncServiceBase):
                 "customer_cancellation_reason": customer_cancellation_reason,
                 "canceled_at_after": canceled_at_after,
                 "canceled_at_before": canceled_at_before,
+                "started_after": started_after,
+                "started_before": started_before,
                 "page": page,
                 "limit": limit,
                 "sorting": sorting,
@@ -134,6 +142,8 @@ class SubscriptionsSync(SyncServiceBase):
         | None = None,
         canceled_at_after: str | None = None,
         canceled_at_before: str | None = None,
+        started_after: str | None = None,
+        started_before: str | None = None,
         page: int = 1,
         limit: int = 10,
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
@@ -156,6 +166,8 @@ class SubscriptionsSync(SyncServiceBase):
             customer_cancellation_reason: Filter by customer cancellation reason.
             canceled_at_after: Filter by cancellation date (after or equal to).
             canceled_at_before: Filter by cancellation date (before or equal to).
+            started_after: Only include subscriptions started after this date.
+            started_before: Only include subscriptions started before this date.
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
@@ -183,6 +195,8 @@ class SubscriptionsSync(SyncServiceBase):
                 customer_cancellation_reason=customer_cancellation_reason,
                 canceled_at_after=canceled_at_after,
                 canceled_at_before=canceled_at_before,
+                started_after=started_after,
+                started_before=started_before,
                 page=page,
                 limit=limit,
                 sorting=sorting,
@@ -245,6 +259,15 @@ class SubscriptionsSync(SyncServiceBase):
         self,
         *,
         organization_id: str | builtins.list[str] | None = None,
+        product_id: str | builtins.list[str] | None = None,
+        status: SubscriptionStatus | builtins.list[SubscriptionStatus] | None = None,
+        cancel_at_period_end: bool | None = None,
+        started_after: str | None = None,
+        started_before: str | None = None,
+        timezone: str = "UTC",
+        columns: SubscriptionExportColumn
+        | builtins.list[SubscriptionExportColumn]
+        | None = None,
     ) -> str:
         """
         Export subscriptions as a CSV file.
@@ -253,6 +276,13 @@ class SubscriptionsSync(SyncServiceBase):
 
         Args:
             organization_id: Filter by organization ID.
+            product_id: Filter by product ID.
+            status: Filter by subscription status.
+            cancel_at_period_end: Filter by subscriptions that are set to cancel at period end.
+            started_after: Only include subscriptions started after this date. Must include a UTC offset.
+            started_before: Only include subscriptions started before this date. Must include a UTC offset.
+            timezone: Time zone used to render dates in the CSV.
+            columns: Columns to include in the CSV, in order. Defaults to email, started_at, product, amount, currency, status and recurring_interval.
 
         Raises:
             HTTPValidationError: Validation Error
@@ -266,6 +296,13 @@ class SubscriptionsSync(SyncServiceBase):
             path_params={},
             query_params={
                 "organization_id": organization_id,
+                "product_id": product_id,
+                "status": status,
+                "cancel_at_period_end": cancel_at_period_end,
+                "started_after": started_after,
+                "started_before": started_before,
+                "timezone": timezone,
+                "columns": columns,
             },
         )
         response = self.client.send_request(request)
@@ -418,7 +455,7 @@ class SubscriptionsSync(SyncServiceBase):
 
         Raises:
             PaymentFailed: Payment required to apply the subscription update.
-            AlreadyCanceledSubscription: Subscription is already canceled or will be at the end of the period.
+            SubscriptionsUpdate403Error: Subscription is already canceled or will be at the end of the period, or is not active.
             ResourceNotFound: Subscription not found.
             SubscriptionLocked: Subscription is pending an update.
             HTTPValidationError: Validation Error
@@ -438,7 +475,7 @@ class SubscriptionsSync(SyncServiceBase):
         response = self.client.send_request(request)
         method_errors = {
             402: PaymentFailed,
-            403: AlreadyCanceledSubscription,
+            403: SubscriptionsUpdate403Error,
             404: ResourceNotFound,
             409: SubscriptionLocked,
             422: HTTPValidationError,
@@ -463,6 +500,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         | None = None,
         canceled_at_after: str | None = None,
         canceled_at_before: str | None = None,
+        started_after: str | None = None,
+        started_before: str | None = None,
         page: int = 1,
         limit: int = 10,
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
@@ -485,6 +524,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             customer_cancellation_reason: Filter by customer cancellation reason.
             canceled_at_after: Filter by cancellation date (after or equal to).
             canceled_at_before: Filter by cancellation date (before or equal to).
+            started_after: Only include subscriptions started after this date.
+            started_before: Only include subscriptions started before this date.
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
@@ -512,6 +553,8 @@ class SubscriptionsAsync(AsyncServiceBase):
                 "customer_cancellation_reason": customer_cancellation_reason,
                 "canceled_at_after": canceled_at_after,
                 "canceled_at_before": canceled_at_before,
+                "started_after": started_after,
+                "started_before": started_before,
                 "page": page,
                 "limit": limit,
                 "sorting": sorting,
@@ -540,6 +583,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         | None = None,
         canceled_at_after: str | None = None,
         canceled_at_before: str | None = None,
+        started_after: str | None = None,
+        started_before: str | None = None,
         page: int = 1,
         limit: int = 10,
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
@@ -562,6 +607,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             customer_cancellation_reason: Filter by customer cancellation reason.
             canceled_at_after: Filter by cancellation date (after or equal to).
             canceled_at_before: Filter by cancellation date (before or equal to).
+            started_after: Only include subscriptions started after this date.
+            started_before: Only include subscriptions started before this date.
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
@@ -589,6 +636,8 @@ class SubscriptionsAsync(AsyncServiceBase):
                 customer_cancellation_reason=customer_cancellation_reason,
                 canceled_at_after=canceled_at_after,
                 canceled_at_before=canceled_at_before,
+                started_after=started_after,
+                started_before=started_before,
                 page=page,
                 limit=limit,
                 sorting=sorting,
@@ -652,6 +701,15 @@ class SubscriptionsAsync(AsyncServiceBase):
         self,
         *,
         organization_id: str | builtins.list[str] | None = None,
+        product_id: str | builtins.list[str] | None = None,
+        status: SubscriptionStatus | builtins.list[SubscriptionStatus] | None = None,
+        cancel_at_period_end: bool | None = None,
+        started_after: str | None = None,
+        started_before: str | None = None,
+        timezone: str = "UTC",
+        columns: SubscriptionExportColumn
+        | builtins.list[SubscriptionExportColumn]
+        | None = None,
     ) -> str:
         """
         Export subscriptions as a CSV file.
@@ -660,6 +718,13 @@ class SubscriptionsAsync(AsyncServiceBase):
 
         Args:
             organization_id: Filter by organization ID.
+            product_id: Filter by product ID.
+            status: Filter by subscription status.
+            cancel_at_period_end: Filter by subscriptions that are set to cancel at period end.
+            started_after: Only include subscriptions started after this date. Must include a UTC offset.
+            started_before: Only include subscriptions started before this date. Must include a UTC offset.
+            timezone: Time zone used to render dates in the CSV.
+            columns: Columns to include in the CSV, in order. Defaults to email, started_at, product, amount, currency, status and recurring_interval.
 
         Raises:
             HTTPValidationError: Validation Error
@@ -673,6 +738,13 @@ class SubscriptionsAsync(AsyncServiceBase):
             path_params={},
             query_params={
                 "organization_id": organization_id,
+                "product_id": product_id,
+                "status": status,
+                "cancel_at_period_end": cancel_at_period_end,
+                "started_after": started_after,
+                "started_before": started_before,
+                "timezone": timezone,
+                "columns": columns,
             },
         )
         response = await self.client.send_request(request)
@@ -825,7 +897,7 @@ class SubscriptionsAsync(AsyncServiceBase):
 
         Raises:
             PaymentFailed: Payment required to apply the subscription update.
-            AlreadyCanceledSubscription: Subscription is already canceled or will be at the end of the period.
+            SubscriptionsUpdate403Error: Subscription is already canceled or will be at the end of the period, or is not active.
             ResourceNotFound: Subscription not found.
             SubscriptionLocked: Subscription is pending an update.
             HTTPValidationError: Validation Error
@@ -845,7 +917,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         response = await self.client.send_request(request)
         method_errors = {
             402: PaymentFailed,
-            403: AlreadyCanceledSubscription,
+            403: SubscriptionsUpdate403Error,
             404: ResourceNotFound,
             409: SubscriptionLocked,
             422: HTTPValidationError,

--- a/sdk/python/polar/v2026_04/webhooks.py
+++ b/sdk/python/polar/v2026_04/webhooks.py
@@ -11,6 +11,7 @@ from polar.v2026_04.outputs import (
     Customer,
     CustomerSeat,
     CustomerState,
+    Discount,
     Member,
     Order,
     Organization,
@@ -257,6 +258,45 @@ class WebhookCustomerUpdatedPayload:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
+class WebhookDiscountCreatedPayload:
+    """Sent when a new discount is created.
+
+    **Discord & Slack support:** Basic"""
+
+    type: typing.Literal["discount.created"]
+
+    timestamp: str
+
+    data: Discount
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class WebhookDiscountDeletedPayload:
+    """Sent when a discount is deleted.
+
+    **Discord & Slack support:** Basic"""
+
+    type: typing.Literal["discount.deleted"]
+
+    timestamp: str
+
+    data: Discount
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class WebhookDiscountUpdatedPayload:
+    """Sent when a discount is updated.
+
+    **Discord & Slack support:** Basic"""
+
+    type: typing.Literal["discount.updated"]
+
+    timestamp: str
+
+    data: Discount
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
 class WebhookMemberCreatedPayload:
     """Sent when a new member is created.
 
@@ -484,6 +524,27 @@ class WebhookSubscriptionCreatedPayload:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
+class WebhookSubscriptionCycledPayload:
+    """Sent when a subscription enters a new billing period.
+
+    The payload carries the new `current_period_start` and `current_period_end`.
+    It fires when the period rolls over, before the renewal order exists and
+    regardless of whether the renewal payment succeeds — listen to `order.paid`
+    if you need the payment.
+
+    A trial converting to a paid subscription starts a new period, so it fires
+    there too. Read `status` to tell the two apart.
+
+    **Discord & Slack support:** Basic"""
+
+    type: typing.Literal["subscription.cycled"]
+
+    timestamp: str
+
+    data: Subscription
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
 class WebhookSubscriptionPastDuePayload:
     """Sent when a subscription payment fails and the subscription enters `past_due` status.
 
@@ -571,7 +632,7 @@ class WebhookSubscriptionUpdatedPayload:
 
     If you want more specific events, you can listen to `subscription.active`, `subscription.canceled`, `subscription.past_due`, and `subscription.revoked`.
 
-    To listen specifically for renewals, you can listen to `order.created` events and check the `billing_reason` field.
+    To listen specifically for renewals, listen to `subscription.cycled`.
 
     **Discord & Slack support:** On cancellation, past due, and revocation. Renewals are skipped."""
 
@@ -599,6 +660,9 @@ WebhookPayload: typing.TypeAlias = (
     | WebhookCustomerSeatRevokedPayload
     | WebhookCustomerStateChangedPayload
     | WebhookCustomerUpdatedPayload
+    | WebhookDiscountCreatedPayload
+    | WebhookDiscountDeletedPayload
+    | WebhookDiscountUpdatedPayload
     | WebhookMemberCreatedPayload
     | WebhookMemberDeletedPayload
     | WebhookMemberUpdatedPayload
@@ -614,6 +678,7 @@ WebhookPayload: typing.TypeAlias = (
     | WebhookSubscriptionActivePayload
     | WebhookSubscriptionCanceledPayload
     | WebhookSubscriptionCreatedPayload
+    | WebhookSubscriptionCycledPayload
     | WebhookSubscriptionPastDuePayload
     | WebhookSubscriptionPausedPayload
     | WebhookSubscriptionResumedPayload
@@ -640,6 +705,9 @@ _KNOWN_EVENT_TYPES = frozenset(
         "customer_seat.assigned",
         "customer_seat.claimed",
         "customer_seat.revoked",
+        "discount.created",
+        "discount.deleted",
+        "discount.updated",
         "member.created",
         "member.deleted",
         "member.updated",
@@ -655,6 +723,7 @@ _KNOWN_EVENT_TYPES = frozenset(
         "subscription.active",
         "subscription.canceled",
         "subscription.created",
+        "subscription.cycled",
         "subscription.past_due",
         "subscription.paused",
         "subscription.resumed",
@@ -696,6 +765,9 @@ __all__ = [
     "WebhookCustomerSeatRevokedPayload",
     "WebhookCustomerStateChangedPayload",
     "WebhookCustomerUpdatedPayload",
+    "WebhookDiscountCreatedPayload",
+    "WebhookDiscountDeletedPayload",
+    "WebhookDiscountUpdatedPayload",
     "WebhookMemberCreatedPayload",
     "WebhookMemberDeletedPayload",
     "WebhookMemberUpdatedPayload",
@@ -712,6 +784,7 @@ __all__ = [
     "WebhookSubscriptionActivePayload",
     "WebhookSubscriptionCanceledPayload",
     "WebhookSubscriptionCreatedPayload",
+    "WebhookSubscriptionCycledPayload",
     "WebhookSubscriptionPastDuePayload",
     "WebhookSubscriptionPausedPayload",
     "WebhookSubscriptionResumedPayload",

--- a/sdk/typescript/src/2026-04/errors.ts
+++ b/sdk/typescript/src/2026-04/errors.ts
@@ -4,9 +4,11 @@ import type {
   CannotCreateOrganizationError as CannotCreateOrganizationErrorModel,
   CheckoutForbiddenError as CheckoutForbiddenErrorModel,
   CustomerNotReady as CustomerNotReadyModel,
+  DisputeAutoAcceptNotEnabled as DisputeAutoAcceptNotEnabledModel,
   DisputeNotOpenError as DisputeNotOpenErrorModel,
   ExpiredCheckoutError as ExpiredCheckoutErrorModel,
   HTTPValidationError as HTTPValidationErrorModel,
+  InactiveSubscription as InactiveSubscriptionModel,
   ManualRetryLimitExceeded as ManualRetryLimitExceededModel,
   MissingInvoiceBillingDetails as MissingInvoiceBillingDetailsModel,
   NotPermitted as NotPermittedModel,
@@ -21,6 +23,7 @@ import type {
   PaymentError as PaymentErrorModel,
   PaymentFailed as PaymentFailedModel,
   PaymentMethodInUseByActiveSubscription as PaymentMethodInUseByActiveSubscriptionModel,
+  PaymentMethodRequired as PaymentMethodRequiredModel,
   PaymentMethodSetupFailed as PaymentMethodSetupFailedModel,
   RefundedAlready as RefundedAlreadyModel,
   ResourceNotFound as ResourceNotFoundModel,
@@ -67,15 +70,17 @@ export class ResourceNotFound extends PolarClientError<ResourceNotFoundModel> {
   }
 }
 /**
- * You don't have the permission to update this organization.
+ * You don't have the permission to update this organization, or dispute auto-accept isn't enabled for it.
  */
-export class NotPermitted extends PolarClientError<NotPermittedModel> {
+export class OrganizationsUpdate403Error extends PolarClientError<
+  NotPermittedModel | DisputeAutoAcceptNotEnabledModel
+> {
   constructor(
     public readonly statusCode: 403,
-    public readonly error: NotPermittedModel,
+    public readonly error: NotPermittedModel | DisputeAutoAcceptNotEnabledModel,
   ) {
     super(statusCode, error);
-    this.name = "NotPermitted";
+    this.name = "OrganizationsUpdate403Error";
   }
 }
 /**
@@ -124,6 +129,32 @@ export class PaymentFailed extends PolarClientError<PaymentFailedModel> {
   ) {
     super(statusCode, error);
     this.name = "PaymentFailed";
+  }
+}
+/**
+ * Subscription is already canceled or will be at the end of the period, or is not active.
+ */
+export class SubscriptionsUpdate403Error extends PolarClientError<
+  AlreadyCanceledSubscriptionModel | InactiveSubscriptionModel
+> {
+  constructor(
+    public readonly statusCode: 403,
+    public readonly error: AlreadyCanceledSubscriptionModel | InactiveSubscriptionModel,
+  ) {
+    super(statusCode, error);
+    this.name = "SubscriptionsUpdate403Error";
+  }
+}
+/**
+ * This benefit is not deletable.
+ */
+export class NotPermitted extends PolarClientError<NotPermittedModel> {
+  constructor(
+    public readonly statusCode: 403,
+    public readonly error: NotPermittedModel,
+  ) {
+    super(statusCode, error);
+    this.name = "NotPermitted";
   }
 }
 /**
@@ -323,7 +354,7 @@ export class CustomerNotReady extends PolarClientError<CustomerNotReadyModel> {
   }
 }
 /**
- * Payment method is used by active subscription(s).
+ * Payment method is still needed to bill a subscription.
  */
 export class PaymentMethodInUseByActiveSubscription extends PolarClientError<PaymentMethodInUseByActiveSubscriptionModel> {
   constructor(
@@ -754,6 +785,18 @@ export class CustomerPortalSubscriptionsUpdate403Error extends PolarClientError<
   ) {
     super(statusCode, error);
     this.name = "CustomerPortalSubscriptionsUpdate403Error";
+  }
+}
+/**
+ * The subscription has no payment method to charge.
+ */
+export class PaymentMethodRequired extends PolarClientError<PaymentMethodRequiredModel> {
+  constructor(
+    public readonly statusCode: 409,
+    public readonly error: PaymentMethodRequiredModel,
+  ) {
+    super(statusCode, error);
+    this.name = "PaymentMethodRequired";
   }
 }
 /**

--- a/sdk/typescript/src/2026-04/models.ts
+++ b/sdk/typescript/src/2026-04/models.ts
@@ -818,7 +818,28 @@ export type OrderBillingReason =
   | "purchase"
   | "subscription_create"
   | "subscription_cycle"
-  | "subscription_update";
+  | "subscription_update"
+  | "subscription_meter_cycle";
+/**
+ * OrderExportColumn
+ */
+export type OrderExportColumn =
+  | "email"
+  | "created_at"
+  | "product"
+  | "net_amount"
+  | "currency"
+  | "status"
+  | "invoice_number"
+  | "customer_name"
+  | "billing_name"
+  | "billing_country"
+  | "subtotal_amount"
+  | "discount_amount"
+  | "tax_amount"
+  | "total_amount"
+  | "refunded_amount"
+  | "billing_reason";
 /**
  * OrderSortProperty
  */
@@ -916,7 +937,7 @@ export type PaymentTrigger =
   | "retry_payment_method_update"
   | "retry_admin";
 /**
- * The permission level to grant. Read more about roles and their permissions on [GitHub documentation](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role).
+ * Permission
  */
 export type Permission = "pull" | "triage" | "push" | "maintain" | "admin";
 /**
@@ -1197,6 +1218,32 @@ export type Status = "active" | "trialing";
  * SubType
  */
 export type SubType = "user" | "organization";
+/**
+ * SubscriptionExportColumn
+ */
+export type SubscriptionExportColumn =
+  | "email"
+  | "started_at"
+  | "product"
+  | "amount"
+  | "currency"
+  | "status"
+  | "recurring_interval"
+  | "customer_name"
+  | "billing_name"
+  | "billing_country"
+  | "net_amount"
+  | "discount"
+  | "seats"
+  | "current_period_start"
+  | "current_period_end"
+  | "cancel_at_period_end"
+  | "canceled_at"
+  | "ends_at"
+  | "ended_at"
+  | "cancellation_reason"
+  | "trial_start"
+  | "trial_end";
 /**
  * SubscriptionProrationBehavior
  */
@@ -1891,6 +1938,7 @@ export type WebhookEventType =
   | "subscription.active"
   | "subscription.canceled"
   | "subscription.uncanceled"
+  | "subscription.cycled"
   | "subscription.revoked"
   | "subscription.past_due"
   | "subscription.paused"
@@ -1899,6 +1947,9 @@ export type WebhookEventType =
   | "refund.updated"
   | "product.created"
   | "product.updated"
+  | "discount.created"
+  | "discount.updated"
+  | "discount.deleted"
   | "benefit.created"
   | "benefit.updated"
   | "benefit_grant.created"
@@ -3271,6 +3322,87 @@ You can store up to **50 key-value pairs**.
    * properties
    */
   properties?: BenefitDiscordCreateProperties | null;
+}
+/**
+ * BenefitDownloadableFile
+ */
+export interface BenefitDownloadableFile {
+  /**
+   * The ID of the object.
+   */
+  id: string;
+  /**
+   * organization_id
+   */
+  organization_id: string;
+  /**
+   * name
+   */
+  name: string;
+  /**
+   * path
+   */
+  path: string;
+  /**
+   * mime_type
+   */
+  mime_type: string;
+  /**
+   * size
+   */
+  size: number;
+  /**
+   * storage_version
+   */
+  storage_version: string | null;
+  /**
+   * checksum_etag
+   */
+  checksum_etag: string | null;
+  /**
+   * checksum_sha256_base64
+   */
+  checksum_sha256_base64: string | null;
+  /**
+   * checksum_sha256_hex
+   */
+  checksum_sha256_hex: string | null;
+  /**
+   * last_modified_at
+   */
+  last_modified_at: string | null;
+  /**
+   * version
+   */
+  version: string | null;
+  /**
+   * service
+   */
+  service: "downloadable";
+  /**
+   * is_uploaded
+   */
+  is_uploaded: boolean;
+  /**
+   * created_at
+   */
+  created_at: string;
+  /**
+   * flagged_malicious_at
+   */
+  flagged_malicious_at: string | null;
+  /**
+   * Number of distinct customers or members who downloaded the file.
+   */
+  downloaders: number;
+  /**
+   * Total number of downloads for the file.
+   */
+  downloads: number;
+  /**
+   * size_readable
+   */
+  size_readable: string;
 }
 /**
  * BenefitDownloadables
@@ -9558,6 +9690,10 @@ export interface CustomerIndividual {
    */
   deleted_at: string | null;
   /**
+   * Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.
+   */
+  first_user_event_at: string | null;
+  /**
    * avatar_url
    */
   avatar_url: string | null;
@@ -10882,6 +11018,10 @@ export interface CustomerStateIndividual {
    */
   deleted_at: string | null;
   /**
+   * Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.
+   */
+  first_user_event_at: string | null;
+  /**
    * avatar_url
    */
   avatar_url: string | null;
@@ -11121,6 +11261,10 @@ export interface CustomerStateTeam {
    * Timestamp for when the customer was soft deleted.
    */
   deleted_at: string | null;
+  /**
+   * Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.
+   */
+  first_user_event_at: string | null;
   /**
    * avatar_url
    */
@@ -11567,6 +11711,10 @@ export interface CustomerTeam {
    */
   deleted_at: string | null;
   /**
+   * Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.
+   */
+  first_user_event_at: string | null;
+  /**
    * avatar_url
    */
   avatar_url: string | null;
@@ -11897,6 +12045,10 @@ You can store up to **50 key-value pairs**.
    */
   max_redemptions?: number | null;
   /**
+   * Optional maximum number of times the discount can be redeemed by a single customer.
+   */
+  max_redemptions_per_customer?: number | null;
+  /**
    * products
    */
   products?: string[] | null;
@@ -11995,6 +12147,10 @@ export interface DiscountFixedOnceForeverDuration {
    */
   max_redemptions: number | null;
   /**
+   * Maximum number of times the discount can be redeemed by a single customer.
+   */
+  max_redemptions_per_customer: number | null;
+  /**
    * Number of times the discount has been redeemed.
    */
   redemptions_count: number;
@@ -12067,6 +12223,10 @@ export interface DiscountFixedOnceForeverDurationBase {
    * Maximum number of times the discount can be redeemed.
    */
   max_redemptions: number | null;
+  /**
+   * Maximum number of times the discount can be redeemed by a single customer.
+   */
+  max_redemptions_per_customer: number | null;
   /**
    * Number of times the discount has been redeemed.
    */
@@ -12141,6 +12301,10 @@ export interface DiscountFixedRepeatDuration {
    * Maximum number of times the discount can be redeemed.
    */
   max_redemptions: number | null;
+  /**
+   * Maximum number of times the discount can be redeemed by a single customer.
+   */
+  max_redemptions_per_customer: number | null;
   /**
    * Number of times the discount has been redeemed.
    */
@@ -12219,6 +12383,10 @@ export interface DiscountFixedRepeatDurationBase {
    */
   max_redemptions: number | null;
   /**
+   * Maximum number of times the discount can be redeemed by a single customer.
+   */
+  max_redemptions_per_customer: number | null;
+  /**
    * Number of times the discount has been redeemed.
    */
   redemptions_count: number;
@@ -12265,6 +12433,10 @@ You can store up to **50 key-value pairs**.
    * Optional maximum number of times the discount can be redeemed.
    */
   max_redemptions?: number | null;
+  /**
+   * Optional maximum number of times the discount can be redeemed by a single customer.
+   */
+  max_redemptions_per_customer?: number | null;
   /**
    * products
    */
@@ -12351,6 +12523,10 @@ export interface DiscountPercentageOnceForeverDuration {
    */
   max_redemptions: number | null;
   /**
+   * Maximum number of times the discount can be redeemed by a single customer.
+   */
+  max_redemptions_per_customer: number | null;
+  /**
    * Number of times the discount has been redeemed.
    */
   redemptions_count: number;
@@ -12415,6 +12591,10 @@ export interface DiscountPercentageOnceForeverDurationBase {
    * Maximum number of times the discount can be redeemed.
    */
   max_redemptions: number | null;
+  /**
+   * Maximum number of times the discount can be redeemed by a single customer.
+   */
+  max_redemptions_per_customer: number | null;
   /**
    * Number of times the discount has been redeemed.
    */
@@ -12481,6 +12661,10 @@ export interface DiscountPercentageRepeatDuration {
    * Maximum number of times the discount can be redeemed.
    */
   max_redemptions: number | null;
+  /**
+   * Maximum number of times the discount can be redeemed by a single customer.
+   */
+  max_redemptions_per_customer: number | null;
   /**
    * Number of times the discount has been redeemed.
    */
@@ -12550,6 +12734,10 @@ export interface DiscountPercentageRepeatDurationBase {
    * Maximum number of times the discount can be redeemed.
    */
   max_redemptions: number | null;
+  /**
+   * Maximum number of times the discount can be redeemed by a single customer.
+   */
+  max_redemptions_per_customer: number | null;
   /**
    * Number of times the discount has been redeemed.
    */
@@ -12629,6 +12817,19 @@ export interface DiscountProduct {
   organization_id: string;
 }
 /**
+ * DiscountRedemptionLimitReached
+ */
+export interface DiscountRedemptionLimitReached {
+  /**
+   * error
+   */
+  error: "DiscountRedemptionLimitReached";
+  /**
+   * detail
+   */
+  detail: string;
+}
+/**
  * Schema to update a discount.
  */
 export interface DiscountUpdate {
@@ -12666,6 +12867,10 @@ You can store up to **50 key-value pairs**.
    * Optional maximum number of times the discount can be redeemed.
    */
   max_redemptions?: number | null;
+  /**
+   * Optional maximum number of times the discount can be redeemed by a single customer.
+   */
+  max_redemptions_per_customer?: number | null;
   /**
    * duration
    */
@@ -12771,6 +12976,19 @@ export interface Dispute {
   case_id: string | null;
 }
 /**
+ * DisputeAutoAcceptNotEnabled
+ */
+export interface DisputeAutoAcceptNotEnabled {
+  /**
+   * error
+   */
+  error: "DisputeAutoAcceptNotEnabled";
+  /**
+   * detail
+   */
+  detail: string;
+}
+/**
  * DisputeCustomer
  */
 export interface DisputeCustomer {
@@ -12838,6 +13056,10 @@ export interface DisputeCustomer {
    * Timestamp for when the customer was soft deleted.
    */
   deleted_at: string | null;
+  /**
+   * Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.
+   */
+  first_user_event_at: string | null;
   /**
    * avatar_url
    */
@@ -12957,6 +13179,10 @@ export interface DownloadableFileRead {
    * created_at
    */
   created_at: string;
+  /**
+   * flagged_malicious_at
+   */
+  flagged_malicious_at: string | null;
   /**
    * size_readable
    */
@@ -13522,6 +13748,19 @@ export interface HTTPValidationError {
   detail?: ValidationError[];
 }
 /**
+ * InactiveSubscription
+ */
+export interface InactiveSubscription {
+  /**
+   * error
+   */
+  error: "InactiveSubscription";
+  /**
+   * detail
+   */
+  detail: string;
+}
+/**
  * IntrospectTokenResponse
  */
 export interface IntrospectTokenResponse {
@@ -13909,6 +14148,10 @@ export interface LicenseKeyCustomer {
    */
   deleted_at: string | null;
   /**
+   * Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.
+   */
+  first_user_event_at: string | null;
+  /**
    * avatar_url
    */
   avatar_url: string | null;
@@ -14148,6 +14391,19 @@ export interface ListResourceBenefit {
    * items
    */
   items: Benefit[];
+  /**
+   * pagination
+   */
+  pagination: Pagination;
+}
+/**
+ * ListResourceBenefitDownloadableFile
+ */
+export interface ListResourceBenefitDownloadableFile {
+  /**
+   * items
+   */
+  items: BenefitDownloadableFile[];
   /**
    * pagination
    */
@@ -16317,6 +16573,10 @@ export interface OrderCustomer {
    */
   deleted_at: string | null;
   /**
+   * Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.
+   */
+  first_user_event_at: string | null;
+  /**
    * avatar_url
    */
   avatar_url: string | null;
@@ -17048,6 +17308,10 @@ export interface Organization {
    */
   details_submitted_at: string | null;
   /**
+   * When Polar requested that the organization review and resubmit its onboarding information, if applicable.
+   */
+  onboarding_resubmission_requested_at: string | null;
+  /**
    * Whether members must access this organization through its SSO connection.
    */
   sso_enforced: boolean;
@@ -17075,6 +17339,18 @@ export interface Organization {
    * customer_portal_settings
    */
   customer_portal_settings: OrganizationCustomerPortalSettings;
+  /**
+   * dispute_settings
+   */
+  dispute_settings: OrganizationDisputeSettings;
+  /**
+   * Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts — `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on.
+   */
+  embed_hosts: string[];
+  /**
+   * Whether an embedding page's origin must match `embed_hosts`. Organizations that have not configured a list yet embed unchecked until the allowlist is enforced for everyone.
+   */
+  embed_hosts_enforced: boolean;
   /**
    * Two-letter country code (ISO 3166-1 alpha-2).
    */
@@ -17320,6 +17596,10 @@ export interface OrganizationCustomerEmailSettings {
    */
   order_confirmation: boolean;
   /**
+   * payment_method_expiration_reminder
+   */
+  payment_method_expiration_reminder: boolean;
+  /**
    * subscription_cancellation
    */
   subscription_cancellation: boolean;
@@ -17431,6 +17711,24 @@ export interface OrganizationDetails {
   previous_annual_revenue?: number | null;
 }
 /**
+ * `auto_accept_below_amount` is in Polar's settlement currency (USD).
+ */
+export interface OrganizationDisputeSettings {
+  /**
+   * auto_accept_below_amount
+   */
+  auto_accept_below_amount: number | null;
+}
+/**
+ * OrganizationDisputeSettingsUpdate
+ */
+export interface OrganizationDisputeSettingsUpdate {
+  /**
+   * Concede disputes below this amount, in USD cents, without asking the organization. A dispute charged in another currency converts at the rate its payment settled at. `null` turns it off. The disputed amount and the processor's dispute fee are still deducted.
+   */
+  auto_accept_below_amount?: number | null;
+}
+/**
  * OrganizationFeatureSettings
  */
 export interface OrganizationFeatureSettings {
@@ -17482,6 +17780,10 @@ export interface OrganizationFeatureSettings {
    * If this organization has single sign-on configuration enabled
    */
   sso_enabled?: boolean;
+  /**
+   * If this organization can set a threshold below which Polar concedes disputes on its behalf. Requires `disputes_enabled`.
+   */
+  dispute_auto_accept_enabled?: boolean;
   /**
    * If this organization has the split product navigation (Billing / Compass / Customers) enabled in the dashboard
    */
@@ -17623,6 +17925,14 @@ export interface OrganizationUpdate {
    * customer_portal_settings
    */
   customer_portal_settings?: OrganizationCustomerPortalSettings | null;
+  /**
+   * dispute_settings
+   */
+  dispute_settings?: OrganizationDisputeSettingsUpdate | null;
+  /**
+   * embed_hosts
+   */
+  embed_hosts?: string[] | null;
   /**
    * Default presentment currency for the organization
    */
@@ -17809,6 +18119,19 @@ export interface PaymentMethodInUseByActiveSubscription {
    * error
    */
   error: "PaymentMethodInUseByActiveSubscription";
+  /**
+   * detail
+   */
+  detail: string;
+}
+/**
+ * PaymentMethodRequired
+ */
+export interface PaymentMethodRequired {
+  /**
+   * error
+   */
+  error: "PaymentMethodRequired";
   /**
    * detail
    */
@@ -20143,6 +20466,10 @@ export interface SubscriptionCustomer {
    */
   deleted_at: string | null;
   /**
+   * Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.
+   */
+  first_user_event_at: string | null;
+  /**
    * avatar_url
    */
   avatar_url: string | null;
@@ -21962,7 +22289,8 @@ export type CheckoutForbiddenError =
   | AlreadyActiveSubscriptionError
   | NotOpenCheckout
   | PaymentNotReady
-  | TrialAlreadyRedeemed;
+  | TrialAlreadyRedeemed
+  | DiscountRedemptionLimitReached;
 /**
  * CheckoutLinkCreate
  */

--- a/sdk/typescript/src/2026-04/services/benefits.ts
+++ b/sdk/typescript/src/2026-04/services/benefits.ts
@@ -4,6 +4,7 @@ import type {
   BenefitCreate,
   BenefitCustomUpdate,
   BenefitDiscordUpdate,
+  BenefitDownloadableFile,
   BenefitDownloadablesUpdate,
   BenefitFeatureFlagUpdate,
   BenefitGitHubRepositoryUpdate,
@@ -14,6 +15,7 @@ import type {
   BenefitSortProperty,
   BenefitType,
   ListResourceBenefit,
+  ListResourceBenefitDownloadableFile,
   ListResourceBenefitGrant,
   MetadataQuery,
 } from "../models";
@@ -244,6 +246,88 @@ export const updateBenefits = (client: ClientBase) => {
     });
   };
 };
+export const filesBenefits = (client: ClientBase) => {
+  /**
+   * List the downloadable files for a benefit with their download statistics.
+   *
+   * **Scopes**: `benefits:read` `benefits:write`
+   *
+   * @param id
+   * @param query - Query parameters
+   * @returns {ListResourceBenefitDownloadableFile}
+   * @throws {PolarNetworkError} When a network error occurs
+   * @throws {PolarRateLimitError} When the rate limit is exceeded
+   * @throws {PolarServerError} When the server returns a 5xx error
+   * @throws {ResourceNotFound} Benefit not found.
+   * @throws {HTTPValidationError} Validation Error
+   */
+  return async (
+    id: string,
+    query?: {
+      page?: number;
+      limit?: number;
+    },
+  ): Promise<ListResourceBenefitDownloadableFile> => {
+    const pathParams = {
+      id: id,
+    };
+    const queryParams = {
+      page: query?.page ?? 1,
+      limit: query?.limit ?? 10,
+    };
+    const request = client.buildRequest(
+      "GET",
+      "/v1/benefits/{id}/files",
+      pathParams,
+      queryParams,
+      undefined,
+    );
+    const response = await client.sendRequest(request);
+    return client.parseResponse<ListResourceBenefitDownloadableFile>(response, "json", {
+      404: ResourceNotFound,
+      422: HTTPValidationError,
+    });
+  };
+};
+/**
+ * List the downloadable files for a benefit with their download statistics.
+ *
+ * **Scopes**: `benefits:read` `benefits:write`
+ *
+ * @param id
+ * @param query - Query parameters
+ * @returns {AsyncGenerator<BenefitDownloadableFile>} A generator that yields items of type BenefitDownloadableFile.
+ * @throws {PolarNetworkError} When a network error occurs
+ * @throws {PolarRateLimitError} When the rate limit is exceeded
+ * @throws {PolarServerError} When the server returns a 5xx error
+ * @throws {ResourceNotFound} Benefit not found.
+ * @throws {HTTPValidationError} Validation Error
+ */
+export const iterFilesBenefits = (client: ClientBase) => {
+  return async function* (
+    id: string,
+    query?: {
+      page?: number;
+      limit?: number;
+    },
+  ): AsyncGenerator<BenefitDownloadableFile> {
+    let page: number;
+    page = query?.page ?? 1;
+    let limit: number | undefined;
+    limit = query?.limit;
+
+    while (true) {
+      const response = await filesBenefits(client)(id, { ...query, page, limit });
+      for (const item of response.items) {
+        yield item;
+      }
+      if (page >= response.pagination.max_page) {
+        break;
+      }
+      page++;
+    }
+  };
+};
 export const grantsBenefits = (client: ClientBase) => {
   /**
    * List the individual grants for a benefit.
@@ -347,8 +431,10 @@ export function createBenefitsService(client: ClientBase) {
     get: getBenefits(client),
     delete: deleteBenefits(client),
     update: updateBenefits(client),
+    files: filesBenefits(client),
     grants: grantsBenefits(client),
     iterList: iterListBenefits(client),
+    iterFiles: iterFilesBenefits(client),
     iterGrants: iterGrantsBenefits(client),
   };
 }

--- a/sdk/typescript/src/2026-04/services/customer_portal/customers.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/customers.ts
@@ -211,7 +211,7 @@ export const deletePaymentMethodCustomers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {PaymentMethodInUseByActiveSubscription} Payment method is used by active subscription(s).
+   * @throws {PaymentMethodInUseByActiveSubscription} Payment method is still needed to bill a subscription.
    * @throws {ResourceNotFound} Payment method not found.
    * @throws {HTTPValidationError} Validation Error
    */

--- a/sdk/typescript/src/2026-04/services/customer_portal/subscriptions.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/subscriptions.ts
@@ -11,6 +11,7 @@ import {
   CustomerPortalSubscriptionsUpdate403Error,
   HTTPValidationError,
   PaymentFailed,
+  PaymentMethodRequired,
   ResourceNotFound,
 } from "../../errors";
 
@@ -174,6 +175,7 @@ export const updateSubscriptions = (client: ClientBase) => {
    * @throws {PaymentFailed} Payment required to apply the subscription update.
    * @throws {CustomerPortalSubscriptionsUpdate403Error} Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
    * @throws {ResourceNotFound} Customer subscription was not found.
+   * @throws {PaymentMethodRequired} The subscription has no payment method to charge.
    * @throws {HTTPValidationError} Validation Error
    */
   return async (id: string, body: CustomerSubscriptionUpdate): Promise<CustomerSubscription> => {
@@ -193,6 +195,7 @@ export const updateSubscriptions = (client: ClientBase) => {
       402: PaymentFailed,
       403: CustomerPortalSubscriptionsUpdate403Error,
       404: ResourceNotFound,
+      409: PaymentMethodRequired,
       422: HTTPValidationError,
     });
   };

--- a/sdk/typescript/src/2026-04/services/orders.ts
+++ b/sdk/typescript/src/2026-04/services/orders.ts
@@ -4,10 +4,12 @@ import type {
   MetadataQuery,
   Order,
   OrderCreate,
+  OrderExportColumn,
   OrderFinalize,
   OrderInvoice,
   OrderReceipt,
   OrderSortProperty,
+  OrderStatus,
   OrderUpdate,
   ProductBillingType,
 } from "../models";
@@ -44,6 +46,9 @@ export const listOrders = (client: ClientBase) => {
     external_customer_id?: string | string[] | null;
     checkout_id?: string | string[] | null;
     subscription_id?: string | string[] | null;
+    status?: OrderStatus | OrderStatus[] | null;
+    created_after?: string | null;
+    created_before?: string | null;
     page?: number;
     limit?: number;
     sorting?: OrderSortProperty[] | null;
@@ -59,6 +64,9 @@ export const listOrders = (client: ClientBase) => {
       external_customer_id: query?.external_customer_id,
       checkout_id: query?.checkout_id,
       subscription_id: query?.subscription_id,
+      status: query?.status,
+      created_after: query?.created_after,
+      created_before: query?.created_before,
       page: query?.page ?? 1,
       limit: query?.limit ?? 10,
       sorting: query?.sorting ?? ["-created_at"],
@@ -93,6 +101,9 @@ export const iterListOrders = (client: ClientBase) => {
     external_customer_id?: string | string[] | null;
     checkout_id?: string | string[] | null;
     subscription_id?: string | string[] | null;
+    status?: OrderStatus | OrderStatus[] | null;
+    created_after?: string | null;
+    created_before?: string | null;
     page?: number;
     limit?: number;
     sorting?: OrderSortProperty[] | null;
@@ -158,11 +169,21 @@ export const exportOrders = (client: ClientBase) => {
   return async (query?: {
     organization_id?: string | string[] | null;
     product_id?: string | string[] | null;
+    status?: OrderStatus | OrderStatus[] | null;
+    created_after?: string | null;
+    created_before?: string | null;
+    timezone?: string;
+    columns?: OrderExportColumn | OrderExportColumn[] | null;
   }): Promise<string> => {
     const pathParams = {};
     const queryParams = {
       organization_id: query?.organization_id,
       product_id: query?.product_id,
+      status: query?.status,
+      created_after: query?.created_after,
+      created_before: query?.created_before,
+      timezone: query?.timezone ?? "UTC",
+      columns: query?.columns,
     };
     const request = client.buildRequest(
       "GET",

--- a/sdk/typescript/src/2026-04/services/organizations.ts
+++ b/sdk/typescript/src/2026-04/services/organizations.ts
@@ -10,7 +10,7 @@ import type {
 import {
   CannotCreateOrganizationError,
   HTTPValidationError,
-  NotPermitted,
+  OrganizationsUpdate403Error,
   ResourceNotFound,
   SSOEnforcementRequiresConnection,
 } from "../errors";
@@ -166,7 +166,7 @@ export const updateOrganizations = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {NotPermitted} You don't have the permission to update this organization.
+   * @throws {OrganizationsUpdate403Error} You don't have the permission to update this organization, or dispute auto-accept isn't enabled for it.
    * @throws {ResourceNotFound} Organization not found.
    * @throws {SSOEnforcementRequiresConnection} Cannot enforce SSO without an enabled connection.
    * @throws {HTTPValidationError} Validation Error
@@ -185,7 +185,7 @@ export const updateOrganizations = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<Organization>(response, "json", {
-      403: NotPermitted,
+      403: OrganizationsUpdate403Error,
       404: ResourceNotFound,
       409: SSOEnforcementRequiresConnection,
       422: HTTPValidationError,

--- a/sdk/typescript/src/2026-04/services/subscriptions.ts
+++ b/sdk/typescript/src/2026-04/services/subscriptions.ts
@@ -6,6 +6,7 @@ import type {
   Subscription,
   SubscriptionCreateCustomer,
   SubscriptionCreateExternalCustomer,
+  SubscriptionExportColumn,
   SubscriptionSortProperty,
   SubscriptionStatus,
   SubscriptionUpdate,
@@ -17,6 +18,7 @@ import {
   PaymentFailed,
   ResourceNotFound,
   SubscriptionLocked,
+  SubscriptionsUpdate403Error,
 } from "../errors";
 
 export const listSubscriptions = (client: ClientBase) => {
@@ -44,6 +46,8 @@ export const listSubscriptions = (client: ClientBase) => {
     customer_cancellation_reason?: CustomerCancellationReason | CustomerCancellationReason[] | null;
     canceled_at_after?: string | null;
     canceled_at_before?: string | null;
+    started_after?: string | null;
+    started_before?: string | null;
     page?: number;
     limit?: number;
     sorting?: SubscriptionSortProperty[] | null;
@@ -62,6 +66,8 @@ export const listSubscriptions = (client: ClientBase) => {
       customer_cancellation_reason: query?.customer_cancellation_reason,
       canceled_at_after: query?.canceled_at_after,
       canceled_at_before: query?.canceled_at_before,
+      started_after: query?.started_after,
+      started_before: query?.started_before,
       page: query?.page ?? 1,
       limit: query?.limit ?? 10,
       sorting: query?.sorting ?? ["-started_at"],
@@ -105,6 +111,8 @@ export const iterListSubscriptions = (client: ClientBase) => {
     customer_cancellation_reason?: CustomerCancellationReason | CustomerCancellationReason[] | null;
     canceled_at_after?: string | null;
     canceled_at_before?: string | null;
+    started_after?: string | null;
+    started_before?: string | null;
     page?: number;
     limit?: number;
     sorting?: SubscriptionSortProperty[] | null;
@@ -176,10 +184,26 @@ export const exportSubscriptions = (client: ClientBase) => {
    * @throws {PolarServerError} When the server returns a 5xx error
    * @throws {HTTPValidationError} Validation Error
    */
-  return async (query?: { organization_id?: string | string[] | null }): Promise<string> => {
+  return async (query?: {
+    organization_id?: string | string[] | null;
+    product_id?: string | string[] | null;
+    status?: SubscriptionStatus | SubscriptionStatus[] | null;
+    cancel_at_period_end?: boolean | null;
+    started_after?: string | null;
+    started_before?: string | null;
+    timezone?: string;
+    columns?: SubscriptionExportColumn | SubscriptionExportColumn[] | null;
+  }): Promise<string> => {
     const pathParams = {};
     const queryParams = {
       organization_id: query?.organization_id,
+      product_id: query?.product_id,
+      status: query?.status,
+      cancel_at_period_end: query?.cancel_at_period_end,
+      started_after: query?.started_after,
+      started_before: query?.started_before,
+      timezone: query?.timezone ?? "UTC",
+      columns: query?.columns,
     };
     const request = client.buildRequest(
       "GET",
@@ -277,7 +301,7 @@ export const updateSubscriptions = (client: ClientBase) => {
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
    * @throws {PaymentFailed} Payment required to apply the subscription update.
-   * @throws {AlreadyCanceledSubscription} Subscription is already canceled or will be at the end of the period.
+   * @throws {SubscriptionsUpdate403Error} Subscription is already canceled or will be at the end of the period, or is not active.
    * @throws {ResourceNotFound} Subscription not found.
    * @throws {SubscriptionLocked} Subscription is pending an update.
    * @throws {HTTPValidationError} Validation Error
@@ -297,7 +321,7 @@ export const updateSubscriptions = (client: ClientBase) => {
     const response = await client.sendRequest(request);
     return client.parseResponse<Subscription>(response, "json", {
       402: PaymentFailed,
-      403: AlreadyCanceledSubscription,
+      403: SubscriptionsUpdate403Error,
       404: ResourceNotFound,
       409: SubscriptionLocked,
       422: HTTPValidationError,

--- a/sdk/typescript/src/2026-04/webhooks.ts
+++ b/sdk/typescript/src/2026-04/webhooks.ts
@@ -5,6 +5,7 @@ import type {
   Customer,
   CustomerSeat,
   CustomerState,
+  Discount,
   Member,
   Order,
   Organization,
@@ -346,6 +347,63 @@ export interface WebhookCustomerUpdatedPayload {
   data: Customer;
 }
 /**
+ * Sent when a new discount is created.
+ *
+ * **Discord & Slack support:** Basic
+ */
+export interface WebhookDiscountCreatedPayload {
+  /**
+   * type
+   */
+  type: "discount.created";
+  /**
+   * timestamp
+   */
+  timestamp: string;
+  /**
+   * data
+   */
+  data: Discount;
+}
+/**
+ * Sent when a discount is deleted.
+ *
+ * **Discord & Slack support:** Basic
+ */
+export interface WebhookDiscountDeletedPayload {
+  /**
+   * type
+   */
+  type: "discount.deleted";
+  /**
+   * timestamp
+   */
+  timestamp: string;
+  /**
+   * data
+   */
+  data: Discount;
+}
+/**
+ * Sent when a discount is updated.
+ *
+ * **Discord & Slack support:** Basic
+ */
+export interface WebhookDiscountUpdatedPayload {
+  /**
+   * type
+   */
+  type: "discount.updated";
+  /**
+   * timestamp
+   */
+  timestamp: string;
+  /**
+   * data
+   */
+  data: Discount;
+}
+/**
  * Sent when a new member is created.
  *
  * A member represents an individual within a customer (team).
@@ -663,6 +721,33 @@ export interface WebhookSubscriptionCreatedPayload {
   data: Subscription;
 }
 /**
+ * Sent when a subscription enters a new billing period.
+ *
+ * The payload carries the new `current_period_start` and `current_period_end`.
+ * It fires when the period rolls over, before the renewal order exists and
+ * regardless of whether the renewal payment succeeds — listen to `order.paid`
+ * if you need the payment.
+ *
+ * A trial converting to a paid subscription starts a new period, so it fires
+ * there too. Read `status` to tell the two apart.
+ *
+ * **Discord & Slack support:** Basic
+ */
+export interface WebhookSubscriptionCycledPayload {
+  /**
+   * type
+   */
+  type: "subscription.cycled";
+  /**
+   * timestamp
+   */
+  timestamp: string;
+  /**
+   * data
+   */
+  data: Subscription;
+}
+/**
  * Sent when a subscription payment fails and the subscription enters `past_due` status.
  *
  * This is a recoverable state - the customer can update their payment method to restore the subscription.
@@ -779,7 +864,7 @@ export interface WebhookSubscriptionUncanceledPayload {
  *
  * If you want more specific events, you can listen to `subscription.active`, `subscription.canceled`, `subscription.past_due`, and `subscription.revoked`.
  *
- * To listen specifically for renewals, you can listen to `order.created` events and check the `billing_reason` field.
+ * To listen specifically for renewals, listen to `subscription.cycled`.
  *
  * **Discord & Slack support:** On cancellation, past due, and revocation. Renewals are skipped.
  */
@@ -814,6 +899,9 @@ export type WebhookPayload =
   | WebhookCustomerSeatRevokedPayload
   | WebhookCustomerStateChangedPayload
   | WebhookCustomerUpdatedPayload
+  | WebhookDiscountCreatedPayload
+  | WebhookDiscountDeletedPayload
+  | WebhookDiscountUpdatedPayload
   | WebhookMemberCreatedPayload
   | WebhookMemberDeletedPayload
   | WebhookMemberUpdatedPayload
@@ -829,6 +917,7 @@ export type WebhookPayload =
   | WebhookSubscriptionActivePayload
   | WebhookSubscriptionCanceledPayload
   | WebhookSubscriptionCreatedPayload
+  | WebhookSubscriptionCycledPayload
   | WebhookSubscriptionPastDuePayload
   | WebhookSubscriptionPausedPayload
   | WebhookSubscriptionResumedPayload
@@ -853,6 +942,9 @@ const knownEventTypes = new Set<string>([
   "customer_seat.assigned",
   "customer_seat.claimed",
   "customer_seat.revoked",
+  "discount.created",
+  "discount.deleted",
+  "discount.updated",
   "member.created",
   "member.deleted",
   "member.updated",
@@ -868,6 +960,7 @@ const knownEventTypes = new Set<string>([
   "subscription.active",
   "subscription.canceled",
   "subscription.created",
+  "subscription.cycled",
   "subscription.past_due",
   "subscription.paused",
   "subscription.resumed",


### PR DESCRIPTION
## Summary

A checkout link with a pre-applied discount and `allow_discount_codes=false` can hit the per-customer redemption limit. The error was set on the `discount_code` field, which isn't rendered in that configuration, so the buyer saw checkout fail
with no message. It now goes to `root` unless the code input is shown.

+ regenerate sdks and open public open api schema.

Closes polarsource/feedback#318
Closes polarsource/feedback#363

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

