### PR TITLE
tf/test: Remove default subnets

### DIFF
--- a/terraform/modules/redis_private_link/variables.tf
+++ b/terraform/modules/redis_private_link/variables.tf
@@ -14,7 +14,7 @@ variable "subnet_ids" {
 }
 
 variable "nlb_name" {
-  description = "Override the NLB name; changing it rotates the NLB behind the endpoint service."
+  description = "Override the NLB name; any replacement must supply a fresh name since create_before_destroy keeps both alive briefly."
   type        = string
   default     = null
 }

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -21,7 +21,7 @@ resource "aws_subnet" "public" {
 }
 
 resource "aws_subnet" "private" {
-  count = length(var.availability_zones)
+  count = var.primary_private_subnets_enabled ? length(var.availability_zones) : 0
 
   vpc_id            = aws_vpc.this.id
   cidr_block        = cidrsubnet(var.cidr_block, 4, count.index + 1)

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -15,6 +15,12 @@ variable "secondary_cidr_block" {
   default     = null
 }
 
+variable "primary_private_subnets_enabled" {
+  description = "Set to false to delete the primary-CIDR private subnets once workloads have moved to the secondary ones."
+  type        = bool
+  default     = true
+}
+
 variable "availability_zones" {
   description = "Availability zones for the private subnets. The first also hosts the NAT gateway's public subnet."
   type        = list(string)

--- a/terraform/test/network.tf
+++ b/terraform/test/network.tf
@@ -13,10 +13,11 @@ module "vpc" {
   count  = local.test_enabled ? 1 : 0
   source = "../modules/vpc"
 
-  name                 = "polar-test"
-  secondary_cidr_block = "10.22.0.0/16"
-  availability_zones   = ["us-east-2a", "us-east-2b", "us-east-2c"]
-  eip_allocation_id    = module.egress_ip[0].allocation_id
+  name                            = "polar-test"
+  secondary_cidr_block            = "10.22.0.0/16"
+  primary_private_subnets_enabled = false
+  availability_zones              = ["us-east-2a", "us-east-2b", "us-east-2c"]
+  eip_allocation_id               = module.egress_ip[0].allocation_id
 }
 
 resource "aws_security_group" "lambda" {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make primary-CIDR private subnets optional and disable them in the test VPC to finish migration to secondary subnets. Previously the VPC module always created primary private subnets; now it skips them when `primary_private_subnets_enabled` is false, which will delete existing primary-CIDR private subnets.

- Adds `primary_private_subnets_enabled` (default true) to `terraform/modules/vpc`; test stack sets it to false to remove the old subnets.
- Required action: before applying with `primary_private_subnets_enabled = false`, move all workloads and references (routes, interface endpoints, databases, security group rules, module inputs) to secondary private subnets.
- Clarifies `terraform/modules/redis_private_link` `nlb_name` description: replacements must use a fresh name because create_before_destroy keeps both NLBs briefly.

<sup>Written for commit 2ae19fac5320ef03774745a328c91084d1d62668. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

