### PR TITLE
feat: render backoffice risk signals per signal type

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/risk_signals.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/risk_signals.py
@@ -1,13 +1,32 @@
 """Rendering helpers for external risk signals (e.g. Stripe Radar)."""
 
 import json
+import re
 from collections.abc import Sequence
+from datetime import datetime
 
 from tagflow import tag, text
 
+from polar.integrations.stripe.account_risk import (
+    MerchantSignalPayload,
+    WebsiteSignalPayload,
+    parse_merchant_payload,
+    parse_website_payload,
+)
 from polar.models.organization_risk_signal import OrganizationRiskSignal
 
 from ....components import card
+
+_CITATION = re.compile(r"\[(\d+)\]")
+_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M UTC"
+
+
+def _humanize(value: str) -> str:
+    return value.replace("_", " ").capitalize()
+
+
+def _timestamp(value: datetime | None) -> str | None:
+    return value.strftime(_TIMESTAMP_FORMAT) if value else None
 
 
 def _signal_type_label(signal: OrganizationRiskSignal) -> str:
@@ -34,22 +53,135 @@ def _render_signal_row(signal: OrganizationRiskSignal) -> None:
             with tag.div(classes=f"badge badge-sm {badge_class}"):
                 text(signal.risk_level)
             with tag.span(classes="text-xs text-base-content/60 ml-auto"):
-                text(signal.created_at.strftime("%Y-%m-%d %H:%M UTC"))
+                text(signal.created_at.strftime(_TIMESTAMP_FORMAT))
 
-        if signal.description:
-            with tag.p(classes="text-xs text-base-content/70 mt-1"):
-                text(signal.description)
+        _render_signal_body(signal)
 
         if signal.payload:
-            with tag.details(classes="mt-2"):
-                with tag.summary(
-                    classes="text-xs text-base-content/60 cursor-pointer hover:text-base-content"
+            _render_raw_payload(signal)
+
+
+def _render_signal_body(signal: OrganizationRiskSignal) -> None:
+    """Render the signal with the parser for its type, or fall back to text."""
+    if signal.source == OrganizationRiskSignal.Source.STRIPE:
+        if signal.type == OrganizationRiskSignal.Type.FRAUDULENT_MERCHANT:
+            merchant = parse_merchant_payload(signal.payload)
+            if merchant is not None:
+                _render_merchant_signal(merchant)
+                return
+        elif signal.type == OrganizationRiskSignal.Type.FRAUDULENT_WEBSITE:
+            website = parse_website_payload(signal.payload)
+            if website is not None:
+                _render_website_signal(website)
+                return
+
+    if signal.description:
+        with tag.p(classes="text-xs text-base-content/70 mt-1 whitespace-pre-line"):
+            text(signal.description)
+
+
+def _render_merchant_signal(payload: MerchantSignalPayload) -> None:
+    if payload.probability is not None:
+        with tag.p(classes="text-xs text-base-content/60 mt-1"):
+            text(f"Fraud probability: {payload.probability:.2f}%")
+
+    with tag.div(classes="space-y-2 mt-3"):
+        for indicator in payload.indicators:
+            with tag.div():
+                with tag.div(classes="flex flex-wrap items-center gap-x-2 text-xs"):
+                    with tag.span(classes="font-medium"):
+                        text(_humanize(indicator.indicator))
+                    with tag.span(classes="text-base-content/50"):
+                        text(_humanize(indicator.impact))
+                with tag.p(classes="text-xs text-base-content/70"):
+                    text(indicator.description)
+
+    _render_meta(payload)
+
+
+def _render_website_signal(payload: WebsiteSignalPayload) -> None:
+    if payload.summary:
+        with tag.p(classes="text-xs text-base-content/70 mt-2"):
+            text(payload.summary)
+
+    if payload.notes:
+        with tag.div(classes="mt-2"):
+            with tag.span(classes="text-xs font-medium"):
+                text("Notes")
+            for note in payload.notes:
+                _render_cited_text(note, payload.references)
+
+    if payload.references:
+        with tag.details(classes="mt-2"):
+            with tag.summary(
+                classes="text-xs text-base-content/60 cursor-pointer hover:text-base-content"
+            ):
+                text(f"{len(payload.references)} source(s)")
+            with tag.ul(classes="mt-1 space-y-0.5"):
+                for number, url in payload.references.items():
+                    with tag.li(classes="text-xs flex gap-1"):
+                        with tag.span(classes="text-base-content/50"):
+                            text(f"[{number}]")
+                        with tag.a(
+                            href=url,
+                            target="_blank",
+                            rel="noopener noreferrer",
+                            classes="link break-all",
+                        ):
+                            text(url)
+
+    _render_meta(payload)
+
+
+def _render_cited_text(note: str, references: dict[int, str]) -> None:
+    """Render a paragraph, turning its ``[n]`` citations into source links."""
+    with tag.p(classes="text-xs text-base-content/70 mt-1"):
+        position = 0
+        for match in _CITATION.finditer(note):
+            text(note[position : match.start()])
+            url = references.get(int(match.group(1)))
+            if url is None:
+                text(match.group(0))
+            else:
+                with tag.a(
+                    href=url,
+                    target="_blank",
+                    rel="noopener noreferrer",
+                    classes="link align-super text-[10px] mx-0.5",
                 ):
-                    text("View raw payload")
-                with tag.pre(
-                    classes="text-xs bg-base-200 p-3 rounded mt-2 overflow-x-auto max-h-64 overflow-y-auto"
-                ):
-                    text(json.dumps(signal.payload, indent=2, default=str))
+                    text(match.group(1))
+            position = match.end()
+        text(note[position:])
+
+
+def _render_meta(payload: MerchantSignalPayload | WebsiteSignalPayload) -> None:
+    items = (
+        ("Account", payload.account_id),
+        ("Evaluated", _timestamp(payload.evaluated_at)),
+        ("Signal", payload.signal_id),
+    )
+    values = [(label, value) for label, value in items if value]
+    if not values:
+        return
+
+    with tag.div(classes="flex flex-wrap gap-x-4 gap-y-1 mt-3 text-xs"):
+        for label, value in values:
+            with tag.span(classes="text-base-content/50"):
+                text(f"{label}: ")
+                with tag.span(classes="font-mono"):
+                    text(value)
+
+
+def _render_raw_payload(signal: OrganizationRiskSignal) -> None:
+    with tag.details(classes="mt-2"):
+        with tag.summary(
+            classes="text-xs text-base-content/60 cursor-pointer hover:text-base-content"
+        ):
+            text("View raw payload")
+        with tag.pre(
+            classes="text-xs bg-base-200 p-3 rounded mt-2 overflow-x-auto max-h-64 overflow-y-auto"
+        ):
+            text(json.dumps(signal.payload, indent=2, default=str))
 
 
 def render_risk_signals_card(signals: Sequence[OrganizationRiskSignal]) -> None:

--- a/server/polar/integrations/stripe/account_risk.py
+++ b/server/polar/integrations/stripe/account_risk.py
@@ -3,14 +3,25 @@
 Normalizes the two live signals (fraudulent website, fraudulent merchant) into
 one small shape. Both arrive as thin events; the full event (fetched by id)
 carries the fields under ``data``, but each signal nests them differently.
+
+``data`` is stored verbatim as ``OrganizationRiskSignal.payload``, so this
+module also reads it back: ``parse_merchant_payload`` and
+``parse_website_payload`` turn a stored payload into the values the backoffice
+displays. Keeping both directions here means the Stripe shape is described once.
 """
 
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any
 
 from polar.models.organization_risk_signal import OrganizationRiskSignal
+
+_REFERENCE_LINE = re.compile(r"^\[(\d+)\]\s+(\S+)$")
+_NOTES_MARKER = "NOTES:"
+_LINKABLE_SCHEMES = ("http://", "https://")
 
 
 class StripeAccountRiskLevel(StrEnum):
@@ -47,6 +58,32 @@ class AccountRiskSignal:
     risk_level: StripeAccountRiskLevel
     description: str | None = None
     payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SignalIndicator:
+    indicator: str
+    impact: str
+    description: str
+
+
+@dataclass(frozen=True)
+class MerchantSignalPayload:
+    indicators: list[SignalIndicator]
+    probability: float | None
+    account_id: str | None
+    signal_id: str | None
+    evaluated_at: datetime | None
+
+
+@dataclass(frozen=True)
+class WebsiteSignalPayload:
+    summary: str
+    notes: list[str]
+    references: dict[int, str]
+    account_id: str | None
+    signal_id: str | None
+    evaluated_at: datetime | None
 
 
 def is_account_risk_event(event_type: str) -> bool:
@@ -104,4 +141,89 @@ def parse_account_risk_event(event: Mapping[str, Any]) -> AccountRiskSignal | No
         risk_level=risk_level,
         description=description,
         payload=dict(data),
+    )
+
+
+def _optional_str(value: Any) -> str | None:
+    return str(value) if value else None
+
+
+def _optional_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def parse_merchant_payload(payload: Mapping[str, Any]) -> MerchantSignalPayload | None:
+    """Read a stored fraudulent merchant payload, or None if it can't be used."""
+    inner = payload.get("fraudulent_merchant")
+    if not isinstance(inner, Mapping):
+        return None
+
+    raw_indicators = inner.get("indicators")
+    indicators = [
+        SignalIndicator(
+            indicator=str(item.get("indicator", "")),
+            impact=str(item.get("impact", "")),
+            description=str(item.get("description", "")),
+        )
+        for item in (raw_indicators if isinstance(raw_indicators, list) else [])
+        if isinstance(item, Mapping)
+    ]
+    probability = _optional_float(inner.get("probability"))
+    if not indicators and probability is None:
+        return None
+
+    return MerchantSignalPayload(
+        indicators=indicators,
+        probability=probability,
+        account_id=_optional_str(payload.get("account")),
+        signal_id=_optional_str(payload.get("id")),
+        evaluated_at=_optional_datetime(payload.get("evaluated_at")),
+    )
+
+
+def parse_website_payload(payload: Mapping[str, Any]) -> WebsiteSignalPayload | None:
+    """Read a stored fraudulent website payload, or None if it can't be used.
+
+    ``details`` is prose: a summary, then notes citing sources as ``[n]``, then
+    the numbered list of source URLs (``[1] https://example.com``). Sources that
+    aren't web links stay in the text instead of becoming references, so the
+    backoffice never turns them into links.
+    """
+    details = payload.get("details")
+    if not isinstance(details, str) or not details.strip():
+        return None
+
+    body_lines: list[str] = []
+    references: dict[int, str] = {}
+    for line in details.splitlines():
+        match = _REFERENCE_LINE.match(line.strip())
+        if match and match.group(2).lower().startswith(_LINKABLE_SCHEMES):
+            references[int(match.group(1))] = match.group(2)
+        else:
+            body_lines.append(line)
+
+    summary, _, notes = "\n".join(body_lines).strip().partition(_NOTES_MARKER)
+
+    return WebsiteSignalPayload(
+        summary=summary.strip(),
+        notes=[block.strip() for block in notes.split("\n\n") if block.strip()],
+        references=references,
+        account_id=_optional_str(payload.get("account")),
+        signal_id=_optional_str(payload.get("signal_id")),
+        evaluated_at=_optional_datetime(payload.get("evaluated_at")),
     )

--- a/server/tests/backoffice/organizations_v2/test_risk_signals.py
+++ b/server/tests/backoffice/organizations_v2/test_risk_signals.py
@@ -1,0 +1,110 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from tagflow import document
+
+from polar.backoffice.organizations_v2.views.sections.risk_signals import (
+    render_risk_signals_card,
+)
+from polar.models import OrganizationRiskSignal
+
+
+def build_signal(
+    type: OrganizationRiskSignal.Type,
+    payload: dict[str, Any],
+    description: str | None = None,
+) -> OrganizationRiskSignal:
+    signal = OrganizationRiskSignal(
+        source=OrganizationRiskSignal.Source.STRIPE,
+        type=type,
+        risk_level="elevated",
+        description=description,
+        payload=payload,
+    )
+    signal.created_at = datetime(2026, 8, 13, 15, 48, tzinfo=UTC)
+    return signal
+
+
+def render(signal: OrganizationRiskSignal) -> str:
+    with document() as doc:
+        render_risk_signals_card([signal])
+    return doc.to_html()
+
+
+class TestRenderRiskSignalsCard:
+    def test_website_citations_link_to_their_source(self) -> None:
+        html = render(
+            build_signal(
+                OrganizationRiskSignal.Type.FRAUDULENT_WEBSITE,
+                {
+                    "details": (
+                        "No verifiable identity.\n"
+                        "\n"
+                        "NOTES: The contact page is empty [2].\n"
+                        "\n"
+                        "[1] https://example.com/\n"
+                        "[2] https://example.com/contact"
+                    )
+                },
+            )
+        )
+
+        assert 'href="https://example.com/contact"' in html
+        assert "The contact page is empty" in html
+
+    def test_website_citation_without_a_source_stays_as_text(self) -> None:
+        html = render(
+            build_signal(
+                OrganizationRiskSignal.Type.FRAUDULENT_WEBSITE,
+                {"details": "Risky.\n\nNOTES: Nothing to see [7]."},
+            )
+        )
+
+        assert "Nothing to see [7]." in html
+        assert "<a" not in html
+
+    def test_non_web_source_is_not_linked(self) -> None:
+        html = render(
+            build_signal(
+                OrganizationRiskSignal.Type.FRAUDULENT_WEBSITE,
+                {"details": ("Risky.\n\nNOTES: See [1].\n\n[1] javascript:alert(1)")},
+            )
+        )
+
+        assert "javascript:alert(1)" in html
+        assert "href=" not in html
+
+    def test_merchant_indicators_are_labelled(self) -> None:
+        html = render(
+            build_signal(
+                OrganizationRiskSignal.Type.FRAUDULENT_MERCHANT,
+                {
+                    "fraudulent_merchant": {
+                        "probability": "52.81",
+                        "indicators": [
+                            {
+                                "indicator": "geolocation",
+                                "impact": "strong_increase",
+                                "description": "Login country mismatch.",
+                            }
+                        ],
+                    }
+                },
+            )
+        )
+
+        assert "Fraud probability: 52.81%" in html
+        assert "Geolocation" in html
+        assert "Strong increase" in html
+        assert "Login country mismatch." in html
+
+    def test_unparsable_payload_falls_back_to_the_description(self) -> None:
+        html = render(
+            build_signal(
+                OrganizationRiskSignal.Type.FRAUDULENT_MERCHANT,
+                {"unexpected": "shape"},
+                description="Stored description.",
+            )
+        )
+
+        assert "Stored description." in html

--- a/server/tests/integrations/stripe/test_account_risk.py
+++ b/server/tests/integrations/stripe/test_account_risk.py
@@ -1,12 +1,55 @@
+from datetime import UTC, datetime
+
 from polar.integrations.stripe.account_risk import (
     StripeAccountRiskLevel,
     is_account_risk_event,
     parse_account_risk_event,
+    parse_merchant_payload,
+    parse_website_payload,
 )
 from polar.models import OrganizationRiskSignal
 
 WEBSITE = "v2.core.account_signals.fraudulent_website_ready"
 MERCHANT = "v2.signals.account_signal.fraudulent_merchant_ready"
+
+MERCHANT_PAYLOAD = {
+    "id": "acctsig_123",
+    "type": "fraudulent_merchant",
+    "account": "acct_123",
+    "evaluated_at": "2026-08-13T15:47:44.000Z",
+    "fraudulent_merchant": {
+        "risk_level": "elevated",
+        "probability": "52.81",
+        "indicators": [
+            {
+                "impact": "strong_increase",
+                "indicator": "business_information_and_account_activity",
+                "description": "The domain was created days before the application.",
+            },
+            {
+                "impact": "neutral",
+                "indicator": "other_related_accounts",
+                "description": "No related accounts.",
+            },
+        ],
+    },
+}
+
+WEBSITE_PAYLOAD = {
+    "account": "acct_456",
+    "signal_id": "acctsig_456",
+    "evaluation_id": "acctevl_456",
+    "evaluated_at": "2026-08-14T13:54:35.801Z",
+    "risk_level": "elevated",
+    "details": (
+        "This merchant is high risk because there is no verifiable identity.\n"
+        "\n"
+        "NOTES: The site lists no legal name [1]. The terms conflict [2].\n"
+        "\n"
+        "[1] https://example.com/\n"
+        "[2] https://example.com/legal"
+    ),
+}
 
 
 class TestIsAccountRiskEvent:
@@ -83,3 +126,107 @@ class TestParseAccountRiskEvent:
         )
         assert result is not None
         assert result.risk_level == StripeAccountRiskLevel.UNKNOWN
+
+
+class TestParseMerchantPayload:
+    def test_valid(self) -> None:
+        payload = parse_merchant_payload(MERCHANT_PAYLOAD)
+
+        assert payload is not None
+        assert payload.probability == 52.81
+        assert payload.account_id == "acct_123"
+        assert payload.signal_id == "acctsig_123"
+        assert payload.evaluated_at == datetime(2026, 8, 13, 15, 47, 44, tzinfo=UTC)
+        assert [indicator.indicator for indicator in payload.indicators] == [
+            "business_information_and_account_activity",
+            "other_related_accounts",
+        ]
+
+    def test_missing_inner_object(self) -> None:
+        assert parse_merchant_payload({"account": "acct_123"}) is None
+
+    def test_nothing_to_show_returns_none(self) -> None:
+        assert parse_merchant_payload({"fraudulent_merchant": {}}) is None
+
+    def test_unparsable_probability(self) -> None:
+        assert (
+            parse_merchant_payload(
+                {"fraudulent_merchant": {"probability": "not a number"}}
+            )
+            is None
+        )
+
+    def test_indicators_without_probability(self) -> None:
+        payload = parse_merchant_payload(
+            {"fraudulent_merchant": {"indicators": [{"indicator": "geolocation"}]}}
+        )
+
+        assert payload is not None
+        assert payload.probability is None
+        assert payload.evaluated_at is None
+        assert payload.indicators[0].indicator == "geolocation"
+
+
+class TestParseWebsitePayload:
+    def test_valid(self) -> None:
+        payload = parse_website_payload(WEBSITE_PAYLOAD)
+
+        assert payload is not None
+        assert payload.summary == (
+            "This merchant is high risk because there is no verifiable identity."
+        )
+        assert payload.notes == [
+            "The site lists no legal name [1]. The terms conflict [2]."
+        ]
+        assert payload.references == {
+            1: "https://example.com/",
+            2: "https://example.com/legal",
+        }
+        assert payload.account_id == "acct_456"
+        assert payload.signal_id == "acctsig_456"
+
+    def test_missing_details(self) -> None:
+        assert parse_website_payload({"account": "acct_456"}) is None
+        assert parse_website_payload({"details": "   "}) is None
+
+    def test_details_without_notes_or_references(self) -> None:
+        payload = parse_website_payload({"details": "Nothing suspicious."})
+
+        assert payload is not None
+        assert payload.summary == "Nothing suspicious."
+        assert payload.notes == []
+        assert payload.references == {}
+
+    def test_unparsable_evaluated_at(self) -> None:
+        payload = parse_website_payload(
+            {"details": "Suspicious.", "evaluated_at": "last tuesday"}
+        )
+
+        assert payload is not None
+        assert payload.evaluated_at is None
+
+    def test_evaluated_at_is_converted_to_utc(self) -> None:
+        payload = parse_website_payload(
+            {"details": "Suspicious.", "evaluated_at": "2026-08-14T15:54:35+02:00"}
+        )
+
+        assert payload is not None
+        assert payload.evaluated_at == datetime(2026, 8, 14, 13, 54, 35, tzinfo=UTC)
+
+    def test_non_web_source_stays_in_the_text(self) -> None:
+        payload = parse_website_payload(
+            {
+                "details": (
+                    "Suspicious.\n"
+                    "\n"
+                    "NOTES: See [1] and [2].\n"
+                    "\n"
+                    "[1] javascript:alert(1)\n"
+                    "[2] https://example.com/legal"
+                )
+            }
+        )
+
+        assert payload is not None
+        assert payload.references == {2: "https://example.com/legal"}
+        assert "[1] javascript:alert(1)" in payload.notes[-1]


### PR DESCRIPTION
## Summary

Stripe risk signals in the backoffice were shown as a raw Python dict dumped into a paragraph. Each signal type now has its own parser and its own layout.

## What

- **Fraudulent merchant**: shows the fraud probability, then one block per indicator with its name, impact and description.
- **Fraudulent website**: shows the summary, the notes, and the cited sources. The `[n]` marks in the notes become links to the source. The source list is collapsed.
- Any signal we cannot parse falls back to the stored description, as before. The raw payload is still one click away on every row.
- Only `http` and `https` sources become links. Anything else stays as plain text.

## Why

Reviewers had to read a stringified dict to understand why a signal was raised. The same data is now readable at a glance.

## How

The parsers read the stored payload and live in `polar/integrations/stripe/account_risk.py`, next to the code that writes it, so the Stripe payload shape is described in one place. The backoffice module only renders.

Checked against all 450 stored signals: every payload parses, so no row falls back to raw text.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

