### PR TITLE
preview demo

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DashboardPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DashboardPage.tsx
@@ -38,6 +38,10 @@ export default function OverviewPage({ organization }: OverviewPageProps) {
       }
       title={null}
     >
+      <div className="rounded-xl bg-blue-500 p-6 text-white">
+        <p className="text-lg font-medium">🚀 Preview environment</p>
+        <p>You are looking at a preview deployment</p>
+      </div>
       <PlanUpsell organization={organization} />
       <OrganizationStatusBanner organization={organization} />
       <DisputesBanner organization={organization} />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DashboardPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DashboardPage.tsx
@@ -41,6 +41,7 @@ export default function OverviewPage({ organization }: OverviewPageProps) {
       <div className="rounded-xl bg-blue-500 p-6 text-white">
         <p className="text-lg font-medium">🚀 Preview environment</p>
         <p>You are looking at a preview deployment</p>
+        <p>It changed</p>
       </div>
       <PlanUpsell organization={organization} />
       <OrganizationStatusBanner organization={organization} />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a preview banner to the organization dashboard to flag preview deployments. Previously there was no banner; now a blue banner with an emoji and three lines renders at the top.

- Renders unconditionally in `OverviewPage` before `PlanUpsell`.
- Banner text: "🚀 Preview environment", "You are looking at a preview deployment", "It changed".
- Gate by env or remove before merging to `main`; otherwise it appears in any deployment of this branch.

<sup>Written for commit 1e6dd47ef6a753bea03dbd6c7a935a8a0ef9ca9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

