### PR TITLE
feat: add focused code review skills and route polar-code-review to them

### DIFF
--- a/.agents/skills/api-surface-review/SKILL.md
+++ b/.agents/skills/api-surface-review/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: api-surface-review
+description: Review changes to Polar's API contract — Pydantic schemas, FastAPI endpoints, OpenAPI output and the generated SDKs. Checks public vs private exposure, schema shape and naming, and whether the change breaks merchants or the generated clients. Use when a diff touches schemas.py, endpoints.py, docs/openapi.json or sdk/, or when the user asks whether an API change is breaking.
+license: MIT
+metadata:
+  author: polar
+  version: "1.0.0"
+---
+
+# API Surface Review (Polar)
+
+The handle is the **diff**. The evidence is **what this change does to the API contract**, and
+whether any of it is breaking.
+
+This is where Polar's most expensive review mistakes live. A schema change does not stay in
+the repo: it flows into `docs/openapi.json`, the generated TypeScript client, the Speakeasy
+SDKs under `sdk/`, and out to merchants who already wrote code against it.
+
+## Scope
+
+Diffs touching `**/schemas.py`, `**/endpoints.py`, `polar/openapi.py`, `docs/openapi.json`,
+`sdk/`, `clients/packages/client/`.
+
+**CI already does part of this job.** The `OpenAPI Diff` workflow posts the schema delta as a
+PR comment, and `OpenAPI Client Regeneration Check` fails if the client is stale. Do not
+recompute either by hand. Read the diff comment if it exists and judge whether the delta is
+acceptable; that judgement is the thing CI cannot make.
+
+Owned elsewhere: `ADR-0002` (status-coded `PolarError`), `ADR-0007` (no default in output
+schemas) → `adr-check`. Endpoint conventions written in `server/AGENTS.md` — `response_model`
+and ORM returns, POST/PATCH/DELETE status codes, `ListResource`, `responses=`, the
+`PolarRequestValidationError` boundary → `conventions-check`. Existing shared types →
+`reuse-check`.
+
+## Checks
+
+### 1. Public or private
+
+`APITag` has two values, `public` and `private` (`polar/openapi.py`). Public means documented
+and in the SDKs.
+
+- Set it deliberately on every new router and route. Never hide something with
+  `include_in_schema=False`; use `tags=[APITag.private]`.
+- Tag the route, not the router, when only one route should change. The pattern: keep
+  `APITag.public` on what stays, add `APITag.private` to the deprecated one.
+- Private endpoints (payouts are the standing example) are not in the SDK. Do not reason about
+  them as public API.
+- **On every new field, ask: does a merchant need to see this?** Internal `Organization`
+  settings keep leaking into the public API this way.
+
+### 2. Schema shape
+
+- Output fields are required, nullable where needed. A `default` makes them optional in
+  OpenAPI, which generates a wrongly-optional TS field. (ADR-0007 — name it, do not restate it.)
+- Type fields with their enum, not `str`.
+- Reuse a related resource's base schema rather than redefining its fields:
+  `class DisputeCustomer(CustomerBase): ...`.
+- A value that already exists as a model property is a plain field, not a reimplemented
+  `computed_field`.
+- Descriptions are user-facing: no implementation detail, and write `None` not `null`.
+- Any field writing to a SQL `INT` column is `Int32`, so out-of-range input is rejected at
+  validation instead of overflowing.
+- Constrain enums by listing allowed values (`reason: Literal[RefundReason.foo, ...]`) rather
+  than a hand-rolled validator. Pydantic validates, OpenAPI documents.
+- Discriminated unions get a plain `Discriminator` plus `SetSchemaReference`, so the union
+  lands in OpenAPI properly.
+- Do not over-constrain fields fed by a payment processor. *"We'll never know what Stripe or
+  other payment processor will send us."*
+
+### 3. Naming
+
+The union takes the clean name, the variants get qualified: `CustomerCreate` is the union,
+`CustomerIndividualCreate` and `CustomerTeamCreate` are members. Same for `CustomerState`.
+
+Fields are `snake_case`. Prefer explicit over clever (`payment_method_type`, not
+`payment_method`). Do not overload an existing concept with a new meaning.
+
+### 4. Breaking changes
+
+Breaking = removing a field, flipping required/optional, changing a type, renaming anything,
+or changing a status code a client branches on.
+
+Before removing a field or behaviour:
+
+1. **Check Logfire for real usage.** This is what François actually does. Merchants create
+   things programmatically that nobody expects.
+2. If it is used, keep a compatibility layer and use `SkipJsonSchema` so runtime still accepts
+   the value while it disappears from future SDKs.
+3. If it is genuinely breaking, say so plainly. That is a human decision, not something to
+   wave through.
+
+### 5. Route shape
+
+Only the parts `AGENTS.md` does not already cover:
+
+- Trailing slash on root endpoints.
+- Errors on the same route need distinct status codes, or their schemas collide in the OpenAPI
+  output.
+- A query parameter must act as a pure filter. If it changes the response shape, the resource
+  is wrong and it wants its own route.
+- Removing an endpoint and updating its frontend caller in one PR is a deploy hazard →
+  `ship-safety` owns the split.
+
+## Output
+
+```
+## API Surface
+
+### 🔴 Blocking
+- `file:line` — <what breaks, and for whom>. Fix: <fix>
+
+### 🟠 Should fix
+- `file:line` — <claim>. Fix: <fix>
+
+### 🟡 Question
+- `file:line` — <question>
+
+### Notes
+- public surface delta: <one line, or "see the OpenAPI Diff PR comment">
+
+### Verdict
+✅ Clean  |  ❌ n blocking, n should-fix
+```
+
+Anything blocking needs a human decision before merge.

--- a/.agents/skills/billing-review/SKILL.md
+++ b/.agents/skills/billing-review/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: billing-review
+description: Review a diff that touches Polar's billing domain — subscriptions, cycles and crons, orders, billing entries, meters and usage, discounts, checkout, payments and dunning, refunds, disputes, payouts, wallets, tax and invoices. Use before opening a PR that changes money movement or subscription lifecycle, when the user asks for a billing review, or when a reviewer needs the domain rules the team enforces in review but that no linter catches.
+license: MIT
+metadata:
+  author: polar
+  version: "1.0.0"
+---
+
+# Billing Review (Polar)
+
+The handle is the **diff**. The evidence is **where the change breaks a billing invariant the
+team enforces in review**.
+
+Not a general code review. The other lenses know Polar's conventions, contract and deploy
+shape. This one knows how the billing domain is supposed to behave.
+
+Distilled from ~210 review comments François (`frankie567`) left on billing PRs between
+February and August 2026, plus domain invariants raised by `pieterbeulque`, `psincraian`,
+`joebon` and `Yopi` on the same PRs. Each rule cites its PR.
+
+**Read `.agents/skills/polar-billing.md` first.** That is the map of the domain — entities,
+services, tasks, the cycle flow, proration, dunning, the ledger. This file is the checklist
+that assumes it.
+
+## Scope
+
+```
+polar/{subscription,order,billing_entry,meter,event,discount,checkout,checkout_link}/
+polar/{payment,payment_method,refund,dispute,payout,payout_account,wallet,transaction}/
+polar/{invoice,receipt,tax,product,customer_seat,account}/  ·  polar/benefit/grant/
+polar/models/{subscription,order,order_item,product,product_price,discount,checkout,
+              payment,billing_entry,refund,dispute,wallet,transaction}.py
+migrations/ and server/scripts/ when they touch those tables
+```
+
+Owned elsewhere: schema and SDK impact → `api-surface-review`; migration and actor deploy
+safety → `ship-safety`; `lazy="raise"` and repository conventions → `conventions-check`;
+`ADR-0006` / `ADR-0007` → `adr-check`; existing helpers → `reuse-check`.
+
+For a domain question you cannot settle from the diff, ask it rather than assert a defect.
+That is how this team reviews.
+
+## Checks
+
+### 1. Money comes from billing entries, not derived state
+
+`BillingEntry` is the ledger tying an invoice line back to the events that caused it. Anything
+computing an amount from a summary or a recomputation loses that trace.
+
+- Invoicing metered usage reads billing entries, never the customer meter's computed balance.
+  *"Billing Entries are the source of truth… Otherwise, we lose the ability to track billing
+  down to the events."* (#12510)
+- If consumption happened, the entries already exist. New code that recomputes usage instead
+  of picking up pending entries is a smell. (#12510)
+- Order creation is what consumes pending entries. The question for a new billing trigger is
+  "should this create an order", not "should this compute an amount".
+
+### 2. Reuse the lifecycle, do not hand-roll the transition
+
+The cycle already moves periods, writes events, and grants or revokes benefits.
+
+- Changing plan during a trial: call `update_trial` so periods and events are right, then let
+  it cycle naturally because the new period is already past — same as ending a trial
+  immediately. (#11898)
+- New periodic behaviour gets a scheduler modelled on `subscription/scheduler.py`, not a
+  bespoke loop. (#12990)
+- **One cycle, one invoice.** Overages from a meter cycle that coincides with a billing cycle
+  belong on the renewal invoice, not a second order with a second payment. (#12510)
+
+### 3. Dunning decisions live in the dunning entry point
+
+- The retry decision belongs in `_handle_first_dunning_attempt`, not the caller. Check the
+  latest payment's decline code, set a retry date if recoverable, leave it `None` otherwise.
+  Everything else (past due, benefit enqueue) is untouched. (#9744)
+- Never schedule a retry for a non-recoverable decline. (#9744)
+- Decline-code knowledge lives on the `Payment` model as a `@property`
+  (`UNRECOVERABLE_DECLINE_CODES`), guarded by `if self.processor == PaymentProcessor.stripe`
+  so a second processor does not inherit Stripe's codes. (#9744)
+- Retry-exhaustion arithmetic is a classic off-by-one. Check the boundary. (#11905)
+
+### 4. Payment locks release on one path
+
+- The webhook handler for the payment outcome (`handle_payment_failure`) releases the lock. A
+  caller that also releases it on its own error path is duplicated logic — delete it and its
+  test. (#10653)
+- **Never release a payment lock on success.** `release_on_success` was removed from the
+  codebase for this reason. A diff reintroducing it is a regression. (#10653)
+- `with_for_update` belongs in the task that owns the unit of work, not inside
+  `transfer_stripe`. *"This logic should be independent from Stripe behavior."* (#12097)
+- A wedged lock breaks dunning silently. (#13272)
+
+### 5. Keep processor state in sync, keep processor names out of the domain
+
+- Domain statuses mirror the processor's vocabulary. `accepted` was rejected as a dispute
+  status because Stripe uses `lost` either way, and diverging breaks the sync. (#12713)
+- A merchant action with a processor counterpart makes the processor call in the same flow.
+  *"The risk is way too high to forget… and let the dispute expire."* (#12713)
+- Name things after the domain: "Payout Account", not "Connect". (#12097)
+
+### 6. Crons and batch jobs
+
+- **Catch-up loops hide missed runs.** A `while` walking forward through skipped cycles
+  computes credits wrong for the periods it skipped. Prefer an invariant alert that the cycle
+  did not run. (psincraian, #12510)
+- Use `repository.stream` rather than a keyset loop over UUIDs. (#12749)
+- Loading every row in a script or sweep is a review stop. *"Won't that blow up in memory?"*
+  (#11728, #13687)
+
+### 7. Discounts
+
+- **Redemption counting is the whole game.** A failed payment should not count. A fully
+  refunded order is an open question the team has not settled. (pieterbeulque, #13328)
+- Concurrent redemption of the same code needs a customer lock, and the caller acquires it —
+  say so at the call site. (joebon, #13328)
+- `max_redemptions` and `max_redemptions_per_customer` are separate limits; a guard checking
+  one usually needs both. (#13394)
+- Expiry is checked in `cycle` but has been missed elsewhere. New paths that apply a discount
+  check it too — prefer extracting the shared check. (psincraian, #12510)
+- Multi-line discounts apply as a waterfall, not proportionally. Questioned in review as
+  unusual for invoices; a change to allocation is a merchant-visible invoice change. (joebon,
+  #12172)
+
+### 8. Amounts, currency and tax
+
+- Fee values are basis points: 4% is `400`. Check the unit before trusting arithmetic.
+- Per-jurisdiction tax comes straight from the Numeral API response. Recomputing it from rates
+  and `polar_round` introduces fractional-cent drift. (#11211)
+- Tax sits on transactions of type `payment`, which are on the **Polar** side and not linked
+  to the merchant's account. Transactions reach an organization through `account_id`;
+  `payment_organization_id` is a Pledge-era leftover that does not mean what it looks like.
+  (#12204)
+- On imports, tax-inclusive versus exclusive must mirror the source provider, or the merchant
+  loses money. (#12502)
+- Voiding or reversing an order credits back what was applied (`applied_balance_amount`), not
+  the customer's current balance. (#11637)
+
+### 9. Free and zero-amount paths
+
+These keep breaking because new code assumes a payment exists.
+
+- Keep `ProductPrice.is_free` / `Checkout.is_free_product_price` checks when reworking price
+  handling. (#12225)
+- A new charge path supports a free price by skipping the payment step, not rejecting it.
+  (#12089)
+- Renewal emails, invoices and receipts all have free-subscription branches. (#9291)
+
+### 10. Billing-specific additions to rules owned elsewhere
+
+Short pointers only — the owning lens reports the general rule.
+
+- **Money tables are busy tables.** `orders`, `subscriptions`, `payments`, `customers`,
+  `events`. Heavy backfills go in a script; indexes go in concurrently. → `ship-safety`
+- **Order foreign keys get `ondelete="restrict"`.** *"A `DELETE` statement is easy to spawn."*
+  (#11206) → `ship-safety`
+- **Lazy loads in money paths are stuck jobs, not just 500s.** `assert order.customer` does
+  not protect you — it raises the lazy-load error itself (#11900). When a denormalized column
+  lands, the matching `joinedload` usually becomes dead; remove it (#12162). →
+  `conventions-check`
+- **Customers cannot choose proration behaviour**, so it does not belong in the customer
+  portal API. (#13095) → `api-surface-review`
+
+## Output
+
+```
+## Billing
+
+### 🔴 Blocking
+- `file:line` — <invariant broken>. Fix: <fix>
+
+### 🟠 Should fix
+- `file:line` — <claim>. Fix: <fix>
+
+### 🟡 Question
+- `file:line` — <question>
+
+### Notes
+- domain context the author may not have: <one line, or omit>
+
+### Verdict
+✅ Clean  |  ❌ n blocking, n should-fix
+```

--- a/.agents/skills/conventions-check/SKILL.md
+++ b/.agents/skills/conventions-check/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: conventions-check
+description: Check a diff against Polar's written conventions in server/AGENTS.md and clients/AGENTS.md — module structure, repository and service patterns, session types, auth dependencies, test organisation, Orbit Box usage, i18n placement. Use before opening a PR or when the user asks whether a change follows Polar's conventions.
+license: MIT
+metadata:
+  author: polar
+  version: "1.0.0"
+---
+
+# Conventions Check (Polar)
+
+The handle is the **diff**. The evidence is a list of **places it breaks a rule written in
+`AGENTS.md`**.
+
+## Rule
+
+`server/AGENTS.md` and `clients/AGENTS.md` are the source of truth. Read them in full before
+reviewing. Do not work from memory, and do not invent a rule that is not in those files. If
+you want to flag something they do not cover, put it under Question.
+
+## Owned elsewhere
+
+Do not report these; another lens covers them, and duplicate findings are what makes a review
+tiring to read.
+
+| Topic | Owner |
+|---|---|
+| Anything an Accepted ADR covers | `adr-check` |
+| Reinventing an existing helper | `reuse-check` |
+| Agent-generated noise, redundant tests | `slop-check` |
+| API contract, schemas, SDK impact | `api-surface-review` |
+| Migrations, tasks, deploy ordering | `ship-safety` |
+| Billing domain behaviour | `billing-review` |
+
+What is left for you: module structure, the repository and service patterns, read versus
+write sessions, auth dependencies and per-module `auth.py`, test layout and fixtures, Orbit
+`<Box />` usage, the 250-line frontend file limit, i18n placement.
+
+## Output
+
+```
+## Conventions
+
+### 🔴 Blocking
+- `file:line` — <claim>. Fix: <fix>
+
+### 🟠 Should fix
+- `file:line` — <claim>. Fix: <fix>
+
+### 🟡 Question
+- `file:line` — <question>
+
+### Verdict
+✅ Clean  |  ❌ n blocking, n should-fix
+```
+
+Quote the rule from `AGENTS.md` in the claim. High-confidence findings only. Never flag
+unchanged code.

--- a/.agents/skills/reuse-check/SKILL.md
+++ b/.agents/skills/reuse-check/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: reuse-check
+description: Check a diff for code that reinvents something Polar already has — a kit helper, a shared Pydantic type, a repository method, an Orbit component, an existing model property. Use before opening a PR, when reviewing a diff, or when the user asks whether a new helper, validator, type or utility already exists in the codebase.
+license: MIT
+metadata:
+  author: polar
+  version: "1.0.0"
+---
+
+# Reuse Check (Polar)
+
+The handle is the **diff**. The evidence is **new code that duplicates something the repo
+already has**, with the import that replaces it.
+
+This is the most common substantive comment in Polar reviews: 84 of ~1,100 human review
+comments from Feb to Aug 2026 point at an existing helper the author did not know about. It
+is also the one category where grep beats a human reviewer, and it got worse once agents
+started writing the code, because an agent that does not search first writes its own helper.
+
+## Scope
+
+Run on any diff that adds a function, constant, `Annotated` type, validator, enum, model
+property, repository method, React component, or hook. Skip deletions, renames, config and
+lockfiles.
+
+Owned elsewhere: agent noise → `slop-check`; API contract → `api-surface-review`; deploy
+safety → `ship-safety`; billing behaviour → `billing-review`.
+
+## Method
+
+For each new symbol:
+
+1. **Name search** — `rg -n "def <name>|<Name>\b" server/polar clients/packages`, plus obvious
+   synonyms (`normalize`/`sanitize`/`clean`, `fetch`/`get`/`load`).
+2. **Behaviour search** — the distinctive part of the body: a regex literal, a library call
+   (`urlparse`, `pycountry`, `stdnum`, `slugify`), a magic constant.
+3. **Inventory** — check the list below.
+
+Report only when you can name the existing symbol and its import path. A hunch is not a
+finding. Always show what you searched for, so a false positive is cheap to dismiss.
+
+## Inventory
+
+| Home | Holds |
+|---|---|
+| `polar/kit/schemas.py` | `Schema`, `IDSchema`, `TimestampedSchema`, `EmptyStrToNone`, `SlugValidator`, `StripValidator`, `HttpsUrl`, `HttpUrlToStr`, `Int32`, `ClassName`, `MergeJSONSchema`, `SetSchemaReference`, `MultipleQueryFilter`, `*_ID_EXAMPLE` |
+| `polar/kit/http.py` | `get_safe_return_url` (open redirect), `get_ip_address`, `add_query_parameters`, `get_content_disposition`, `is_localhost`, SSRF-safe crawling (`SSRFBlockedError`, `UnsafeCrawlableUrl`, `UrlReachability`) |
+| `polar/kit/currency.py`, `money.py`, `math.py` | `get_currency_decimal_factor` (zero-decimal currencies), `get_minimum_currency_amount`, `get_maximum_currency_amount`, `format_currency`, `get_presentment_currency`, `get_cents_in_dollar_string`, `polar_round`, `non_negative_running_sum` |
+| `polar/kit/pagination.py` | `ListResource`, `Pagination`, `PaginationParams`, `count_subquery` |
+| `polar/kit/repository/base.py` | `get_base_statement`, `get_one_or_none`, `get_all`, `paginate`, `create`, `update`, `from_session`, `stream` |
+| `polar/kit/` (rest) | `address`, `anonymization`, `crypto`, `csv`, `db`, `email` (`EmailStrDNS`), `encryption`, `html`, `json`, `jwk`, `jwt`, `locale`, `metadata`, `operator`, `routing`, `services`, `sorting`, `time_queries`, `trial`, `utils`, `visibility` |
+| `server/scripts/helper.py` | `run_batched_update` |
+| `polar/backoffice/forms.py` | Form builder classes. Pattern: `polar/backoffice/orders/endpoints.py` |
+| `clients/packages/orbit/src/components` | `Alert`, `Avatar`, `Box`, `Button`, `ButtonGroup`, `Checkbox`, `Grid`, `GridItem`, `InlineModal`, `Input`, `List`, `ListGroup`, `Modal`, `Pill`, `SegmentedControl`, `Select`, `Spinner`, `Status`, `Subnav`, `Switch`, `Tabs`, `Text`, `TextArea`, `Tooltip`, `Truncated`, `datatable` |
+| Libraries already in use | `stdnum` (tax IDs), `pycountry` (country names), `slugify`, `email_validator` |
+
+**Also grep the model.** A lot of duplicated logic is a property that already exists:
+`Organization.is_payout_ready`, `Organization.can_authenticate`, `ProductPrice.is_free`,
+`Checkout.is_free_product_price`, `Payment.UNRECOVERABLE_DECLINE_CODES`.
+
+### The ones people actually miss
+
+- A hand-written "empty string means null" validator instead of `EmptyStrToNone`.
+- A keyset loop over UUIDs instead of `RepositoryBase.stream`, which batches implicitly.
+- Fetching rows only to count them, instead of an existence query.
+- Hand-rolled cents conversion or currency rounding.
+- A country-code table or slug regex instead of `pycountry` / `slugify`.
+- A hand-built HTMX form in a new backoffice view.
+- A hand-styled div that duplicates an Orbit primitive.
+
+## Output
+
+```
+## Reuse
+
+### 🟠 Should fix
+- `file:line` — <what the new code does>. Fix: `from polar.kit.schemas import EmptyStrToNone`
+  (searched: `rg "empty_str|strip_to_none" server/polar`)
+
+### 🟡 Question
+- `file:line` — <question>
+
+### Verdict
+✅ Nothing reinvented  |  ❌ n duplicates
+```

--- a/.agents/skills/ship-safety/SKILL.md
+++ b/.agents/skills/ship-safety/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: ship-safety
+description: Check whether a diff is safe to deploy — schema changes that break the currently running code, blocking DDL, renaming or moving background task actors while jobs are in flight, queue priority, cron catch-up, locking, batch size, and whether the change should be split into more than one PR. Use before merging a PR that touches migrations, tasks.py, models, or removes an endpoint.
+license: MIT
+metadata:
+  author: polar
+  version: "1.0.0"
+---
+
+# Ship Safety (Polar)
+
+The handle is the **diff**. The evidence is **what breaks between the moment this merges and
+the moment it is fully deployed**.
+
+Every check here is about that gap. Polar does not deploy atomically: migrations run first,
+the API deploys before the workers, the old frontend can be live against the new backend, and
+the queues already hold jobs enqueued under the old names. Code that is correct in its final
+state can still take production down on the way there.
+
+## Scope
+
+Diffs touching `server/migrations/versions/`, `**/tasks.py`, `polar/models/`,
+`server/scripts/`; or that remove or rename an endpoint; or that span `server/` and `clients/`
+with a dependency between them.
+
+**Owned elsewhere.** `ADR-0006` covers the migration rules — lock timeout, nullable → batched
+`run_batched_update` script → NOT NULL across separate PRs, the unconditional `UPDATE` in the
+enforce migration, and keeping migration PRs isolated from code. CI enforces it with the
+Migration Isolation Check. `adr-check` reports violations; do not restate ADR-0006 here.
+Reinvented helpers → `reuse-check`. Billing-specific lock and cycle rules → `billing-review`.
+
+What is left for you is everything ADR-0006 does not say.
+
+## Checks
+
+### 1. Schema ahead of code
+
+ADR-0006 stops code shipping ahead of its schema. The reverse still bites: between the
+migration and the new code, the **old code runs against the new schema**.
+
+- **Dropping a column or table** breaks the running app immediately — SQLAlchemy maps every
+  model to a table at import, so a dropped table can fail before any query runs. Stop using
+  it, deploy, drop in a later PR.
+- **Renaming** is always two steps.
+
+Ask of every schema change: *is the currently-deployed code still correct against this?*
+
+### 2. Blocking DDL
+
+- `postgresql_concurrently=True` for an index on a large table, with the migration outside a
+  transaction.
+- For NOT NULL on a large table, prefer `CHECK ... NOT VALID` then `VALIDATE CONSTRAINT`, so
+  Postgres skips the full-table lock. On a small table this is ceremony — say which you think
+  applies.
+- New foreign keys on money tables get `ondelete="restrict"`.
+
+### 3. Tasks already in flight
+
+When the PR merges, the queues hold jobs enqueued by the old code.
+
+- **Renaming an actor strands every queued job** — the worker looks for the old `actor_name`
+  and finds nothing. Sequence: add `order.invoice.v2`, start enqueueing it, deploy, wait for
+  the old queue to drain, then remove the old actor and swap the name back. Moving an actor to
+  a different queue is the same problem.
+- **Changing a signature** breaks jobs enqueued with the old arguments. New parameters need
+  defaults.
+- **Queue priority.** `TaskPriority.HIGH` is checkout-path only. Analytics, exports and
+  backfills go `LOW`. Slow work on `HIGH` starves checkout.
+- **Cron actors.** A new `cron_trigger` needs an answer for a missed run. A catch-up loop that
+  walks forward through skipped periods usually computes state wrong; prefer an invariant
+  alert that the run did not happen.
+- **Retries.** Polar relies on automatic retries. A new failure path must raise, not swallow,
+  and `max_retries=0` must be deliberate.
+
+### 4. Locks and volume
+
+- A new `with_for_update` belongs in the task or service that owns the unit of work, not
+  inside a processor-specific helper. Every lock needs an answer to *what releases this if the
+  process dies?*
+- Release on one path only. A lock released on two paths is a bug waiting to happen.
+- Loading every matching row into memory does not survive production volume.
+- A scheduled sweep that scans an entire busy table needs an index or a bounded window.
+
+### 5. Split this PR
+
+Flag for splitting when the diff:
+
+- removes a backend endpoint **and** updates its frontend caller — the old frontend can be
+  live against the new backend;
+- renames an actor and removes the old one together;
+- changes native mobile code alongside TypeScript — native blocks an over-the-air release, so
+  ship the TS-only change first;
+- was already flagged in review as "should move to another module". A follow-up PR is a fine
+  answer, but say so rather than silently deferring.
+
+## Output
+
+```
+## Ship Safety
+
+### 🔴 Blocking
+- `file:line` — <what breaks, in which window>. Fix: <fix>
+
+### 🟠 Should fix
+- `file:line` — <what happens under load>. Fix: <fix>
+
+### 🟡 Question
+- `file:line` — <question, including "split this PR?">
+
+### Notes
+- run before merge: <script path, or none>
+- manual step after deploy: <e.g. "remove order.invoice v1 after 4h", or none>
+
+### Verdict
+✅ Safe to ship  |  ❌ n blocking, n should-fix
+```
+
+Fill in Notes even when the verdict is green. A required script run that is not written down
+is a required script run that does not happen.

--- a/.agents/skills/slop-check/SKILL.md
+++ b/.agents/skills/slop-check/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: slop-check
+description: Strip agent-generated noise from a diff — comments that restate the code, private helpers in test files, near-duplicate tests, tests with no assertions, unrequested indexes and validation, defensive guards that duplicate an existing check. Use before opening a PR on agent-written code, or when the user asks to tighten a diff, remove slop, or cut verbose comments.
+license: MIT
+metadata:
+  author: polar
+  version: "1.0.0"
+---
+
+# Slop Check (Polar)
+
+The handle is the **diff**. The evidence is **lines that should not exist**.
+
+Not a bug hunt, not a style guide. One job: delete code that is recognisably agent-written
+and that a Polar reviewer would ask you to remove. Run it before the other lenses, because
+everything it cuts is diff nobody else has to read.
+
+Calibration, from real reviews:
+
+> "Verbosy LLM comment" · "Meaningless slop comment imho, let's drop" · "That's typical of
+> Claude, it puts those private helper functions everywhere!" · "Lol, LLM was zealous here" ·
+> "This feels like a new thing that Claude always wants to throw in" · "Overengineering IMO,
+> that case would be at most rare"
+
+## Scope
+
+Any diff. It is cheap, there is no reason to skip it.
+
+Owned elsewhere: reinvented helpers → `reuse-check`; written conventions → `conventions-check`.
+
+## Checks
+
+Propose a deletion, not a rewrite, wherever a deletion will do.
+
+**1. Comments that restate the code.** The repo rule is: no comments unless necessary, the
+code should be self-explanatory. Comment the non-obvious *why*, never the *what*.
+Endpoint docstrings are not slop — they render into OpenAPI — but strip implementation
+detail out of them.
+
+**2. Private helpers in test files.** The strongest agent tell here. `_make_auth_subject()`
+or `_create_order(...)` at the top of a test module instead of the fixtures. If a helper is
+genuinely needed it is a pytest fixture. Also flag `save_fixture` called twice on one object,
+and re-setting data a fixture already provides.
+
+**3. Near-duplicate tests.** Agents write one test per input permutation. Flag any group in
+the diff that differs only by an input value and asserts the same branch, and say which to
+keep.
+
+**4. Tests that assert nothing.** A test body with no `assert` / `expect` always passes.
+Grep every new test.
+
+**5. Unrequested extras.** An index nobody asked for, validation the type already enforces, a
+config flag with one caller, an abstraction with one implementation, a `try/except` for
+something the framework handles, an overload that changes no behaviour. Ask of each: *what
+breaks if this is deleted?* If nothing, delete it.
+
+**6. Guards that duplicate an existing check.** Defensive code repeating an upstream check, or
+guarding a case the data model makes impossible. Also a superfluous `session.flush()` —
+flushing is only for data that must be visible before the request ends.
+
+**7. Dead on arrival.** Added in the diff but nothing calls it: unused argument, unused
+import, method with no caller, `getattr` where attribute access works, a wrapper that only
+forwards.
+
+## Do not flag
+
+Two ways this check goes wrong, both worse than the slop itself.
+
+- **Domain comments.** A comment explaining why a lock is released only on the webhook path,
+  or why a status maps to Stripe's `lost`, is exactly what the team wants. The test is whether
+  the sentence carries information the code cannot.
+- **Real coverage.** Only flag a test that duplicates another test *in this diff*, or that
+  asserts nothing. Cutting coverage to hit a "fewer tests" target is a worse outcome.
+
+## Output
+
+```
+## Slop
+
+### 🟠 Delete
+- `file:line-line` — <why>
+
+### 🟡 Question
+- `file:line` — <question, e.g. "index added but the task did not ask for one. What query needs it?">
+
+### Verdict
+✅ Clean  |  ❌ n lines to remove
+```
+
+Group by file and give line ranges, so the author can act without re-reading the diff.

--- a/.claude/commands/polar-code-review.md
+++ b/.claude/commands/polar-code-review.md
@@ -1,119 +1,95 @@
 # Polar Code Review
 
-Review the diff against Polar-specific rules that the built-in reviewers cannot know:
-conventions and Accepted ADRs.
+Review the diff against the things only Polar knows: its conventions, its Accepted ADRs, its
+shared helpers, its API contract, its deploy shape, its billing domain.
 
-This command does NOT hunt for bugs, security issues, or generic simplifications. Those are
-covered better by the built-in `/code-review`, `/security-review`, and `/simplify` (they verify
-findings and can apply fixes). This command adds the one thing they lack: knowledge of Polar's
-own patterns and architecture decisions.
+Not a bug hunt and not a security review — `/code-review` and `/security-review` do those
+better, and they verify findings and can apply fixes. This adds what they cannot know.
 
-## Instructions
+This is only a router. Every lens is a skill you can also run on its own.
 
-1. **Get the diff** against main:
-   ```bash
-   git diff main...HEAD
-   ```
-   If that fails, use `git diff HEAD~1` or ask the user for the comparison base. Keep both the
-   file list and the full diff. You will pass the diff to the agents, not just file names.
+## 1. Diff
 
-2. **List the Accepted ADRs** so the ADR agent knows what to check:
-   ```bash
-   ls handbook/engineering/decisions/
-   ```
+```bash
+git diff main...HEAD --stat
+git diff main...HEAD
+```
 
-3. **Launch 2 agents IN PARALLEL** using the Task tool. Both must be launched in a SINGLE message
-   with two Task tool calls. Give each agent the full diff from step 1.
+If that fails use `git diff HEAD~1`, or ask for the base. Keep the full diff — every agent
+gets it, not just file names.
 
-   The two agents must NOT overlap. Agent 2 owns everything covered by an Accepted ADR. Agent 1
-   only checks conventions that no ADR covers. If a rule is in an ADR, leave it to Agent 2.
+## 2. Route
 
-### Agent 1: Conventions Review
+Run the first four always. Add the rest only when the trigger matches.
+
+| Skill | Runs when |
+|---|---|
+| `conventions-check` | always |
+| `adr-check` | always |
+| `reuse-check` | always |
+| `slop-check` | always |
+| `api-surface-review` | `**/schemas.py`, `**/endpoints.py`, `polar/openapi.py`, `docs/openapi.json`, `sdk/`, `clients/packages/client/` |
+| `ship-safety` | `migrations/versions/`, `**/tasks.py`, `polar/models/`, `server/scripts/`; an endpoint is removed; or the diff spans `server/` and `clients/` with a dependency between them |
+| `billing-review` | the billing paths listed in that skill's Scope section |
+
+## 3. Launch
+
+One message, one `Agent` call per selected skill, `subagent_type: "general-purpose"`. They are
+independent and must not wait on each other. Same prompt for every lens:
 
 ```
-description: "Conventions review"
-subagent_type: "feature-dev:code-reviewer"
+description: "<skill name>"
+subagent_type: "general-purpose"
 prompt: |
-  CONVENTIONS REVIEW for the Polar codebase.
+  Read `.agents/skills/<skill name>/SKILL.md` and follow it exactly.
 
-  Review this diff against Polar conventions. Only the changed lines are in scope.
+  Review this diff. Only changed lines are in scope — never the rest of the repo.
 
   [INSERT FULL DIFF]
 
-  These rules are NOT covered by an ADR. Do not check ADR topics here (errors, transactions,
-  auth, Orbit Box, output schema defaults, migrations). Another agent owns those.
-
-  **Backend (server/polar/):**
-  - All DB queries live in repository files, not services.
-  - Services are singletons: instance at module level, e.g. `resource = ResourceService()`.
-  - Use AsyncReadSession for reads, AsyncSession for writes.
-  - Pydantic schemas: separate read, create, and update schemas.
-  - Update (input) schemas: every field optional with a None default.
-  - Create repositories with `from_session(session)`.
-  - Relationships use lazy="raise". Load what you need explicitly.
-  - Endpoints return ORM models, not hand-built dicts.
-
-  **Frontend (clients/):**
-  - TanStack Query for data fetching. Zustand for client state.
-  - New translatable strings go only in clients/packages/i18n/src/locales/en.ts.
-  - Keep files under the 250-line max-lines limit.
-
-  **API:**
-  - POST returns 201. PATCH returns 200. DELETE returns 204.
-  - List endpoints return ListResource with pagination.
-  - Use PolarRequestValidationError for 422 errors.
-  - API fields are snake_case.
-
-  Report each violation with a file:line reference, the rule it breaks, and the fix.
-  Only report HIGH-confidence violations. Do not nitpick style or flag unchanged code.
+  Use the output format the skill defines. High-confidence findings only. If you are unsure
+  whether something is a defect, put it under Question instead of asserting it.
 ```
 
-### Agent 2: ADR Compliance
+Each skill declares what it does **not** own, so the lenses do not overlap by construction.
 
-```
-description: "ADR compliance"
-subagent_type: "feature-dev:code-reviewer"
-prompt: |
-  ADR COMPLIANCE REVIEW for the Polar codebase.
+`adr-check` predates this command and has its own terser format: either `No violations`, or a
+list of ADR id, `file:line`, what breaks, and the fix. Map its findings to 🔴.
 
-  Accepted ADRs live in handbook/engineering/decisions/. Read the index at
-  handbook/engineering/decisions/index.mdx and any ADR that looks relevant to this diff.
+## 4. Merge
 
-  Review this diff. Only the changed lines are in scope.
+- **Deduplicate.** One line, one finding. Precedence when two lenses hit the same line:
+  `billing-review` → `api-surface-review` → `ship-safety` → `adr-check` →
+  `conventions-check` → `reuse-check` → `slop-check`.
+- **Surface conflicts.** If two lenses disagree, say so rather than picking silently.
+- **Cut the padding.** A short report that is all true beats a long one that is half true.
 
-  [INSERT FULL DIFF]
+## 5. Report
 
-  For each change, check whether it contradicts an Accepted ADR. If it does, report:
-  - file:line reference
-  - the ADR id and title it violates (e.g. "violates ADR-0002")
-  - a short explanation of the conflict
-  - the fix, or a note that a new ADR may be needed
+```markdown
+## Polar Review
 
-  Only report HIGH-confidence conflicts. If nothing conflicts, say so.
-```
+### 🔴 Blocking
+- **[lens]** `file:line` — <what breaks>. Fix: <fix>
 
-4. **Wait for both agents to complete**, then summarize.
+### 🟠 Should fix
+- **[lens]** `file:line` — <claim>. Fix: <fix>
 
-## Summary Format
+### 🟡 Questions
+- **[lens]** `file:line` — <question>
 
----
+### 🧹 Delete
+- `file:line-line` — <why>
 
-## Polar Review Summary
+### Notes
+<deploy notes from ship-safety, surface delta from api-surface-review. Omit if neither ran.>
 
-### 🟡 Convention Violations
-[Findings from Agent 1, or "None found"]
-- [rule broken] - `file:line` - [fix]
-
-### 📐 ADR Conflicts
-[Findings from Agent 2, or "None found"]
-- **violates ADR-XXXX**: [explanation] - `file:line`
+### Coverage
+Ran: <...>. Skipped: <...> (no matching paths).
 
 ### Verdict
+✅ APPROVED  |  ❌ CHANGES REQUESTED — n blocking, n should-fix
+```
 
-**✅ APPROVED** - No Polar-specific issues found
-or
-**❌ CHANGES REQUESTED** - [number] issues to address
-
----
-
-Any ADR conflict makes the verdict CHANGES REQUESTED.
+Any 🔴 means CHANGES REQUESTED. 🟠 alone is a judgement call: say which way you lean and why.
+The 🟡 section is expected to have content — Polar reviews are mostly questions.


### PR DESCRIPTION
## Summary

Splits the Polar-specific code review into seven small skills. Each one does a single job. You can run one on its own, or run them all through `/polar-code-review`.

## What

Six new skills in `.agents/skills/`:

| Skill | Job |
|---|---|
| `conventions-check` | rules written in `AGENTS.md` |
| `reuse-check` | code that reinvents an existing kit helper, type or component |
| `slop-check` | agent-generated noise: comments that restate code, duplicate tests |
| `api-surface-review` | schemas, OpenAPI and SDK impact |
| `ship-safety` | what breaks between merge and full deploy |
| `billing-review` | subscriptions, cycles, discounts, money movement |

`/polar-code-review` is now just a router. It picks the skills that match the changed paths, runs them, and merges the findings.

## Why

I tried and this performs much better than a single skill.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

