### PR TITLE
refactor(product_price): make pricing tiers reusable across price types

### DIFF
--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -343,7 +343,7 @@ class TieredPrice:
 
     __abstract__ = True
 
-    tiers: Mapped[Tiers | None] = mapped_column(
+    tiers: Mapped[Tiers] = mapped_column(
         TiersType(none_as_null=True),
         use_existing_column=True,
         nullable=True,
@@ -362,14 +362,8 @@ class TieredPrice:
         default=None,
     )
 
-    def get_tiers(self) -> Tiers:
-        """The tiers this price bills on."""
-        if self.tiers is None:
-            raise ValueError("Price has no tiers")
-        return self.tiers
-
     def get_tiered_amount(self, quantity: int) -> Decimal:
-        return self.get_tiers().calculate(quantity)
+        return self.tiers.calculate(quantity)
 
     def get_minimum_units(self) -> int:
         """The smallest purchasable quantity (inclusive), 0 when unset.
@@ -381,7 +375,7 @@ class TieredPrice:
         open-ended. Defaults to the last tier's bound when unset."""
         if self.maximum_units is not None:
             return self.maximum_units
-        return self.get_tiers().last_bound
+        return self.tiers.last_bound
 
 
 class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
@@ -413,7 +407,7 @@ class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
 
     @property
     def is_free(self) -> bool:
-        return all(tier.unit_amount == 0 for tier in self.get_tiers().tiers)
+        return all(tier.unit_amount == 0 for tier in self.tiers.tiers)
 
     __mapper_args__ = {
         "polymorphic_identity": ProductPriceAmountType.seat_based,
@@ -431,7 +425,7 @@ def _write_tiers_from_seat_tiers(
     """Dual-write to the shared `tiers`, `minimum_units` and `maximum_units`
     columns. Delete when `seat_tiers` is dropped."""
     if value is None:
-        target.tiers = None
+        target.tiers = None  # type: ignore[assignment]
         target.minimum_units = None
         target.maximum_units = None
     else:

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -33,6 +33,7 @@ from polar.enums import (
     SubscriptionRecurringInterval,
     TaxBehaviorOption,
 )
+from polar.exceptions import PolarError
 from polar.kit.currency import format_currency
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy.types import StringEnum
@@ -68,16 +69,16 @@ class TierType(StrEnum):
 
 
 class Tier(TypedDict):
-    """A per-unit rate up to and including `up_to`.
+    """A per-unit rate up to and including `bound`.
 
     Each tier starts where the previous one ended. The first starts at
-    zero. `up_to` is None on the last tier if it's unbounded. Rates are
+    zero. `bound` is None on the last tier if it's unbounded. Rates are
     in cents and may be fractional, so they're stored as strings and
     parsed to Decimal before any math.
     """
 
-    up_to: int | None
-    price_per_unit: str
+    bound: int | None
+    unit_amount: str
 
 
 class TiersData(TypedDict):
@@ -86,12 +87,17 @@ class TiersData(TypedDict):
     `maximum_units` columns, not here.
     """
 
-    tier_type: TierType
+    type: TierType
     tiers: list[Tier]
 
 
-class InvalidTiersError(ValueError):
-    pass
+class TiersError(PolarError):
+    """Base error for invalid or unusable tiered pricing data."""
+
+
+class InvalidTiersError(TiersError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, status_code=400)
 
 
 class UnboundedTierNotLastError(InvalidTiersError):
@@ -111,12 +117,13 @@ class NonContiguousTiersError(InvalidTiersError):
         self.next_min_seats = next_min_seats
 
 
-class InvalidQuantityError(ValueError):
-    pass
+class InvalidQuantityError(TiersError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, status_code=400)
 
 
 def _parse_tier_type(data: TiersData) -> TierType:
-    tier_type = data.get("tier_type")
+    tier_type = data.get("type")
     try:
         return TierType(tier_type)
     except ValueError as e:
@@ -124,45 +131,45 @@ def _parse_tier_type(data: TiersData) -> TierType:
 
 
 class _ParsedTier(TypedDict):
-    up_to: int | None
-    price_per_unit: Decimal
+    bound: int | None
+    unit_amount: Decimal
 
 
 def _parse_tiers(data: TiersData) -> list[_ParsedTier]:
     parsed: list[_ParsedTier] = [
         {
-            "up_to": tier["up_to"],
-            "price_per_unit": Decimal(tier["price_per_unit"]),
+            "bound": tier["bound"],
+            "unit_amount": Decimal(tier["unit_amount"]),
         }
         for tier in data.get("tiers", [])
     ]
-    return sorted(parsed, key=lambda t: (t["up_to"] is None, t["up_to"] or 0))
+    return sorted(parsed, key=lambda t: (t["bound"] is None, t["bound"] or 0))
 
 
 def _calculate_volume(quantity: int, tiers: list[_ParsedTier]) -> Decimal:
     for tier in tiers:
-        up_to = tier["up_to"]
-        if up_to is None or quantity <= up_to:
-            return tier["price_per_unit"] * quantity
+        bound = tier["bound"]
+        if bound is None or quantity <= bound:
+            return tier["unit_amount"] * quantity
     raise InvalidQuantityError(f"No tier covers quantity {quantity}")
 
 
 def _calculate_graduated(quantity: int, tiers: list[_ParsedTier]) -> Decimal:
     total = Decimal(0)
     remaining = quantity
-    previous_up_to = 0
+    previous_bound = 0
     for tier in tiers:
         if remaining <= 0:
             break
-        up_to = tier["up_to"]
-        tier_capacity = (up_to - previous_up_to) if up_to is not None else None
+        bound = tier["bound"]
+        tier_capacity = (bound - previous_bound) if bound is not None else None
         units_in_tier = (
             remaining if tier_capacity is None else min(remaining, tier_capacity)
         )
-        total += units_in_tier * tier["price_per_unit"]
+        total += units_in_tier * tier["unit_amount"]
         remaining -= units_in_tier
-        if up_to is not None:
-            previous_up_to = up_to
+        if bound is not None:
+            previous_bound = bound
     return total
 
 
@@ -179,31 +186,31 @@ def validate_tiers_data(
         raise InvalidTiersError("At least one tier is required")
 
     for tier in tiers:
-        if tier["price_per_unit"] < 0:
+        if tier["unit_amount"] < 0:
             raise InvalidTiersError(
-                f"Tier price_per_unit must be >= 0, got {tier['price_per_unit']}"
+                f"Tier unit_amount must be >= 0, got {tier['unit_amount']}"
             )
-        up_to = tier["up_to"]
-        if up_to is not None and up_to <= 0:
-            raise InvalidTiersError(f"Tier up_to must be > 0, got {up_to}")
+        bound = tier["bound"]
+        if bound is not None and bound <= 0:
+            raise InvalidTiersError(f"Tier bound must be > 0, got {bound}")
 
     for current, next_tier in pairwise(tiers):
         # Tiers are sorted with None last, so a duplicate None lands here.
-        if current["up_to"] is None:
+        if current["bound"] is None:
             raise UnboundedTierNotLastError()
-        if next_tier["up_to"] == current["up_to"]:
+        if next_tier["bound"] == current["bound"]:
             raise InvalidTiersError(
-                f"Tier up_to values must be unique, got {current['up_to']} twice"
+                f"Tier bound values must be unique, got {current['bound']} twice"
             )
 
-    last_up_to = tiers[-1]["up_to"]
+    last_bound = tiers[-1]["bound"]
     if minimum_units is not None:
         if minimum_units < 0:
             raise InvalidTiersError(f"minimum_units must be >= 0, got {minimum_units}")
-        if last_up_to is not None and minimum_units > last_up_to:
+        if last_bound is not None and minimum_units > last_bound:
             raise InvalidTiersError(
-                f"minimum_units must not exceed the last tier's up_to, "
-                f"got {minimum_units} > {last_up_to}"
+                f"minimum_units must not exceed the last tier's bound, "
+                f"got {minimum_units} > {last_bound}"
             )
     if maximum_units is not None:
         if maximum_units <= 0:
@@ -213,10 +220,10 @@ def validate_tiers_data(
                 f"maximum_units must be >= minimum_units, "
                 f"got {maximum_units} < {minimum_units}"
             )
-        if last_up_to is not None and maximum_units > last_up_to:
+        if last_bound is not None and maximum_units > last_bound:
             raise InvalidTiersError(
-                f"maximum_units must not exceed the last tier's up_to, "
-                f"got {maximum_units} > {last_up_to}"
+                f"maximum_units must not exceed the last tier's bound, "
+                f"got {maximum_units} > {last_bound}"
             )
 
 
@@ -243,7 +250,7 @@ class SeatTiersData(TypedDict):
 def seat_tiers_to_tiers_data(seat_tiers: SeatTiersData) -> TiersData:
     """Translate the legacy seat tier format to the shared tiers format.
 
-    Each tier's max_seats becomes `up_to`. Gaps and overlaps raise, since the
+    Each tier's max_seats becomes `bound`. Gaps and overlaps raise, since the
     shared format can't represent them. A missing seat_tier_type means volume.
     """
     tier_type = TierType(seat_tiers.get("seat_tier_type", SeatTierType.volume))
@@ -260,12 +267,12 @@ def seat_tiers_to_tiers_data(seat_tiers: SeatTiersData) -> TiersData:
 
     tiers: list[Tier] = [
         {
-            "up_to": tier.get("max_seats"),
-            "price_per_unit": str(tier["price_per_seat"]),
+            "bound": tier.get("max_seats"),
+            "unit_amount": str(tier["price_per_seat"]),
         }
         for tier in sorted_seat_tiers
     ]
-    return {"tier_type": tier_type, "tiers": tiers}
+    return {"type": tier_type, "tiers": tiers}
 
 
 def seat_tiers_unit_bounds(seat_tiers: SeatTiersData) -> tuple[int | None, int | None]:
@@ -601,13 +608,13 @@ class TieredPrice:
 
     def get_maximum_units(self) -> int | None:
         """The largest purchasable quantity (inclusive), or None if
-        open-ended. Defaults to the last tier's up_to when unset."""
+        open-ended. Defaults to the last tier's bound when unset."""
         if self.maximum_units is not None:
             return self.maximum_units
         tiers = _parse_tiers(self.get_tiers_data())
         if not tiers:
             return None
-        return tiers[-1]["up_to"]
+        return tiers[-1]["bound"]
 
 
 class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
@@ -653,7 +660,7 @@ class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
         tiers = self.get_tiers_data()["tiers"]
         if not tiers:
             return True
-        return all(Decimal(tier["price_per_unit"]) == 0 for tier in tiers)
+        return all(Decimal(tier["unit_amount"]) == 0 for tier in tiers)
 
     __mapper_args__ = {
         "polymorphic_identity": ProductPriceAmountType.seat_based,

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from enum import StrEnum
+from itertools import pairwise
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
 from uuid import UUID
 
@@ -26,6 +27,7 @@ from sqlalchemy.orm import (
     object_mapper,
     relationship,
 )
+from sqlalchemy.orm.attributes import Event
 
 from polar.enums import (
     SubscriptionRecurringInterval,
@@ -60,6 +62,165 @@ class ProductPriceSource(StrEnum):
     ad_hoc = "ad_hoc"
 
 
+class TierType(StrEnum):
+    volume = "volume"
+    graduated = "graduated"
+
+
+class Tier(TypedDict):
+    """A per-unit rate applying up to `up_to` units, inclusive.
+
+    Each tier starts where the previous one ends, the first at zero, and
+    `up_to` is None on the last tier if it's unbounded. Rates are in cents
+    and may be fractional, so they're stored as strings and parsed to
+    Decimal before any math.
+    """
+
+    up_to: int | None
+    price_per_unit: str
+
+
+class TiersData(TypedDict):
+    """The structure of the shared tiers JSONB column, used by every tiered
+    price type. Purchasable quantity bounds live in the `minimum_units` and
+    `maximum_units` columns, not here.
+    """
+
+    tier_type: TierType
+    tiers: list[Tier]
+
+
+class InvalidTiersError(ValueError):
+    pass
+
+
+class UnboundedTierNotLastError(InvalidTiersError):
+    def __init__(self) -> None:
+        super().__init__("Only the last tier can be unbounded")
+
+
+class NonContiguousTiersError(InvalidTiersError):
+    """Gap or overlap in legacy seat tiers, caught before translating to the
+    shared format, where non-contiguous ranges cannot be represented."""
+
+    def __init__(self, previous_max_seats: int, next_min_seats: int) -> None:
+        super().__init__(
+            "Gap or overlap between tiers: "
+            f"tier ending at {previous_max_seats} and tier starting at {next_min_seats}"
+        )
+        self.previous_max_seats = previous_max_seats
+        self.next_min_seats = next_min_seats
+
+
+class InvalidQuantityError(ValueError):
+    pass
+
+
+def _parse_tier_type(data: TiersData) -> TierType:
+    tier_type = data.get("tier_type")
+    try:
+        return TierType(tier_type)
+    except ValueError as e:
+        raise InvalidTiersError(f"Missing or unknown tier_type: {tier_type!r}") from e
+
+
+class _ParsedTier(TypedDict):
+    up_to: int | None
+    price_per_unit: Decimal
+
+
+def _parse_tiers(data: TiersData) -> list[_ParsedTier]:
+    parsed: list[_ParsedTier] = [
+        {
+            "up_to": tier["up_to"],
+            "price_per_unit": Decimal(tier["price_per_unit"]),
+        }
+        for tier in data.get("tiers", [])
+    ]
+    return sorted(parsed, key=lambda t: (t["up_to"] is None, t["up_to"] or 0))
+
+
+def _calculate_volume(quantity: int, tiers: list[_ParsedTier]) -> Decimal:
+    for tier in tiers:
+        up_to = tier["up_to"]
+        if up_to is None or quantity <= up_to:
+            return tier["price_per_unit"] * quantity
+    raise InvalidQuantityError(f"No tier covers quantity {quantity}")
+
+
+def _calculate_graduated(quantity: int, tiers: list[_ParsedTier]) -> Decimal:
+    total = Decimal(0)
+    remaining = quantity
+    previous_up_to = 0
+    for tier in tiers:
+        if remaining <= 0:
+            break
+        up_to = tier["up_to"]
+        tier_capacity = (up_to - previous_up_to) if up_to is not None else None
+        units_in_tier = (
+            remaining if tier_capacity is None else min(remaining, tier_capacity)
+        )
+        total += units_in_tier * tier["price_per_unit"]
+        remaining -= units_in_tier
+        if up_to is not None:
+            previous_up_to = up_to
+    return total
+
+
+def validate_tiers_data(
+    data: TiersData,
+    *,
+    minimum_units: int | None = None,
+    maximum_units: int | None = None,
+) -> None:
+    _parse_tier_type(data)
+    tiers = _parse_tiers(data)
+
+    if not tiers:
+        raise InvalidTiersError("At least one tier is required")
+
+    for tier in tiers:
+        if tier["price_per_unit"] < 0:
+            raise InvalidTiersError(
+                f"Tier price_per_unit must be >= 0, got {tier['price_per_unit']}"
+            )
+        up_to = tier["up_to"]
+        if up_to is not None and up_to <= 0:
+            raise InvalidTiersError(f"Tier up_to must be > 0, got {up_to}")
+
+    for current, next_tier in pairwise(tiers):
+        # Tiers are sorted with None last, so a duplicate None lands here.
+        if current["up_to"] is None:
+            raise UnboundedTierNotLastError()
+        if next_tier["up_to"] == current["up_to"]:
+            raise InvalidTiersError(
+                f"Tier up_to values must be unique, got {current['up_to']} twice"
+            )
+
+    last_up_to = tiers[-1]["up_to"]
+    if minimum_units is not None:
+        if minimum_units < 0:
+            raise InvalidTiersError(f"minimum_units must be >= 0, got {minimum_units}")
+        if last_up_to is not None and minimum_units > last_up_to:
+            raise InvalidTiersError(
+                f"minimum_units must not exceed the last tier's up_to, "
+                f"got {minimum_units} > {last_up_to}"
+            )
+    if maximum_units is not None:
+        if maximum_units <= 0:
+            raise InvalidTiersError(f"maximum_units must be > 0, got {maximum_units}")
+        if minimum_units is not None and maximum_units < minimum_units:
+            raise InvalidTiersError(
+                f"maximum_units must be >= minimum_units, "
+                f"got {maximum_units} < {minimum_units}"
+            )
+        if last_up_to is not None and maximum_units > last_up_to:
+            raise InvalidTiersError(
+                f"maximum_units must not exceed the last tier's up_to, "
+                f"got {maximum_units} > {last_up_to}"
+            )
+
+
 class SeatTierType(StrEnum):
     volume = "volume"
     graduated = "graduated"
@@ -78,6 +239,45 @@ class SeatTiersData(TypedDict):
 
     seat_tier_type: SeatTierType
     tiers: list[SeatTier]
+
+
+def seat_tiers_to_tiers_data(seat_tiers: SeatTiersData) -> TiersData:
+    """Translate the legacy seat tier format to the shared tiers format.
+
+    Each tier's max_seats becomes `up_to`. Gaps and overlaps raise, since the
+    shared format can't represent them. A missing seat_tier_type means volume.
+    """
+    tier_type = TierType(seat_tiers.get("seat_tier_type", SeatTierType.volume))
+    sorted_seat_tiers = sorted(
+        seat_tiers.get("tiers", []), key=lambda t: t["min_seats"]
+    )
+
+    for current, next_tier in pairwise(sorted_seat_tiers):
+        max_seats = current.get("max_seats")
+        if max_seats is None:
+            raise UnboundedTierNotLastError()
+        if next_tier["min_seats"] != max_seats + 1:
+            raise NonContiguousTiersError(max_seats, next_tier["min_seats"])
+
+    tiers: list[Tier] = [
+        {
+            "up_to": tier.get("max_seats"),
+            "price_per_unit": str(tier["price_per_seat"]),
+        }
+        for tier in sorted_seat_tiers
+    ]
+    return {"tier_type": tier_type, "tiers": tiers}
+
+
+def seat_tiers_unit_bounds(seat_tiers: SeatTiersData) -> tuple[int | None, int | None]:
+    """The purchasable quantity bounds implied by legacy seat tiers: the
+    first tier's min_seats and the last tier's max_seats."""
+    sorted_seat_tiers = sorted(
+        seat_tiers.get("tiers", []), key=lambda t: t["min_seats"]
+    )
+    if not sorted_seat_tiers:
+        return None, None
+    return sorted_seat_tiers[0]["min_seats"], sorted_seat_tiers[-1].get("max_seats")
 
 
 LEGACY_IDENTITY_PREFIX = "legacy_"
@@ -346,7 +546,76 @@ class ProductPriceMeteredUnit(ProductPrice, NewProductPrice):
     }
 
 
-class ProductPriceSeatUnit(NewProductPrice, ProductPrice):
+class TieredPrice:
+    """Mixin for prices that bill from a shared list of tiers.
+
+    Gives you the amount in cents for a quantity of whole units, and the
+    unit range those tiers cover. The price class is responsible for
+    translating that into its own terms (seats, integer cents, …).
+    """
+
+    __abstract__ = True
+
+    tiers: Mapped[TiersData | None] = mapped_column(
+        postgresql.JSONB,
+        use_existing_column=True,
+        nullable=True,
+        default=None,
+    )
+    minimum_units: Mapped[int | None] = mapped_column(
+        BigInteger,
+        use_existing_column=True,
+        nullable=True,
+        default=None,
+    )
+    maximum_units: Mapped[int | None] = mapped_column(
+        BigInteger,
+        use_existing_column=True,
+        nullable=True,
+        default=None,
+    )
+
+    def get_tiers_data(self) -> TiersData:
+        """The tiers this price bills on. A type mid-migration overrides this
+        to read from its legacy column instead."""
+        if self.tiers is None:
+            raise InvalidTiersError("Price has no tiers")
+        return self.tiers
+
+    def get_tiered_amount(self, quantity: int) -> Decimal:
+        data = self.get_tiers_data()
+        tier_type = _parse_tier_type(data)
+        tiers = _parse_tiers(data)
+
+        if quantity < 0:
+            raise InvalidQuantityError(f"Negative quantity: {quantity}")
+        if quantity == 0:
+            return Decimal(0)
+
+        match tier_type:
+            case TierType.volume:
+                return _calculate_volume(quantity, tiers)
+            case TierType.graduated:
+                return _calculate_graduated(quantity, tiers)
+
+    def get_minimum_units(self) -> int:
+        """The smallest purchasable quantity (inclusive), 0 when unset.
+        Enforced by the purchase layer, not the pricing engine."""
+        return self.minimum_units or 0
+
+    def get_maximum_units(self) -> int | None:
+        """The largest purchasable quantity (inclusive), or None if
+        open-ended. Falls back to the end of the last tier, past which a
+        quantity can't be priced anyway."""
+        if self.maximum_units is not None:
+            return self.maximum_units
+        tiers = _parse_tiers(self.get_tiers_data())
+        if not tiers:
+            return None
+        return tiers[-1]["up_to"]
+
+
+class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
     amount_type: Mapped[Literal[ProductPriceAmountType.seat_based]] = mapped_column(
         use_existing_column=True, default=ProductPriceAmountType.seat_based
     )
@@ -354,99 +623,65 @@ class ProductPriceSeatUnit(NewProductPrice, ProductPrice):
         postgresql.JSONB,
         nullable=True,
     )
-    tiers: Mapped[dict[str, Any] | None] = mapped_column(
-        postgresql.JSONB(none_as_null=True),
-        nullable=True,
-        default=None,
-    )
-    minimum_units: Mapped[int | None] = mapped_column(
-        BigInteger,
-        nullable=True,
-        default=None,
-    )
-    maximum_units: Mapped[int | None] = mapped_column(
-        BigInteger,
-        nullable=True,
-        default=None,
-    )
 
-    def get_tier_for_seats(self, seats: int) -> SeatTier:
-        for tier in self.seat_tiers.get("tiers", []):
-            min_seats = tier["min_seats"]
-            max_seats = tier.get("max_seats")
-            if seats >= min_seats and (max_seats is None or seats <= max_seats):
-                return tier
-        raise ValueError(f"No tier found for {seats} seats")
+    def get_tiers_data(self) -> TiersData:
+        """`seat_tiers` is still the source of truth, delete this override once reads move to `tiers`."""
+        return seat_tiers_to_tiers_data(self.seat_tiers)
+
+    def get_minimum_units(self) -> int:
+        """Same migration state as `get_tiers_data`: read from `seat_tiers`
+        until the `minimum_units` column takes over."""
+        minimum_units, _ = seat_tiers_unit_bounds(self.seat_tiers)
+        return minimum_units or 0
+
+    def get_maximum_units(self) -> int | None:
+        """Same migration state as `get_tiers_data`: read from `seat_tiers`
+        until the `maximum_units` column takes over."""
+        _, maximum_units = seat_tiers_unit_bounds(self.seat_tiers)
+        return maximum_units
 
     def calculate_amount(self, seats: int) -> int:
-        seat_tier_type = self.seat_tiers.get("seat_tier_type", SeatTierType.volume)
-        match seat_tier_type:
-            case SeatTierType.volume:
-                return self._calculate_volume(seats)
-            case SeatTierType.graduated:
-                return self._calculate_graduated(seats)
-
-    def _calculate_volume(self, seats: int) -> int:
-        tier = self.get_tier_for_seats(seats)
-        return tier["price_per_seat"] * seats
-
-    def _calculate_graduated(self, seats: int) -> int:
-        total = 0
-        remaining = seats
-        # Tier capacity is measured from the previous tier's upper bound, not the
-        # tier's own min_seats. The first tier's min_seats doubles as the minimum
-        # order quantity (see get_minimum_seats), so it may be > 1; the first tier
-        # must still bill from seat 1, otherwise seats below it spill into cheaper
-        # tiers (T-28449).
-        previous_max = 0
-        for tier in sorted(
-            self.seat_tiers.get("tiers", []), key=lambda t: t["min_seats"]
-        ):
-            if remaining <= 0:
-                break
-            max_seats = tier.get("max_seats")
-            tier_capacity = (
-                (max_seats - previous_max) if max_seats is not None else remaining
-            )
-            seats_in_tier = min(remaining, tier_capacity)
-            total += seats_in_tier * tier["price_per_seat"]
-            remaining -= seats_in_tier
-            if max_seats is not None:
-                previous_max = max_seats
-        return total
+        amount = self.get_tiered_amount(seats)
+        # Seat rates are whole cents, so any fraction means corrupt data.
+        if amount != amount.to_integral_value():
+            raise ValueError(f"Seat price produced non-integral amount {amount}")
+        return int(amount)
 
     def get_minimum_seats(self) -> int:
-        """Get the minimum number of seats allowed, derived from first tier's min_seats."""
-        tiers = self.seat_tiers.get("tiers", [])
-        if not tiers:
-            return 1
-        sorted_tiers = sorted(tiers, key=lambda t: t["min_seats"])
-        return sorted_tiers[0]["min_seats"]
+        return max(1, self.get_minimum_units())
 
     def get_maximum_seats(self) -> int | None:
-        """Get the maximum number of seats allowed, derived from last tier's max_seats."""
-        tiers = self.seat_tiers.get("tiers", [])
-        if not tiers:
-            return None
-        sorted_tiers = sorted(tiers, key=lambda t: t["min_seats"])
-        return sorted_tiers[-1].get("max_seats")
+        return self.get_maximum_units()
 
     @property
     def is_free(self) -> bool:
-        """Check if ALL tiers have price_per_seat == 0.
-
-        A seat-based price is only considered free if every single tier
-        has a zero price per seat. If any tier charges, it's not free.
-        """
-        tiers = self.seat_tiers.get("tiers", [])
+        tiers = self.get_tiers_data()["tiers"]
         if not tiers:
             return True
-        return all(tier["price_per_seat"] == 0 for tier in tiers)
+        return all(Decimal(tier["price_per_unit"]) == 0 for tier in tiers)
 
     __mapper_args__ = {
         "polymorphic_identity": ProductPriceAmountType.seat_based,
         "polymorphic_load": "inline",
     }
+
+
+@event.listens_for(ProductPriceSeatUnit.seat_tiers, "set")
+def _write_tiers_from_seat_tiers(
+    target: ProductPriceSeatUnit,
+    value: SeatTiersData | None,
+    oldvalue: SeatTiersData | None,
+    initiator: Event,
+) -> None:
+    """Dual-write to the shared `tiers`, `minimum_units` and `maximum_units`
+    columns, delete when `seat_tiers` is dropped."""
+    if value is None:
+        target.tiers = None
+        target.minimum_units = None
+        target.maximum_units = None
+    else:
+        target.tiers = seat_tiers_to_tiers_data(value)
+        target.minimum_units, target.maximum_units = seat_tiers_unit_bounds(value)
 
 
 @event.listens_for(ProductPrice, "init", propagate=True)

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -1,7 +1,6 @@
 from decimal import Decimal
 from enum import StrEnum
-from itertools import pairwise
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID
 
 from babel.numbers import format_decimal
@@ -33,11 +32,17 @@ from polar.enums import (
     SubscriptionRecurringInterval,
     TaxBehaviorOption,
 )
-from polar.exceptions import PolarError
 from polar.kit.currency import format_currency
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy.types import StringEnum
 from polar.kit.math import polar_round
+from polar.product.tiers import (
+    SeatTiersData,
+    Tiers,
+    TiersType,
+    seat_tiers_to_tiers,
+    seat_tiers_unit_bounds,
+)
 
 if TYPE_CHECKING:
     from polar.models import Meter, Product
@@ -61,228 +66,6 @@ class ProductPriceAmountType(StrEnum):
 class ProductPriceSource(StrEnum):
     catalog = "catalog"
     ad_hoc = "ad_hoc"
-
-
-class TierType(StrEnum):
-    volume = "volume"
-    graduated = "graduated"
-
-
-class Tier(TypedDict):
-    """A per-unit rate up to and including `bound`.
-
-    Each tier starts where the previous one ended. The first starts at
-    zero. `bound` is None on the last tier if it's unbounded. Rates are
-    in cents and may be fractional, so they're stored as strings and
-    parsed to Decimal before any math.
-    """
-
-    bound: int | None
-    unit_amount: str
-
-
-class TiersData(TypedDict):
-    """The structure of the shared tiers JSONB column, used by every tiered
-    price type. Purchasable quantity bounds live in the `minimum_units` and
-    `maximum_units` columns, not here.
-    """
-
-    type: TierType
-    tiers: list[Tier]
-
-
-class TiersError(PolarError):
-    """Base error for invalid or unusable tiered pricing data."""
-
-
-class InvalidTiersError(TiersError):
-    def __init__(self, message: str) -> None:
-        super().__init__(message, status_code=400)
-
-
-class UnboundedTierNotLastError(InvalidTiersError):
-    def __init__(self) -> None:
-        super().__init__("Only the last tier can be unbounded")
-
-
-class NonContiguousTiersError(InvalidTiersError):
-    """Raised when translating seat tiers that have a gap or overlap."""
-
-    def __init__(self, previous_max_seats: int, next_min_seats: int) -> None:
-        super().__init__(
-            "Gap or overlap between tiers: "
-            f"tier ending at {previous_max_seats} and tier starting at {next_min_seats}"
-        )
-        self.previous_max_seats = previous_max_seats
-        self.next_min_seats = next_min_seats
-
-
-class InvalidQuantityError(TiersError):
-    def __init__(self, message: str) -> None:
-        super().__init__(message, status_code=400)
-
-
-def _parse_tier_type(data: TiersData) -> TierType:
-    tier_type = data.get("type")
-    try:
-        return TierType(tier_type)
-    except ValueError as e:
-        raise InvalidTiersError(f"Missing or unknown tier_type: {tier_type!r}") from e
-
-
-class _ParsedTier(TypedDict):
-    bound: int | None
-    unit_amount: Decimal
-
-
-def _parse_tiers(data: TiersData) -> list[_ParsedTier]:
-    parsed: list[_ParsedTier] = [
-        {
-            "bound": tier["bound"],
-            "unit_amount": Decimal(tier["unit_amount"]),
-        }
-        for tier in data.get("tiers", [])
-    ]
-    return sorted(parsed, key=lambda t: (t["bound"] is None, t["bound"] or 0))
-
-
-def _calculate_volume(quantity: int, tiers: list[_ParsedTier]) -> Decimal:
-    for tier in tiers:
-        bound = tier["bound"]
-        if bound is None or quantity <= bound:
-            return tier["unit_amount"] * quantity
-    raise InvalidQuantityError(f"No tier covers quantity {quantity}")
-
-
-def _calculate_graduated(quantity: int, tiers: list[_ParsedTier]) -> Decimal:
-    total = Decimal(0)
-    remaining = quantity
-    previous_bound = 0
-    for tier in tiers:
-        if remaining <= 0:
-            break
-        bound = tier["bound"]
-        tier_capacity = (bound - previous_bound) if bound is not None else None
-        units_in_tier = (
-            remaining if tier_capacity is None else min(remaining, tier_capacity)
-        )
-        total += units_in_tier * tier["unit_amount"]
-        remaining -= units_in_tier
-        if bound is not None:
-            previous_bound = bound
-    return total
-
-
-def validate_tiers_data(
-    data: TiersData,
-    *,
-    minimum_units: int | None = None,
-    maximum_units: int | None = None,
-) -> None:
-    _parse_tier_type(data)
-    tiers = _parse_tiers(data)
-
-    if not tiers:
-        raise InvalidTiersError("At least one tier is required")
-
-    for tier in tiers:
-        if tier["unit_amount"] < 0:
-            raise InvalidTiersError(
-                f"Tier unit_amount must be >= 0, got {tier['unit_amount']}"
-            )
-        bound = tier["bound"]
-        if bound is not None and bound <= 0:
-            raise InvalidTiersError(f"Tier bound must be > 0, got {bound}")
-
-    for current, next_tier in pairwise(tiers):
-        # Tiers are sorted with None last, so a duplicate None lands here.
-        if current["bound"] is None:
-            raise UnboundedTierNotLastError()
-        if next_tier["bound"] == current["bound"]:
-            raise InvalidTiersError(
-                f"Tier bound values must be unique, got {current['bound']} twice"
-            )
-
-    last_bound = tiers[-1]["bound"]
-    if minimum_units is not None:
-        if minimum_units < 0:
-            raise InvalidTiersError(f"minimum_units must be >= 0, got {minimum_units}")
-        if last_bound is not None and minimum_units > last_bound:
-            raise InvalidTiersError(
-                f"minimum_units must not exceed the last tier's bound, "
-                f"got {minimum_units} > {last_bound}"
-            )
-    if maximum_units is not None:
-        if maximum_units <= 0:
-            raise InvalidTiersError(f"maximum_units must be > 0, got {maximum_units}")
-        if minimum_units is not None and maximum_units < minimum_units:
-            raise InvalidTiersError(
-                f"maximum_units must be >= minimum_units, "
-                f"got {maximum_units} < {minimum_units}"
-            )
-        if last_bound is not None and maximum_units > last_bound:
-            raise InvalidTiersError(
-                f"maximum_units must not exceed the last tier's bound, "
-                f"got {maximum_units} > {last_bound}"
-            )
-
-
-class SeatTierType(StrEnum):
-    volume = "volume"
-    graduated = "graduated"
-
-
-class SeatTier(TypedDict):
-    """A single pricing tier for seat-based pricing."""
-
-    min_seats: int
-    max_seats: int | None
-    price_per_seat: int
-
-
-class SeatTiersData(TypedDict):
-    """The structure of the seat_tiers JSONB column."""
-
-    seat_tier_type: SeatTierType
-    tiers: list[SeatTier]
-
-
-def seat_tiers_to_tiers_data(seat_tiers: SeatTiersData) -> TiersData:
-    """Translate the legacy seat tier format to the shared tiers format.
-
-    Each tier's max_seats becomes `bound`. Gaps and overlaps raise, since the
-    shared format can't represent them. A missing seat_tier_type means volume.
-    """
-    tier_type = TierType(seat_tiers.get("seat_tier_type", SeatTierType.volume))
-    sorted_seat_tiers = sorted(
-        seat_tiers.get("tiers", []), key=lambda t: t["min_seats"]
-    )
-
-    for current, next_tier in pairwise(sorted_seat_tiers):
-        max_seats = current.get("max_seats")
-        if max_seats is None:
-            raise UnboundedTierNotLastError()
-        if next_tier["min_seats"] != max_seats + 1:
-            raise NonContiguousTiersError(max_seats, next_tier["min_seats"])
-
-    tiers: list[Tier] = [
-        {
-            "bound": tier.get("max_seats"),
-            "unit_amount": str(tier["price_per_seat"]),
-        }
-        for tier in sorted_seat_tiers
-    ]
-    return {"type": tier_type, "tiers": tiers}
-
-
-def seat_tiers_unit_bounds(seat_tiers: SeatTiersData) -> tuple[int | None, int | None]:
-    """Return the first tier's min_seats and the last tier's max_seats."""
-    sorted_seat_tiers = sorted(
-        seat_tiers.get("tiers", []), key=lambda t: t["min_seats"]
-    )
-    if not sorted_seat_tiers:
-        return None, None
-    return sorted_seat_tiers[0]["min_seats"], sorted_seat_tiers[-1].get("max_seats")
 
 
 LEGACY_IDENTITY_PREFIX = "legacy_"
@@ -560,8 +343,8 @@ class TieredPrice:
 
     __abstract__ = True
 
-    tiers: Mapped[TiersData | None] = mapped_column(
-        postgresql.JSONB(none_as_null=True),
+    tiers: Mapped[Tiers | None] = mapped_column(
+        TiersType(none_as_null=True),
         use_existing_column=True,
         nullable=True,
         default=None,
@@ -579,27 +362,14 @@ class TieredPrice:
         default=None,
     )
 
-    def get_tiers_data(self) -> TiersData:
+    def get_tiers(self) -> Tiers:
         """The tiers this price bills on."""
         if self.tiers is None:
-            raise InvalidTiersError("Price has no tiers")
+            raise ValueError("Price has no tiers")
         return self.tiers
 
     def get_tiered_amount(self, quantity: int) -> Decimal:
-        data = self.get_tiers_data()
-        tier_type = _parse_tier_type(data)
-        tiers = _parse_tiers(data)
-
-        if quantity < 0:
-            raise InvalidQuantityError(f"Negative quantity: {quantity}")
-        if quantity == 0:
-            return Decimal(0)
-
-        match tier_type:
-            case TierType.volume:
-                return _calculate_volume(quantity, tiers)
-            case TierType.graduated:
-                return _calculate_graduated(quantity, tiers)
+        return self.get_tiers().calculate(quantity)
 
     def get_minimum_units(self) -> int:
         """The smallest purchasable quantity (inclusive), 0 when unset.
@@ -611,16 +381,13 @@ class TieredPrice:
         open-ended. Defaults to the last tier's bound when unset."""
         if self.maximum_units is not None:
             return self.maximum_units
-        tiers = _parse_tiers(self.get_tiers_data())
-        if not tiers:
-            return None
-        return tiers[-1]["bound"]
+        return self.get_tiers().last_bound
 
 
 class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
-    """Seat-based price. Billing still reads `seat_tiers`; the shared
-    columns are dual-written. Delete the overrides when reads move to
-    `tiers`.
+    """Seat-based price. The public API still reads and writes
+    `seat_tiers`; that column is translated into the shared `tiers`,
+    `minimum_units` and `maximum_units` columns, which billing uses.
     """
 
     amount_type: Mapped[Literal[ProductPriceAmountType.seat_based]] = mapped_column(
@@ -630,17 +397,6 @@ class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
         postgresql.JSONB,
         nullable=True,
     )
-
-    def get_tiers_data(self) -> TiersData:
-        return seat_tiers_to_tiers_data(self.seat_tiers)
-
-    def get_minimum_units(self) -> int:
-        minimum_units, _ = seat_tiers_unit_bounds(self.seat_tiers)
-        return minimum_units or 0
-
-    def get_maximum_units(self) -> int | None:
-        _, maximum_units = seat_tiers_unit_bounds(self.seat_tiers)
-        return maximum_units
 
     def calculate_amount(self, seats: int) -> int:
         amount = self.get_tiered_amount(seats)
@@ -657,10 +413,7 @@ class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
 
     @property
     def is_free(self) -> bool:
-        tiers = self.get_tiers_data()["tiers"]
-        if not tiers:
-            return True
-        return all(Decimal(tier["unit_amount"]) == 0 for tier in tiers)
+        return all(tier.unit_amount == 0 for tier in self.get_tiers().tiers)
 
     __mapper_args__ = {
         "polymorphic_identity": ProductPriceAmountType.seat_based,
@@ -682,7 +435,7 @@ def _write_tiers_from_seat_tiers(
         target.minimum_units = None
         target.maximum_units = None
     else:
-        target.tiers = seat_tiers_to_tiers_data(value)
+        target.tiers = seat_tiers_to_tiers(value)
         target.minimum_units, target.maximum_units = seat_tiers_unit_bounds(value)
 
 

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -557,7 +557,7 @@ class TieredPrice:
     __abstract__ = True
 
     tiers: Mapped[TiersData | None] = mapped_column(
-        postgresql.JSONB,
+        postgresql.JSONB(none_as_null=True),
         use_existing_column=True,
         nullable=True,
         default=None,

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -379,9 +379,9 @@ class TieredPrice:
 
 
 class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
-    """Seat-based price. The public API still reads and writes
-    `seat_tiers`; that column is translated into the shared `tiers`,
-    `minimum_units` and `maximum_units` columns, which billing uses.
+    """Seat-based price. Billing still reads `seat_tiers`. That column is
+    dual-written into the shared `tiers` columns so they can become the
+    billing source after backfill.
     """
 
     amount_type: Mapped[Literal[ProductPriceAmountType.seat_based]] = mapped_column(
@@ -393,21 +393,26 @@ class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
     )
 
     def calculate_amount(self, seats: int) -> int:
-        amount = self.get_tiered_amount(seats)
+        amount = seat_tiers_to_tiers(self.seat_tiers).calculate(seats)
         # Seat rates are whole cents, so any fraction means corrupt data.
         if amount != amount.to_integral_value():
             raise ValueError(f"Seat price produced non-integral amount {amount}")
         return int(amount)
 
     def get_minimum_seats(self) -> int:
-        return max(1, self.get_minimum_units())
+        minimum, _ = seat_tiers_unit_bounds(self.seat_tiers)
+        return minimum if minimum is not None else 1
 
     def get_maximum_seats(self) -> int | None:
-        return self.get_maximum_units()
+        _, maximum = seat_tiers_unit_bounds(self.seat_tiers)
+        return maximum
 
     @property
     def is_free(self) -> bool:
-        return all(tier.unit_amount == 0 for tier in self.tiers.tiers)
+        tiers = self.seat_tiers.get("tiers", [])
+        if not tiers:
+            return True
+        return all(tier["price_per_seat"] == 0 for tier in tiers)
 
     __mapper_args__ = {
         "polymorphic_identity": ProductPriceAmountType.seat_based,

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -68,12 +68,12 @@ class TierType(StrEnum):
 
 
 class Tier(TypedDict):
-    """A per-unit rate applying up to `up_to` units, inclusive.
+    """A per-unit rate up to and including `up_to`.
 
-    Each tier starts where the previous one ends, the first at zero, and
-    `up_to` is None on the last tier if it's unbounded. Rates are in cents
-    and may be fractional, so they're stored as strings and parsed to
-    Decimal before any math.
+    Each tier starts where the previous one ended. The first starts at
+    zero. `up_to` is None on the last tier if it's unbounded. Rates are
+    in cents and may be fractional, so they're stored as strings and
+    parsed to Decimal before any math.
     """
 
     up_to: int | None
@@ -100,8 +100,7 @@ class UnboundedTierNotLastError(InvalidTiersError):
 
 
 class NonContiguousTiersError(InvalidTiersError):
-    """Gap or overlap in legacy seat tiers, caught before translating to the
-    shared format, where non-contiguous ranges cannot be represented."""
+    """Raised when translating seat tiers that have a gap or overlap."""
 
     def __init__(self, previous_max_seats: int, next_min_seats: int) -> None:
         super().__init__(
@@ -270,8 +269,7 @@ def seat_tiers_to_tiers_data(seat_tiers: SeatTiersData) -> TiersData:
 
 
 def seat_tiers_unit_bounds(seat_tiers: SeatTiersData) -> tuple[int | None, int | None]:
-    """The purchasable quantity bounds implied by legacy seat tiers: the
-    first tier's min_seats and the last tier's max_seats."""
+    """Return the first tier's min_seats and the last tier's max_seats."""
     sorted_seat_tiers = sorted(
         seat_tiers.get("tiers", []), key=lambda t: t["min_seats"]
     )
@@ -547,11 +545,10 @@ class ProductPriceMeteredUnit(ProductPrice, NewProductPrice):
 
 
 class TieredPrice:
-    """Mixin for prices that bill from a shared list of tiers.
+    """Mixin for prices billed from a shared list of tiers.
 
-    Gives you the amount in cents for a quantity of whole units, and the
-    unit range those tiers cover. The price class is responsible for
-    translating that into its own terms (seats, integer cents, …).
+    `get_tiered_amount` returns cents for a whole-unit quantity.
+    Subclasses interpret those units (seats, metered usage, …).
     """
 
     __abstract__ = True
@@ -576,8 +573,7 @@ class TieredPrice:
     )
 
     def get_tiers_data(self) -> TiersData:
-        """The tiers this price bills on. A type mid-migration overrides this
-        to read from its legacy column instead."""
+        """The tiers this price bills on."""
         if self.tiers is None:
             raise InvalidTiersError("Price has no tiers")
         return self.tiers
@@ -605,8 +601,7 @@ class TieredPrice:
 
     def get_maximum_units(self) -> int | None:
         """The largest purchasable quantity (inclusive), or None if
-        open-ended. Falls back to the end of the last tier, past which a
-        quantity can't be priced anyway."""
+        open-ended. Defaults to the last tier's up_to when unset."""
         if self.maximum_units is not None:
             return self.maximum_units
         tiers = _parse_tiers(self.get_tiers_data())
@@ -616,6 +611,11 @@ class TieredPrice:
 
 
 class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
+    """Seat-based price. Billing still reads `seat_tiers`; the shared
+    columns are dual-written. Delete the overrides when reads move to
+    `tiers`.
+    """
+
     amount_type: Mapped[Literal[ProductPriceAmountType.seat_based]] = mapped_column(
         use_existing_column=True, default=ProductPriceAmountType.seat_based
     )
@@ -625,18 +625,13 @@ class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
     )
 
     def get_tiers_data(self) -> TiersData:
-        """`seat_tiers` is still the source of truth, delete this override once reads move to `tiers`."""
         return seat_tiers_to_tiers_data(self.seat_tiers)
 
     def get_minimum_units(self) -> int:
-        """Same migration state as `get_tiers_data`: read from `seat_tiers`
-        until the `minimum_units` column takes over."""
         minimum_units, _ = seat_tiers_unit_bounds(self.seat_tiers)
         return minimum_units or 0
 
     def get_maximum_units(self) -> int | None:
-        """Same migration state as `get_tiers_data`: read from `seat_tiers`
-        until the `maximum_units` column takes over."""
         _, maximum_units = seat_tiers_unit_bounds(self.seat_tiers)
         return maximum_units
 
@@ -674,7 +669,7 @@ def _write_tiers_from_seat_tiers(
     initiator: Event,
 ) -> None:
     """Dual-write to the shared `tiers`, `minimum_units` and `maximum_units`
-    columns, delete when `seat_tiers` is dropped."""
+    columns. Delete when `seat_tiers` is dropped."""
     if value is None:
         target.tiers = None
         target.minimum_units = None

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -9,7 +9,6 @@ from pydantic import (
     Discriminator,
     Field,
     Tag,
-    ValidationError,
     ValidationInfo,
     computed_field,
     field_validator,
@@ -84,6 +83,7 @@ from polar.product.tiers import (
     UnboundedTierNotLastError,
     seat_tiers_to_tiers,
     seat_tiers_unit_bounds,
+    validate_unit_bounds,
 )
 
 PRODUCT_NAME_MIN_LENGTH = 3
@@ -287,7 +287,11 @@ class ProductPriceSeatTiers(Schema):
     def validate_tiers(
         cls, v: list[ProductPriceSeatTier]
     ) -> list[ProductPriceSeatTier]:
-        """Validate that tiers are well-formed and form continuous ranges."""
+        """
+        Validate that tiers are well-formed and form continuous ranges.
+
+        This will be slimmed down once we make the move to the shared tiers data.
+        """
         sorted_tiers = sorted(v, key=lambda t: t.min_seats)
         if sorted_tiers[0].min_seats < 1:
             raise ValueError("First tier must start at min_seats >= 1")
@@ -306,7 +310,8 @@ class ProductPriceSeatTiers(Schema):
         try:
             minimum_units, maximum_units = seat_tiers_unit_bounds(seat_tiers)
             shared_tiers = seat_tiers_to_tiers(seat_tiers)
-            shared_tiers.validate_unit_bounds(
+            validate_unit_bounds(
+                shared_tiers,
                 minimum_units=minimum_units,
                 maximum_units=maximum_units,
             )
@@ -316,19 +321,12 @@ class ProductPriceSeatTiers(Schema):
             ) from None
         except NonContiguousTiersError as e:
             raise ValueError(str(e)) from None
-        except ValidationError as e:
-            error = e.errors()[0]
-            if error["type"] == "duplicate_tier_bound":
-                bound = error["ctx"]["bound"]
-                raise ValueError(
-                    f"Tier max_seats values must be unique, got {bound} twice"
-                ) from None
-            raise ValueError(error["msg"]) from None
         except ValueError as e:
             message = (
                 str(e)
                 .replace("minimum_units", "minimum_seats")
                 .replace("maximum_units", "maximum_seats")
+                .replace("bound values", "max_seats values")
                 .replace("last tier's bound", "last tier's max_seats")
             )
             raise ValueError(message) from None

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -9,6 +9,7 @@ from pydantic import (
     Discriminator,
     Field,
     Tag,
+    ValidationError,
     ValidationInfo,
     computed_field,
     field_validator,
@@ -58,16 +59,9 @@ from polar.meter.unit import MeterUnit
 from polar.models import Benefit as BenefitModel
 from polar.models.product import ProductVisibility
 from polar.models.product_price import (
-    NonContiguousTiersError,
     ProductPriceAmountType,
     ProductPriceSource,
     ProductPriceType,
-    SeatTiersData,
-    SeatTierType,
-    UnboundedTierNotLastError,
-    seat_tiers_to_tiers_data,
-    seat_tiers_unit_bounds,
-    validate_tiers_data,
 )
 from polar.models.product_price import (
     ProductPriceCustom as ProductPriceCustomModel,
@@ -83,6 +77,14 @@ from polar.models.product_price import (
 )
 from polar.organization.schemas import OrganizationID
 from polar.product.meter_interval import meter_interval_divides_billing_interval
+from polar.product.tiers import (
+    NonContiguousTiersError,
+    SeatTiersData,
+    SeatTierType,
+    UnboundedTierNotLastError,
+    seat_tiers_to_tiers,
+    seat_tiers_unit_bounds,
+)
 
 PRODUCT_NAME_MIN_LENGTH = 3
 PRODUCT_NAME_MAX_LENGTH = 64
@@ -303,8 +305,8 @@ class ProductPriceSeatTiers(Schema):
         }
         try:
             minimum_units, maximum_units = seat_tiers_unit_bounds(seat_tiers)
-            validate_tiers_data(
-                seat_tiers_to_tiers_data(seat_tiers),
+            shared_tiers = seat_tiers_to_tiers(seat_tiers)
+            shared_tiers.validate_unit_bounds(
                 minimum_units=minimum_units,
                 maximum_units=maximum_units,
             )
@@ -314,6 +316,22 @@ class ProductPriceSeatTiers(Schema):
             ) from None
         except NonContiguousTiersError as e:
             raise ValueError(str(e)) from None
+        except ValidationError as e:
+            error = e.errors()[0]
+            if error["type"] == "duplicate_tier_bound":
+                bound = error["ctx"]["bound"]
+                raise ValueError(
+                    f"Tier max_seats values must be unique, got {bound} twice"
+                ) from None
+            raise ValueError(error["msg"]) from None
+        except ValueError as e:
+            message = (
+                str(e)
+                .replace("minimum_units", "minimum_seats")
+                .replace("maximum_units", "maximum_seats")
+                .replace("last tier's bound", "last tier's max_seats")
+            )
+            raise ValueError(message) from None
 
         return sorted_tiers
 

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -58,10 +58,16 @@ from polar.meter.unit import MeterUnit
 from polar.models import Benefit as BenefitModel
 from polar.models.product import ProductVisibility
 from polar.models.product_price import (
+    NonContiguousTiersError,
     ProductPriceAmountType,
     ProductPriceSource,
     ProductPriceType,
+    SeatTiersData,
     SeatTierType,
+    UnboundedTierNotLastError,
+    seat_tiers_to_tiers_data,
+    seat_tiers_unit_bounds,
+    validate_tiers_data,
 )
 from polar.models.product_price import (
     ProductPriceCustom as ProductPriceCustomModel,
@@ -280,31 +286,34 @@ class ProductPriceSeatTiers(Schema):
         cls, v: list[ProductPriceSeatTier]
     ) -> list[ProductPriceSeatTier]:
         """Validate that tiers form continuous ranges without gaps or overlaps."""
-        if not v:
-            raise ValueError("At least one tier is required")
-
-        # Sort by min_seats
         sorted_tiers = sorted(v, key=lambda t: t.min_seats)
-
-        # First tier must start at >= 1
         if sorted_tiers[0].min_seats < 1:
             raise ValueError("First tier must start at min_seats >= 1")
 
-        # Validate continuous ranges without gaps/overlaps
-        for i in range(len(sorted_tiers) - 1):
-            current = sorted_tiers[i]
-            next_tier = sorted_tiers[i + 1]
-
-            if current.max_seats is None:
-                raise ValueError(
-                    "Only the last tier can have unlimited max_seats (None)"
-                )
-
-            if next_tier.min_seats != current.max_seats + 1:
-                raise ValueError(
-                    "Gap or overlap between tiers: "
-                    + f"tier ending at {current.max_seats} and tier starting at {next_tier.min_seats}"
-                )
+        seat_tiers: SeatTiersData = {
+            "seat_tier_type": SeatTierType.volume,
+            "tiers": [
+                {
+                    "min_seats": tier.min_seats,
+                    "max_seats": tier.max_seats,
+                    "price_per_seat": tier.price_per_seat,
+                }
+                for tier in sorted_tiers
+            ],
+        }
+        try:
+            minimum_units, maximum_units = seat_tiers_unit_bounds(seat_tiers)
+            validate_tiers_data(
+                seat_tiers_to_tiers_data(seat_tiers),
+                minimum_units=minimum_units,
+                maximum_units=maximum_units,
+            )
+        except UnboundedTierNotLastError:
+            raise ValueError(
+                "Only the last tier can have unlimited max_seats (None)"
+            ) from None
+        except NonContiguousTiersError as e:
+            raise ValueError(str(e)) from None
 
         return sorted_tiers
 

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -285,7 +285,7 @@ class ProductPriceSeatTiers(Schema):
     def validate_tiers(
         cls, v: list[ProductPriceSeatTier]
     ) -> list[ProductPriceSeatTier]:
-        """Validate that tiers form continuous ranges without gaps or overlaps."""
+        """Validate that tiers are well-formed and form continuous ranges."""
         sorted_tiers = sorted(v, key=lambda t: t.min_seats)
         if sorted_tiers[0].min_seats < 1:
             raise ValueError("First tier must start at min_seats >= 1")

--- a/server/polar/product/tiers.py
+++ b/server/polar/product/tiers.py
@@ -1,0 +1,223 @@
+from decimal import Decimal
+from enum import StrEnum
+from itertools import pairwise
+from typing import Any, TypedDict
+
+from pydantic import BaseModel, Field, field_validator
+from pydantic_core import PydanticCustomError
+from sqlalchemy import Dialect, TypeDecorator
+from sqlalchemy.dialects.postgresql import JSONB
+
+from polar.exceptions import PolarError
+
+
+class TierType(StrEnum):
+    volume = "volume"
+    graduated = "graduated"
+
+
+class Tier(BaseModel):
+    """A per-unit rate up to and including `bound`.
+
+    Each tier starts where the previous one ended. The first starts at
+    zero. `bound` is None on the last tier if it's unbounded. Rates are
+    in cents and may be fractional.
+    """
+
+    bound: int | None = Field(default=None, gt=0)
+    unit_amount: Decimal = Field(ge=0, allow_inf_nan=False)
+
+
+class Tiers(BaseModel):
+    """The structure of the shared tiers JSONB column, used by every tiered
+    price type. Purchasable quantity bounds live in the `minimum_units` and
+    `maximum_units` columns, not here.
+    """
+
+    type: TierType
+    tiers: list[Tier] = Field(min_length=1)
+
+    @field_validator("tiers")
+    @classmethod
+    def validate_tiers(cls, tiers: list[Tier]) -> list[Tier]:
+        sorted_tiers = sorted(
+            tiers, key=lambda tier: (tier.bound is None, tier.bound or 0)
+        )
+        for current, next_tier in pairwise(sorted_tiers):
+            if current.bound is None:
+                raise PydanticCustomError(
+                    "unbounded_tier_not_last",
+                    "Only the last tier can be unbounded",
+                )
+            if next_tier.bound == current.bound:
+                raise PydanticCustomError(
+                    "duplicate_tier_bound",
+                    "Tier bound values must be unique, got {bound} twice",
+                    {"bound": current.bound},
+                )
+        return sorted_tiers
+
+    def validate_unit_bounds(
+        self,
+        *,
+        minimum_units: int | None = None,
+        maximum_units: int | None = None,
+    ) -> None:
+        last_bound = self.tiers[-1].bound
+        if minimum_units is not None:
+            if minimum_units < 0:
+                raise ValueError(f"minimum_units must be >= 0, got {minimum_units}")
+            if last_bound is not None and minimum_units > last_bound:
+                raise ValueError(
+                    f"minimum_units must not exceed the last tier's bound, "
+                    f"got {minimum_units} > {last_bound}"
+                )
+        if maximum_units is not None:
+            if maximum_units <= 0:
+                raise ValueError(f"maximum_units must be > 0, got {maximum_units}")
+            if minimum_units is not None and maximum_units < minimum_units:
+                raise ValueError(
+                    f"maximum_units must be >= minimum_units, "
+                    f"got {maximum_units} < {minimum_units}"
+                )
+            if last_bound is not None and maximum_units > last_bound:
+                raise ValueError(
+                    f"maximum_units must not exceed the last tier's bound, "
+                    f"got {maximum_units} > {last_bound}"
+                )
+
+    def calculate(self, quantity: int) -> Decimal:
+        if quantity < 0:
+            raise InvalidQuantityError(f"Negative quantity: {quantity}")
+        if quantity == 0:
+            return Decimal(0)
+
+        match self.type:
+            case TierType.volume:
+                return self._calculate_volume(quantity)
+            case TierType.graduated:
+                return self._calculate_graduated(quantity)
+
+    def _calculate_volume(self, quantity: int) -> Decimal:
+        for tier in self.tiers:
+            if tier.bound is None or quantity <= tier.bound:
+                return tier.unit_amount * quantity
+        raise InvalidQuantityError(f"No tier covers quantity {quantity}")
+
+    def _calculate_graduated(self, quantity: int) -> Decimal:
+        total = Decimal(0)
+        remaining = quantity
+        previous_bound = 0
+        for tier in self.tiers:
+            if remaining <= 0:
+                break
+            tier_capacity = (
+                tier.bound - previous_bound if tier.bound is not None else None
+            )
+            units_in_tier = (
+                remaining if tier_capacity is None else min(remaining, tier_capacity)
+            )
+            total += units_in_tier * tier.unit_amount
+            remaining -= units_in_tier
+            if tier.bound is not None:
+                previous_bound = tier.bound
+        return total
+
+    @property
+    def last_bound(self) -> int | None:
+        return self.tiers[-1].bound
+
+
+class TiersType(TypeDecorator[Any]):
+    impl = JSONB
+    cache_ok = True
+
+    def process_bind_param(self, value: Any, dialect: Dialect) -> Any:
+        if value is None:
+            return None
+        return Tiers.model_validate(value).model_dump(mode="json")
+
+    def process_result_value(self, value: Any, dialect: Dialect) -> Tiers | None:
+        if value is None:
+            return None
+        return Tiers.model_validate(value)
+
+
+class UnboundedTierNotLastError(ValueError):
+    def __init__(self) -> None:
+        super().__init__("Only the last tier can be unbounded")
+
+
+class NonContiguousTiersError(ValueError):
+    """Raised when translating seat tiers that have a gap or overlap."""
+
+    def __init__(self, previous_max_seats: int, next_min_seats: int) -> None:
+        super().__init__(
+            "Gap or overlap between tiers: "
+            f"tier ending at {previous_max_seats} and tier starting at {next_min_seats}"
+        )
+        self.previous_max_seats = previous_max_seats
+        self.next_min_seats = next_min_seats
+
+
+class InvalidQuantityError(PolarError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, status_code=400)
+
+
+class SeatTierType(StrEnum):
+    volume = "volume"
+    graduated = "graduated"
+
+
+class SeatTier(TypedDict):
+    """A single pricing tier for seat-based pricing."""
+
+    min_seats: int
+    max_seats: int | None
+    price_per_seat: int
+
+
+class SeatTiersData(TypedDict):
+    """The structure of the seat_tiers JSONB column."""
+
+    seat_tier_type: SeatTierType
+    tiers: list[SeatTier]
+
+
+def seat_tiers_to_tiers(seat_tiers: SeatTiersData) -> Tiers:
+    """Translate the legacy seat tier format to the shared tiers format.
+
+    Each tier's max_seats becomes `bound`. Gaps and overlaps raise, since the
+    shared format can't represent them. A missing seat_tier_type means volume.
+    """
+    tier_type = TierType(seat_tiers.get("seat_tier_type", SeatTierType.volume))
+    sorted_seat_tiers = sorted(
+        seat_tiers.get("tiers", []), key=lambda t: t["min_seats"]
+    )
+
+    for current, next_tier in pairwise(sorted_seat_tiers):
+        max_seats = current.get("max_seats")
+        if max_seats is None:
+            raise UnboundedTierNotLastError()
+        if next_tier["min_seats"] != max_seats + 1:
+            raise NonContiguousTiersError(max_seats, next_tier["min_seats"])
+
+    tiers = [
+        Tier(
+            bound=tier.get("max_seats"),
+            unit_amount=Decimal(tier["price_per_seat"]),
+        )
+        for tier in sorted_seat_tiers
+    ]
+    return Tiers(type=tier_type, tiers=tiers)
+
+
+def seat_tiers_unit_bounds(seat_tiers: SeatTiersData) -> tuple[int | None, int | None]:
+    """Return the first tier's min_seats and the last tier's max_seats."""
+    sorted_seat_tiers = sorted(
+        seat_tiers.get("tiers", []), key=lambda t: t["min_seats"]
+    )
+    if not sorted_seat_tiers:
+        return None, None
+    return sorted_seat_tiers[0]["min_seats"], sorted_seat_tiers[-1].get("max_seats")

--- a/server/polar/product/tiers.py
+++ b/server/polar/product/tiers.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 from itertools import pairwise
 from typing import Any, TypedDict
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 from pydantic_core import PydanticCustomError
 from sqlalchemy import Dialect, TypeDecorator
 from sqlalchemy.dialects.postgresql import JSONB
@@ -57,35 +57,6 @@ class Tiers(BaseModel):
                 )
         return sorted_tiers
 
-    def validate_unit_bounds(
-        self,
-        *,
-        minimum_units: int | None = None,
-        maximum_units: int | None = None,
-    ) -> None:
-        last_bound = self.tiers[-1].bound
-        if minimum_units is not None:
-            if minimum_units < 0:
-                raise ValueError(f"minimum_units must be >= 0, got {minimum_units}")
-            if last_bound is not None and minimum_units > last_bound:
-                raise ValueError(
-                    f"minimum_units must not exceed the last tier's bound, "
-                    f"got {minimum_units} > {last_bound}"
-                )
-        if maximum_units is not None:
-            if maximum_units <= 0:
-                raise ValueError(f"maximum_units must be > 0, got {maximum_units}")
-            if minimum_units is not None and maximum_units < minimum_units:
-                raise ValueError(
-                    f"maximum_units must be >= minimum_units, "
-                    f"got {maximum_units} < {minimum_units}"
-                )
-            if last_bound is not None and maximum_units > last_bound:
-                raise ValueError(
-                    f"maximum_units must not exceed the last tier's bound, "
-                    f"got {maximum_units} > {last_bound}"
-                )
-
     def calculate(self, quantity: int) -> Decimal:
         if quantity < 0:
             raise InvalidQuantityError(f"Negative quantity: {quantity}")
@@ -126,6 +97,40 @@ class Tiers(BaseModel):
     @property
     def last_bound(self) -> int | None:
         return self.tiers[-1].bound
+
+
+def validate_unit_bounds(
+    tiers: Tiers,
+    *,
+    minimum_units: int | None = None,
+    maximum_units: int | None = None,
+) -> None:
+    """Check purchasable quantity columns against the rate schedule.
+
+    `minimum_units` / `maximum_units` live on the price, not in `tiers`.
+    """
+    last_bound = tiers.last_bound
+    if minimum_units is not None:
+        if minimum_units < 0:
+            raise ValueError(f"minimum_units must be >= 0, got {minimum_units}")
+        if last_bound is not None and minimum_units > last_bound:
+            raise ValueError(
+                f"minimum_units must not exceed the last tier's bound, "
+                f"got {minimum_units} > {last_bound}"
+            )
+    if maximum_units is not None:
+        if maximum_units <= 0:
+            raise ValueError(f"maximum_units must be > 0, got {maximum_units}")
+        if minimum_units is not None and maximum_units < minimum_units:
+            raise ValueError(
+                f"maximum_units must be >= minimum_units, "
+                f"got {maximum_units} < {minimum_units}"
+            )
+        if last_bound is not None and maximum_units > last_bound:
+            raise ValueError(
+                f"maximum_units must not exceed the last tier's bound, "
+                f"got {maximum_units} > {last_bound}"
+            )
 
 
 class TiersType(TypeDecorator[Any]):
@@ -203,14 +208,19 @@ def seat_tiers_to_tiers(seat_tiers: SeatTiersData) -> Tiers:
         if next_tier["min_seats"] != max_seats + 1:
             raise NonContiguousTiersError(max_seats, next_tier["min_seats"])
 
-    tiers = [
-        Tier(
-            bound=tier.get("max_seats"),
-            unit_amount=Decimal(tier["price_per_seat"]),
+    try:
+        return Tiers(
+            type=tier_type,
+            tiers=[
+                Tier(
+                    bound=tier.get("max_seats"),
+                    unit_amount=Decimal(tier["price_per_seat"]),
+                )
+                for tier in sorted_seat_tiers
+            ],
         )
-        for tier in sorted_seat_tiers
-    ]
-    return Tiers(type=tier_type, tiers=tiers)
+    except ValidationError as e:
+        raise ValueError(e.errors()[0]["msg"]) from None
 
 
 def seat_tiers_unit_bounds(seat_tiers: SeatTiersData) -> tuple[int | None, int | None]:

--- a/server/scripts/backfill_product_price_tiers.py
+++ b/server/scripts/backfill_product_price_tiers.py
@@ -10,13 +10,9 @@ import typer
 from sqlalchemy import func, select
 
 from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
-from polar.models.product_price import (
-    ProductPriceSeatUnit,
-    seat_tiers_to_tiers_data,
-    seat_tiers_unit_bounds,
-    validate_tiers_data,
-)
+from polar.models.product_price import ProductPriceSeatUnit
 from polar.postgres import create_async_engine
+from polar.product.tiers import seat_tiers_to_tiers, seat_tiers_unit_bounds
 from scripts.helper import configure_script_logging, typer_async
 
 cli = typer.Typer()
@@ -73,16 +69,15 @@ async def _run(session: AsyncSession, *, batch_size: int, dry_run: bool) -> int:
             break
 
         for price in prices:
-            tiers_data = seat_tiers_to_tiers_data(price.seat_tiers)
+            tiers = seat_tiers_to_tiers(price.seat_tiers)
             minimum_units, maximum_units = seat_tiers_unit_bounds(price.seat_tiers)
             # Crash on corrupt legacy rows rather than copying them into the
             # canonical columns.
-            validate_tiers_data(
-                tiers_data,
+            tiers.validate_unit_bounds(
                 minimum_units=minimum_units,
                 maximum_units=maximum_units,
             )
-            price.tiers = tiers_data
+            price.tiers = tiers
             price.minimum_units = minimum_units
             price.maximum_units = maximum_units
         last_id = prices[-1].id

--- a/server/scripts/backfill_product_price_tiers.py
+++ b/server/scripts/backfill_product_price_tiers.py
@@ -4,14 +4,17 @@ on seat-based product prices.
 Translates each row's legacy `seat_tiers` with the same functions the
 dual-write hook uses, so backfilled and newly written rows match.
 Re-running the script is safe: the translation is deterministic.
+
+Dry-run still translates and validates every row, so corrupt legacy
+data is detected before `--execute`.
 """
 
 import typer
-from sqlalchemy import func, select
 
 from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
 from polar.models.product_price import ProductPriceSeatUnit
 from polar.postgres import create_async_engine
+from polar.product.repository import ProductPriceRepository
 from polar.product.tiers import (
     seat_tiers_to_tiers,
     seat_tiers_unit_bounds,
@@ -26,71 +29,54 @@ configure_script_logging()
 
 async def run_backfill(
     *,
-    batch_size: int = 1000,
     dry_run: bool = True,
     session: AsyncSession | None = None,
 ) -> int:
     if session is not None:
-        return await _run(session, batch_size=batch_size, dry_run=dry_run)
+        return await _run(session, dry_run=dry_run)
 
     engine = create_async_engine("script")
     try:
         sessionmaker = create_async_sessionmaker(engine)
         async with sessionmaker() as script_session:
-            return await _run(script_session, batch_size=batch_size, dry_run=dry_run)
+            return await _run(script_session, dry_run=dry_run)
     finally:
         await engine.dispose()
 
 
-async def _run(session: AsyncSession, *, batch_size: int, dry_run: bool) -> int:
-    where_clause = ProductPriceSeatUnit.seat_tiers.isnot(None)
-
-    if dry_run:
-        count = (
-            await session.execute(
-                select(func.count(ProductPriceSeatUnit.id)).where(where_clause)
-            )
-        ).scalar_one()
-        typer.echo(
-            f"[dry-run] {count} seat prices would be backfilled. "
-            "Re-run with --execute to apply."
-        )
-        return count
+async def _run(session: AsyncSession, *, dry_run: bool) -> int:
+    repository = ProductPriceRepository.from_session(session)
+    statement = repository.get_base_statement(include_deleted=True).where(
+        ProductPriceSeatUnit.seat_tiers.isnot(None)
+    )
 
     total = 0
-    last_id = None
-    while True:
-        statement = (
-            select(ProductPriceSeatUnit)
-            .where(where_clause)
-            .order_by(ProductPriceSeatUnit.id)
-            .limit(batch_size)
+    async for price in repository.stream(statement):
+        assert isinstance(price, ProductPriceSeatUnit)
+        tiers = seat_tiers_to_tiers(price.seat_tiers)
+        minimum_units, maximum_units = seat_tiers_unit_bounds(price.seat_tiers)
+        # Crash on corrupt legacy rows rather than copying them into the
+        # canonical columns.
+        validate_unit_bounds(
+            tiers,
+            minimum_units=minimum_units,
+            maximum_units=maximum_units,
         )
-        if last_id is not None:
-            statement = statement.where(ProductPriceSeatUnit.id > last_id)
-        prices = (await session.execute(statement)).scalars().all()
-        if not prices:
-            break
-
-        for price in prices:
-            tiers = seat_tiers_to_tiers(price.seat_tiers)
-            minimum_units, maximum_units = seat_tiers_unit_bounds(price.seat_tiers)
-            # Crash on corrupt legacy rows rather than copying them into the
-            # canonical columns.
-            validate_unit_bounds(
-                tiers,
-                minimum_units=minimum_units,
-                maximum_units=maximum_units,
-            )
+        if not dry_run:
             price.tiers = tiers
             price.minimum_units = minimum_units
             price.maximum_units = maximum_units
-        last_id = prices[-1].id
-        await session.commit()
+        total += 1
 
-        total += len(prices)
-        typer.echo(f"Backfilled {total} seat prices")
+    if dry_run:
+        typer.echo(
+            f"[dry-run] {total} seat prices would be backfilled. "
+            "Re-run with --execute to apply."
+        )
+        return total
 
+    await session.commit()
+    typer.echo(f"Backfilled {total} seat prices")
     return total
 
 
@@ -100,9 +86,8 @@ async def backfill_product_price_tiers(
     execute: bool = typer.Option(
         False, "--execute", help="Apply changes. Without it, runs as a dry run."
     ),
-    batch_size: int = typer.Option(1000, help="Number of rows to process per batch"),
 ) -> None:
-    await run_backfill(batch_size=batch_size, dry_run=not execute)
+    await run_backfill(dry_run=not execute)
 
 
 if __name__ == "__main__":

--- a/server/scripts/backfill_product_price_tiers.py
+++ b/server/scripts/backfill_product_price_tiers.py
@@ -1,0 +1,114 @@
+"""Backfill the shared `tiers`, `minimum_units` and `maximum_units` columns
+on seat-based product prices.
+
+Translates each row's legacy `seat_tiers` (inclusive seat ranges) to the
+shared tiers format (per-tier `up_to` bounds) and the unit-bound columns
+with the same functions the dual-write hook uses for new rows, so
+backfilled and freshly written rows are byte-identical.
+
+The translation is deterministic, so the script is idempotent: re-running it
+recomputes the same value for every seat price, including rows already
+backfilled or dual-written.
+"""
+
+import typer
+from sqlalchemy import func, select
+
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.models.product_price import (
+    ProductPriceSeatUnit,
+    seat_tiers_to_tiers_data,
+    seat_tiers_unit_bounds,
+    validate_tiers_data,
+)
+from polar.postgres import create_async_engine
+from scripts.helper import configure_script_logging, typer_async
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+async def run_backfill(
+    *,
+    batch_size: int = 1000,
+    dry_run: bool = True,
+    session: AsyncSession | None = None,
+) -> int:
+    if session is not None:
+        return await _run(session, batch_size=batch_size, dry_run=dry_run)
+
+    engine = create_async_engine("script")
+    try:
+        sessionmaker = create_async_sessionmaker(engine)
+        async with sessionmaker() as script_session:
+            return await _run(script_session, batch_size=batch_size, dry_run=dry_run)
+    finally:
+        await engine.dispose()
+
+
+async def _run(session: AsyncSession, *, batch_size: int, dry_run: bool) -> int:
+    where_clause = ProductPriceSeatUnit.seat_tiers.isnot(None)
+
+    if dry_run:
+        count = (
+            await session.execute(
+                select(func.count(ProductPriceSeatUnit.id)).where(where_clause)
+            )
+        ).scalar_one()
+        typer.echo(
+            f"[dry-run] {count} seat prices would be backfilled. "
+            "Re-run with --execute to apply."
+        )
+        return count
+
+    total = 0
+    last_id = None
+    while True:
+        statement = (
+            select(ProductPriceSeatUnit)
+            .where(where_clause)
+            .order_by(ProductPriceSeatUnit.id)
+            .limit(batch_size)
+        )
+        if last_id is not None:
+            statement = statement.where(ProductPriceSeatUnit.id > last_id)
+        prices = (await session.execute(statement)).scalars().all()
+        if not prices:
+            break
+
+        for price in prices:
+            tiers_data = seat_tiers_to_tiers_data(price.seat_tiers)
+            minimum_units, maximum_units = seat_tiers_unit_bounds(price.seat_tiers)
+            # Crash on corrupt legacy rows rather than copying them into the
+            # canonical columns.
+            validate_tiers_data(
+                tiers_data,
+                minimum_units=minimum_units,
+                maximum_units=maximum_units,
+            )
+            price.tiers = tiers_data
+            price.minimum_units = minimum_units
+            price.maximum_units = maximum_units
+        last_id = prices[-1].id
+        await session.commit()
+
+        total += len(prices)
+        typer.echo(f"Backfilled {total} seat prices")
+
+    return total
+
+
+@cli.command()
+@typer_async
+async def backfill_product_price_tiers(
+    execute: bool = typer.Option(
+        False, "--execute", help="Apply changes. Without it, runs as a dry run."
+    ),
+    batch_size: int = typer.Option(1000, help="Number of rows to process per batch"),
+) -> None:
+    await run_backfill(batch_size=batch_size, dry_run=not execute)
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/scripts/backfill_product_price_tiers.py
+++ b/server/scripts/backfill_product_price_tiers.py
@@ -1,14 +1,9 @@
 """Backfill the shared `tiers`, `minimum_units` and `maximum_units` columns
 on seat-based product prices.
 
-Translates each row's legacy `seat_tiers` (inclusive seat ranges) to the
-shared tiers format (per-tier `up_to` bounds) and the unit-bound columns
-with the same functions the dual-write hook uses for new rows, so
-backfilled and freshly written rows are byte-identical.
-
-The translation is deterministic, so the script is idempotent: re-running it
-recomputes the same value for every seat price, including rows already
-backfilled or dual-written.
+Translates each row's legacy `seat_tiers` with the same functions the
+dual-write hook uses, so backfilled and newly written rows match.
+Re-running the script is safe: the translation is deterministic.
 """
 
 import typer

--- a/server/scripts/backfill_product_price_tiers.py
+++ b/server/scripts/backfill_product_price_tiers.py
@@ -12,7 +12,11 @@ from sqlalchemy import func, select
 from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
 from polar.models.product_price import ProductPriceSeatUnit
 from polar.postgres import create_async_engine
-from polar.product.tiers import seat_tiers_to_tiers, seat_tiers_unit_bounds
+from polar.product.tiers import (
+    seat_tiers_to_tiers,
+    seat_tiers_unit_bounds,
+    validate_unit_bounds,
+)
 from scripts.helper import configure_script_logging, typer_async
 
 cli = typer.Typer()
@@ -73,7 +77,8 @@ async def _run(session: AsyncSession, *, batch_size: int, dry_run: bool) -> int:
             minimum_units, maximum_units = seat_tiers_unit_bounds(price.seat_tiers)
             # Crash on corrupt legacy rows rather than copying them into the
             # canonical columns.
-            tiers.validate_unit_bounds(
+            validate_unit_bounds(
+                tiers,
                 minimum_units=minimum_units,
                 maximum_units=maximum_units,
             )

--- a/server/scripts/backfill_product_price_tiers.py
+++ b/server/scripts/backfill_product_price_tiers.py
@@ -12,7 +12,7 @@ data is detected before `--execute`.
 import typer
 
 from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
-from polar.models.product_price import ProductPriceSeatUnit
+from polar.models.product_price import ProductPrice, ProductPriceSeatUnit
 from polar.postgres import create_async_engine
 from polar.product.repository import ProductPriceRepository
 from polar.product.tiers import (
@@ -49,6 +49,10 @@ async def _run(session: AsyncSession, *, dry_run: bool) -> int:
     statement = repository.get_base_statement(include_deleted=True).where(
         ProductPriceSeatUnit.seat_tiers.isnot(None)
     )
+    if not dry_run:
+        # Lock each row so a concurrent seat_tiers write cannot commit new
+        # canonical values that this snapshot would then overwrite.
+        statement = statement.with_for_update(of=ProductPrice)
 
     total = 0
     async for price in repository.stream(statement):

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -120,7 +120,6 @@ from polar.models.pledge import Pledge, PledgeState, PledgeType
 from polar.models.product_price import (
     ProductPriceAmountType,
     ProductPriceType,
-    SeatTierType,
 )
 from polar.models.subscription import SubscriptionStatus
 from polar.models.support_case import (
@@ -138,6 +137,7 @@ from polar.models.wallet import WalletType
 from polar.models.webhook_endpoint import WebhookEventType, WebhookFormat
 from polar.notification_recipient.schemas import NotificationRecipientPlatform
 from polar.product.price_set import PriceSet
+from polar.product.tiers import SeatTierType
 from polar.tax.calculation import TaxBreakdownItem
 from polar.tax.tax_id import TaxID
 from tests.fixtures.database import SaveFixture

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -2,26 +2,27 @@ from decimal import Decimal
 from typing import Any
 
 import pytest
+from sqlalchemy import select
 
+from polar.kit.db.postgres import AsyncSession
 from polar.models import Meter, Product
 from polar.models.product_price import (
-    InvalidQuantityError,
-    InvalidTiersError,
-    NonContiguousTiersError,
     ProductPriceFixed,
     ProductPriceSeatUnit,
-    SeatTierType,
-    Tier,
     TieredPrice,
-    TiersData,
+)
+from polar.product.tiers import (
+    InvalidQuantityError,
+    SeatTierType,
+    Tiers,
     TierType,
-    UnboundedTierNotLastError,
-    seat_tiers_to_tiers_data,
-    seat_tiers_unit_bounds,
-    validate_tiers_data,
+    seat_tiers_to_tiers,
 )
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_product_price_metered_unit
+from tests.fixtures.random_objects import (
+    create_product_price_metered_unit,
+    create_product_price_seat_unit,
+)
 
 
 @pytest.mark.asyncio
@@ -262,23 +263,23 @@ class TestGraduatedPricing:
         assert price.calculate_amount(15) == 10 * 20000 + 5 * 6000
 
 
-def _tiers_data(tier_type: TierType, tiers: list[Tier]) -> TiersData:
-    return {"type": tier_type, "tiers": tiers}
+def _tiers_data(tier_type: TierType, tiers: list[dict[str, Any]]) -> Tiers:
+    return Tiers.model_validate({"type": tier_type, "tiers": tiers})
 
 
 def _make_tiered_price(
-    data: TiersData,
+    tiers: Tiers,
     minimum_units: int | None = None,
     maximum_units: int | None = None,
 ) -> TieredPrice:
     price = object.__new__(TieredPrice)
-    price.tiers = data
+    price.tiers = tiers
     price.minimum_units = minimum_units
     price.maximum_units = maximum_units
     return price
 
 
-SHARED_MULTI_TIER: list[Tier] = [
+SHARED_MULTI_TIER: list[dict[str, Any]] = [
     {"bound": 10, "unit_amount": "1000"},
     {"bound": 50, "unit_amount": "800"},
     {"bound": None, "unit_amount": "600"},
@@ -405,274 +406,11 @@ class TestGetTieredAmountContract:
         with pytest.raises(InvalidQuantityError):
             price.get_tiered_amount(-5)
 
-    def test_missing_tier_type_raises(self) -> None:
-        price = _make_tiered_price({"tiers": SHARED_MULTI_TIER})  # type: ignore[typeddict-item]
-        with pytest.raises(InvalidTiersError, match="Missing or unknown tier_type"):
-            price.get_tiered_amount(10)
-
-    def test_unknown_tier_type_raises(self) -> None:
-        price = _make_tiered_price(
-            {"type": "stepped", "tiers": SHARED_MULTI_TIER}  # type: ignore[typeddict-item]
-        )
-        with pytest.raises(InvalidTiersError, match="Missing or unknown tier_type"):
-            price.get_tiered_amount(10)
-
-
-class TestValidateTiersData:
-    def test_valid_multi_tier(self) -> None:
-        validate_tiers_data(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
-
-    def test_valid_single_unbounded_tier(self) -> None:
-        validate_tiers_data(
-            _tiers_data(
-                TierType.graduated,
-                [{"bound": None, "unit_amount": "500"}],
-            )
-        )
-
-    def test_valid_unsorted_input(self) -> None:
-        validate_tiers_data(
-            _tiers_data(TierType.volume, list(reversed(SHARED_MULTI_TIER)))
-        )
-
-    def test_valid_unit_bounds(self) -> None:
-        validate_tiers_data(
-            _tiers_data(TierType.volume, SHARED_MULTI_TIER),
-            minimum_units=5,
-            maximum_units=100,
-        )
-
-    def test_empty_tiers_raises(self) -> None:
-        with pytest.raises(InvalidTiersError, match="At least one tier is required"):
-            validate_tiers_data(_tiers_data(TierType.volume, []))
-
-    def test_missing_tier_type_raises(self) -> None:
-        data: Any = {"tiers": SHARED_MULTI_TIER}
-        with pytest.raises(InvalidTiersError, match="Missing or unknown tier_type"):
-            validate_tiers_data(data)
-
-    def test_negative_price_raises(self) -> None:
-        with pytest.raises(InvalidTiersError, match="unit_amount must be >= 0"):
-            validate_tiers_data(
-                _tiers_data(
-                    TierType.volume,
-                    [{"bound": None, "unit_amount": "-500"}],
-                )
-            )
-
-    def test_zero_bound_raises(self) -> None:
-        with pytest.raises(InvalidTiersError, match="bound must be > 0"):
-            validate_tiers_data(
-                _tiers_data(
-                    TierType.volume,
-                    [
-                        {"bound": 0, "unit_amount": "500"},
-                        {"bound": None, "unit_amount": "300"},
-                    ],
-                )
-            )
-
-    def test_two_unbounded_tiers_raises(self) -> None:
-        with pytest.raises(UnboundedTierNotLastError):
-            validate_tiers_data(
-                _tiers_data(
-                    TierType.volume,
-                    [
-                        {"bound": None, "unit_amount": "500"},
-                        {"bound": None, "unit_amount": "300"},
-                    ],
-                )
-            )
-
-    def test_duplicate_bound_raises(self) -> None:
-        with pytest.raises(InvalidTiersError, match="must be unique"):
-            validate_tiers_data(
-                _tiers_data(
-                    TierType.volume,
-                    [
-                        {"bound": 10, "unit_amount": "500"},
-                        {"bound": 10, "unit_amount": "300"},
-                    ],
-                )
-            )
-
-    def test_negative_minimum_units_raises(self) -> None:
-        with pytest.raises(InvalidTiersError, match="minimum_units must be >= 0"):
-            validate_tiers_data(
-                _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}]),
-                minimum_units=-1,
-            )
-
-    def test_minimum_units_above_last_bounded_tier_raises(self) -> None:
-        with pytest.raises(InvalidTiersError, match="minimum_units must not exceed"):
-            validate_tiers_data(
-                _tiers_data(TierType.volume, [{"bound": 10, "unit_amount": "500"}]),
-                minimum_units=11,
-            )
-
-    def test_minimum_units_with_unbounded_last_tier(self) -> None:
-        validate_tiers_data(
-            _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}]),
-            minimum_units=1000,
-        )
-
-    def test_zero_maximum_units_raises(self) -> None:
-        with pytest.raises(InvalidTiersError, match="maximum_units must be > 0"):
-            validate_tiers_data(
-                _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}]),
-                maximum_units=0,
-            )
-
-    def test_maximum_units_below_minimum_raises(self) -> None:
-        with pytest.raises(
-            InvalidTiersError, match="maximum_units must be >= minimum_units"
-        ):
-            validate_tiers_data(
-                _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}]),
-                minimum_units=10,
-                maximum_units=5,
-            )
-
-    def test_maximum_units_above_last_bounded_tier_raises(self) -> None:
-        with pytest.raises(InvalidTiersError, match="maximum_units must not exceed"):
-            validate_tiers_data(
-                _tiers_data(TierType.volume, [{"bound": 10, "unit_amount": "500"}]),
-                maximum_units=11,
-            )
-
-    def test_maximum_units_with_unbounded_last_tier(self) -> None:
-        validate_tiers_data(
-            _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}]),
-            maximum_units=1000,
-        )
-
-
-class TestSeatTiersToTiersData:
-    def test_converts_max_seats_to_bound(self) -> None:
-        result = seat_tiers_to_tiers_data(
-            {
-                "seat_tier_type": SeatTierType.graduated,
-                "tiers": [
-                    {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
-                    {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
-                ],
-            }
-        )
-        assert result == {
-            "type": TierType.graduated,
-            "tiers": [
-                {"bound": 10, "unit_amount": "1000"},
-                {"bound": None, "unit_amount": "800"},
-            ],
-        }
-
-    def test_missing_seat_tier_type_defaults_to_volume(self) -> None:
-        result = seat_tiers_to_tiers_data(
-            {"tiers": [{"min_seats": 1, "max_seats": None, "price_per_seat": 500}]}  # type: ignore[typeddict-item]
-        )
-        assert result["type"] == TierType.volume
-
-    def test_sorts_tiers(self) -> None:
-        result = seat_tiers_to_tiers_data(
-            {
-                "seat_tier_type": SeatTierType.volume,
-                "tiers": [
-                    {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
-                    {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
-                ],
-            }
-        )
-        assert [t["bound"] for t in result["tiers"]] == [10, None]
-
-    def test_missing_max_seats_key(self) -> None:
-        result = seat_tiers_to_tiers_data(
-            {
-                "seat_tier_type": SeatTierType.volume,
-                "tiers": [{"min_seats": 1, "price_per_seat": 500}],  # type: ignore[typeddict-item]
-            }
-        )
-        assert result["tiers"][0]["bound"] is None
-
-    def test_gap_raises(self) -> None:
-        # A gap cannot be represented with bound bounds, so translation must
-        # reject it instead of silently swallowing it.
-        with pytest.raises(NonContiguousTiersError):
-            seat_tiers_to_tiers_data(
-                {
-                    "seat_tier_type": SeatTierType.volume,
-                    "tiers": [
-                        {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
-                        {"min_seats": 12, "max_seats": None, "price_per_seat": 800},
-                    ],
-                }
-            )
-
-    def test_overlap_raises(self) -> None:
-        with pytest.raises(NonContiguousTiersError):
-            seat_tiers_to_tiers_data(
-                {
-                    "seat_tier_type": SeatTierType.volume,
-                    "tiers": [
-                        {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
-                        {"min_seats": 8, "max_seats": None, "price_per_seat": 800},
-                    ],
-                }
-            )
-
-    def test_unbounded_tier_not_last_raises(self) -> None:
-        with pytest.raises(UnboundedTierNotLastError):
-            seat_tiers_to_tiers_data(
-                {
-                    "seat_tier_type": SeatTierType.volume,
-                    "tiers": [
-                        {"min_seats": 1, "max_seats": None, "price_per_seat": 1000},
-                        {"min_seats": 11, "max_seats": 20, "price_per_seat": 800},
-                    ],
-                }
-            )
-
-
-class TestSeatTiersUnitBounds:
-    def test_first_min_and_last_max(self) -> None:
-        assert seat_tiers_unit_bounds(
-            {
-                "seat_tier_type": SeatTierType.volume,
-                "tiers": [
-                    {"min_seats": 5, "max_seats": 10, "price_per_seat": 1000},
-                    {"min_seats": 11, "max_seats": 20, "price_per_seat": 800},
-                ],
-            }
-        ) == (5, 20)
-
-    def test_unbounded_last_tier(self) -> None:
-        assert seat_tiers_unit_bounds(
-            {
-                "seat_tier_type": SeatTierType.volume,
-                "tiers": [{"min_seats": 1, "max_seats": None, "price_per_seat": 500}],
-            }
-        ) == (1, None)
-
-    def test_sorts_tiers(self) -> None:
-        assert seat_tiers_unit_bounds(
-            {
-                "seat_tier_type": SeatTierType.volume,
-                "tiers": [
-                    {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
-                    {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
-                ],
-            }
-        ) == (1, None)
-
-    def test_empty_tiers(self) -> None:
-        assert seat_tiers_unit_bounds(
-            {"seat_tier_type": SeatTierType.volume, "tiers": []}
-        ) == (None, None)
-
 
 class TestSeatTiersDualWrite:
     def test_constructor_populates_tiers(self) -> None:
         price = _make_seat_price(MULTI_TIER, SeatTierType.graduated)
-        assert price.tiers == seat_tiers_to_tiers_data(price.seat_tiers)
+        assert price.tiers == seat_tiers_to_tiers(price.seat_tiers)
         assert price.minimum_units == 1
         assert price.maximum_units is None
 
@@ -682,23 +420,57 @@ class TestSeatTiersDualWrite:
             "seat_tier_type": SeatTierType.volume,
             "tiers": [{"min_seats": 5, "max_seats": 20, "price_per_seat": 250}],
         }
-        assert price.tiers == {
-            "type": TierType.volume,
-            "tiers": [
-                {"bound": 20, "unit_amount": "250"},
-            ],
-        }
+        assert price.tiers == _tiers_data(
+            TierType.volume,
+            [{"bound": 20, "unit_amount": "250"}],
+        )
         assert price.minimum_units == 5
         assert price.maximum_units == 20
 
     def test_dual_written_seat_data_passes_validation(self) -> None:
         price = _make_seat_price(MULTI_TIER, SeatTierType.graduated)
         assert price.tiers is not None
-        validate_tiers_data(
-            price.tiers,
+        price.tiers.validate_unit_bounds(
             minimum_units=price.minimum_units,
             maximum_units=price.maximum_units,
         )
+
+    def test_billing_reads_shared_columns(self) -> None:
+        price = _make_seat_price(MULTI_TIER, SeatTierType.graduated)
+        assert price.tiers is not None
+        assert price.calculate_amount(15) == int(price.tiers.calculate(15))
+        assert price.get_minimum_seats() == max(1, price.minimum_units or 0)
+        assert price.get_maximum_seats() == price.maximum_units
+
+    @pytest.mark.asyncio
+    async def test_database_round_trip_returns_tiers_model(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+    ) -> None:
+        price = await create_product_price_seat_unit(
+            save_fixture,
+            product=product,
+            tiers=MULTI_TIER,
+            seat_tier_type=SeatTierType.graduated,
+        )
+
+        tiers = (
+            await session.execute(
+                select(ProductPriceSeatUnit.tiers).where(
+                    ProductPriceSeatUnit.id == price.id
+                )
+            )
+        ).scalar_one()
+
+        assert isinstance(tiers, Tiers)
+        assert tiers.type == TierType.graduated
+        assert [tier.unit_amount for tier in tiers.tiers] == [
+            Decimal("1000"),
+            Decimal("800"),
+            Decimal("600"),
+        ]
 
 
 class TestMinimumMaximumUnits:

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -17,6 +17,7 @@ from polar.product.tiers import (
     Tiers,
     TierType,
     seat_tiers_to_tiers,
+    validate_unit_bounds,
 )
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -430,7 +431,8 @@ class TestSeatTiersDualWrite:
     def test_dual_written_seat_data_passes_validation(self) -> None:
         price = _make_seat_price(MULTI_TIER, SeatTierType.graduated)
         assert price.tiers is not None
-        price.tiers.validate_unit_bounds(
+        validate_unit_bounds(
+            price.tiers,
             minimum_units=price.minimum_units,
             maximum_units=price.maximum_units,
         )

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -12,7 +12,6 @@ from polar.models.product_price import (
     TieredPrice,
 )
 from polar.product.tiers import (
-    InvalidQuantityError,
     SeatTierType,
     Tiers,
     TierType,
@@ -238,7 +237,7 @@ class TestGraduatedPricing:
         assert price.calculate_amount(15) == 10 * 1000
 
     def test_first_tier_min_seats_above_one(self) -> None:
-        # Regression for T-28449: a merchant enforcing a 10-seat minimum sets the
+        # A merchant enforcing a 10-seat minimum sets the
         # first tier's min_seats to 10. The first 10 seats should all be priced at
         # the first tier's rate ($200/seat = $2000), then cheaper after.
         # Reproduces the exact sandbox config of product 231d03ca.
@@ -278,54 +277,9 @@ SHARED_MULTI_TIER: list[dict[str, Any]] = [
 ]
 
 
-class TestGetTieredAmountVolume:
-    def test_fractional_rate(self) -> None:
-        price = _make_tiered_price(
-            _tiers_data(
-                TierType.volume,
-                [{"bound": None, "unit_amount": "0.5"}],
-            )
-        )
-        assert price.get_tiered_amount(10) == Decimal("5")
-
-    def test_below_minimum_units_still_prices(self) -> None:
-        # The minimum is a purchase-layer constraint; the engine prices from 0.
-        price = _make_tiered_price(
-            _tiers_data(
-                TierType.volume,
-                [
-                    {"bound": 10, "unit_amount": "20000"},
-                    {"bound": None, "unit_amount": "6000"},
-                ],
-            ),
-            minimum_units=10,
-        )
-        assert price.get_tiered_amount(5) == 5 * 20000
-
-    def test_past_bounded_last_tier_raises(self) -> None:
-        price = _make_tiered_price(
-            _tiers_data(
-                TierType.volume,
-                [{"bound": 10, "unit_amount": "500"}],
-            )
-        )
-        with pytest.raises(InvalidQuantityError):
-            price.get_tiered_amount(11)
-
-
-class TestGetTieredAmountGraduated:
-    def test_past_bounded_last_tier_bills_covered_units(self) -> None:
-        price = _make_tiered_price(
-            _tiers_data(
-                TierType.graduated,
-                [{"bound": 10, "unit_amount": "500"}],
-            )
-        )
-        assert price.get_tiered_amount(15) == 10 * 500
-
-    def test_minimum_units_does_not_shift_billing(self) -> None:
-        # T-28449: the minimum is a purchase floor, not a billing start — the
-        # first tier still bills from unit one.
+class TestGetTieredAmount:
+    def test_ignores_minimum_units(self) -> None:
+        # Purchase floors live on the price; billing is a pass-through to the engine.
         price = _make_tiered_price(
             _tiers_data(
                 TierType.graduated,
@@ -336,23 +290,7 @@ class TestGetTieredAmountGraduated:
             ),
             minimum_units=10,
         )
-        assert price.get_tiered_amount(10) == 10 * 20000
-        assert price.get_tiered_amount(15) == 10 * 20000 + 5 * 6000
-        # Below the floor still bills at the first tier's rate.
-        assert price.get_tiered_amount(5) == 5 * 20000
-
-
-class TestGetTieredAmountContract:
-    @pytest.mark.parametrize("tier_type", [TierType.volume, TierType.graduated])
-    def test_zero_quantity_costs_zero(self, tier_type: TierType) -> None:
-        price = _make_tiered_price(_tiers_data(tier_type, SHARED_MULTI_TIER))
-        assert price.get_tiered_amount(0) == 0
-
-    @pytest.mark.parametrize("tier_type", [TierType.volume, TierType.graduated])
-    def test_negative_quantity_raises(self, tier_type: TierType) -> None:
-        price = _make_tiered_price(_tiers_data(tier_type, SHARED_MULTI_TIER))
-        with pytest.raises(InvalidQuantityError):
-            price.get_tiered_amount(-5)
+        assert price.get_tiered_amount(5) == price.tiers.calculate(5)
 
 
 class TestSeatTiersDualWrite:

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -181,6 +181,39 @@ class TestCalculateAmountIntegralityGuard:
             price.calculate_amount(3)
 
 
+def _clear_shared_tier_columns(price: ProductPriceSeatUnit) -> ProductPriceSeatUnit:
+    price.tiers = None  # type: ignore[assignment]
+    price.minimum_units = None
+    price.maximum_units = None
+    return price
+
+
+class TestSeatBillingReadsSeatTiers:
+    """Billing must not depend on the dual-written `tiers` columns yet."""
+
+    def test_amount_with_empty_shared_columns(self) -> None:
+        price = _clear_shared_tier_columns(_make_seat_price(MULTI_TIER))
+        assert price.calculate_amount(10) == 10_000
+        assert price.calculate_amount(11) == 11 * 800
+
+    def test_bounds_with_empty_shared_columns(self) -> None:
+        price = _clear_shared_tier_columns(
+            _make_seat_price(
+                [{"min_seats": 5, "max_seats": 20, "price_per_seat": 250}],
+            )
+        )
+        assert price.get_minimum_seats() == 5
+        assert price.get_maximum_seats() == 20
+
+    def test_is_free_with_empty_shared_columns(self) -> None:
+        price = _clear_shared_tier_columns(
+            _make_seat_price(
+                [{"min_seats": 1, "max_seats": None, "price_per_seat": 0}],
+            )
+        )
+        assert price.is_free is True
+
+
 class TestGraduatedPricing:
     def test_single_tier(self) -> None:
         price = _make_seat_price(

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -5,9 +5,20 @@ import pytest
 
 from polar.models import Meter, Product
 from polar.models.product_price import (
+    InvalidQuantityError,
+    InvalidTiersError,
+    NonContiguousTiersError,
     ProductPriceFixed,
     ProductPriceSeatUnit,
     SeatTierType,
+    Tier,
+    TieredPrice,
+    TiersData,
+    TierType,
+    UnboundedTierNotLastError,
+    seat_tiers_to_tiers_data,
+    seat_tiers_unit_bounds,
+    validate_tiers_data,
 )
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_product_price_metered_unit
@@ -159,6 +170,20 @@ class TestVolumePricing:
         )
         assert price.calculate_amount(100) == 0
 
+    def test_zero_seats_cost_zero(self) -> None:
+        price = _make_seat_price(MULTI_TIER, SeatTierType.volume)
+        assert price.calculate_amount(0) == 0
+
+
+class TestCalculateAmountIntegralityGuard:
+    def test_fractional_stored_rate_raises(self) -> None:
+        price = _make_seat_price(
+            [{"min_seats": 1, "max_seats": None, "price_per_seat": 500.5}],
+            SeatTierType.volume,
+        )
+        with pytest.raises(ValueError, match="non-integral amount"):
+            price.calculate_amount(3)
+
 
 class TestGraduatedPricing:
     def test_single_tier(self) -> None:
@@ -215,6 +240,10 @@ class TestGraduatedPricing:
         assert price.calculate_amount(8) == 3 * 1000
         assert price.calculate_amount(15) == 10 * 1000
 
+    def test_zero_seats_cost_zero(self) -> None:
+        price = _make_seat_price(MULTI_TIER, SeatTierType.graduated)
+        assert price.calculate_amount(0) == 0
+
     def test_first_tier_min_seats_above_one(self) -> None:
         # Regression for T-28449: a merchant enforcing a 10-seat minimum sets the
         # first tier's min_seats to 10. The first 10 seats should all be priced at
@@ -231,3 +260,509 @@ class TestGraduatedPricing:
         assert price.calculate_amount(10) == 10 * 20000
         # 10 at first tier + 5 at second tier.
         assert price.calculate_amount(15) == 10 * 20000 + 5 * 6000
+
+
+def _tiers_data(tier_type: TierType, tiers: list[Tier]) -> TiersData:
+    return {"tier_type": tier_type, "tiers": tiers}
+
+
+def _make_tiered_price(
+    data: TiersData,
+    minimum_units: int | None = None,
+    maximum_units: int | None = None,
+) -> TieredPrice:
+    price = object.__new__(TieredPrice)
+    price.tiers = data
+    price.minimum_units = minimum_units
+    price.maximum_units = maximum_units
+    return price
+
+
+SHARED_MULTI_TIER: list[Tier] = [
+    {"up_to": 10, "price_per_unit": "1000"},
+    {"up_to": 50, "price_per_unit": "800"},
+    {"up_to": None, "price_per_unit": "600"},
+]
+
+
+class TestGetTieredAmountVolume:
+    def test_single_tier(self) -> None:
+        price = _make_tiered_price(
+            _tiers_data(
+                TierType.volume,
+                [{"up_to": None, "price_per_unit": "500"}],
+            )
+        )
+        assert price.get_tiered_amount(1) == 500
+        assert price.get_tiered_amount(10) == 5000
+
+    def test_fractional_rate(self) -> None:
+        price = _make_tiered_price(
+            _tiers_data(
+                TierType.volume,
+                [{"up_to": None, "price_per_unit": "0.5"}],
+            )
+        )
+        assert price.get_tiered_amount(10) == Decimal("5")
+
+    def test_multi_tier(self) -> None:
+        price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
+        assert price.get_tiered_amount(10) == 10_000
+        assert price.get_tiered_amount(11) == 11 * 800
+        assert price.get_tiered_amount(50) == 50 * 800
+        assert price.get_tiered_amount(51) == 51 * 600
+
+    def test_boundary_is_inclusive_up_to(self) -> None:
+        price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
+        assert price.get_tiered_amount(10) == 10 * 1000
+
+    def test_below_minimum_units_still_prices(self) -> None:
+        # The minimum is a purchase-layer constraint; the engine prices from 0.
+        price = _make_tiered_price(
+            _tiers_data(
+                TierType.volume,
+                [
+                    {"up_to": 10, "price_per_unit": "20000"},
+                    {"up_to": None, "price_per_unit": "6000"},
+                ],
+            ),
+            minimum_units=10,
+        )
+        assert price.get_tiered_amount(5) == 5 * 20000
+
+    def test_past_bounded_last_tier_raises(self) -> None:
+        price = _make_tiered_price(
+            _tiers_data(
+                TierType.volume,
+                [{"up_to": 10, "price_per_unit": "500"}],
+            )
+        )
+        with pytest.raises(InvalidQuantityError):
+            price.get_tiered_amount(11)
+
+    def test_unsorted_tiers(self) -> None:
+        price = _make_tiered_price(
+            _tiers_data(TierType.volume, list(reversed(SHARED_MULTI_TIER)))
+        )
+        assert price.get_tiered_amount(5) == 5 * 1000
+        assert price.get_tiered_amount(51) == 51 * 600
+
+
+class TestGetTieredAmountGraduated:
+    def test_spans_tiers(self) -> None:
+        price = _make_tiered_price(_tiers_data(TierType.graduated, SHARED_MULTI_TIER))
+        assert price.get_tiered_amount(15) == 10 * 1000 + 5 * 800
+        assert price.get_tiered_amount(100) == 10 * 1000 + 40 * 800 + 50 * 600
+
+    def test_exact_boundary(self) -> None:
+        price = _make_tiered_price(_tiers_data(TierType.graduated, SHARED_MULTI_TIER))
+        assert price.get_tiered_amount(10) == 10 * 1000
+        assert price.get_tiered_amount(50) == 10 * 1000 + 40 * 800
+
+    def test_past_bounded_last_tier_bills_covered_units(self) -> None:
+        price = _make_tiered_price(
+            _tiers_data(
+                TierType.graduated,
+                [{"up_to": 10, "price_per_unit": "500"}],
+            )
+        )
+        assert price.get_tiered_amount(15) == 10 * 500
+
+    def test_minimum_units_does_not_shift_billing(self) -> None:
+        # T-28449: the minimum is a purchase floor, not a billing start — the
+        # first tier still bills from unit one.
+        price = _make_tiered_price(
+            _tiers_data(
+                TierType.graduated,
+                [
+                    {"up_to": 10, "price_per_unit": "20000"},
+                    {"up_to": None, "price_per_unit": "6000"},
+                ],
+            ),
+            minimum_units=10,
+        )
+        assert price.get_tiered_amount(10) == 10 * 20000
+        assert price.get_tiered_amount(15) == 10 * 20000 + 5 * 6000
+        # Below the floor still bills at the first tier's rate.
+        assert price.get_tiered_amount(5) == 5 * 20000
+
+    def test_unsorted_tiers(self) -> None:
+        price = _make_tiered_price(
+            _tiers_data(TierType.graduated, list(reversed(SHARED_MULTI_TIER)))
+        )
+        assert price.get_tiered_amount(15) == 10 * 1000 + 5 * 800
+
+
+class TestGetTieredAmountContract:
+    @pytest.mark.parametrize("tier_type", [TierType.volume, TierType.graduated])
+    def test_zero_quantity_costs_zero(self, tier_type: TierType) -> None:
+        price = _make_tiered_price(_tiers_data(tier_type, SHARED_MULTI_TIER))
+        assert price.get_tiered_amount(0) == 0
+
+    @pytest.mark.parametrize("tier_type", [TierType.volume, TierType.graduated])
+    def test_negative_quantity_raises(self, tier_type: TierType) -> None:
+        price = _make_tiered_price(_tiers_data(tier_type, SHARED_MULTI_TIER))
+        with pytest.raises(InvalidQuantityError):
+            price.get_tiered_amount(-5)
+
+    def test_missing_tier_type_raises(self) -> None:
+        price = _make_tiered_price({"tiers": SHARED_MULTI_TIER})  # type: ignore[typeddict-item]
+        with pytest.raises(InvalidTiersError, match="Missing or unknown tier_type"):
+            price.get_tiered_amount(10)
+
+    def test_unknown_tier_type_raises(self) -> None:
+        price = _make_tiered_price(
+            {"tier_type": "stepped", "tiers": SHARED_MULTI_TIER}  # type: ignore[typeddict-item]
+        )
+        with pytest.raises(InvalidTiersError, match="Missing or unknown tier_type"):
+            price.get_tiered_amount(10)
+
+
+class TestValidateTiersData:
+    def test_valid_multi_tier(self) -> None:
+        validate_tiers_data(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
+
+    def test_valid_single_unbounded_tier(self) -> None:
+        validate_tiers_data(
+            _tiers_data(
+                TierType.graduated,
+                [{"up_to": None, "price_per_unit": "500"}],
+            )
+        )
+
+    def test_valid_unsorted_input(self) -> None:
+        validate_tiers_data(
+            _tiers_data(TierType.volume, list(reversed(SHARED_MULTI_TIER)))
+        )
+
+    def test_valid_unit_bounds(self) -> None:
+        validate_tiers_data(
+            _tiers_data(TierType.volume, SHARED_MULTI_TIER),
+            minimum_units=5,
+            maximum_units=100,
+        )
+
+    def test_empty_tiers_raises(self) -> None:
+        with pytest.raises(InvalidTiersError, match="At least one tier is required"):
+            validate_tiers_data(_tiers_data(TierType.volume, []))
+
+    def test_missing_tier_type_raises(self) -> None:
+        data: Any = {"tiers": SHARED_MULTI_TIER}
+        with pytest.raises(InvalidTiersError, match="Missing or unknown tier_type"):
+            validate_tiers_data(data)
+
+    def test_negative_price_raises(self) -> None:
+        with pytest.raises(InvalidTiersError, match="price_per_unit must be >= 0"):
+            validate_tiers_data(
+                _tiers_data(
+                    TierType.volume,
+                    [{"up_to": None, "price_per_unit": "-500"}],
+                )
+            )
+
+    def test_zero_up_to_raises(self) -> None:
+        with pytest.raises(InvalidTiersError, match="up_to must be > 0"):
+            validate_tiers_data(
+                _tiers_data(
+                    TierType.volume,
+                    [
+                        {"up_to": 0, "price_per_unit": "500"},
+                        {"up_to": None, "price_per_unit": "300"},
+                    ],
+                )
+            )
+
+    def test_two_unbounded_tiers_raises(self) -> None:
+        with pytest.raises(UnboundedTierNotLastError):
+            validate_tiers_data(
+                _tiers_data(
+                    TierType.volume,
+                    [
+                        {"up_to": None, "price_per_unit": "500"},
+                        {"up_to": None, "price_per_unit": "300"},
+                    ],
+                )
+            )
+
+    def test_duplicate_up_to_raises(self) -> None:
+        with pytest.raises(InvalidTiersError, match="must be unique"):
+            validate_tiers_data(
+                _tiers_data(
+                    TierType.volume,
+                    [
+                        {"up_to": 10, "price_per_unit": "500"},
+                        {"up_to": 10, "price_per_unit": "300"},
+                    ],
+                )
+            )
+
+    def test_negative_minimum_units_raises(self) -> None:
+        with pytest.raises(InvalidTiersError, match="minimum_units must be >= 0"):
+            validate_tiers_data(
+                _tiers_data(
+                    TierType.volume, [{"up_to": None, "price_per_unit": "500"}]
+                ),
+                minimum_units=-1,
+            )
+
+    def test_minimum_units_above_last_bounded_tier_raises(self) -> None:
+        with pytest.raises(InvalidTiersError, match="minimum_units must not exceed"):
+            validate_tiers_data(
+                _tiers_data(TierType.volume, [{"up_to": 10, "price_per_unit": "500"}]),
+                minimum_units=11,
+            )
+
+    def test_minimum_units_with_unbounded_last_tier(self) -> None:
+        validate_tiers_data(
+            _tiers_data(TierType.volume, [{"up_to": None, "price_per_unit": "500"}]),
+            minimum_units=1000,
+        )
+
+    def test_zero_maximum_units_raises(self) -> None:
+        with pytest.raises(InvalidTiersError, match="maximum_units must be > 0"):
+            validate_tiers_data(
+                _tiers_data(
+                    TierType.volume, [{"up_to": None, "price_per_unit": "500"}]
+                ),
+                maximum_units=0,
+            )
+
+    def test_maximum_units_below_minimum_raises(self) -> None:
+        with pytest.raises(
+            InvalidTiersError, match="maximum_units must be >= minimum_units"
+        ):
+            validate_tiers_data(
+                _tiers_data(
+                    TierType.volume, [{"up_to": None, "price_per_unit": "500"}]
+                ),
+                minimum_units=10,
+                maximum_units=5,
+            )
+
+    def test_maximum_units_above_last_bounded_tier_raises(self) -> None:
+        with pytest.raises(InvalidTiersError, match="maximum_units must not exceed"):
+            validate_tiers_data(
+                _tiers_data(TierType.volume, [{"up_to": 10, "price_per_unit": "500"}]),
+                maximum_units=11,
+            )
+
+    def test_maximum_units_with_unbounded_last_tier(self) -> None:
+        validate_tiers_data(
+            _tiers_data(TierType.volume, [{"up_to": None, "price_per_unit": "500"}]),
+            maximum_units=1000,
+        )
+
+
+class TestSeatTiersToTiersData:
+    def test_converts_max_seats_to_up_to(self) -> None:
+        result = seat_tiers_to_tiers_data(
+            {
+                "seat_tier_type": SeatTierType.graduated,
+                "tiers": [
+                    {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+                    {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
+                ],
+            }
+        )
+        assert result == {
+            "tier_type": TierType.graduated,
+            "tiers": [
+                {"up_to": 10, "price_per_unit": "1000"},
+                {"up_to": None, "price_per_unit": "800"},
+            ],
+        }
+
+    def test_missing_seat_tier_type_defaults_to_volume(self) -> None:
+        result = seat_tiers_to_tiers_data(
+            {"tiers": [{"min_seats": 1, "max_seats": None, "price_per_seat": 500}]}  # type: ignore[typeddict-item]
+        )
+        assert result["tier_type"] == TierType.volume
+
+    def test_sorts_tiers(self) -> None:
+        result = seat_tiers_to_tiers_data(
+            {
+                "seat_tier_type": SeatTierType.volume,
+                "tiers": [
+                    {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
+                    {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+                ],
+            }
+        )
+        assert [t["up_to"] for t in result["tiers"]] == [10, None]
+
+    def test_missing_max_seats_key(self) -> None:
+        result = seat_tiers_to_tiers_data(
+            {
+                "seat_tier_type": SeatTierType.volume,
+                "tiers": [{"min_seats": 1, "price_per_seat": 500}],  # type: ignore[typeddict-item]
+            }
+        )
+        assert result["tiers"][0]["up_to"] is None
+
+    def test_gap_raises(self) -> None:
+        # A gap cannot be represented with up_to bounds, so translation must
+        # reject it instead of silently swallowing it.
+        with pytest.raises(NonContiguousTiersError):
+            seat_tiers_to_tiers_data(
+                {
+                    "seat_tier_type": SeatTierType.volume,
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+                        {"min_seats": 12, "max_seats": None, "price_per_seat": 800},
+                    ],
+                }
+            )
+
+    def test_overlap_raises(self) -> None:
+        with pytest.raises(NonContiguousTiersError):
+            seat_tiers_to_tiers_data(
+                {
+                    "seat_tier_type": SeatTierType.volume,
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+                        {"min_seats": 8, "max_seats": None, "price_per_seat": 800},
+                    ],
+                }
+            )
+
+    def test_unbounded_tier_not_last_raises(self) -> None:
+        with pytest.raises(UnboundedTierNotLastError):
+            seat_tiers_to_tiers_data(
+                {
+                    "seat_tier_type": SeatTierType.volume,
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": None, "price_per_seat": 1000},
+                        {"min_seats": 11, "max_seats": 20, "price_per_seat": 800},
+                    ],
+                }
+            )
+
+
+class TestSeatTiersUnitBounds:
+    def test_first_min_and_last_max(self) -> None:
+        assert seat_tiers_unit_bounds(
+            {
+                "seat_tier_type": SeatTierType.volume,
+                "tiers": [
+                    {"min_seats": 5, "max_seats": 10, "price_per_seat": 1000},
+                    {"min_seats": 11, "max_seats": 20, "price_per_seat": 800},
+                ],
+            }
+        ) == (5, 20)
+
+    def test_unbounded_last_tier(self) -> None:
+        assert seat_tiers_unit_bounds(
+            {
+                "seat_tier_type": SeatTierType.volume,
+                "tiers": [{"min_seats": 1, "max_seats": None, "price_per_seat": 500}],
+            }
+        ) == (1, None)
+
+    def test_sorts_tiers(self) -> None:
+        assert seat_tiers_unit_bounds(
+            {
+                "seat_tier_type": SeatTierType.volume,
+                "tiers": [
+                    {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
+                    {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+                ],
+            }
+        ) == (1, None)
+
+    def test_empty_tiers(self) -> None:
+        assert seat_tiers_unit_bounds(
+            {"seat_tier_type": SeatTierType.volume, "tiers": []}
+        ) == (None, None)
+
+
+class TestSeatTiersDualWrite:
+    def test_constructor_populates_tiers(self) -> None:
+        price = _make_seat_price(MULTI_TIER, SeatTierType.graduated)
+        assert price.tiers == seat_tiers_to_tiers_data(price.seat_tiers)
+        assert price.minimum_units == 1
+        assert price.maximum_units is None
+
+    def test_updating_seat_tiers_updates_tiers(self) -> None:
+        price = _make_seat_price(MULTI_TIER, SeatTierType.volume)
+        price.seat_tiers = {
+            "seat_tier_type": SeatTierType.volume,
+            "tiers": [{"min_seats": 5, "max_seats": 20, "price_per_seat": 250}],
+        }
+        assert price.tiers == {
+            "tier_type": TierType.volume,
+            "tiers": [
+                {"up_to": 20, "price_per_unit": "250"},
+            ],
+        }
+        assert price.minimum_units == 5
+        assert price.maximum_units == 20
+
+    def test_dual_written_seat_data_passes_validation(self) -> None:
+        price = _make_seat_price(MULTI_TIER, SeatTierType.graduated)
+        assert price.tiers is not None
+        validate_tiers_data(
+            price.tiers,
+            minimum_units=price.minimum_units,
+            maximum_units=price.maximum_units,
+        )
+
+
+class TestMinimumMaximumUnits:
+    def test_minimum_units_from_column(self) -> None:
+        price = _make_tiered_price(
+            _tiers_data(TierType.volume, SHARED_MULTI_TIER), minimum_units=5
+        )
+        assert price.get_minimum_units() == 5
+
+    def test_minimum_units_defaults_to_zero(self) -> None:
+        price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
+        assert price.get_minimum_units() == 0
+
+    def test_maximum_units_from_column(self) -> None:
+        price = _make_tiered_price(
+            _tiers_data(TierType.volume, SHARED_MULTI_TIER), maximum_units=100
+        )
+        assert price.get_maximum_units() == 100
+
+    def test_maximum_units_falls_back_to_last_tier(self) -> None:
+        price = _make_tiered_price(
+            _tiers_data(
+                TierType.volume,
+                [
+                    {"up_to": 10, "price_per_unit": "500"},
+                    {"up_to": 20, "price_per_unit": "300"},
+                ],
+            )
+        )
+        assert price.get_maximum_units() == 20
+
+    def test_maximum_units_unbounded(self) -> None:
+        price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
+        assert price.get_maximum_units() is None
+
+
+class TestSeatMinimumMaximum:
+    def test_minimum_seats_from_first_tier(self) -> None:
+        price = _make_seat_price(
+            [
+                {"min_seats": 5, "max_seats": 10, "price_per_seat": 1000},
+                {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
+            ]
+        )
+        assert price.get_minimum_seats() == 5
+
+    def test_minimum_seats_defaults_to_one(self) -> None:
+        price = _make_seat_price(
+            [{"min_seats": 1, "max_seats": None, "price_per_seat": 1000}]
+        )
+        assert price.get_minimum_seats() == 1
+
+    def test_maximum_seats_from_last_tier(self) -> None:
+        price = _make_seat_price(
+            [{"min_seats": 1, "max_seats": 20, "price_per_seat": 1000}]
+        )
+        assert price.get_maximum_seats() == 20
+
+    def test_maximum_seats_unbounded(self) -> None:
+        price = _make_seat_price(MULTI_TIER)
+        assert price.get_maximum_seats() is None

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -263,7 +263,7 @@ class TestGraduatedPricing:
 
 
 def _tiers_data(tier_type: TierType, tiers: list[Tier]) -> TiersData:
-    return {"tier_type": tier_type, "tiers": tiers}
+    return {"type": tier_type, "tiers": tiers}
 
 
 def _make_tiered_price(
@@ -279,9 +279,9 @@ def _make_tiered_price(
 
 
 SHARED_MULTI_TIER: list[Tier] = [
-    {"up_to": 10, "price_per_unit": "1000"},
-    {"up_to": 50, "price_per_unit": "800"},
-    {"up_to": None, "price_per_unit": "600"},
+    {"bound": 10, "unit_amount": "1000"},
+    {"bound": 50, "unit_amount": "800"},
+    {"bound": None, "unit_amount": "600"},
 ]
 
 
@@ -290,7 +290,7 @@ class TestGetTieredAmountVolume:
         price = _make_tiered_price(
             _tiers_data(
                 TierType.volume,
-                [{"up_to": None, "price_per_unit": "500"}],
+                [{"bound": None, "unit_amount": "500"}],
             )
         )
         assert price.get_tiered_amount(1) == 500
@@ -300,7 +300,7 @@ class TestGetTieredAmountVolume:
         price = _make_tiered_price(
             _tiers_data(
                 TierType.volume,
-                [{"up_to": None, "price_per_unit": "0.5"}],
+                [{"bound": None, "unit_amount": "0.5"}],
             )
         )
         assert price.get_tiered_amount(10) == Decimal("5")
@@ -312,7 +312,7 @@ class TestGetTieredAmountVolume:
         assert price.get_tiered_amount(50) == 50 * 800
         assert price.get_tiered_amount(51) == 51 * 600
 
-    def test_boundary_is_inclusive_up_to(self) -> None:
+    def test_boundary_is_inclusive_bound(self) -> None:
         price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
         assert price.get_tiered_amount(10) == 10 * 1000
 
@@ -322,8 +322,8 @@ class TestGetTieredAmountVolume:
             _tiers_data(
                 TierType.volume,
                 [
-                    {"up_to": 10, "price_per_unit": "20000"},
-                    {"up_to": None, "price_per_unit": "6000"},
+                    {"bound": 10, "unit_amount": "20000"},
+                    {"bound": None, "unit_amount": "6000"},
                 ],
             ),
             minimum_units=10,
@@ -334,7 +334,7 @@ class TestGetTieredAmountVolume:
         price = _make_tiered_price(
             _tiers_data(
                 TierType.volume,
-                [{"up_to": 10, "price_per_unit": "500"}],
+                [{"bound": 10, "unit_amount": "500"}],
             )
         )
         with pytest.raises(InvalidQuantityError):
@@ -363,7 +363,7 @@ class TestGetTieredAmountGraduated:
         price = _make_tiered_price(
             _tiers_data(
                 TierType.graduated,
-                [{"up_to": 10, "price_per_unit": "500"}],
+                [{"bound": 10, "unit_amount": "500"}],
             )
         )
         assert price.get_tiered_amount(15) == 10 * 500
@@ -375,8 +375,8 @@ class TestGetTieredAmountGraduated:
             _tiers_data(
                 TierType.graduated,
                 [
-                    {"up_to": 10, "price_per_unit": "20000"},
-                    {"up_to": None, "price_per_unit": "6000"},
+                    {"bound": 10, "unit_amount": "20000"},
+                    {"bound": None, "unit_amount": "6000"},
                 ],
             ),
             minimum_units=10,
@@ -412,7 +412,7 @@ class TestGetTieredAmountContract:
 
     def test_unknown_tier_type_raises(self) -> None:
         price = _make_tiered_price(
-            {"tier_type": "stepped", "tiers": SHARED_MULTI_TIER}  # type: ignore[typeddict-item]
+            {"type": "stepped", "tiers": SHARED_MULTI_TIER}  # type: ignore[typeddict-item]
         )
         with pytest.raises(InvalidTiersError, match="Missing or unknown tier_type"):
             price.get_tiered_amount(10)
@@ -426,7 +426,7 @@ class TestValidateTiersData:
         validate_tiers_data(
             _tiers_data(
                 TierType.graduated,
-                [{"up_to": None, "price_per_unit": "500"}],
+                [{"bound": None, "unit_amount": "500"}],
             )
         )
 
@@ -452,22 +452,22 @@ class TestValidateTiersData:
             validate_tiers_data(data)
 
     def test_negative_price_raises(self) -> None:
-        with pytest.raises(InvalidTiersError, match="price_per_unit must be >= 0"):
+        with pytest.raises(InvalidTiersError, match="unit_amount must be >= 0"):
             validate_tiers_data(
                 _tiers_data(
                     TierType.volume,
-                    [{"up_to": None, "price_per_unit": "-500"}],
+                    [{"bound": None, "unit_amount": "-500"}],
                 )
             )
 
-    def test_zero_up_to_raises(self) -> None:
-        with pytest.raises(InvalidTiersError, match="up_to must be > 0"):
+    def test_zero_bound_raises(self) -> None:
+        with pytest.raises(InvalidTiersError, match="bound must be > 0"):
             validate_tiers_data(
                 _tiers_data(
                     TierType.volume,
                     [
-                        {"up_to": 0, "price_per_unit": "500"},
-                        {"up_to": None, "price_per_unit": "300"},
+                        {"bound": 0, "unit_amount": "500"},
+                        {"bound": None, "unit_amount": "300"},
                     ],
                 )
             )
@@ -478,20 +478,20 @@ class TestValidateTiersData:
                 _tiers_data(
                     TierType.volume,
                     [
-                        {"up_to": None, "price_per_unit": "500"},
-                        {"up_to": None, "price_per_unit": "300"},
+                        {"bound": None, "unit_amount": "500"},
+                        {"bound": None, "unit_amount": "300"},
                     ],
                 )
             )
 
-    def test_duplicate_up_to_raises(self) -> None:
+    def test_duplicate_bound_raises(self) -> None:
         with pytest.raises(InvalidTiersError, match="must be unique"):
             validate_tiers_data(
                 _tiers_data(
                     TierType.volume,
                     [
-                        {"up_to": 10, "price_per_unit": "500"},
-                        {"up_to": 10, "price_per_unit": "300"},
+                        {"bound": 10, "unit_amount": "500"},
+                        {"bound": 10, "unit_amount": "300"},
                     ],
                 )
             )
@@ -499,31 +499,27 @@ class TestValidateTiersData:
     def test_negative_minimum_units_raises(self) -> None:
         with pytest.raises(InvalidTiersError, match="minimum_units must be >= 0"):
             validate_tiers_data(
-                _tiers_data(
-                    TierType.volume, [{"up_to": None, "price_per_unit": "500"}]
-                ),
+                _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}]),
                 minimum_units=-1,
             )
 
     def test_minimum_units_above_last_bounded_tier_raises(self) -> None:
         with pytest.raises(InvalidTiersError, match="minimum_units must not exceed"):
             validate_tiers_data(
-                _tiers_data(TierType.volume, [{"up_to": 10, "price_per_unit": "500"}]),
+                _tiers_data(TierType.volume, [{"bound": 10, "unit_amount": "500"}]),
                 minimum_units=11,
             )
 
     def test_minimum_units_with_unbounded_last_tier(self) -> None:
         validate_tiers_data(
-            _tiers_data(TierType.volume, [{"up_to": None, "price_per_unit": "500"}]),
+            _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}]),
             minimum_units=1000,
         )
 
     def test_zero_maximum_units_raises(self) -> None:
         with pytest.raises(InvalidTiersError, match="maximum_units must be > 0"):
             validate_tiers_data(
-                _tiers_data(
-                    TierType.volume, [{"up_to": None, "price_per_unit": "500"}]
-                ),
+                _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}]),
                 maximum_units=0,
             )
 
@@ -532,9 +528,7 @@ class TestValidateTiersData:
             InvalidTiersError, match="maximum_units must be >= minimum_units"
         ):
             validate_tiers_data(
-                _tiers_data(
-                    TierType.volume, [{"up_to": None, "price_per_unit": "500"}]
-                ),
+                _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}]),
                 minimum_units=10,
                 maximum_units=5,
             )
@@ -542,19 +536,19 @@ class TestValidateTiersData:
     def test_maximum_units_above_last_bounded_tier_raises(self) -> None:
         with pytest.raises(InvalidTiersError, match="maximum_units must not exceed"):
             validate_tiers_data(
-                _tiers_data(TierType.volume, [{"up_to": 10, "price_per_unit": "500"}]),
+                _tiers_data(TierType.volume, [{"bound": 10, "unit_amount": "500"}]),
                 maximum_units=11,
             )
 
     def test_maximum_units_with_unbounded_last_tier(self) -> None:
         validate_tiers_data(
-            _tiers_data(TierType.volume, [{"up_to": None, "price_per_unit": "500"}]),
+            _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}]),
             maximum_units=1000,
         )
 
 
 class TestSeatTiersToTiersData:
-    def test_converts_max_seats_to_up_to(self) -> None:
+    def test_converts_max_seats_to_bound(self) -> None:
         result = seat_tiers_to_tiers_data(
             {
                 "seat_tier_type": SeatTierType.graduated,
@@ -565,10 +559,10 @@ class TestSeatTiersToTiersData:
             }
         )
         assert result == {
-            "tier_type": TierType.graduated,
+            "type": TierType.graduated,
             "tiers": [
-                {"up_to": 10, "price_per_unit": "1000"},
-                {"up_to": None, "price_per_unit": "800"},
+                {"bound": 10, "unit_amount": "1000"},
+                {"bound": None, "unit_amount": "800"},
             ],
         }
 
@@ -576,7 +570,7 @@ class TestSeatTiersToTiersData:
         result = seat_tiers_to_tiers_data(
             {"tiers": [{"min_seats": 1, "max_seats": None, "price_per_seat": 500}]}  # type: ignore[typeddict-item]
         )
-        assert result["tier_type"] == TierType.volume
+        assert result["type"] == TierType.volume
 
     def test_sorts_tiers(self) -> None:
         result = seat_tiers_to_tiers_data(
@@ -588,7 +582,7 @@ class TestSeatTiersToTiersData:
                 ],
             }
         )
-        assert [t["up_to"] for t in result["tiers"]] == [10, None]
+        assert [t["bound"] for t in result["tiers"]] == [10, None]
 
     def test_missing_max_seats_key(self) -> None:
         result = seat_tiers_to_tiers_data(
@@ -597,10 +591,10 @@ class TestSeatTiersToTiersData:
                 "tiers": [{"min_seats": 1, "price_per_seat": 500}],  # type: ignore[typeddict-item]
             }
         )
-        assert result["tiers"][0]["up_to"] is None
+        assert result["tiers"][0]["bound"] is None
 
     def test_gap_raises(self) -> None:
-        # A gap cannot be represented with up_to bounds, so translation must
+        # A gap cannot be represented with bound bounds, so translation must
         # reject it instead of silently swallowing it.
         with pytest.raises(NonContiguousTiersError):
             seat_tiers_to_tiers_data(
@@ -689,9 +683,9 @@ class TestSeatTiersDualWrite:
             "tiers": [{"min_seats": 5, "max_seats": 20, "price_per_seat": 250}],
         }
         assert price.tiers == {
-            "tier_type": TierType.volume,
+            "type": TierType.volume,
             "tiers": [
-                {"up_to": 20, "price_per_unit": "250"},
+                {"bound": 20, "unit_amount": "250"},
             ],
         }
         assert price.minimum_units == 5
@@ -729,8 +723,8 @@ class TestMinimumMaximumUnits:
             _tiers_data(
                 TierType.volume,
                 [
-                    {"up_to": 10, "price_per_unit": "500"},
-                    {"up_to": 20, "price_per_unit": "300"},
+                    {"bound": 10, "unit_amount": "500"},
+                    {"bound": 20, "unit_amount": "300"},
                 ],
             )
         )

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -17,7 +17,6 @@ from polar.product.tiers import (
     Tiers,
     TierType,
     seat_tiers_to_tiers,
-    validate_unit_bounds,
 )
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -172,10 +171,6 @@ class TestVolumePricing:
         )
         assert price.calculate_amount(100) == 0
 
-    def test_zero_seats_cost_zero(self) -> None:
-        price = _make_seat_price(MULTI_TIER, SeatTierType.volume)
-        assert price.calculate_amount(0) == 0
-
 
 class TestCalculateAmountIntegralityGuard:
     def test_fractional_stored_rate_raises(self) -> None:
@@ -242,10 +237,6 @@ class TestGraduatedPricing:
         assert price.calculate_amount(8) == 3 * 1000
         assert price.calculate_amount(15) == 10 * 1000
 
-    def test_zero_seats_cost_zero(self) -> None:
-        price = _make_seat_price(MULTI_TIER, SeatTierType.graduated)
-        assert price.calculate_amount(0) == 0
-
     def test_first_tier_min_seats_above_one(self) -> None:
         # Regression for T-28449: a merchant enforcing a 10-seat minimum sets the
         # first tier's min_seats to 10. The first 10 seats should all be priced at
@@ -288,16 +279,6 @@ SHARED_MULTI_TIER: list[dict[str, Any]] = [
 
 
 class TestGetTieredAmountVolume:
-    def test_single_tier(self) -> None:
-        price = _make_tiered_price(
-            _tiers_data(
-                TierType.volume,
-                [{"bound": None, "unit_amount": "500"}],
-            )
-        )
-        assert price.get_tiered_amount(1) == 500
-        assert price.get_tiered_amount(10) == 5000
-
     def test_fractional_rate(self) -> None:
         price = _make_tiered_price(
             _tiers_data(
@@ -306,17 +287,6 @@ class TestGetTieredAmountVolume:
             )
         )
         assert price.get_tiered_amount(10) == Decimal("5")
-
-    def test_multi_tier(self) -> None:
-        price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
-        assert price.get_tiered_amount(10) == 10_000
-        assert price.get_tiered_amount(11) == 11 * 800
-        assert price.get_tiered_amount(50) == 50 * 800
-        assert price.get_tiered_amount(51) == 51 * 600
-
-    def test_boundary_is_inclusive_bound(self) -> None:
-        price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
-        assert price.get_tiered_amount(10) == 10 * 1000
 
     def test_below_minimum_units_still_prices(self) -> None:
         # The minimum is a purchase-layer constraint; the engine prices from 0.
@@ -342,25 +312,8 @@ class TestGetTieredAmountVolume:
         with pytest.raises(InvalidQuantityError):
             price.get_tiered_amount(11)
 
-    def test_unsorted_tiers(self) -> None:
-        price = _make_tiered_price(
-            _tiers_data(TierType.volume, list(reversed(SHARED_MULTI_TIER)))
-        )
-        assert price.get_tiered_amount(5) == 5 * 1000
-        assert price.get_tiered_amount(51) == 51 * 600
-
 
 class TestGetTieredAmountGraduated:
-    def test_spans_tiers(self) -> None:
-        price = _make_tiered_price(_tiers_data(TierType.graduated, SHARED_MULTI_TIER))
-        assert price.get_tiered_amount(15) == 10 * 1000 + 5 * 800
-        assert price.get_tiered_amount(100) == 10 * 1000 + 40 * 800 + 50 * 600
-
-    def test_exact_boundary(self) -> None:
-        price = _make_tiered_price(_tiers_data(TierType.graduated, SHARED_MULTI_TIER))
-        assert price.get_tiered_amount(10) == 10 * 1000
-        assert price.get_tiered_amount(50) == 10 * 1000 + 40 * 800
-
     def test_past_bounded_last_tier_bills_covered_units(self) -> None:
         price = _make_tiered_price(
             _tiers_data(
@@ -387,12 +340,6 @@ class TestGetTieredAmountGraduated:
         assert price.get_tiered_amount(15) == 10 * 20000 + 5 * 6000
         # Below the floor still bills at the first tier's rate.
         assert price.get_tiered_amount(5) == 5 * 20000
-
-    def test_unsorted_tiers(self) -> None:
-        price = _make_tiered_price(
-            _tiers_data(TierType.graduated, list(reversed(SHARED_MULTI_TIER)))
-        )
-        assert price.get_tiered_amount(15) == 10 * 1000 + 5 * 800
 
 
 class TestGetTieredAmountContract:
@@ -427,22 +374,6 @@ class TestSeatTiersDualWrite:
         )
         assert price.minimum_units == 5
         assert price.maximum_units == 20
-
-    def test_dual_written_seat_data_passes_validation(self) -> None:
-        price = _make_seat_price(MULTI_TIER, SeatTierType.graduated)
-        assert price.tiers is not None
-        validate_unit_bounds(
-            price.tiers,
-            minimum_units=price.minimum_units,
-            maximum_units=price.maximum_units,
-        )
-
-    def test_billing_reads_shared_columns(self) -> None:
-        price = _make_seat_price(MULTI_TIER, SeatTierType.graduated)
-        assert price.tiers is not None
-        assert price.calculate_amount(15) == int(price.tiers.calculate(15))
-        assert price.get_minimum_seats() == max(1, price.minimum_units or 0)
-        assert price.get_maximum_seats() == price.maximum_units
 
     @pytest.mark.asyncio
     async def test_database_round_trip_returns_tiers_model(
@@ -507,30 +438,3 @@ class TestMinimumMaximumUnits:
     def test_maximum_units_unbounded(self) -> None:
         price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
         assert price.get_maximum_units() is None
-
-
-class TestSeatMinimumMaximum:
-    def test_minimum_seats_from_first_tier(self) -> None:
-        price = _make_seat_price(
-            [
-                {"min_seats": 5, "max_seats": 10, "price_per_seat": 1000},
-                {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
-            ]
-        )
-        assert price.get_minimum_seats() == 5
-
-    def test_minimum_seats_defaults_to_one(self) -> None:
-        price = _make_seat_price(
-            [{"min_seats": 1, "max_seats": None, "price_per_seat": 1000}]
-        )
-        assert price.get_minimum_seats() == 1
-
-    def test_maximum_seats_from_last_tier(self) -> None:
-        price = _make_seat_price(
-            [{"min_seats": 1, "max_seats": 20, "price_per_seat": 1000}]
-        )
-        assert price.get_maximum_seats() == 20
-
-    def test_maximum_seats_unbounded(self) -> None:
-        price = _make_seat_price(MULTI_TIER)
-        assert price.get_maximum_seats() is None

--- a/server/tests/product/test_schemas.py
+++ b/server/tests/product/test_schemas.py
@@ -18,6 +18,7 @@ from polar.product.schemas import (
     ProductPriceCustomCreate,
     ProductPriceFixedCreate,
     ProductPriceMeteredUnitCreate,
+    ProductPriceSeatTiers,
 )
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import METER_ID, create_benefit
@@ -698,4 +699,31 @@ class TestProductCreateMeterInterval:
             _recurring_product(
                 recurring_interval=SubscriptionRecurringInterval.month,
                 meter_interval=SubscriptionRecurringInterval.year,
+            )
+
+
+class TestProductPriceSeatTiers:
+    def test_unbounded_not_last_keeps_seat_wording(self) -> None:
+        with pytest.raises(ValidationError, match="unlimited max_seats"):
+            ProductPriceSeatTiers.model_validate(
+                {
+                    "seat_tier_type": "volume",
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": None, "price_per_seat": 500},
+                        {"min_seats": 11, "max_seats": 20, "price_per_seat": 300},
+                    ],
+                }
+            )
+
+    def test_earlier_gap_wins_over_later_unbounded(self) -> None:
+        with pytest.raises(ValidationError, match="Gap or overlap"):
+            ProductPriceSeatTiers.model_validate(
+                {
+                    "seat_tier_type": "volume",
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": 10, "price_per_seat": 500},
+                        {"min_seats": 20, "max_seats": None, "price_per_seat": 300},
+                        {"min_seats": 21, "max_seats": 30, "price_per_seat": 200},
+                    ],
+                }
             )

--- a/server/tests/product/test_schemas.py
+++ b/server/tests/product/test_schemas.py
@@ -727,3 +727,15 @@ class TestProductPriceSeatTiers:
                     ],
                 }
             )
+
+    def test_duplicate_bound_keeps_seat_wording(self) -> None:
+        with pytest.raises(ValidationError, match="max_seats values must be unique"):
+            ProductPriceSeatTiers.model_validate(
+                {
+                    "seat_tier_type": "volume",
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": 10, "price_per_seat": 500},
+                        {"min_seats": 11, "max_seats": 10, "price_per_seat": 300},
+                    ],
+                }
+            )

--- a/server/tests/product/test_tiers.py
+++ b/server/tests/product/test_tiers.py
@@ -11,6 +11,7 @@ from polar.product.tiers import (
     UnboundedTierNotLastError,
     seat_tiers_to_tiers,
     seat_tiers_unit_bounds,
+    validate_unit_bounds,
 )
 
 
@@ -43,13 +44,6 @@ class TestTiersValidation:
             list(reversed(SHARED_MULTI_TIER)),
         )
         assert [tier.bound for tier in tiers.tiers] == [10, 50, None]
-
-    def test_valid_unit_bounds(self) -> None:
-        tiers = _tiers_data(TierType.volume, SHARED_MULTI_TIER)
-        tiers.validate_unit_bounds(
-            minimum_units=5,
-            maximum_units=100,
-        )
 
     def test_empty_tiers_raises(self) -> None:
         with pytest.raises(ValidationError) as exc:
@@ -126,29 +120,40 @@ class TestTiersValidation:
         assert serialized["tiers"][0]["bound"] is None
         assert serialized["tiers"][0]["unit_amount"] == "1E-12"
 
+
+class TestValidateUnitBounds:
+    def test_valid_unit_bounds(self) -> None:
+        tiers = _tiers_data(TierType.volume, SHARED_MULTI_TIER)
+        validate_unit_bounds(
+            tiers,
+            minimum_units=5,
+            maximum_units=100,
+        )
+
     def test_negative_minimum_units_raises(self) -> None:
         tiers = _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}])
         with pytest.raises(ValueError, match="minimum_units must be >= 0"):
-            tiers.validate_unit_bounds(minimum_units=-1)
+            validate_unit_bounds(tiers, minimum_units=-1)
 
     def test_minimum_units_above_last_bounded_tier_raises(self) -> None:
         tiers = _tiers_data(TierType.volume, [{"bound": 10, "unit_amount": "500"}])
         with pytest.raises(ValueError, match="minimum_units must not exceed"):
-            tiers.validate_unit_bounds(minimum_units=11)
+            validate_unit_bounds(tiers, minimum_units=11)
 
     def test_minimum_units_with_unbounded_last_tier(self) -> None:
         tiers = _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}])
-        tiers.validate_unit_bounds(minimum_units=1000)
+        validate_unit_bounds(tiers, minimum_units=1000)
 
     def test_zero_maximum_units_raises(self) -> None:
         tiers = _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}])
         with pytest.raises(ValueError, match="maximum_units must be > 0"):
-            tiers.validate_unit_bounds(maximum_units=0)
+            validate_unit_bounds(tiers, maximum_units=0)
 
     def test_maximum_units_below_minimum_raises(self) -> None:
         tiers = _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}])
         with pytest.raises(ValueError, match="maximum_units must be >= minimum_units"):
-            tiers.validate_unit_bounds(
+            validate_unit_bounds(
+                tiers,
                 minimum_units=10,
                 maximum_units=5,
             )
@@ -156,11 +161,11 @@ class TestTiersValidation:
     def test_maximum_units_above_last_bounded_tier_raises(self) -> None:
         tiers = _tiers_data(TierType.volume, [{"bound": 10, "unit_amount": "500"}])
         with pytest.raises(ValueError, match="maximum_units must not exceed"):
-            tiers.validate_unit_bounds(maximum_units=11)
+            validate_unit_bounds(tiers, maximum_units=11)
 
     def test_maximum_units_with_unbounded_last_tier(self) -> None:
         tiers = _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}])
-        tiers.validate_unit_bounds(maximum_units=1000)
+        validate_unit_bounds(tiers, maximum_units=1000)
 
 
 class TestSeatTiersToTiers:
@@ -243,6 +248,18 @@ class TestSeatTiersToTiers:
                     "tiers": [
                         {"min_seats": 1, "max_seats": None, "price_per_seat": 1000},
                         {"min_seats": 11, "max_seats": 20, "price_per_seat": 800},
+                    ],
+                }
+            )
+
+    def test_duplicate_max_seats_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="bound values must be unique"):
+            seat_tiers_to_tiers(
+                {
+                    "seat_tier_type": SeatTierType.volume,
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+                        {"min_seats": 11, "max_seats": 10, "price_per_seat": 800},
                     ],
                 }
             )

--- a/server/tests/product/test_tiers.py
+++ b/server/tests/product/test_tiers.py
@@ -1,0 +1,285 @@
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from polar.product.tiers import (
+    NonContiguousTiersError,
+    SeatTierType,
+    Tiers,
+    TierType,
+    UnboundedTierNotLastError,
+    seat_tiers_to_tiers,
+    seat_tiers_unit_bounds,
+)
+
+
+def _tiers_data(tier_type: TierType, tiers: list[dict[str, Any]]) -> Tiers:
+    return Tiers.model_validate({"type": tier_type, "tiers": tiers})
+
+
+SHARED_MULTI_TIER: list[dict[str, Any]] = [
+    {"bound": 10, "unit_amount": "1000"},
+    {"bound": 50, "unit_amount": "800"},
+    {"bound": None, "unit_amount": "600"},
+]
+
+
+class TestTiersValidation:
+    def test_valid_multi_tier(self) -> None:
+        tiers = _tiers_data(TierType.volume, SHARED_MULTI_TIER)
+        assert len(tiers.tiers) == 3
+
+    def test_valid_single_unbounded_tier(self) -> None:
+        tiers = _tiers_data(
+            TierType.graduated,
+            [{"bound": None, "unit_amount": "500"}],
+        )
+        assert tiers.last_bound is None
+
+    def test_valid_unsorted_input(self) -> None:
+        tiers = _tiers_data(
+            TierType.volume,
+            list(reversed(SHARED_MULTI_TIER)),
+        )
+        assert [tier.bound for tier in tiers.tiers] == [10, 50, None]
+
+    def test_valid_unit_bounds(self) -> None:
+        tiers = _tiers_data(TierType.volume, SHARED_MULTI_TIER)
+        tiers.validate_unit_bounds(
+            minimum_units=5,
+            maximum_units=100,
+        )
+
+    def test_empty_tiers_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _tiers_data(TierType.volume, [])
+        assert exc.value.errors()[0]["type"] == "too_short"
+
+    def test_missing_tier_type_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            Tiers.model_validate({"tiers": SHARED_MULTI_TIER})
+        assert exc.value.errors()[0]["type"] == "missing"
+
+    def test_unknown_tier_type_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            Tiers.model_validate({"type": "stepped", "tiers": SHARED_MULTI_TIER})
+        assert exc.value.errors()[0]["type"] == "enum"
+
+    def test_negative_price_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _tiers_data(
+                TierType.volume,
+                [{"bound": None, "unit_amount": "-500"}],
+            )
+        assert exc.value.errors()[0]["type"] == "greater_than_equal"
+
+    @pytest.mark.parametrize("unit_amount", ["NaN", "Infinity", "-Infinity"])
+    def test_non_finite_price_raises(self, unit_amount: str) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _tiers_data(
+                TierType.volume,
+                [{"bound": None, "unit_amount": unit_amount}],
+            )
+        assert exc.value.errors()[0]["type"] == "finite_number"
+
+    def test_zero_bound_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _tiers_data(
+                TierType.volume,
+                [
+                    {"bound": 0, "unit_amount": "500"},
+                    {"bound": None, "unit_amount": "300"},
+                ],
+            )
+        assert exc.value.errors()[0]["type"] == "greater_than"
+
+    def test_two_unbounded_tiers_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _tiers_data(
+                TierType.volume,
+                [
+                    {"bound": None, "unit_amount": "500"},
+                    {"bound": None, "unit_amount": "300"},
+                ],
+            )
+        assert exc.value.errors()[0]["type"] == "unbounded_tier_not_last"
+
+    def test_duplicate_bound_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            _tiers_data(
+                TierType.volume,
+                [
+                    {"bound": 10, "unit_amount": "500"},
+                    {"bound": 10, "unit_amount": "300"},
+                ],
+            )
+        assert exc.value.errors()[0]["type"] == "duplicate_tier_bound"
+
+    def test_serializes_decimal_rates_as_strings(self) -> None:
+        tiers = _tiers_data(
+            TierType.volume,
+            [{"bound": None, "unit_amount": "0.000000000001"}],
+        )
+        serialized = tiers.model_dump(mode="json")
+        assert serialized["type"] == "volume"
+        assert serialized["tiers"][0]["bound"] is None
+        assert serialized["tiers"][0]["unit_amount"] == "1E-12"
+
+    def test_negative_minimum_units_raises(self) -> None:
+        tiers = _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}])
+        with pytest.raises(ValueError, match="minimum_units must be >= 0"):
+            tiers.validate_unit_bounds(minimum_units=-1)
+
+    def test_minimum_units_above_last_bounded_tier_raises(self) -> None:
+        tiers = _tiers_data(TierType.volume, [{"bound": 10, "unit_amount": "500"}])
+        with pytest.raises(ValueError, match="minimum_units must not exceed"):
+            tiers.validate_unit_bounds(minimum_units=11)
+
+    def test_minimum_units_with_unbounded_last_tier(self) -> None:
+        tiers = _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}])
+        tiers.validate_unit_bounds(minimum_units=1000)
+
+    def test_zero_maximum_units_raises(self) -> None:
+        tiers = _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}])
+        with pytest.raises(ValueError, match="maximum_units must be > 0"):
+            tiers.validate_unit_bounds(maximum_units=0)
+
+    def test_maximum_units_below_minimum_raises(self) -> None:
+        tiers = _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}])
+        with pytest.raises(ValueError, match="maximum_units must be >= minimum_units"):
+            tiers.validate_unit_bounds(
+                minimum_units=10,
+                maximum_units=5,
+            )
+
+    def test_maximum_units_above_last_bounded_tier_raises(self) -> None:
+        tiers = _tiers_data(TierType.volume, [{"bound": 10, "unit_amount": "500"}])
+        with pytest.raises(ValueError, match="maximum_units must not exceed"):
+            tiers.validate_unit_bounds(maximum_units=11)
+
+    def test_maximum_units_with_unbounded_last_tier(self) -> None:
+        tiers = _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}])
+        tiers.validate_unit_bounds(maximum_units=1000)
+
+
+class TestSeatTiersToTiers:
+    def test_converts_max_seats_to_bound(self) -> None:
+        result = seat_tiers_to_tiers(
+            {
+                "seat_tier_type": SeatTierType.graduated,
+                "tiers": [
+                    {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+                    {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
+                ],
+            }
+        )
+        assert result.model_dump(mode="json") == {
+            "type": TierType.graduated,
+            "tiers": [
+                {"bound": 10, "unit_amount": "1000"},
+                {"bound": None, "unit_amount": "800"},
+            ],
+        }
+
+    def test_missing_seat_tier_type_defaults_to_volume(self) -> None:
+        result = seat_tiers_to_tiers(
+            {"tiers": [{"min_seats": 1, "max_seats": None, "price_per_seat": 500}]}  # type: ignore[typeddict-item]
+        )
+        assert result.type == TierType.volume
+
+    def test_sorts_tiers(self) -> None:
+        result = seat_tiers_to_tiers(
+            {
+                "seat_tier_type": SeatTierType.volume,
+                "tiers": [
+                    {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
+                    {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+                ],
+            }
+        )
+        assert [tier.bound for tier in result.tiers] == [10, None]
+
+    def test_missing_max_seats_key(self) -> None:
+        result = seat_tiers_to_tiers(
+            {
+                "seat_tier_type": SeatTierType.volume,
+                "tiers": [{"min_seats": 1, "price_per_seat": 500}],  # type: ignore[typeddict-item]
+            }
+        )
+        assert result.tiers[0].bound is None
+
+    def test_gap_raises(self) -> None:
+        # A gap cannot be represented with bound bounds, so translation must
+        # reject it instead of silently swallowing it.
+        with pytest.raises(NonContiguousTiersError):
+            seat_tiers_to_tiers(
+                {
+                    "seat_tier_type": SeatTierType.volume,
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+                        {"min_seats": 12, "max_seats": None, "price_per_seat": 800},
+                    ],
+                }
+            )
+
+    def test_overlap_raises(self) -> None:
+        with pytest.raises(NonContiguousTiersError):
+            seat_tiers_to_tiers(
+                {
+                    "seat_tier_type": SeatTierType.volume,
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+                        {"min_seats": 8, "max_seats": None, "price_per_seat": 800},
+                    ],
+                }
+            )
+
+    def test_unbounded_tier_not_last_raises(self) -> None:
+        with pytest.raises(UnboundedTierNotLastError):
+            seat_tiers_to_tiers(
+                {
+                    "seat_tier_type": SeatTierType.volume,
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": None, "price_per_seat": 1000},
+                        {"min_seats": 11, "max_seats": 20, "price_per_seat": 800},
+                    ],
+                }
+            )
+
+
+class TestSeatTiersUnitBounds:
+    def test_first_min_and_last_max(self) -> None:
+        assert seat_tiers_unit_bounds(
+            {
+                "seat_tier_type": SeatTierType.volume,
+                "tiers": [
+                    {"min_seats": 5, "max_seats": 10, "price_per_seat": 1000},
+                    {"min_seats": 11, "max_seats": 20, "price_per_seat": 800},
+                ],
+            }
+        ) == (5, 20)
+
+    def test_unbounded_last_tier(self) -> None:
+        assert seat_tiers_unit_bounds(
+            {
+                "seat_tier_type": SeatTierType.volume,
+                "tiers": [{"min_seats": 1, "max_seats": None, "price_per_seat": 500}],
+            }
+        ) == (1, None)
+
+    def test_sorts_tiers(self) -> None:
+        assert seat_tiers_unit_bounds(
+            {
+                "seat_tier_type": SeatTierType.volume,
+                "tiers": [
+                    {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
+                    {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+                ],
+            }
+        ) == (1, None)
+
+    def test_empty_tiers(self) -> None:
+        assert seat_tiers_unit_bounds(
+            {"seat_tier_type": SeatTierType.volume, "tiers": []}
+        ) == (None, None)

--- a/server/tests/product/test_tiers.py
+++ b/server/tests/product/test_tiers.py
@@ -27,66 +27,12 @@ SHARED_MULTI_TIER: list[dict[str, Any]] = [
 
 
 class TestTiersValidation:
-    def test_valid_multi_tier(self) -> None:
-        tiers = _tiers_data(TierType.volume, SHARED_MULTI_TIER)
-        assert len(tiers.tiers) == 3
-
-    def test_valid_single_unbounded_tier(self) -> None:
-        tiers = _tiers_data(
-            TierType.graduated,
-            [{"bound": None, "unit_amount": "500"}],
-        )
-        assert tiers.last_bound is None
-
     def test_valid_unsorted_input(self) -> None:
         tiers = _tiers_data(
             TierType.volume,
             list(reversed(SHARED_MULTI_TIER)),
         )
         assert [tier.bound for tier in tiers.tiers] == [10, 50, None]
-
-    def test_empty_tiers_raises(self) -> None:
-        with pytest.raises(ValidationError) as exc:
-            _tiers_data(TierType.volume, [])
-        assert exc.value.errors()[0]["type"] == "too_short"
-
-    def test_missing_tier_type_raises(self) -> None:
-        with pytest.raises(ValidationError) as exc:
-            Tiers.model_validate({"tiers": SHARED_MULTI_TIER})
-        assert exc.value.errors()[0]["type"] == "missing"
-
-    def test_unknown_tier_type_raises(self) -> None:
-        with pytest.raises(ValidationError) as exc:
-            Tiers.model_validate({"type": "stepped", "tiers": SHARED_MULTI_TIER})
-        assert exc.value.errors()[0]["type"] == "enum"
-
-    def test_negative_price_raises(self) -> None:
-        with pytest.raises(ValidationError) as exc:
-            _tiers_data(
-                TierType.volume,
-                [{"bound": None, "unit_amount": "-500"}],
-            )
-        assert exc.value.errors()[0]["type"] == "greater_than_equal"
-
-    @pytest.mark.parametrize("unit_amount", ["NaN", "Infinity", "-Infinity"])
-    def test_non_finite_price_raises(self, unit_amount: str) -> None:
-        with pytest.raises(ValidationError) as exc:
-            _tiers_data(
-                TierType.volume,
-                [{"bound": None, "unit_amount": unit_amount}],
-            )
-        assert exc.value.errors()[0]["type"] == "finite_number"
-
-    def test_zero_bound_raises(self) -> None:
-        with pytest.raises(ValidationError) as exc:
-            _tiers_data(
-                TierType.volume,
-                [
-                    {"bound": 0, "unit_amount": "500"},
-                    {"bound": None, "unit_amount": "300"},
-                ],
-            )
-        assert exc.value.errors()[0]["type"] == "greater_than"
 
     def test_two_unbounded_tiers_raises(self) -> None:
         with pytest.raises(ValidationError) as exc:
@@ -123,9 +69,8 @@ class TestTiersValidation:
 
 class TestValidateUnitBounds:
     def test_valid_unit_bounds(self) -> None:
-        tiers = _tiers_data(TierType.volume, SHARED_MULTI_TIER)
         validate_unit_bounds(
-            tiers,
+            _tiers_data(TierType.volume, SHARED_MULTI_TIER),
             minimum_units=5,
             maximum_units=100,
         )
@@ -162,10 +107,6 @@ class TestValidateUnitBounds:
         tiers = _tiers_data(TierType.volume, [{"bound": 10, "unit_amount": "500"}])
         with pytest.raises(ValueError, match="maximum_units must not exceed"):
             validate_unit_bounds(tiers, maximum_units=11)
-
-    def test_maximum_units_with_unbounded_last_tier(self) -> None:
-        tiers = _tiers_data(TierType.volume, [{"bound": None, "unit_amount": "500"}])
-        validate_unit_bounds(tiers, maximum_units=1000)
 
 
 class TestSeatTiersToTiers:
@@ -205,18 +146,7 @@ class TestSeatTiersToTiers:
         )
         assert [tier.bound for tier in result.tiers] == [10, None]
 
-    def test_missing_max_seats_key(self) -> None:
-        result = seat_tiers_to_tiers(
-            {
-                "seat_tier_type": SeatTierType.volume,
-                "tiers": [{"min_seats": 1, "price_per_seat": 500}],  # type: ignore[typeddict-item]
-            }
-        )
-        assert result.tiers[0].bound is None
-
     def test_gap_raises(self) -> None:
-        # A gap cannot be represented with bound bounds, so translation must
-        # reject it instead of silently swallowing it.
         with pytest.raises(NonContiguousTiersError):
             seat_tiers_to_tiers(
                 {
@@ -252,18 +182,6 @@ class TestSeatTiersToTiers:
                 }
             )
 
-    def test_duplicate_max_seats_raises_value_error(self) -> None:
-        with pytest.raises(ValueError, match="bound values must be unique"):
-            seat_tiers_to_tiers(
-                {
-                    "seat_tier_type": SeatTierType.volume,
-                    "tiers": [
-                        {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
-                        {"min_seats": 11, "max_seats": 10, "price_per_seat": 800},
-                    ],
-                }
-            )
-
 
 class TestSeatTiersUnitBounds:
     def test_first_min_and_last_max(self) -> None:
@@ -282,17 +200,6 @@ class TestSeatTiersUnitBounds:
             {
                 "seat_tier_type": SeatTierType.volume,
                 "tiers": [{"min_seats": 1, "max_seats": None, "price_per_seat": 500}],
-            }
-        ) == (1, None)
-
-    def test_sorts_tiers(self) -> None:
-        assert seat_tiers_unit_bounds(
-            {
-                "seat_tier_type": SeatTierType.volume,
-                "tiers": [
-                    {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
-                    {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
-                ],
             }
         ) == (1, None)
 

--- a/server/tests/product/test_tiers.py
+++ b/server/tests/product/test_tiers.py
@@ -1,9 +1,11 @@
+from decimal import Decimal
 from typing import Any
 
 import pytest
 from pydantic import ValidationError
 
 from polar.product.tiers import (
+    InvalidQuantityError,
     NonContiguousTiersError,
     SeatTierType,
     Tiers,
@@ -65,6 +67,69 @@ class TestTiersValidation:
         assert serialized["type"] == "volume"
         assert serialized["tiers"][0]["bound"] is None
         assert serialized["tiers"][0]["unit_amount"] == "1E-12"
+
+
+class TestTiersCalculateVolume:
+    def test_fractional_rate(self) -> None:
+        tiers = _tiers_data(
+            TierType.volume,
+            [{"bound": None, "unit_amount": "0.5"}],
+        )
+        assert tiers.calculate(10) == Decimal("5")
+
+    def test_quantity_below_first_bound(self) -> None:
+        # The engine prices from 0; purchase floors live on the price.
+        tiers = _tiers_data(
+            TierType.volume,
+            [
+                {"bound": 10, "unit_amount": "20000"},
+                {"bound": None, "unit_amount": "6000"},
+            ],
+        )
+        assert tiers.calculate(5) == 5 * 20000
+
+    def test_past_bounded_last_tier_raises(self) -> None:
+        tiers = _tiers_data(
+            TierType.volume,
+            [{"bound": 10, "unit_amount": "500"}],
+        )
+        with pytest.raises(InvalidQuantityError):
+            tiers.calculate(11)
+
+
+class TestTiersCalculateGraduated:
+    def test_past_bounded_last_tier_bills_covered_units(self) -> None:
+        tiers = _tiers_data(
+            TierType.graduated,
+            [{"bound": 10, "unit_amount": "500"}],
+        )
+        assert tiers.calculate(15) == 10 * 500
+
+    def test_first_tier_bills_from_unit_one(self) -> None:
+        # The first tier still bills from unit one.
+        tiers = _tiers_data(
+            TierType.graduated,
+            [
+                {"bound": 10, "unit_amount": "20000"},
+                {"bound": None, "unit_amount": "6000"},
+            ],
+        )
+        assert tiers.calculate(10) == 10 * 20000
+        assert tiers.calculate(15) == 10 * 20000 + 5 * 6000
+        assert tiers.calculate(5) == 5 * 20000
+
+
+class TestTiersCalculateContract:
+    @pytest.mark.parametrize("tier_type", [TierType.volume, TierType.graduated])
+    def test_zero_quantity_costs_zero(self, tier_type: TierType) -> None:
+        tiers = _tiers_data(tier_type, SHARED_MULTI_TIER)
+        assert tiers.calculate(0) == 0
+
+    @pytest.mark.parametrize("tier_type", [TierType.volume, TierType.graduated])
+    def test_negative_quantity_raises(self, tier_type: TierType) -> None:
+        tiers = _tiers_data(tier_type, SHARED_MULTI_TIER)
+        with pytest.raises(InvalidQuantityError):
+            tiers.calculate(-5)
 
 
 class TestValidateUnitBounds:

--- a/server/tests/scripts/test_backfill_product_price_tiers.py
+++ b/server/tests/scripts/test_backfill_product_price_tiers.py
@@ -33,7 +33,7 @@ async def _legacy_seat_price(
         tiers=TIERS,
         seat_tier_type=SeatTierType.graduated,
     )
-    price.tiers = None
+    price.tiers = None  # type: ignore[assignment]
     price.minimum_units = None
     price.maximum_units = None
     await save_fixture(price)

--- a/server/tests/scripts/test_backfill_product_price_tiers.py
+++ b/server/tests/scripts/test_backfill_product_price_tiers.py
@@ -24,8 +24,8 @@ async def _legacy_seat_price(
     save_fixture: SaveFixture,
     product: Product,
 ) -> ProductPriceSeatUnit:
-    """A seat price whose `tiers`, `minimum_units` and `maximum_units` columns
-    are empty, as rows written before the dual-write hook are."""
+    """A seat price with empty shared columns, like rows written
+    before the dual-write hook existed."""
     price = await create_product_price_seat_unit(
         save_fixture,
         product=product,

--- a/server/tests/scripts/test_backfill_product_price_tiers.py
+++ b/server/tests/scripts/test_backfill_product_price_tiers.py
@@ -1,12 +1,16 @@
 from typing import Any
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from polar.kit.db.postgres import AsyncSession
 from polar.models import Product
 from polar.models.product_price import ProductPriceSeatUnit
-from polar.product.tiers import SeatTierType, seat_tiers_to_tiers
+from polar.product.tiers import (
+    NonContiguousTiersError,
+    SeatTierType,
+    seat_tiers_to_tiers,
+)
 from scripts.backfill_product_price_tiers import run_backfill
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_product_price_seat_unit
@@ -59,7 +63,7 @@ class TestBackfillProductPriceTiers:
     ) -> None:
         price = await _legacy_seat_price(save_fixture, product)
 
-        updated = await run_backfill(batch_size=10, dry_run=False, session=session)
+        updated = await run_backfill(dry_run=False, session=session)
 
         assert updated == 1
         tiers, minimum_units, maximum_units = await _get_tier_columns(session, price)
@@ -80,9 +84,38 @@ class TestBackfillProductPriceTiers:
     ) -> None:
         price = await _legacy_seat_price(save_fixture, product)
 
-        counted = await run_backfill(batch_size=10, dry_run=True, session=session)
+        counted = await run_backfill(dry_run=True, session=session)
 
         assert counted == 1
+        assert await _get_tier_columns(session, price) == (None, None, None)
+
+    async def test_dry_run_raises_on_invalid_tiers(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+    ) -> None:
+        price = await _legacy_seat_price(save_fixture, product)
+        # Bypass the dual-write setter so we can persist corrupt legacy JSON.
+        await session.execute(
+            update(ProductPriceSeatUnit)
+            .where(ProductPriceSeatUnit.id == price.id)
+            .values(
+                seat_tiers={
+                    "seat_tier_type": SeatTierType.volume,
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": 5, "price_per_seat": 1000},
+                        {"min_seats": 10, "max_seats": None, "price_per_seat": 800},
+                    ],
+                }
+            )
+        )
+        await session.flush()
+        session.expire(price)
+
+        with pytest.raises(NonContiguousTiersError):
+            await run_backfill(dry_run=True, session=session)
+
         assert await _get_tier_columns(session, price) == (None, None, None)
 
     async def test_idempotent(
@@ -93,9 +126,9 @@ class TestBackfillProductPriceTiers:
     ) -> None:
         price = await _legacy_seat_price(save_fixture, product)
 
-        await run_backfill(batch_size=10, dry_run=False, session=session)
+        await run_backfill(dry_run=False, session=session)
         first = await _get_tier_columns(session, price)
-        await run_backfill(batch_size=10, dry_run=False, session=session)
+        await run_backfill(dry_run=False, session=session)
         second = await _get_tier_columns(session, price)
 
         assert first == second

--- a/server/tests/scripts/test_backfill_product_price_tiers.py
+++ b/server/tests/scripts/test_backfill_product_price_tiers.py
@@ -1,0 +1,104 @@
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+
+from polar.kit.db.postgres import AsyncSession
+from polar.models import Product
+from polar.models.product_price import (
+    ProductPriceSeatUnit,
+    SeatTierType,
+    seat_tiers_to_tiers_data,
+)
+from scripts.backfill_product_price_tiers import run_backfill
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_product_price_seat_unit
+
+TIERS: list[dict[str, Any]] = [
+    {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+    {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
+]
+
+
+async def _legacy_seat_price(
+    save_fixture: SaveFixture,
+    product: Product,
+) -> ProductPriceSeatUnit:
+    """A seat price whose `tiers`, `minimum_units` and `maximum_units` columns
+    are empty, as rows written before the dual-write hook are."""
+    price = await create_product_price_seat_unit(
+        save_fixture,
+        product=product,
+        tiers=TIERS,
+        seat_tier_type=SeatTierType.graduated,
+    )
+    price.tiers = None
+    price.minimum_units = None
+    price.maximum_units = None
+    await save_fixture(price)
+    return price
+
+
+async def _get_tier_columns(
+    session: AsyncSession, price: ProductPriceSeatUnit
+) -> tuple[object, int | None, int | None]:
+    result = await session.execute(
+        select(
+            ProductPriceSeatUnit.tiers,
+            ProductPriceSeatUnit.minimum_units,
+            ProductPriceSeatUnit.maximum_units,
+        ).where(ProductPriceSeatUnit.id == price.id)
+    )
+    return result.tuples().one()
+
+
+@pytest.mark.asyncio
+class TestBackfillProductPriceTiers:
+    async def test_backfills_legacy_rows(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+    ) -> None:
+        price = await _legacy_seat_price(save_fixture, product)
+
+        updated = await run_backfill(batch_size=10, dry_run=False, session=session)
+
+        assert updated == 1
+        tiers, minimum_units, maximum_units = await _get_tier_columns(session, price)
+        assert tiers == seat_tiers_to_tiers_data(
+            {
+                "seat_tier_type": SeatTierType.graduated,
+                "tiers": TIERS,  # type: ignore[typeddict-item]
+            }
+        )
+        assert minimum_units == 1
+        assert maximum_units is None
+
+    async def test_dry_run_counts_without_writing(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+    ) -> None:
+        price = await _legacy_seat_price(save_fixture, product)
+
+        counted = await run_backfill(batch_size=10, dry_run=True, session=session)
+
+        assert counted == 1
+        assert await _get_tier_columns(session, price) == (None, None, None)
+
+    async def test_idempotent(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+    ) -> None:
+        price = await _legacy_seat_price(save_fixture, product)
+
+        await run_backfill(batch_size=10, dry_run=False, session=session)
+        first = await _get_tier_columns(session, price)
+        await run_backfill(batch_size=10, dry_run=False, session=session)
+        second = await _get_tier_columns(session, price)
+
+        assert first == second

--- a/server/tests/scripts/test_backfill_product_price_tiers.py
+++ b/server/tests/scripts/test_backfill_product_price_tiers.py
@@ -5,11 +5,8 @@ from sqlalchemy import select
 
 from polar.kit.db.postgres import AsyncSession
 from polar.models import Product
-from polar.models.product_price import (
-    ProductPriceSeatUnit,
-    SeatTierType,
-    seat_tiers_to_tiers_data,
-)
+from polar.models.product_price import ProductPriceSeatUnit
+from polar.product.tiers import SeatTierType, seat_tiers_to_tiers
 from scripts.backfill_product_price_tiers import run_backfill
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_product_price_seat_unit
@@ -66,7 +63,7 @@ class TestBackfillProductPriceTiers:
 
         assert updated == 1
         tiers, minimum_units, maximum_units = await _get_tier_columns(session, price)
-        assert tiers == seat_tiers_to_tiers_data(
+        assert tiers == seat_tiers_to_tiers(
             {
                 "seat_tier_type": SeatTierType.graduated,
                 "tiers": TIERS,  # type: ignore[typeddict-item]

--- a/server/tests/subscription/test_service_prorations.py
+++ b/server/tests/subscription/test_service_prorations.py
@@ -26,13 +26,13 @@ from polar.models import (
 )
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
 from polar.models.discount import DiscountDuration, DiscountType
-from polar.models.product_price import SeatTierType
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from polar.product.guard import (
     is_fixed_price,
     is_seat_price,
 )
+from polar.product.tiers import SeatTierType
 from polar.subscription.repository import SubscriptionUpdateRepository
 from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service


### PR DESCRIPTION
## Summary

Only seat prices have tiered pricing today. The storage format, the calculation, and the validation all live on the seat price type. A new price type with tiers would have to copy all of it.

This PR adds one shared system to store, calculate, and validate tiers. Seat prices are the first price type on it. Future tiered price types (metered tiers, next in the stack) use the shared system and must not add their own format.

**Invariant: seat prices bill the same amounts before, during, and after this change.** Reads still come from `seat_tiers`. This PR changes how the code computes the amount, not the data it computes from.

Stacked on #13792, which adds the `tiers` column this PR writes to.

## The shared format

```json
{
  "tier_type": "graduated",
  "minimum_units": 1,
  "tiers": [
    {"up_to": 10, "price_per_unit": "500"},
    {"up_to": null, "price_per_unit": "300"}
  ]
}
```

Two things differ from the seat format:

- **Tiers are gates, not ranges.** A tier covers everything up to and including `up_to`, starting where the previous tier ended. The last tier's `up_to` is `null` if it's open-ended. Gaps and overlaps aren't expressible, so they can't exist in stored data.
- **`price_per_unit` is a string.** Python reads JSON decimals as floats. Some pricing rates could go below a cent (metered for example have `unit_amount` which is `Numeric(17, 12)`), so strings parse to `Decimal` without loss. `up_to` and `minimum_units` are whole units and stay plain integers.

**`minimum_units` is the smallest purchasable quantity, not a tier bound.** The seat format overloads the first tier's `min_seats` for this. The engine always prices from zero, and the purchase layer enforces the floor. Nothing in this PR reads `minimum_units` for billing.

## Changes

### Calculation
A `TieredPrice` mixin owns the `tiers` column and gives a price `get_tiered_amount(quantity) -> Decimal`, plus `get_minimum_units()` and `get_maximum_units()`. Module-level `_calculate_volume` / `_calculate_graduated` do the arithmetic. Same results as the seat calculation, with three additions:

- A missing or unknown `tier_type` raises. The old code read a missing type as volume, only the legacy translation keeps that default.
- Quantity 0 costs 0, and a negative quantity raises. Seats can't be 0, but metered usage can.
- A quantity no tier covers still raises for volume, and still bills only the covered units for graduated. Both errors are `ValueError` subclasses, so callers see no change.

### Validation
`validate_tiers_data` holds every rule about the shared format: at least one tier, non-negative rates, `up_to > 0`, unique `up_to` values, only the last tier unbounded, and `minimum_units` between 0 and the last tier's `up_to`.

### Legacy translation
`seat_tiers_to_tiers_data` is the only function that knows the seat format. `max_seats` becomes `up_to`, the first tier's `min_seats` becomes `minimum_units`, numbers become strings, a missing type means volume. It rejects gaps and overlaps, since the shared format can't represent them, that's the one place the contiguity check still lives.

### Seat API
ProductPriceSeatTiers` translates incoming tiers and runs the shared validator, then converts the errors back to seat wording (`max_seats`, "Gap or overlap between tiers"). Request and response shapes are unchanged.

### Dual write
A SQLAlchemy `set` listener on `seat_tiers` translates each write into `tiers`. New and updated rows fill both columns.

### Backfill
`scripts/backfill_product_price_tiers.py` fills `tiers` from existing seat_tiers` rows using the same translation function as the dual-write, so backfilled and freshly written rows are identical. Dry run by default, `--execute` to apply, keyset pagination by id, one commit per batch. Each translated row goes through the validator first, so a corrupt legacy row stops the script instead of landing in the shared column.

## Migration path

- [x] 1. Add the nullable `tiers` column (#13792).
- [x] 2. Calculate seat amounts through the shared engine.
- [x] 3. Write to both `tiers` and `seat_tiers`.
- [x] 4. Add the backfill script. Run it after deploy.
- [ ] 5. Verify both columns produce the same amounts.
- [ ] 6. Read from `tiers`, stop writing `seat_tiers`, drop the column.

Steps 5 and 6 are follow-up PRs. Step 6 is mostly deleting the `get_tiers_data()` override on
`ProductPriceSeatUnit` — it's the only thing still reading `seat_tiers` for billing.


## Testing

- Existing seat pricing tests pass unchanged, including the T-28449 case where the first tier starts above 1.
- Engine tests: volume and graduated across tier boundaries, unsorted tiers, fractional rates, quantity 0, negative quantity, missing and unknown `tier_type`, past the last bounded tier for both types, and `minimum_units` not shifting what gets billed.
- Validator tests for each rule, including `minimum_units` above the last tier's `up_to`.
- Translation tests: bounds to `up_to`, first `min_seats` to `minimum_units`, missing
  `max_seats`, gaps, overlaps, unbounded tier not last.
- Dual-write tests (constructor and update) and backfill tests (dry run, apply, idempotency).

## Out of scope

- Tiers on metered prices, that's #13793, next in the stack.
- Frontend changes (#13794).
- Any change to what seat validation accepts or rejects.
 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

