### PR TITLE
fix(checkout): keep the error raised while capturing contact details

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutForm.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.test.tsx
@@ -700,6 +700,29 @@ describe('CheckoutForm', () => {
       expect(screen.queryByText('Server said no')).not.toBeInTheDocument()
     })
 
+    it('keeps the error the rejected write raised', async () => {
+      const holder: {
+        form?: UseFormReturn<schemas['CheckoutUpdatePublic']>
+      } = {}
+      const failingUpdate = vi.fn(async () => {
+        holder.form?.setError('customer_email', {
+          message:
+            'buyer@example.com is not a valid email address: The domain name example.com does not accept email.',
+        })
+        throw new Error('rejected')
+      })
+
+      holder.form = renderForm(createCheckout(), failingUpdate).form
+
+      await act(async () => {
+        fill('Email', 'buyer@example.com')
+      })
+
+      expect(
+        screen.getByText(/The domain name example.com does not accept email/),
+      ).toBeInTheDocument()
+    })
+
     it('stores the value again after a rejected write', async () => {
       const { update } = renderForm(createCheckout(), rejectingUpdate())
 

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -194,7 +194,9 @@ const BaseCheckoutForm = ({
         return
       }
       clearErrors(name)
-      update({ [name]: contact }).catch(() => {})
+      update({ [name]: contact }).catch(() => {
+        /* API errors handled by provider */
+      })
     },
     [checkout, update, clearErrors],
   )

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -193,7 +193,8 @@ const BaseCheckoutForm = ({
       if (!contact || checkout[name] === contact) {
         return
       }
-      update({ [name]: contact }).catch(() => clearErrors(name))
+      clearErrors(name)
+      update({ [name]: contact }).catch(() => {})
     },
     [checkout, update, clearErrors],
   )


### PR DESCRIPTION
captureContact cleared the field error from its catch, where the only error present is the one that call just raised. An email the server refuses now stays reported under the field instead of vanishing on blur.

Closes polarsource/feedback#381

## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

