### PR TITLE
tf/test: Move resources to test specific subnets

### DIFF
--- a/terraform/modules/redis_private_link/main.tf
+++ b/terraform/modules/redis_private_link/main.tf
@@ -14,7 +14,7 @@ resource "aws_vpc_security_group_egress_rule" "redis" {
 }
 
 resource "aws_lb" "this" {
-  name                             = var.name
+  name                             = coalesce(var.nlb_name, var.name)
   internal                         = true
   load_balancer_type               = "network"
   subnets                          = var.subnet_ids
@@ -24,10 +24,14 @@ resource "aws_lb" "this" {
   enforce_security_group_inbound_rules_on_private_link_traffic = "off"
 
   tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_lb_target_group" "redis" {
-  name        = var.name
+  name        = coalesce(var.target_group_name, var.name)
   port        = var.redis_port
   protocol    = "TCP"
   vpc_id      = var.vpc_id
@@ -42,6 +46,10 @@ resource "aws_lb_target_group" "redis" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_lb_listener" "redis" {
@@ -55,6 +63,10 @@ resource "aws_lb_listener" "redis" {
   }
 
   tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_vpc_endpoint_service" "this" {

--- a/terraform/modules/redis_private_link/variables.tf
+++ b/terraform/modules/redis_private_link/variables.tf
@@ -13,6 +13,18 @@ variable "subnet_ids" {
   type        = list(string)
 }
 
+variable "nlb_name" {
+  description = "Override the NLB name; changing it rotates the NLB behind the endpoint service."
+  type        = string
+  default     = null
+}
+
+variable "target_group_name" {
+  description = "Override the target group name; must rotate together with the NLB."
+  type        = string
+  default     = null
+}
+
 variable "redis_host" {
   description = "ElastiCache endpoint hostname to expose through the endpoint service."
   type        = string

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -25,7 +25,7 @@ module "redis" {
 
   name       = "polar-test-worker"
   vpc_id     = module.vpc[0].vpc_id
-  subnet_ids = module.vpc[0].private_subnet_ids
+  subnet_ids = module.vpc[0].secondary_private_subnet_ids
 }
 
 resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
@@ -43,7 +43,9 @@ module "redis_private_link" {
 
   name                     = "polar-test-worker-redis"
   vpc_id                   = module.vpc[0].vpc_id
-  subnet_ids               = module.vpc[0].private_subnet_ids
+  subnet_ids               = module.vpc[0].secondary_private_subnet_ids
+  nlb_name                 = "polar-test-worker-redis-b"
+  target_group_name        = "polar-test-worker-redis-b"
   redis_host               = module.redis[0].host
   redis_port               = module.redis[0].port
   redis_arn                = module.redis[0].arn

--- a/terraform/test/network.tf
+++ b/terraform/test/network.tf
@@ -34,6 +34,6 @@ resource "aws_security_group" "lambda" {
 }
 
 locals {
-  lambda_subnet_ids         = local.test_enabled ? module.vpc[0].private_subnet_ids : []
+  lambda_subnet_ids         = local.test_enabled ? module.vpc[0].secondary_private_subnet_ids : []
   lambda_security_group_ids = local.test_enabled ? [aws_security_group.lambda[0].id] : []
 }


### PR DESCRIPTION
This is the first step in moving out resources from overlapping IP addresses between our environments.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

