### PR TITLE
Add Vercel Services Terraform module

### DIFF
--- a/terraform/modules/vercel_services/main.tf
+++ b/terraform/modules/vercel_services/main.tf
@@ -1,0 +1,47 @@
+resource "vercel_project" "this" {
+  name      = var.name
+  framework = "services"
+
+  build_machine_type         = var.build_machine_type
+  resource_config            = var.resource_config
+  enable_preview_feedback    = var.enable_preview_feedback
+  enable_production_feedback = var.enable_production_feedback
+
+  automatically_expose_system_environment_variables = true
+
+  git_repository = {
+    type              = "github"
+    repo              = var.git_repo
+    production_branch = var.production_branch
+  }
+
+  lifecycle {
+    ignore_changes = [environment]
+  }
+}
+
+locals {
+  environment_variable_names = nonsensitive(toset(keys(var.environment_variables)))
+
+  integration_ids = {
+    neon    = "icfg_biMWLfepTR29FamF2JyDnPzV"
+    upstash = "icfg_JGYSjNyO8c1hpzKrjZdZhxUm"
+  }
+}
+
+resource "vercel_integration_project_access" "this" {
+  for_each = local.integration_ids
+
+  integration_id = each.value
+  project_id     = vercel_project.this.id
+}
+
+resource "vercel_project_environment_variable" "this" {
+  for_each = local.environment_variable_names
+
+  project_id = vercel_project.this.id
+  key        = coalesce(var.environment_variables[each.key].key, each.key)
+  value      = var.environment_variables[each.key].value
+  target     = var.environment_variables[each.key].target
+  sensitive  = var.environment_variables[each.key].sensitive
+}

--- a/terraform/modules/vercel_services/main.tf
+++ b/terraform/modules/vercel_services/main.tf
@@ -21,22 +21,7 @@ resource "vercel_project" "this" {
 }
 
 locals {
-  environment_variables = flatten([
-    for _, variables in var.environment_variable_groups : [
-      for name, variable in variables : {
-        key       = coalesce(variable.key, name)
-        value     = variable.value
-        target    = variable.target
-        sensitive = variable.sensitive
-      }
-    ]
-  ])
-  environment_variable_identities = nonsensitive([
-    for variable in local.environment_variables : jsonencode({
-      key    = variable.key
-      target = sort(tolist(variable.target))
-    })
-  ])
+  environment_variable_names = nonsensitive(toset(keys(var.environment_variables)))
 
   integration_ids = {
     neon    = "icfg_biMWLfepTR29FamF2JyDnPzV"
@@ -51,21 +36,12 @@ resource "vercel_integration_project_access" "this" {
   project_id     = vercel_project.this.id
 }
 
-resource "vercel_project_environment_variables" "this" {
-  project_id = vercel_project.this.id
-  variables = [
-    for variable in local.environment_variables : {
-      key       = variable.key
-      value     = variable.value
-      target    = variable.target
-      sensitive = variable.sensitive
-    }
-  ]
+resource "vercel_project_environment_variable" "this" {
+  for_each = local.environment_variable_names
 
-  lifecycle {
-    precondition {
-      condition     = length(local.environment_variable_identities) == length(distinct(local.environment_variable_identities))
-      error_message = "Environment variable key and target combinations must be unique across groups."
-    }
-  }
+  project_id = vercel_project.this.id
+  key        = coalesce(var.environment_variables[each.key].key, each.key)
+  value      = var.environment_variables[each.key].value
+  target     = var.environment_variables[each.key].target
+  sensitive  = var.environment_variables[each.key].sensitive
 }

--- a/terraform/modules/vercel_services/main.tf
+++ b/terraform/modules/vercel_services/main.tf
@@ -21,7 +21,22 @@ resource "vercel_project" "this" {
 }
 
 locals {
-  environment_variable_group_names = nonsensitive(toset(keys(var.environment_variable_groups)))
+  environment_variables = flatten([
+    for _, variables in var.environment_variable_groups : [
+      for name, variable in variables : {
+        key       = coalesce(variable.key, name)
+        value     = variable.value
+        target    = variable.target
+        sensitive = variable.sensitive
+      }
+    ]
+  ])
+  environment_variable_identities = nonsensitive([
+    for variable in local.environment_variables : jsonencode({
+      key    = variable.key
+      target = sort(tolist(variable.target))
+    })
+  ])
 
   integration_ids = {
     neon    = "icfg_biMWLfepTR29FamF2JyDnPzV"
@@ -37,15 +52,20 @@ resource "vercel_integration_project_access" "this" {
 }
 
 resource "vercel_project_environment_variables" "this" {
-  for_each = local.environment_variable_group_names
-
   project_id = vercel_project.this.id
   variables = [
-    for name, variable in var.environment_variable_groups[each.key] : {
-      key       = coalesce(variable.key, name)
+    for variable in local.environment_variables : {
+      key       = variable.key
       value     = variable.value
       target    = variable.target
       sensitive = variable.sensitive
     }
   ]
+
+  lifecycle {
+    precondition {
+      condition     = length(local.environment_variable_identities) == length(distinct(local.environment_variable_identities))
+      error_message = "Environment variable key and target combinations must be unique across groups."
+    }
+  }
 }

--- a/terraform/modules/vercel_services/main.tf
+++ b/terraform/modules/vercel_services/main.tf
@@ -21,7 +21,7 @@ resource "vercel_project" "this" {
 }
 
 locals {
-  environment_variable_names = nonsensitive(toset(keys(var.environment_variables)))
+  environment_variable_group_names = nonsensitive(toset(keys(var.environment_variable_groups)))
 
   integration_ids = {
     neon    = "icfg_biMWLfepTR29FamF2JyDnPzV"
@@ -36,12 +36,16 @@ resource "vercel_integration_project_access" "this" {
   project_id     = vercel_project.this.id
 }
 
-resource "vercel_project_environment_variable" "this" {
-  for_each = local.environment_variable_names
+resource "vercel_project_environment_variables" "this" {
+  for_each = local.environment_variable_group_names
 
   project_id = vercel_project.this.id
-  key        = coalesce(var.environment_variables[each.key].key, each.key)
-  value      = var.environment_variables[each.key].value
-  target     = var.environment_variables[each.key].target
-  sensitive  = var.environment_variables[each.key].sensitive
+  variables = [
+    for name, variable in var.environment_variable_groups[each.key] : {
+      key       = coalesce(variable.key, name)
+      value     = variable.value
+      target    = variable.target
+      sensitive = variable.sensitive
+    }
+  ]
 }

--- a/terraform/modules/vercel_services/outputs.tf
+++ b/terraform/modules/vercel_services/outputs.tf
@@ -1,0 +1,9 @@
+output "project_id" {
+  description = "The ID of the Vercel Services project"
+  value       = vercel_project.this.id
+}
+
+output "project_name" {
+  description = "The name of the Vercel Services project"
+  value       = vercel_project.this.name
+}

--- a/terraform/modules/vercel_services/terraform.tf
+++ b/terraform/modules/vercel_services/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    vercel = {
+      source  = "vercel/vercel"
+      version = "~> 5.4"
+    }
+  }
+
+  required_version = ">= 1.2"
+}

--- a/terraform/modules/vercel_services/variables.tf
+++ b/terraform/modules/vercel_services/variables.tf
@@ -43,13 +43,13 @@ variable "enable_production_feedback" {
   default     = null
 }
 
-variable "environment_variables" {
-  description = "Environment variables exposed to the services in the project. The map key is used as the Vercel key unless key is set explicitly."
-  type = map(object({
+variable "environment_variable_groups" {
+  description = "Named groups of environment variables exposed to the services in the project. Variable map keys are used as Vercel keys unless key is set explicitly."
+  type = map(map(object({
     key       = optional(string)
     value     = string
     target    = optional(set(string), ["production", "preview"])
     sensitive = optional(bool, true)
-  }))
+  })))
   sensitive = true
 }

--- a/terraform/modules/vercel_services/variables.tf
+++ b/terraform/modules/vercel_services/variables.tf
@@ -1,0 +1,55 @@
+variable "name" {
+  description = "The Vercel Services project name"
+  type        = string
+}
+
+variable "git_repo" {
+  description = "Connected Git repository, e.g. \"polarsource/polar\""
+  type        = string
+}
+
+variable "production_branch" {
+  description = "Branch deployed to the project's production environment"
+  type        = string
+  default     = "main"
+}
+
+variable "build_machine_type" {
+  description = "Vercel build machine type"
+  type        = string
+  default     = "elastic"
+}
+
+variable "resource_config" {
+  description = "Vercel project resource configuration"
+  type = object({
+    fluid                     = optional(bool, true)
+    function_default_cpu_type = optional(string)
+    function_default_regions  = optional(set(string), ["iad1"])
+    function_default_timeout  = optional(number)
+  })
+  default = {}
+}
+
+variable "enable_preview_feedback" {
+  description = "Enable the Vercel Toolbar on preview deployments"
+  type        = bool
+  default     = null
+}
+
+variable "enable_production_feedback" {
+  description = "Enable the Vercel Toolbar on production deployments"
+  type        = bool
+  default     = null
+}
+
+variable "environment_variables" {
+  description = "Environment variables exposed to the services in the project. The map key is used as the Vercel key unless key is set explicitly."
+  type = map(object({
+    key       = optional(string)
+    value     = string
+    target    = optional(set(string), ["production", "preview"])
+    sensitive = optional(bool, true)
+  }))
+  sensitive = true
+}

--- a/terraform/modules/vercel_services/variables.tf
+++ b/terraform/modules/vercel_services/variables.tf
@@ -43,13 +43,13 @@ variable "enable_production_feedback" {
   default     = null
 }
 
-variable "environment_variable_groups" {
-  description = "Named groups of environment variables exposed to the services in the project. Variable map keys are used as Vercel keys unless key is set explicitly."
-  type = map(map(object({
+variable "environment_variables" {
+  description = "Environment variables exposed to the services in the project. The map key is used as the Vercel key unless key is set explicitly."
+  type = map(object({
     key       = optional(string)
     value     = string
     target    = optional(set(string), ["production", "preview"])
     sensitive = optional(bool, true)
-  })))
+  }))
   sensitive = true
 }

--- a/terraform/test/outputs.tf
+++ b/terraform/test/outputs.tf
@@ -7,3 +7,8 @@ output "redis_endpoint_service_name" {
   description = "VPC endpoint service name for the worker Redis. Provide to Render when creating the private link."
   value       = try(module.redis_private_link[0].service_name, null)
 }
+
+output "vercel_services_project_id" {
+  description = "Vercel project ID for the full-stack Services test deployment."
+  value       = module.vercel_services.project_id
+}

--- a/terraform/test/vercel-services.tf
+++ b/terraform/test/vercel-services.tf
@@ -5,7 +5,7 @@
 locals {
   # Vercel's Postgres and Redis integrations own POLAR_POSTGRES_URL_NON_POOLING
   # and POLAR_REDIS_URL. They are intentionally not duplicated here.
-  vercel_services_environment_variables = {
+  vercel_services_base_environment_variables = {
     SENTRY_ORG = {
       value     = "polar-sh"
       sensitive = false
@@ -305,9 +305,6 @@ locals {
     AWS_SECRET_ACCESS_KEY = {
       value = var.aws_secret_access_key
     }
-    POLAR_AWS_KMS_KEY_ID = {
-      value = one(module.secrets_kms[*].key_arn)
-    }
     POLAR_S3_FILES_BUCKET_NAME = {
       value     = local.files_bucket_name
       sensitive = false
@@ -409,6 +406,15 @@ locals {
       value = var.tinybird_workspace
     }
   }
+
+  vercel_services_environment_variables = merge(
+    local.vercel_services_base_environment_variables,
+    local.test_enabled ? {
+      POLAR_AWS_KMS_KEY_ID = {
+        value = module.secrets_kms[0].key_arn
+      }
+    } : {},
+  )
 }
 
 module "vercel_services" {
@@ -425,17 +431,21 @@ module "vercel_services" {
 }
 
 data "aws_iam_policy_document" "vercel_services_kms" {
+  count = local.test_enabled ? 1 : 0
+
   statement {
     actions = [
       "kms:GenerateDataKey",
       "kms:Decrypt",
     ]
-    resources = [one(module.secrets_kms[*].key_arn)]
+    resources = [module.secrets_kms[0].key_arn]
   }
 }
 
 resource "aws_iam_user_policy" "vercel_services_kms" {
+  count = local.test_enabled ? 1 : 0
+
   name   = "polar-test-vercel-services-kms"
   user   = "polar-test-files"
-  policy = data.aws_iam_policy_document.vercel_services_kms.json
+  policy = data.aws_iam_policy_document.vercel_services_kms[0].json
 }

--- a/terraform/test/vercel-services.tf
+++ b/terraform/test/vercel-services.tf
@@ -5,413 +5,439 @@
 locals {
   # Vercel's Postgres and Redis integrations own POLAR_POSTGRES_URL_NON_POOLING
   # and POLAR_REDIS_URL. They are intentionally not duplicated here.
-  vercel_services_base_environment_variables = {
-    SENTRY_ORG = {
-      value     = "polar-sh"
-      sensitive = false
-    }
-    SENTRY_PROJECT = {
-      value     = "dashboard"
-      sensitive = false
-    }
-    NEXT_PUBLIC_ENVIRONMENT = {
-      value     = "test"
-      sensitive = false
-    }
-    NEXT_PUBLIC_BACKOFFICE_URL = {
-      value     = "/api/backoffice"
-      sensitive = false
-    }
-    NEXT_PUBLIC_SANDBOX_FRONTEND_BASE_URL = {
-      value     = "https://sandbox.polar.sh"
-      sensitive = false
-    }
-    NEXT_PUBLIC_SENTRY_DSN = {
-      value     = var.next_public_sentry_dsn
-      sensitive = false
-    }
-    NEXT_PUBLIC_POSTHOG_TOKEN = {
-      value     = var.next_public_posthog_token
-      sensitive = false
-    }
-    NEXT_PUBLIC_APPLE_DOMAIN_ASSOCIATION = {
-      value     = var.next_public_apple_domain_association
-      sensitive = false
-    }
-    NEXT_PUBLIC_CHECKOUT_EMBED_SCRIPT_SRC = {
-      value     = "https://cdn.jsdelivr.net/npm/@polar-sh/checkout@0.1/dist/embed.global.js"
-      sensitive = false
-    }
-    NEXT_PUBLIC_STRIPE_PAYMENT_METHOD_CONFIGURATION = {
-      value     = var.next_public_stripe_payment_method_configuration
-      sensitive = false
-    }
-    NEXT_PUBLIC_TURNSTILE_SITE_KEY = {
-      value     = "1x00000000000000000000AA"
-      sensitive = false
-    }
-    next_public_stripe_key_production = {
-      key       = "NEXT_PUBLIC_STRIPE_KEY"
-      value     = var.stripe_publishable_key
-      target    = ["production"]
-      sensitive = false
-    }
-    next_public_stripe_key_preview = {
-      key       = "NEXT_PUBLIC_STRIPE_KEY"
-      value     = var.stripe_publishable_key_preview
-      target    = ["preview"]
-      sensitive = false
-    }
-    S3_PUBLIC_IMAGES_BUCKET_PROTOCOL = {
-      value     = "https"
-      sensitive = false
-    }
-    S3_PUBLIC_IMAGES_BUCKET_HOSTNAME = {
-      value     = "polar-test-public-files.s3.amazonaws.com"
-      sensitive = false
-    }
-    S3_PUBLIC_IMAGES_BUCKET_PATHNAME = {
-      value     = "/product_media/**"
-      sensitive = false
-    }
-    S3_UPLOAD_ORIGINS = {
-      value     = "https://polar-test-files.s3.amazonaws.com https://polar-test-files.s3.us-east-2.amazonaws.com https://polar-test-public-files.s3.amazonaws.com https://polar-test-public-files.s3.us-east-2.amazonaws.com"
-      sensitive = false
-    }
-    POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS = {
-      value     = "https://polar.sh,https://sandbox.polar.sh,https://test.polar.sh"
-      sensitive = false
-    }
-    POLAR_OPENAPI_SCHEMA_URL = {
-      value     = "https://api.polar.sh/openapi.json"
-      sensitive = false
-    }
-    ENABLE_EXPERIMENTAL_COREPACK = {
-      value     = "1"
-      sensitive = false
-    }
-    PYDANTIC_AI_GATEWAY_API_KEY = {
-      value = var.pydantic_ai_gateway_api_key
-    }
-    MINTLIFY_ASSISTANT_API_KEY = {
-      value = var.mintlify_assistant_api_key
-    }
-    GRAM_API_KEY = {
-      value = var.gram_api_key
-    }
-    SENTRY_AUTH_TOKEN = {
-      value = var.sentry_auth_token
-    }
-    POLAR_PREVIEW_ACCESS_TOKEN = {
-      value  = var.polar_preview_access_token
-      target = ["preview"]
-    }
-    MCP_OAUTH2_CLIENT_ID = {
-      value = var.mcp_oauth2_client_id
-    }
-    MCP_OAUTH2_CLIENT_SECRET = {
-      value = var.mcp_oauth2_client_secret
-    }
-    POLAR_ENV = {
-      value     = "test"
-      sensitive = false
-    }
-    POLAR_DEBUG = {
-      value     = "0"
-      sensitive = false
-    }
-    POLAR_TESTING = {
-      value     = "0"
-      sensitive = false
-    }
-    POLAR_LOG_LEVEL = {
-      value     = "INFO"
-      sensitive = false
-    }
-    POLAR_CORS_ORIGINS = {
-      value     = "[\"https://github.com\", \"https://docs.polar.sh\"]"
-      sensitive = false
-    }
-    POLAR_DATABASE_POOL_SIZE = {
-      value     = "5"
-      sensitive = false
-    }
-    POLAR_USER_SESSION_COOKIE_KEY = {
-      value     = "polar_test_session"
-      sensitive = false
-    }
-    POLAR_AUTH_COOKIE_KEY = {
-      value     = "polar_test_session"
-      sensitive = false
-    }
-    POLAR_EMAIL_SENDER = {
-      value     = "resend"
-      sensitive = false
-    }
-    POLAR_EMAIL_FROM_NAME = {
-      value     = "[TEST] Polar"
-      sensitive = false
-    }
-    POLAR_EMAIL_FROM_DOMAIN = {
-      value     = "notifications.test.polar.sh"
-      sensitive = false
-    }
-    POLAR_JWKS = {
-      value = var.backend_jwks
-    }
-    POLAR_CURRENT_JWK_KID = {
-      value = var.backend_current_jwk_kid
-    }
-    POLAR_SECRET = {
-      value = var.backend_secret
-    }
-    POLAR_SENTRY_DSN = {
-      value = var.backend_sentry_dsn
-    }
-    POLAR_TAX_PROCESSORS = {
-      value     = "[\"numeral\",\"stripe\"]"
-      sensitive = false
-    }
-    POLAR_TAX_RECORD_PROCESSOR = {
-      value     = "numeral"
-      sensitive = false
-    }
-    POLAR_CUSTOMER_PORTAL_URL_OVERRIDES = {
-      value     = var.customer_portal_url_overrides
-      sensitive = false
-    }
-    POLAR_PLAIN_DEFAULT_TIER_EXTERNAL_ID = {
-      value     = var.plain_default_tier_external_id
-      sensitive = false
-    }
-    POLAR_TURNSTILE_SECRET = {
-      value = "1x0000000000000000000000000000000AA"
-    }
-    POLAR_FIRECRAWL_API_KEY = {
-      value = var.firecrawl_api_key
-    }
-    POLAR_LOGO_DEV_PUBLISHABLE_KEY = {
-      value     = var.backend_logo_dev_publishable_key
-      sensitive = false
-    }
-    POLAR_DISCORD_BOT_TOKEN = {
-      value = var.backend_discord_bot_token
-    }
-    POLAR_DISCORD_CLIENT_ID = {
-      value = var.backend_discord_client_id
-    }
-    POLAR_DISCORD_CLIENT_SECRET = {
-      value = var.backend_discord_client_secret
-    }
-    POLAR_DISCORD_PROXY_URL = {
-      value = var.backend_discord_proxy_url
-    }
-    POLAR_RESEND_API_KEY = {
-      value = var.backend_resend_api_key
-    }
-    POLAR_RESEND_WEBHOOK_SECRET = {
-      value = var.backend_resend_webhook_secret
-    }
-    POLAR_NUMERAL_API_KEY = {
-      value = var.numeral_api_key
-    }
-    POLAR_GOOGLE_CLIENT_ID = {
-      value = var.google_client_id
-    }
-    POLAR_GOOGLE_CLIENT_SECRET = {
-      value = var.google_client_secret
-    }
-    POLAR_GOOGLE_SERVICE_ACCOUNT_JSON = {
-      value = var.google_service_account_json
-    }
-    POLAR_OPENAI_API_KEY = {
-      value = var.openai_api_key
-    }
-    POLAR_PYDANTIC_AI_GATEWAY_API_KEY = {
-      value = var.pydantic_ai_gateway_api_key
-    }
-    POLAR_GITHUB_CLIENT_ID = {
-      value = var.github_client_id
-    }
-    POLAR_GITHUB_CLIENT_SECRET = {
-      value = var.github_client_secret
-    }
-    POLAR_GITHUB_REPOSITORY_BENEFITS_APP_IDENTIFIER = {
-      value = var.github_repository_benefits_app_identifier
-    }
-    POLAR_GITHUB_REPOSITORY_BENEFITS_APP_NAMESPACE = {
-      value = var.github_repository_benefits_app_namespace
-    }
-    POLAR_GITHUB_REPOSITORY_BENEFITS_APP_PRIVATE_KEY = {
-      value = var.github_repository_benefits_app_private_key
-    }
-    POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_ID = {
-      value = var.github_repository_benefits_client_id
-    }
-    POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_SECRET = {
-      value = var.github_repository_benefits_client_secret
-    }
-    POLAR_STRIPE_PUBLISHABLE_KEY = {
-      value     = var.stripe_publishable_key
-      sensitive = false
-    }
-    POLAR_STRIPE_CONNECT_WEBHOOK_SECRET = {
-      value = var.stripe_connect_webhook_secret
-    }
-    POLAR_STRIPE_SECRET_KEY = {
-      value = var.stripe_secret_key
-    }
-    POLAR_STRIPE_WEBHOOK_SECRET = {
-      value = var.stripe_webhook_secret
-    }
-    POLAR_STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET = {
-      value = var.stripe_account_risk_webhook_secret
-    }
-    POLAR_STRIPE_APP_CLIENT_ID = {
-      value = var.stripe_app_client_id
-    }
-    POLAR_STRIPE_APP_CLIENT_LINK_ID = {
-      value = var.stripe_app_client_link_id
-    }
-    POLAR_APPLE_CLIENT_ID = {
-      value = var.apple_client_id
-    }
-    POLAR_APPLE_TEAM_ID = {
-      value = var.apple_team_id
-    }
-    POLAR_APPLE_KEY_ID = {
-      value = var.apple_key_id
-    }
-    POLAR_APPLE_KEY_VALUE = {
-      value = var.apple_key_value
-    }
-    POLAR_AWS_REGION = {
-      value     = "us-east-2"
-      sensitive = false
-    }
-    POLAR_AWS_SIGNATURE_VERSION = {
-      value     = "v4"
-      sensitive = false
-    }
-    POLAR_AWS_ACCESS_KEY_ID = {
-      value = var.aws_access_key_id
-    }
-    POLAR_AWS_SECRET_ACCESS_KEY = {
-      value = var.aws_secret_access_key
-    }
-    AWS_ACCESS_KEY_ID = {
-      value = var.aws_access_key_id
-    }
-    AWS_SECRET_ACCESS_KEY = {
-      value = var.aws_secret_access_key
-    }
-    POLAR_S3_FILES_BUCKET_NAME = {
-      value     = local.files_bucket_name
-      sensitive = false
-    }
-    POLAR_S3_FILES_PRESIGN_TTL = {
-      value     = "600"
-      sensitive = false
-    }
-    POLAR_S3_FILES_PUBLIC_BUCKET_NAME = {
-      value     = local.files_public_bucket_name
-      sensitive = false
-    }
-    POLAR_S3_CUSTOMER_INVOICES_BUCKET_NAME = {
-      value     = "polar-test-customer-invoices"
-      sensitive = false
-    }
-    POLAR_S3_CUSTOMER_RECEIPTS_BUCKET_NAME = {
-      value     = "polar-test-customer-receipts"
-      sensitive = false
-    }
-    POLAR_S3_PAYOUT_INVOICES_BUCKET_NAME = {
-      value     = "polar-test-payout-invoices"
-      sensitive = false
-    }
-    POLAR_S3_LOGS_BUCKET_NAME = {
-      value     = "polar-test-logs"
-      sensitive = false
-    }
-    POLAR_S3_FILES_DOWNLOAD_SALT = {
-      value = var.s3_files_download_salt
-    }
-    POLAR_S3_FILES_DOWNLOAD_SECRET = {
-      value = var.s3_files_download_secret
-    }
-    POLAR_LOGFIRE_PROJECT_NAME = {
-      value     = "polar"
-      sensitive = false
-    }
-    POLAR_LOGFIRE_TOKEN = {
-      value = var.logfire_token
-    }
-    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_URL = {
-      value     = "${var.grafana_cloud_prometheus_url}/api/prom/push"
-      sensitive = false
-    }
-    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_USERNAME = {
-      value = var.grafana_cloud_prometheus_username
-    }
-    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_PASSWORD = {
-      value = var.grafana_cloud_prometheus_password
-    }
-    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_INTERVAL = {
-      value     = "60"
-      sensitive = false
-    }
-    POLAR_POLAR_ACCESS_TOKEN = {
-      value = var.polar_access_token
-    }
-    POLAR_POLAR_WEBHOOK_SECRET = {
-      value = var.polar_webhook_secret
-    }
-    POLAR_POLAR_ORGANIZATION_ID = {
-      value     = var.polar_organization_id
-      sensitive = false
-    }
-    POLAR_POLAR_FREE_PRODUCT_ID = {
-      value     = var.polar_free_product_id
-      sensitive = false
-    }
-    POLAR_POLAR_SCALE_PRODUCT_ID = {
-      value     = var.polar_scale_product_id
-      sensitive = false
-    }
-    POLAR_POLAR_API_URL = {
-      value     = "https://test-api.polar.sh"
-      sensitive = false
-    }
-    POLAR_TINYBIRD_API_URL = {
-      value     = "https://api.us-east.aws.tinybird.co"
-      sensitive = false
-    }
-    POLAR_TINYBIRD_CLICKHOUSE_URL = {
-      value     = "https://clickhouse.us-east.aws.tinybird.co"
-      sensitive = false
-    }
-    POLAR_TINYBIRD_API_TOKEN = {
-      value = var.tinybird_api_token
-    }
-    POLAR_TINYBIRD_READ_TOKEN = {
-      value = var.tinybird_read_token
-    }
-    POLAR_TINYBIRD_CLICKHOUSE_USERNAME = {
-      value = var.tinybird_clickhouse_username
-    }
-    POLAR_TINYBIRD_CLICKHOUSE_TOKEN = {
-      value = var.tinybird_clickhouse_token
-    }
-    POLAR_TINYBIRD_WORKSPACE = {
-      value = var.tinybird_workspace
+  vercel_services_base_environment_variable_groups = {
+    frontend_build = {
+      SENTRY_ORG = {
+        value     = "polar-sh"
+        sensitive = false
+      }
+      SENTRY_PROJECT = {
+        value     = "dashboard"
+        sensitive = false
+      }
+      NEXT_PUBLIC_ENVIRONMENT = {
+        value     = "test"
+        sensitive = false
+      }
+      NEXT_PUBLIC_BACKOFFICE_URL = {
+        value     = "/api/backoffice"
+        sensitive = false
+      }
+      NEXT_PUBLIC_SANDBOX_FRONTEND_BASE_URL = {
+        value     = "https://sandbox.polar.sh"
+        sensitive = false
+      }
+      NEXT_PUBLIC_SENTRY_DSN = {
+        value     = var.next_public_sentry_dsn
+        sensitive = false
+      }
+      NEXT_PUBLIC_POSTHOG_TOKEN = {
+        value     = var.next_public_posthog_token
+        sensitive = false
+      }
+      NEXT_PUBLIC_APPLE_DOMAIN_ASSOCIATION = {
+        value     = var.next_public_apple_domain_association
+        sensitive = false
+      }
+      NEXT_PUBLIC_CHECKOUT_EMBED_SCRIPT_SRC = {
+        value     = "https://cdn.jsdelivr.net/npm/@polar-sh/checkout@0.1/dist/embed.global.js"
+        sensitive = false
+      }
+      NEXT_PUBLIC_STRIPE_PAYMENT_METHOD_CONFIGURATION = {
+        value     = var.next_public_stripe_payment_method_configuration
+        sensitive = false
+      }
+      NEXT_PUBLIC_TURNSTILE_SITE_KEY = {
+        value     = "1x00000000000000000000AA"
+        sensitive = false
+      }
+      next_public_stripe_key_production = {
+        key       = "NEXT_PUBLIC_STRIPE_KEY"
+        value     = var.stripe_publishable_key
+        target    = ["production"]
+        sensitive = false
+      }
+      next_public_stripe_key_preview = {
+        key       = "NEXT_PUBLIC_STRIPE_KEY"
+        value     = var.stripe_publishable_key_preview
+        target    = ["preview"]
+        sensitive = false
+      }
+      S3_PUBLIC_IMAGES_BUCKET_PROTOCOL = {
+        value     = "https"
+        sensitive = false
+      }
+      S3_PUBLIC_IMAGES_BUCKET_HOSTNAME = {
+        value     = "polar-test-public-files.s3.amazonaws.com"
+        sensitive = false
+      }
+      S3_PUBLIC_IMAGES_BUCKET_PATHNAME = {
+        value     = "/product_media/**"
+        sensitive = false
+      }
+      S3_UPLOAD_ORIGINS = {
+        value     = "https://polar-test-files.s3.amazonaws.com https://polar-test-files.s3.us-east-2.amazonaws.com https://polar-test-public-files.s3.amazonaws.com https://polar-test-public-files.s3.us-east-2.amazonaws.com"
+        sensitive = false
+      }
+      POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS = {
+        value     = "https://polar.sh,https://sandbox.polar.sh,https://test.polar.sh"
+        sensitive = false
+      }
+      POLAR_OPENAPI_SCHEMA_URL = {
+        value     = "https://api.polar.sh/openapi.json"
+        sensitive = false
+      }
+      ENABLE_EXPERIMENTAL_COREPACK = {
+        value     = "1"
+        sensitive = false
+      }
+      PYDANTIC_AI_GATEWAY_API_KEY = {
+        value = var.pydantic_ai_gateway_api_key
+      }
+      MINTLIFY_ASSISTANT_API_KEY = {
+        value = var.mintlify_assistant_api_key
+      }
+      GRAM_API_KEY = {
+        value = var.gram_api_key
+      }
+      SENTRY_AUTH_TOKEN = {
+        value = var.sentry_auth_token
+      }
+      POLAR_PREVIEW_ACCESS_TOKEN = {
+        value  = var.polar_preview_access_token
+        target = ["preview"]
+      }
+    }
+    mcp = {
+      MCP_OAUTH2_CLIENT_ID = {
+        value = var.mcp_oauth2_client_id
+      }
+      MCP_OAUTH2_CLIENT_SECRET = {
+        value = var.mcp_oauth2_client_secret
+      }
+    }
+    backend = {
+      POLAR_ENV = {
+        value     = "test"
+        sensitive = false
+      }
+      POLAR_DEBUG = {
+        value     = "0"
+        sensitive = false
+      }
+      POLAR_TESTING = {
+        value     = "0"
+        sensitive = false
+      }
+      POLAR_LOG_LEVEL = {
+        value     = "INFO"
+        sensitive = false
+      }
+      POLAR_CORS_ORIGINS = {
+        value     = "[\"https://github.com\", \"https://docs.polar.sh\"]"
+        sensitive = false
+      }
+      POLAR_DATABASE_POOL_SIZE = {
+        value     = "5"
+        sensitive = false
+      }
+      POLAR_USER_SESSION_COOKIE_KEY = {
+        value     = "polar_test_session"
+        sensitive = false
+      }
+      POLAR_AUTH_COOKIE_KEY = {
+        value     = "polar_test_session"
+        sensitive = false
+      }
+      POLAR_EMAIL_SENDER = {
+        value     = "resend"
+        sensitive = false
+      }
+      POLAR_EMAIL_FROM_NAME = {
+        value     = "[TEST] Polar"
+        sensitive = false
+      }
+      POLAR_EMAIL_FROM_DOMAIN = {
+        value     = "notifications.test.polar.sh"
+        sensitive = false
+      }
+      POLAR_JWKS = {
+        value = var.backend_jwks
+      }
+      POLAR_CURRENT_JWK_KID = {
+        value = var.backend_current_jwk_kid
+      }
+      POLAR_SECRET = {
+        value = var.backend_secret
+      }
+      POLAR_SENTRY_DSN = {
+        value = var.backend_sentry_dsn
+      }
+      POLAR_TAX_PROCESSORS = {
+        value     = "[\"numeral\",\"stripe\"]"
+        sensitive = false
+      }
+      POLAR_TAX_RECORD_PROCESSOR = {
+        value     = "numeral"
+        sensitive = false
+      }
+      POLAR_CUSTOMER_PORTAL_URL_OVERRIDES = {
+        value     = var.customer_portal_url_overrides
+        sensitive = false
+      }
+      POLAR_PLAIN_DEFAULT_TIER_EXTERNAL_ID = {
+        value     = var.plain_default_tier_external_id
+        sensitive = false
+      }
+      POLAR_TURNSTILE_SECRET = {
+        value = "1x0000000000000000000000000000000AA"
+      }
+      POLAR_FIRECRAWL_API_KEY = {
+        value = var.firecrawl_api_key
+      }
+      POLAR_LOGO_DEV_PUBLISHABLE_KEY = {
+        value     = var.backend_logo_dev_publishable_key
+        sensitive = false
+      }
+      POLAR_DISCORD_BOT_TOKEN = {
+        value = var.backend_discord_bot_token
+      }
+      POLAR_DISCORD_CLIENT_ID = {
+        value = var.backend_discord_client_id
+      }
+      POLAR_DISCORD_CLIENT_SECRET = {
+        value = var.backend_discord_client_secret
+      }
+      POLAR_DISCORD_PROXY_URL = {
+        value = var.backend_discord_proxy_url
+      }
+      POLAR_RESEND_API_KEY = {
+        value = var.backend_resend_api_key
+      }
+      POLAR_RESEND_WEBHOOK_SECRET = {
+        value = var.backend_resend_webhook_secret
+      }
+      POLAR_NUMERAL_API_KEY = {
+        value = var.numeral_api_key
+      }
+    }
+    google = {
+      POLAR_GOOGLE_CLIENT_ID = {
+        value = var.google_client_id
+      }
+      POLAR_GOOGLE_CLIENT_SECRET = {
+        value = var.google_client_secret
+      }
+      POLAR_GOOGLE_SERVICE_ACCOUNT_JSON = {
+        value = var.google_service_account_json
+      }
+    }
+    ai = {
+      POLAR_OPENAI_API_KEY = {
+        value = var.openai_api_key
+      }
+      POLAR_PYDANTIC_AI_GATEWAY_API_KEY = {
+        value = var.pydantic_ai_gateway_api_key
+      }
+    }
+    github = {
+      POLAR_GITHUB_CLIENT_ID = {
+        value = var.github_client_id
+      }
+      POLAR_GITHUB_CLIENT_SECRET = {
+        value = var.github_client_secret
+      }
+      POLAR_GITHUB_REPOSITORY_BENEFITS_APP_IDENTIFIER = {
+        value = var.github_repository_benefits_app_identifier
+      }
+      POLAR_GITHUB_REPOSITORY_BENEFITS_APP_NAMESPACE = {
+        value = var.github_repository_benefits_app_namespace
+      }
+      POLAR_GITHUB_REPOSITORY_BENEFITS_APP_PRIVATE_KEY = {
+        value = var.github_repository_benefits_app_private_key
+      }
+      POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_ID = {
+        value = var.github_repository_benefits_client_id
+      }
+      POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_SECRET = {
+        value = var.github_repository_benefits_client_secret
+      }
+    }
+    stripe = {
+      POLAR_STRIPE_PUBLISHABLE_KEY = {
+        value     = var.stripe_publishable_key
+        sensitive = false
+      }
+      POLAR_STRIPE_CONNECT_WEBHOOK_SECRET = {
+        value = var.stripe_connect_webhook_secret
+      }
+      POLAR_STRIPE_SECRET_KEY = {
+        value = var.stripe_secret_key
+      }
+      POLAR_STRIPE_WEBHOOK_SECRET = {
+        value = var.stripe_webhook_secret
+      }
+      POLAR_STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET = {
+        value = var.stripe_account_risk_webhook_secret
+      }
+      POLAR_STRIPE_APP_CLIENT_ID = {
+        value = var.stripe_app_client_id
+      }
+      POLAR_STRIPE_APP_CLIENT_LINK_ID = {
+        value = var.stripe_app_client_link_id
+      }
+    }
+    apple = {
+      POLAR_APPLE_CLIENT_ID = {
+        value = var.apple_client_id
+      }
+      POLAR_APPLE_TEAM_ID = {
+        value = var.apple_team_id
+      }
+      POLAR_APPLE_KEY_ID = {
+        value = var.apple_key_id
+      }
+      POLAR_APPLE_KEY_VALUE = {
+        value = var.apple_key_value
+      }
+    }
+    aws_s3 = {
+      POLAR_AWS_REGION = {
+        value     = "us-east-2"
+        sensitive = false
+      }
+      POLAR_AWS_SIGNATURE_VERSION = {
+        value     = "v4"
+        sensitive = false
+      }
+      POLAR_AWS_ACCESS_KEY_ID = {
+        value = var.aws_access_key_id
+      }
+      POLAR_AWS_SECRET_ACCESS_KEY = {
+        value = var.aws_secret_access_key
+      }
+      AWS_ACCESS_KEY_ID = {
+        value = var.aws_access_key_id
+      }
+      AWS_SECRET_ACCESS_KEY = {
+        value = var.aws_secret_access_key
+      }
+      POLAR_S3_FILES_BUCKET_NAME = {
+        value     = local.files_bucket_name
+        sensitive = false
+      }
+      POLAR_S3_FILES_PRESIGN_TTL = {
+        value     = "600"
+        sensitive = false
+      }
+      POLAR_S3_FILES_PUBLIC_BUCKET_NAME = {
+        value     = local.files_public_bucket_name
+        sensitive = false
+      }
+      POLAR_S3_CUSTOMER_INVOICES_BUCKET_NAME = {
+        value     = "polar-test-customer-invoices"
+        sensitive = false
+      }
+      POLAR_S3_CUSTOMER_RECEIPTS_BUCKET_NAME = {
+        value     = "polar-test-customer-receipts"
+        sensitive = false
+      }
+      POLAR_S3_PAYOUT_INVOICES_BUCKET_NAME = {
+        value     = "polar-test-payout-invoices"
+        sensitive = false
+      }
+      POLAR_S3_LOGS_BUCKET_NAME = {
+        value     = "polar-test-logs"
+        sensitive = false
+      }
+      POLAR_S3_FILES_DOWNLOAD_SALT = {
+        value = var.s3_files_download_salt
+      }
+      POLAR_S3_FILES_DOWNLOAD_SECRET = {
+        value = var.s3_files_download_secret
+      }
+    }
+    observability = {
+      POLAR_LOGFIRE_PROJECT_NAME = {
+        value     = "polar"
+        sensitive = false
+      }
+      POLAR_LOGFIRE_TOKEN = {
+        value = var.logfire_token
+      }
+      POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_URL = {
+        value     = "${var.grafana_cloud_prometheus_url}/api/prom/push"
+        sensitive = false
+      }
+      POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_USERNAME = {
+        value = var.grafana_cloud_prometheus_username
+      }
+      POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_PASSWORD = {
+        value = var.grafana_cloud_prometheus_password
+      }
+      POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_INTERVAL = {
+        value     = "60"
+        sensitive = false
+      }
+    }
+    polar_self = {
+      POLAR_POLAR_ACCESS_TOKEN = {
+        value = var.polar_access_token
+      }
+      POLAR_POLAR_WEBHOOK_SECRET = {
+        value = var.polar_webhook_secret
+      }
+      POLAR_POLAR_ORGANIZATION_ID = {
+        value     = var.polar_organization_id
+        sensitive = false
+      }
+      POLAR_POLAR_FREE_PRODUCT_ID = {
+        value     = var.polar_free_product_id
+        sensitive = false
+      }
+      POLAR_POLAR_SCALE_PRODUCT_ID = {
+        value     = var.polar_scale_product_id
+        sensitive = false
+      }
+      POLAR_POLAR_API_URL = {
+        value     = "https://test-api.polar.sh"
+        sensitive = false
+      }
+    }
+    tinybird = {
+      POLAR_TINYBIRD_API_URL = {
+        value     = "https://api.us-east.aws.tinybird.co"
+        sensitive = false
+      }
+      POLAR_TINYBIRD_CLICKHOUSE_URL = {
+        value     = "https://clickhouse.us-east.aws.tinybird.co"
+        sensitive = false
+      }
+      POLAR_TINYBIRD_API_TOKEN = {
+        value = var.tinybird_api_token
+      }
+      POLAR_TINYBIRD_READ_TOKEN = {
+        value = var.tinybird_read_token
+      }
+      POLAR_TINYBIRD_CLICKHOUSE_USERNAME = {
+        value = var.tinybird_clickhouse_username
+      }
+      POLAR_TINYBIRD_CLICKHOUSE_TOKEN = {
+        value = var.tinybird_clickhouse_token
+      }
+      POLAR_TINYBIRD_WORKSPACE = {
+        value = var.tinybird_workspace
+      }
     }
   }
 
-  vercel_services_environment_variables = merge(
-    local.vercel_services_base_environment_variables,
+  vercel_services_environment_variable_groups = merge(
+    local.vercel_services_base_environment_variable_groups,
     local.test_enabled ? {
-      POLAR_AWS_KMS_KEY_ID = {
-        value = module.secrets_kms[0].key_arn
+      secrets_kms = {
+        POLAR_AWS_KMS_KEY_ID = {
+          value = module.secrets_kms[0].key_arn
+        }
       }
     } : {},
   )
@@ -427,7 +453,7 @@ module "vercel_services" {
     function_default_regions = ["cle1"]
   }
 
-  environment_variables = local.vercel_services_environment_variables
+  environment_variable_groups = local.vercel_services_environment_variable_groups
 }
 
 data "aws_iam_policy_document" "vercel_services_kms" {

--- a/terraform/test/vercel-services.tf
+++ b/terraform/test/vercel-services.tf
@@ -1,0 +1,441 @@
+# =============================================================================
+# Vercel Services — full-stack test deployment
+# =============================================================================
+
+locals {
+  # Vercel's Postgres and Redis integrations own POLAR_POSTGRES_URL_NON_POOLING
+  # and POLAR_REDIS_URL. They are intentionally not duplicated here.
+  vercel_services_environment_variables = {
+    SENTRY_ORG = {
+      value     = "polar-sh"
+      sensitive = false
+    }
+    SENTRY_PROJECT = {
+      value     = "dashboard"
+      sensitive = false
+    }
+    NEXT_PUBLIC_ENVIRONMENT = {
+      value     = "test"
+      sensitive = false
+    }
+    NEXT_PUBLIC_BACKOFFICE_URL = {
+      value     = "/api/backoffice"
+      sensitive = false
+    }
+    NEXT_PUBLIC_SANDBOX_FRONTEND_BASE_URL = {
+      value     = "https://sandbox.polar.sh"
+      sensitive = false
+    }
+    NEXT_PUBLIC_SENTRY_DSN = {
+      value     = var.next_public_sentry_dsn
+      sensitive = false
+    }
+    NEXT_PUBLIC_POSTHOG_TOKEN = {
+      value     = var.next_public_posthog_token
+      sensitive = false
+    }
+    NEXT_PUBLIC_APPLE_DOMAIN_ASSOCIATION = {
+      value     = var.next_public_apple_domain_association
+      sensitive = false
+    }
+    NEXT_PUBLIC_CHECKOUT_EMBED_SCRIPT_SRC = {
+      value     = "https://cdn.jsdelivr.net/npm/@polar-sh/checkout@0.1/dist/embed.global.js"
+      sensitive = false
+    }
+    NEXT_PUBLIC_STRIPE_PAYMENT_METHOD_CONFIGURATION = {
+      value     = var.next_public_stripe_payment_method_configuration
+      sensitive = false
+    }
+    NEXT_PUBLIC_TURNSTILE_SITE_KEY = {
+      value     = "1x00000000000000000000AA"
+      sensitive = false
+    }
+    next_public_stripe_key_production = {
+      key       = "NEXT_PUBLIC_STRIPE_KEY"
+      value     = var.stripe_publishable_key
+      target    = ["production"]
+      sensitive = false
+    }
+    next_public_stripe_key_preview = {
+      key       = "NEXT_PUBLIC_STRIPE_KEY"
+      value     = var.stripe_publishable_key_preview
+      target    = ["preview"]
+      sensitive = false
+    }
+    S3_PUBLIC_IMAGES_BUCKET_PROTOCOL = {
+      value     = "https"
+      sensitive = false
+    }
+    S3_PUBLIC_IMAGES_BUCKET_HOSTNAME = {
+      value     = "polar-test-public-files.s3.amazonaws.com"
+      sensitive = false
+    }
+    S3_PUBLIC_IMAGES_BUCKET_PATHNAME = {
+      value     = "/product_media/**"
+      sensitive = false
+    }
+    S3_UPLOAD_ORIGINS = {
+      value     = "https://polar-test-files.s3.amazonaws.com https://polar-test-files.s3.us-east-2.amazonaws.com https://polar-test-public-files.s3.amazonaws.com https://polar-test-public-files.s3.us-east-2.amazonaws.com"
+      sensitive = false
+    }
+    POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS = {
+      value     = "https://polar.sh,https://sandbox.polar.sh,https://test.polar.sh"
+      sensitive = false
+    }
+    POLAR_OPENAPI_SCHEMA_URL = {
+      value     = "https://api.polar.sh/openapi.json"
+      sensitive = false
+    }
+    ENABLE_EXPERIMENTAL_COREPACK = {
+      value     = "1"
+      sensitive = false
+    }
+    PYDANTIC_AI_GATEWAY_API_KEY = {
+      value = var.pydantic_ai_gateway_api_key
+    }
+    MINTLIFY_ASSISTANT_API_KEY = {
+      value = var.mintlify_assistant_api_key
+    }
+    GRAM_API_KEY = {
+      value = var.gram_api_key
+    }
+    SENTRY_AUTH_TOKEN = {
+      value = var.sentry_auth_token
+    }
+    POLAR_PREVIEW_ACCESS_TOKEN = {
+      value  = var.polar_preview_access_token
+      target = ["preview"]
+    }
+    MCP_OAUTH2_CLIENT_ID = {
+      value = var.mcp_oauth2_client_id
+    }
+    MCP_OAUTH2_CLIENT_SECRET = {
+      value = var.mcp_oauth2_client_secret
+    }
+    POLAR_ENV = {
+      value     = "test"
+      sensitive = false
+    }
+    POLAR_DEBUG = {
+      value     = "0"
+      sensitive = false
+    }
+    POLAR_TESTING = {
+      value     = "0"
+      sensitive = false
+    }
+    POLAR_LOG_LEVEL = {
+      value     = "INFO"
+      sensitive = false
+    }
+    POLAR_CORS_ORIGINS = {
+      value     = "[\"https://github.com\", \"https://docs.polar.sh\"]"
+      sensitive = false
+    }
+    POLAR_DATABASE_POOL_SIZE = {
+      value     = "5"
+      sensitive = false
+    }
+    POLAR_USER_SESSION_COOKIE_KEY = {
+      value     = "polar_test_session"
+      sensitive = false
+    }
+    POLAR_AUTH_COOKIE_KEY = {
+      value     = "polar_test_session"
+      sensitive = false
+    }
+    POLAR_EMAIL_SENDER = {
+      value     = "resend"
+      sensitive = false
+    }
+    POLAR_EMAIL_FROM_NAME = {
+      value     = "[TEST] Polar"
+      sensitive = false
+    }
+    POLAR_EMAIL_FROM_DOMAIN = {
+      value     = "notifications.test.polar.sh"
+      sensitive = false
+    }
+    POLAR_JWKS = {
+      value = var.backend_jwks
+    }
+    POLAR_CURRENT_JWK_KID = {
+      value = var.backend_current_jwk_kid
+    }
+    POLAR_SECRET = {
+      value = var.backend_secret
+    }
+    POLAR_SENTRY_DSN = {
+      value = var.backend_sentry_dsn
+    }
+    POLAR_TAX_PROCESSORS = {
+      value     = "[\"numeral\",\"stripe\"]"
+      sensitive = false
+    }
+    POLAR_TAX_RECORD_PROCESSOR = {
+      value     = "numeral"
+      sensitive = false
+    }
+    POLAR_CUSTOMER_PORTAL_URL_OVERRIDES = {
+      value     = var.customer_portal_url_overrides
+      sensitive = false
+    }
+    POLAR_PLAIN_DEFAULT_TIER_EXTERNAL_ID = {
+      value     = var.plain_default_tier_external_id
+      sensitive = false
+    }
+    POLAR_TURNSTILE_SECRET = {
+      value = "1x0000000000000000000000000000000AA"
+    }
+    POLAR_FIRECRAWL_API_KEY = {
+      value = var.firecrawl_api_key
+    }
+    POLAR_LOGO_DEV_PUBLISHABLE_KEY = {
+      value     = var.backend_logo_dev_publishable_key
+      sensitive = false
+    }
+    POLAR_DISCORD_BOT_TOKEN = {
+      value = var.backend_discord_bot_token
+    }
+    POLAR_DISCORD_CLIENT_ID = {
+      value = var.backend_discord_client_id
+    }
+    POLAR_DISCORD_CLIENT_SECRET = {
+      value = var.backend_discord_client_secret
+    }
+    POLAR_DISCORD_PROXY_URL = {
+      value = var.backend_discord_proxy_url
+    }
+    POLAR_RESEND_API_KEY = {
+      value = var.backend_resend_api_key
+    }
+    POLAR_RESEND_WEBHOOK_SECRET = {
+      value = var.backend_resend_webhook_secret
+    }
+    POLAR_NUMERAL_API_KEY = {
+      value = var.numeral_api_key
+    }
+    POLAR_GOOGLE_CLIENT_ID = {
+      value = var.google_client_id
+    }
+    POLAR_GOOGLE_CLIENT_SECRET = {
+      value = var.google_client_secret
+    }
+    POLAR_GOOGLE_SERVICE_ACCOUNT_JSON = {
+      value = var.google_service_account_json
+    }
+    POLAR_OPENAI_API_KEY = {
+      value = var.openai_api_key
+    }
+    POLAR_PYDANTIC_AI_GATEWAY_API_KEY = {
+      value = var.pydantic_ai_gateway_api_key
+    }
+    POLAR_GITHUB_CLIENT_ID = {
+      value = var.github_client_id
+    }
+    POLAR_GITHUB_CLIENT_SECRET = {
+      value = var.github_client_secret
+    }
+    POLAR_GITHUB_REPOSITORY_BENEFITS_APP_IDENTIFIER = {
+      value = var.github_repository_benefits_app_identifier
+    }
+    POLAR_GITHUB_REPOSITORY_BENEFITS_APP_NAMESPACE = {
+      value = var.github_repository_benefits_app_namespace
+    }
+    POLAR_GITHUB_REPOSITORY_BENEFITS_APP_PRIVATE_KEY = {
+      value = var.github_repository_benefits_app_private_key
+    }
+    POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_ID = {
+      value = var.github_repository_benefits_client_id
+    }
+    POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_SECRET = {
+      value = var.github_repository_benefits_client_secret
+    }
+    POLAR_STRIPE_PUBLISHABLE_KEY = {
+      value     = var.stripe_publishable_key
+      sensitive = false
+    }
+    POLAR_STRIPE_CONNECT_WEBHOOK_SECRET = {
+      value = var.stripe_connect_webhook_secret
+    }
+    POLAR_STRIPE_SECRET_KEY = {
+      value = var.stripe_secret_key
+    }
+    POLAR_STRIPE_WEBHOOK_SECRET = {
+      value = var.stripe_webhook_secret
+    }
+    POLAR_STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET = {
+      value = var.stripe_account_risk_webhook_secret
+    }
+    POLAR_STRIPE_APP_CLIENT_ID = {
+      value = var.stripe_app_client_id
+    }
+    POLAR_STRIPE_APP_CLIENT_LINK_ID = {
+      value = var.stripe_app_client_link_id
+    }
+    POLAR_APPLE_CLIENT_ID = {
+      value = var.apple_client_id
+    }
+    POLAR_APPLE_TEAM_ID = {
+      value = var.apple_team_id
+    }
+    POLAR_APPLE_KEY_ID = {
+      value = var.apple_key_id
+    }
+    POLAR_APPLE_KEY_VALUE = {
+      value = var.apple_key_value
+    }
+    POLAR_AWS_REGION = {
+      value     = "us-east-2"
+      sensitive = false
+    }
+    POLAR_AWS_SIGNATURE_VERSION = {
+      value     = "v4"
+      sensitive = false
+    }
+    POLAR_AWS_ACCESS_KEY_ID = {
+      value = var.aws_access_key_id
+    }
+    POLAR_AWS_SECRET_ACCESS_KEY = {
+      value = var.aws_secret_access_key
+    }
+    AWS_ACCESS_KEY_ID = {
+      value = var.aws_access_key_id
+    }
+    AWS_SECRET_ACCESS_KEY = {
+      value = var.aws_secret_access_key
+    }
+    POLAR_AWS_KMS_KEY_ID = {
+      value = one(module.secrets_kms[*].key_arn)
+    }
+    POLAR_S3_FILES_BUCKET_NAME = {
+      value     = local.files_bucket_name
+      sensitive = false
+    }
+    POLAR_S3_FILES_PRESIGN_TTL = {
+      value     = "600"
+      sensitive = false
+    }
+    POLAR_S3_FILES_PUBLIC_BUCKET_NAME = {
+      value     = local.files_public_bucket_name
+      sensitive = false
+    }
+    POLAR_S3_CUSTOMER_INVOICES_BUCKET_NAME = {
+      value     = "polar-test-customer-invoices"
+      sensitive = false
+    }
+    POLAR_S3_CUSTOMER_RECEIPTS_BUCKET_NAME = {
+      value     = "polar-test-customer-receipts"
+      sensitive = false
+    }
+    POLAR_S3_PAYOUT_INVOICES_BUCKET_NAME = {
+      value     = "polar-test-payout-invoices"
+      sensitive = false
+    }
+    POLAR_S3_LOGS_BUCKET_NAME = {
+      value     = "polar-test-logs"
+      sensitive = false
+    }
+    POLAR_S3_FILES_DOWNLOAD_SALT = {
+      value = var.s3_files_download_salt
+    }
+    POLAR_S3_FILES_DOWNLOAD_SECRET = {
+      value = var.s3_files_download_secret
+    }
+    POLAR_LOGFIRE_PROJECT_NAME = {
+      value     = "polar"
+      sensitive = false
+    }
+    POLAR_LOGFIRE_TOKEN = {
+      value = var.logfire_token
+    }
+    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_URL = {
+      value     = "${var.grafana_cloud_prometheus_url}/api/prom/push"
+      sensitive = false
+    }
+    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_USERNAME = {
+      value = var.grafana_cloud_prometheus_username
+    }
+    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_PASSWORD = {
+      value = var.grafana_cloud_prometheus_password
+    }
+    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_INTERVAL = {
+      value     = "60"
+      sensitive = false
+    }
+    POLAR_POLAR_ACCESS_TOKEN = {
+      value = var.polar_access_token
+    }
+    POLAR_POLAR_WEBHOOK_SECRET = {
+      value = var.polar_webhook_secret
+    }
+    POLAR_POLAR_ORGANIZATION_ID = {
+      value     = var.polar_organization_id
+      sensitive = false
+    }
+    POLAR_POLAR_FREE_PRODUCT_ID = {
+      value     = var.polar_free_product_id
+      sensitive = false
+    }
+    POLAR_POLAR_SCALE_PRODUCT_ID = {
+      value     = var.polar_scale_product_id
+      sensitive = false
+    }
+    POLAR_POLAR_API_URL = {
+      value     = "https://test-api.polar.sh"
+      sensitive = false
+    }
+    POLAR_TINYBIRD_API_URL = {
+      value     = "https://api.us-east.aws.tinybird.co"
+      sensitive = false
+    }
+    POLAR_TINYBIRD_CLICKHOUSE_URL = {
+      value     = "https://clickhouse.us-east.aws.tinybird.co"
+      sensitive = false
+    }
+    POLAR_TINYBIRD_API_TOKEN = {
+      value = var.tinybird_api_token
+    }
+    POLAR_TINYBIRD_READ_TOKEN = {
+      value = var.tinybird_read_token
+    }
+    POLAR_TINYBIRD_CLICKHOUSE_USERNAME = {
+      value = var.tinybird_clickhouse_username
+    }
+    POLAR_TINYBIRD_CLICKHOUSE_TOKEN = {
+      value = var.tinybird_clickhouse_token
+    }
+    POLAR_TINYBIRD_WORKSPACE = {
+      value = var.tinybird_workspace
+    }
+  }
+}
+
+module "vercel_services" {
+  source = "../modules/vercel_services"
+
+  name     = "polar-test-services"
+  git_repo = "polarsource/polar"
+
+  resource_config = {
+    function_default_regions = ["cle1"]
+  }
+
+  environment_variables = local.vercel_services_environment_variables
+}
+
+data "aws_iam_policy_document" "vercel_services_kms" {
+  statement {
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt",
+    ]
+    resources = [one(module.secrets_kms[*].key_arn)]
+  }
+}
+
+resource "aws_iam_user_policy" "vercel_services_kms" {
+  name   = "polar-test-vercel-services-kms"
+  user   = "polar-test-files"
+  policy = data.aws_iam_policy_document.vercel_services_kms.json
+}

--- a/terraform/test/vercel-services.tf
+++ b/terraform/test/vercel-services.tf
@@ -5,439 +5,413 @@
 locals {
   # Vercel's Postgres and Redis integrations own POLAR_POSTGRES_URL_NON_POOLING
   # and POLAR_REDIS_URL. They are intentionally not duplicated here.
-  vercel_services_base_environment_variable_groups = {
-    frontend_build = {
-      SENTRY_ORG = {
-        value     = "polar-sh"
-        sensitive = false
-      }
-      SENTRY_PROJECT = {
-        value     = "dashboard"
-        sensitive = false
-      }
-      NEXT_PUBLIC_ENVIRONMENT = {
-        value     = "test"
-        sensitive = false
-      }
-      NEXT_PUBLIC_BACKOFFICE_URL = {
-        value     = "/api/backoffice"
-        sensitive = false
-      }
-      NEXT_PUBLIC_SANDBOX_FRONTEND_BASE_URL = {
-        value     = "https://sandbox.polar.sh"
-        sensitive = false
-      }
-      NEXT_PUBLIC_SENTRY_DSN = {
-        value     = var.next_public_sentry_dsn
-        sensitive = false
-      }
-      NEXT_PUBLIC_POSTHOG_TOKEN = {
-        value     = var.next_public_posthog_token
-        sensitive = false
-      }
-      NEXT_PUBLIC_APPLE_DOMAIN_ASSOCIATION = {
-        value     = var.next_public_apple_domain_association
-        sensitive = false
-      }
-      NEXT_PUBLIC_CHECKOUT_EMBED_SCRIPT_SRC = {
-        value     = "https://cdn.jsdelivr.net/npm/@polar-sh/checkout@0.1/dist/embed.global.js"
-        sensitive = false
-      }
-      NEXT_PUBLIC_STRIPE_PAYMENT_METHOD_CONFIGURATION = {
-        value     = var.next_public_stripe_payment_method_configuration
-        sensitive = false
-      }
-      NEXT_PUBLIC_TURNSTILE_SITE_KEY = {
-        value     = "1x00000000000000000000AA"
-        sensitive = false
-      }
-      next_public_stripe_key_production = {
-        key       = "NEXT_PUBLIC_STRIPE_KEY"
-        value     = var.stripe_publishable_key
-        target    = ["production"]
-        sensitive = false
-      }
-      next_public_stripe_key_preview = {
-        key       = "NEXT_PUBLIC_STRIPE_KEY"
-        value     = var.stripe_publishable_key_preview
-        target    = ["preview"]
-        sensitive = false
-      }
-      S3_PUBLIC_IMAGES_BUCKET_PROTOCOL = {
-        value     = "https"
-        sensitive = false
-      }
-      S3_PUBLIC_IMAGES_BUCKET_HOSTNAME = {
-        value     = "polar-test-public-files.s3.amazonaws.com"
-        sensitive = false
-      }
-      S3_PUBLIC_IMAGES_BUCKET_PATHNAME = {
-        value     = "/product_media/**"
-        sensitive = false
-      }
-      S3_UPLOAD_ORIGINS = {
-        value     = "https://polar-test-files.s3.amazonaws.com https://polar-test-files.s3.us-east-2.amazonaws.com https://polar-test-public-files.s3.amazonaws.com https://polar-test-public-files.s3.us-east-2.amazonaws.com"
-        sensitive = false
-      }
-      POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS = {
-        value     = "https://polar.sh,https://sandbox.polar.sh,https://test.polar.sh"
-        sensitive = false
-      }
-      POLAR_OPENAPI_SCHEMA_URL = {
-        value     = "https://api.polar.sh/openapi.json"
-        sensitive = false
-      }
-      ENABLE_EXPERIMENTAL_COREPACK = {
-        value     = "1"
-        sensitive = false
-      }
-      PYDANTIC_AI_GATEWAY_API_KEY = {
-        value = var.pydantic_ai_gateway_api_key
-      }
-      MINTLIFY_ASSISTANT_API_KEY = {
-        value = var.mintlify_assistant_api_key
-      }
-      GRAM_API_KEY = {
-        value = var.gram_api_key
-      }
-      SENTRY_AUTH_TOKEN = {
-        value = var.sentry_auth_token
-      }
-      POLAR_PREVIEW_ACCESS_TOKEN = {
-        value  = var.polar_preview_access_token
-        target = ["preview"]
-      }
+  vercel_services_base_environment_variables = {
+    SENTRY_ORG = {
+      value     = "polar-sh"
+      sensitive = false
     }
-    mcp = {
-      MCP_OAUTH2_CLIENT_ID = {
-        value = var.mcp_oauth2_client_id
-      }
-      MCP_OAUTH2_CLIENT_SECRET = {
-        value = var.mcp_oauth2_client_secret
-      }
+    SENTRY_PROJECT = {
+      value     = "dashboard"
+      sensitive = false
     }
-    backend = {
-      POLAR_ENV = {
-        value     = "test"
-        sensitive = false
-      }
-      POLAR_DEBUG = {
-        value     = "0"
-        sensitive = false
-      }
-      POLAR_TESTING = {
-        value     = "0"
-        sensitive = false
-      }
-      POLAR_LOG_LEVEL = {
-        value     = "INFO"
-        sensitive = false
-      }
-      POLAR_CORS_ORIGINS = {
-        value     = "[\"https://github.com\", \"https://docs.polar.sh\"]"
-        sensitive = false
-      }
-      POLAR_DATABASE_POOL_SIZE = {
-        value     = "5"
-        sensitive = false
-      }
-      POLAR_USER_SESSION_COOKIE_KEY = {
-        value     = "polar_test_session"
-        sensitive = false
-      }
-      POLAR_AUTH_COOKIE_KEY = {
-        value     = "polar_test_session"
-        sensitive = false
-      }
-      POLAR_EMAIL_SENDER = {
-        value     = "resend"
-        sensitive = false
-      }
-      POLAR_EMAIL_FROM_NAME = {
-        value     = "[TEST] Polar"
-        sensitive = false
-      }
-      POLAR_EMAIL_FROM_DOMAIN = {
-        value     = "notifications.test.polar.sh"
-        sensitive = false
-      }
-      POLAR_JWKS = {
-        value = var.backend_jwks
-      }
-      POLAR_CURRENT_JWK_KID = {
-        value = var.backend_current_jwk_kid
-      }
-      POLAR_SECRET = {
-        value = var.backend_secret
-      }
-      POLAR_SENTRY_DSN = {
-        value = var.backend_sentry_dsn
-      }
-      POLAR_TAX_PROCESSORS = {
-        value     = "[\"numeral\",\"stripe\"]"
-        sensitive = false
-      }
-      POLAR_TAX_RECORD_PROCESSOR = {
-        value     = "numeral"
-        sensitive = false
-      }
-      POLAR_CUSTOMER_PORTAL_URL_OVERRIDES = {
-        value     = var.customer_portal_url_overrides
-        sensitive = false
-      }
-      POLAR_PLAIN_DEFAULT_TIER_EXTERNAL_ID = {
-        value     = var.plain_default_tier_external_id
-        sensitive = false
-      }
-      POLAR_TURNSTILE_SECRET = {
-        value = "1x0000000000000000000000000000000AA"
-      }
-      POLAR_FIRECRAWL_API_KEY = {
-        value = var.firecrawl_api_key
-      }
-      POLAR_LOGO_DEV_PUBLISHABLE_KEY = {
-        value     = var.backend_logo_dev_publishable_key
-        sensitive = false
-      }
-      POLAR_DISCORD_BOT_TOKEN = {
-        value = var.backend_discord_bot_token
-      }
-      POLAR_DISCORD_CLIENT_ID = {
-        value = var.backend_discord_client_id
-      }
-      POLAR_DISCORD_CLIENT_SECRET = {
-        value = var.backend_discord_client_secret
-      }
-      POLAR_DISCORD_PROXY_URL = {
-        value = var.backend_discord_proxy_url
-      }
-      POLAR_RESEND_API_KEY = {
-        value = var.backend_resend_api_key
-      }
-      POLAR_RESEND_WEBHOOK_SECRET = {
-        value = var.backend_resend_webhook_secret
-      }
-      POLAR_NUMERAL_API_KEY = {
-        value = var.numeral_api_key
-      }
+    NEXT_PUBLIC_ENVIRONMENT = {
+      value     = "test"
+      sensitive = false
     }
-    google = {
-      POLAR_GOOGLE_CLIENT_ID = {
-        value = var.google_client_id
-      }
-      POLAR_GOOGLE_CLIENT_SECRET = {
-        value = var.google_client_secret
-      }
-      POLAR_GOOGLE_SERVICE_ACCOUNT_JSON = {
-        value = var.google_service_account_json
-      }
+    NEXT_PUBLIC_BACKOFFICE_URL = {
+      value     = "/api/backoffice"
+      sensitive = false
     }
-    ai = {
-      POLAR_OPENAI_API_KEY = {
-        value = var.openai_api_key
-      }
-      POLAR_PYDANTIC_AI_GATEWAY_API_KEY = {
-        value = var.pydantic_ai_gateway_api_key
-      }
+    NEXT_PUBLIC_SANDBOX_FRONTEND_BASE_URL = {
+      value     = "https://sandbox.polar.sh"
+      sensitive = false
     }
-    github = {
-      POLAR_GITHUB_CLIENT_ID = {
-        value = var.github_client_id
-      }
-      POLAR_GITHUB_CLIENT_SECRET = {
-        value = var.github_client_secret
-      }
-      POLAR_GITHUB_REPOSITORY_BENEFITS_APP_IDENTIFIER = {
-        value = var.github_repository_benefits_app_identifier
-      }
-      POLAR_GITHUB_REPOSITORY_BENEFITS_APP_NAMESPACE = {
-        value = var.github_repository_benefits_app_namespace
-      }
-      POLAR_GITHUB_REPOSITORY_BENEFITS_APP_PRIVATE_KEY = {
-        value = var.github_repository_benefits_app_private_key
-      }
-      POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_ID = {
-        value = var.github_repository_benefits_client_id
-      }
-      POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_SECRET = {
-        value = var.github_repository_benefits_client_secret
-      }
+    NEXT_PUBLIC_SENTRY_DSN = {
+      value     = var.next_public_sentry_dsn
+      sensitive = false
     }
-    stripe = {
-      POLAR_STRIPE_PUBLISHABLE_KEY = {
-        value     = var.stripe_publishable_key
-        sensitive = false
-      }
-      POLAR_STRIPE_CONNECT_WEBHOOK_SECRET = {
-        value = var.stripe_connect_webhook_secret
-      }
-      POLAR_STRIPE_SECRET_KEY = {
-        value = var.stripe_secret_key
-      }
-      POLAR_STRIPE_WEBHOOK_SECRET = {
-        value = var.stripe_webhook_secret
-      }
-      POLAR_STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET = {
-        value = var.stripe_account_risk_webhook_secret
-      }
-      POLAR_STRIPE_APP_CLIENT_ID = {
-        value = var.stripe_app_client_id
-      }
-      POLAR_STRIPE_APP_CLIENT_LINK_ID = {
-        value = var.stripe_app_client_link_id
-      }
+    NEXT_PUBLIC_POSTHOG_TOKEN = {
+      value     = var.next_public_posthog_token
+      sensitive = false
     }
-    apple = {
-      POLAR_APPLE_CLIENT_ID = {
-        value = var.apple_client_id
-      }
-      POLAR_APPLE_TEAM_ID = {
-        value = var.apple_team_id
-      }
-      POLAR_APPLE_KEY_ID = {
-        value = var.apple_key_id
-      }
-      POLAR_APPLE_KEY_VALUE = {
-        value = var.apple_key_value
-      }
+    NEXT_PUBLIC_APPLE_DOMAIN_ASSOCIATION = {
+      value     = var.next_public_apple_domain_association
+      sensitive = false
     }
-    aws_s3 = {
-      POLAR_AWS_REGION = {
-        value     = "us-east-2"
-        sensitive = false
-      }
-      POLAR_AWS_SIGNATURE_VERSION = {
-        value     = "v4"
-        sensitive = false
-      }
-      POLAR_AWS_ACCESS_KEY_ID = {
-        value = var.aws_access_key_id
-      }
-      POLAR_AWS_SECRET_ACCESS_KEY = {
-        value = var.aws_secret_access_key
-      }
-      AWS_ACCESS_KEY_ID = {
-        value = var.aws_access_key_id
-      }
-      AWS_SECRET_ACCESS_KEY = {
-        value = var.aws_secret_access_key
-      }
-      POLAR_S3_FILES_BUCKET_NAME = {
-        value     = local.files_bucket_name
-        sensitive = false
-      }
-      POLAR_S3_FILES_PRESIGN_TTL = {
-        value     = "600"
-        sensitive = false
-      }
-      POLAR_S3_FILES_PUBLIC_BUCKET_NAME = {
-        value     = local.files_public_bucket_name
-        sensitive = false
-      }
-      POLAR_S3_CUSTOMER_INVOICES_BUCKET_NAME = {
-        value     = "polar-test-customer-invoices"
-        sensitive = false
-      }
-      POLAR_S3_CUSTOMER_RECEIPTS_BUCKET_NAME = {
-        value     = "polar-test-customer-receipts"
-        sensitive = false
-      }
-      POLAR_S3_PAYOUT_INVOICES_BUCKET_NAME = {
-        value     = "polar-test-payout-invoices"
-        sensitive = false
-      }
-      POLAR_S3_LOGS_BUCKET_NAME = {
-        value     = "polar-test-logs"
-        sensitive = false
-      }
-      POLAR_S3_FILES_DOWNLOAD_SALT = {
-        value = var.s3_files_download_salt
-      }
-      POLAR_S3_FILES_DOWNLOAD_SECRET = {
-        value = var.s3_files_download_secret
-      }
+    NEXT_PUBLIC_CHECKOUT_EMBED_SCRIPT_SRC = {
+      value     = "https://cdn.jsdelivr.net/npm/@polar-sh/checkout@0.1/dist/embed.global.js"
+      sensitive = false
     }
-    observability = {
-      POLAR_LOGFIRE_PROJECT_NAME = {
-        value     = "polar"
-        sensitive = false
-      }
-      POLAR_LOGFIRE_TOKEN = {
-        value = var.logfire_token
-      }
-      POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_URL = {
-        value     = "${var.grafana_cloud_prometheus_url}/api/prom/push"
-        sensitive = false
-      }
-      POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_USERNAME = {
-        value = var.grafana_cloud_prometheus_username
-      }
-      POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_PASSWORD = {
-        value = var.grafana_cloud_prometheus_password
-      }
-      POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_INTERVAL = {
-        value     = "60"
-        sensitive = false
-      }
+    NEXT_PUBLIC_STRIPE_PAYMENT_METHOD_CONFIGURATION = {
+      value     = var.next_public_stripe_payment_method_configuration
+      sensitive = false
     }
-    polar_self = {
-      POLAR_POLAR_ACCESS_TOKEN = {
-        value = var.polar_access_token
-      }
-      POLAR_POLAR_WEBHOOK_SECRET = {
-        value = var.polar_webhook_secret
-      }
-      POLAR_POLAR_ORGANIZATION_ID = {
-        value     = var.polar_organization_id
-        sensitive = false
-      }
-      POLAR_POLAR_FREE_PRODUCT_ID = {
-        value     = var.polar_free_product_id
-        sensitive = false
-      }
-      POLAR_POLAR_SCALE_PRODUCT_ID = {
-        value     = var.polar_scale_product_id
-        sensitive = false
-      }
-      POLAR_POLAR_API_URL = {
-        value     = "https://test-api.polar.sh"
-        sensitive = false
-      }
+    NEXT_PUBLIC_TURNSTILE_SITE_KEY = {
+      value     = "1x00000000000000000000AA"
+      sensitive = false
     }
-    tinybird = {
-      POLAR_TINYBIRD_API_URL = {
-        value     = "https://api.us-east.aws.tinybird.co"
-        sensitive = false
-      }
-      POLAR_TINYBIRD_CLICKHOUSE_URL = {
-        value     = "https://clickhouse.us-east.aws.tinybird.co"
-        sensitive = false
-      }
-      POLAR_TINYBIRD_API_TOKEN = {
-        value = var.tinybird_api_token
-      }
-      POLAR_TINYBIRD_READ_TOKEN = {
-        value = var.tinybird_read_token
-      }
-      POLAR_TINYBIRD_CLICKHOUSE_USERNAME = {
-        value = var.tinybird_clickhouse_username
-      }
-      POLAR_TINYBIRD_CLICKHOUSE_TOKEN = {
-        value = var.tinybird_clickhouse_token
-      }
-      POLAR_TINYBIRD_WORKSPACE = {
-        value = var.tinybird_workspace
-      }
+    next_public_stripe_key_production = {
+      key       = "NEXT_PUBLIC_STRIPE_KEY"
+      value     = var.stripe_publishable_key
+      target    = ["production"]
+      sensitive = false
+    }
+    next_public_stripe_key_preview = {
+      key       = "NEXT_PUBLIC_STRIPE_KEY"
+      value     = var.stripe_publishable_key_preview
+      target    = ["preview"]
+      sensitive = false
+    }
+    S3_PUBLIC_IMAGES_BUCKET_PROTOCOL = {
+      value     = "https"
+      sensitive = false
+    }
+    S3_PUBLIC_IMAGES_BUCKET_HOSTNAME = {
+      value     = "polar-test-public-files.s3.amazonaws.com"
+      sensitive = false
+    }
+    S3_PUBLIC_IMAGES_BUCKET_PATHNAME = {
+      value     = "/product_media/**"
+      sensitive = false
+    }
+    S3_UPLOAD_ORIGINS = {
+      value     = "https://polar-test-files.s3.amazonaws.com https://polar-test-files.s3.us-east-2.amazonaws.com https://polar-test-public-files.s3.amazonaws.com https://polar-test-public-files.s3.us-east-2.amazonaws.com"
+      sensitive = false
+    }
+    POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS = {
+      value     = "https://polar.sh,https://sandbox.polar.sh,https://test.polar.sh"
+      sensitive = false
+    }
+    POLAR_OPENAPI_SCHEMA_URL = {
+      value     = "https://api.polar.sh/openapi.json"
+      sensitive = false
+    }
+    ENABLE_EXPERIMENTAL_COREPACK = {
+      value     = "1"
+      sensitive = false
+    }
+    PYDANTIC_AI_GATEWAY_API_KEY = {
+      value = var.pydantic_ai_gateway_api_key
+    }
+    MINTLIFY_ASSISTANT_API_KEY = {
+      value = var.mintlify_assistant_api_key
+    }
+    GRAM_API_KEY = {
+      value = var.gram_api_key
+    }
+    SENTRY_AUTH_TOKEN = {
+      value = var.sentry_auth_token
+    }
+    POLAR_PREVIEW_ACCESS_TOKEN = {
+      value  = var.polar_preview_access_token
+      target = ["preview"]
+    }
+    MCP_OAUTH2_CLIENT_ID = {
+      value = var.mcp_oauth2_client_id
+    }
+    MCP_OAUTH2_CLIENT_SECRET = {
+      value = var.mcp_oauth2_client_secret
+    }
+    POLAR_ENV = {
+      value     = "test"
+      sensitive = false
+    }
+    POLAR_DEBUG = {
+      value     = "0"
+      sensitive = false
+    }
+    POLAR_TESTING = {
+      value     = "0"
+      sensitive = false
+    }
+    POLAR_LOG_LEVEL = {
+      value     = "INFO"
+      sensitive = false
+    }
+    POLAR_CORS_ORIGINS = {
+      value     = "[\"https://github.com\", \"https://docs.polar.sh\"]"
+      sensitive = false
+    }
+    POLAR_DATABASE_POOL_SIZE = {
+      value     = "5"
+      sensitive = false
+    }
+    POLAR_USER_SESSION_COOKIE_KEY = {
+      value     = "polar_test_session"
+      sensitive = false
+    }
+    POLAR_AUTH_COOKIE_KEY = {
+      value     = "polar_test_session"
+      sensitive = false
+    }
+    POLAR_EMAIL_SENDER = {
+      value     = "resend"
+      sensitive = false
+    }
+    POLAR_EMAIL_FROM_NAME = {
+      value     = "[TEST] Polar"
+      sensitive = false
+    }
+    POLAR_EMAIL_FROM_DOMAIN = {
+      value     = "notifications.test.polar.sh"
+      sensitive = false
+    }
+    POLAR_JWKS = {
+      value = var.backend_jwks
+    }
+    POLAR_CURRENT_JWK_KID = {
+      value = var.backend_current_jwk_kid
+    }
+    POLAR_SECRET = {
+      value = var.backend_secret
+    }
+    POLAR_SENTRY_DSN = {
+      value = var.backend_sentry_dsn
+    }
+    POLAR_TAX_PROCESSORS = {
+      value     = "[\"numeral\",\"stripe\"]"
+      sensitive = false
+    }
+    POLAR_TAX_RECORD_PROCESSOR = {
+      value     = "numeral"
+      sensitive = false
+    }
+    POLAR_CUSTOMER_PORTAL_URL_OVERRIDES = {
+      value     = var.customer_portal_url_overrides
+      sensitive = false
+    }
+    POLAR_PLAIN_DEFAULT_TIER_EXTERNAL_ID = {
+      value     = var.plain_default_tier_external_id
+      sensitive = false
+    }
+    POLAR_TURNSTILE_SECRET = {
+      value = "1x0000000000000000000000000000000AA"
+    }
+    POLAR_FIRECRAWL_API_KEY = {
+      value = var.firecrawl_api_key
+    }
+    POLAR_LOGO_DEV_PUBLISHABLE_KEY = {
+      value     = var.backend_logo_dev_publishable_key
+      sensitive = false
+    }
+    POLAR_DISCORD_BOT_TOKEN = {
+      value = var.backend_discord_bot_token
+    }
+    POLAR_DISCORD_CLIENT_ID = {
+      value = var.backend_discord_client_id
+    }
+    POLAR_DISCORD_CLIENT_SECRET = {
+      value = var.backend_discord_client_secret
+    }
+    POLAR_DISCORD_PROXY_URL = {
+      value = var.backend_discord_proxy_url
+    }
+    POLAR_RESEND_API_KEY = {
+      value = var.backend_resend_api_key
+    }
+    POLAR_RESEND_WEBHOOK_SECRET = {
+      value = var.backend_resend_webhook_secret
+    }
+    POLAR_NUMERAL_API_KEY = {
+      value = var.numeral_api_key
+    }
+    POLAR_GOOGLE_CLIENT_ID = {
+      value = var.google_client_id
+    }
+    POLAR_GOOGLE_CLIENT_SECRET = {
+      value = var.google_client_secret
+    }
+    POLAR_GOOGLE_SERVICE_ACCOUNT_JSON = {
+      value = var.google_service_account_json
+    }
+    POLAR_OPENAI_API_KEY = {
+      value = var.openai_api_key
+    }
+    POLAR_PYDANTIC_AI_GATEWAY_API_KEY = {
+      value = var.pydantic_ai_gateway_api_key
+    }
+    POLAR_GITHUB_CLIENT_ID = {
+      value = var.github_client_id
+    }
+    POLAR_GITHUB_CLIENT_SECRET = {
+      value = var.github_client_secret
+    }
+    POLAR_GITHUB_REPOSITORY_BENEFITS_APP_IDENTIFIER = {
+      value = var.github_repository_benefits_app_identifier
+    }
+    POLAR_GITHUB_REPOSITORY_BENEFITS_APP_NAMESPACE = {
+      value = var.github_repository_benefits_app_namespace
+    }
+    POLAR_GITHUB_REPOSITORY_BENEFITS_APP_PRIVATE_KEY = {
+      value = var.github_repository_benefits_app_private_key
+    }
+    POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_ID = {
+      value = var.github_repository_benefits_client_id
+    }
+    POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_SECRET = {
+      value = var.github_repository_benefits_client_secret
+    }
+    POLAR_STRIPE_PUBLISHABLE_KEY = {
+      value     = var.stripe_publishable_key
+      sensitive = false
+    }
+    POLAR_STRIPE_CONNECT_WEBHOOK_SECRET = {
+      value = var.stripe_connect_webhook_secret
+    }
+    POLAR_STRIPE_SECRET_KEY = {
+      value = var.stripe_secret_key
+    }
+    POLAR_STRIPE_WEBHOOK_SECRET = {
+      value = var.stripe_webhook_secret
+    }
+    POLAR_STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET = {
+      value = var.stripe_account_risk_webhook_secret
+    }
+    POLAR_STRIPE_APP_CLIENT_ID = {
+      value = var.stripe_app_client_id
+    }
+    POLAR_STRIPE_APP_CLIENT_LINK_ID = {
+      value = var.stripe_app_client_link_id
+    }
+    POLAR_APPLE_CLIENT_ID = {
+      value = var.apple_client_id
+    }
+    POLAR_APPLE_TEAM_ID = {
+      value = var.apple_team_id
+    }
+    POLAR_APPLE_KEY_ID = {
+      value = var.apple_key_id
+    }
+    POLAR_APPLE_KEY_VALUE = {
+      value = var.apple_key_value
+    }
+    POLAR_AWS_REGION = {
+      value     = "us-east-2"
+      sensitive = false
+    }
+    POLAR_AWS_SIGNATURE_VERSION = {
+      value     = "v4"
+      sensitive = false
+    }
+    POLAR_AWS_ACCESS_KEY_ID = {
+      value = var.aws_access_key_id
+    }
+    POLAR_AWS_SECRET_ACCESS_KEY = {
+      value = var.aws_secret_access_key
+    }
+    AWS_ACCESS_KEY_ID = {
+      value = var.aws_access_key_id
+    }
+    AWS_SECRET_ACCESS_KEY = {
+      value = var.aws_secret_access_key
+    }
+    POLAR_S3_FILES_BUCKET_NAME = {
+      value     = local.files_bucket_name
+      sensitive = false
+    }
+    POLAR_S3_FILES_PRESIGN_TTL = {
+      value     = "600"
+      sensitive = false
+    }
+    POLAR_S3_FILES_PUBLIC_BUCKET_NAME = {
+      value     = local.files_public_bucket_name
+      sensitive = false
+    }
+    POLAR_S3_CUSTOMER_INVOICES_BUCKET_NAME = {
+      value     = "polar-test-customer-invoices"
+      sensitive = false
+    }
+    POLAR_S3_CUSTOMER_RECEIPTS_BUCKET_NAME = {
+      value     = "polar-test-customer-receipts"
+      sensitive = false
+    }
+    POLAR_S3_PAYOUT_INVOICES_BUCKET_NAME = {
+      value     = "polar-test-payout-invoices"
+      sensitive = false
+    }
+    POLAR_S3_LOGS_BUCKET_NAME = {
+      value     = "polar-test-logs"
+      sensitive = false
+    }
+    POLAR_S3_FILES_DOWNLOAD_SALT = {
+      value = var.s3_files_download_salt
+    }
+    POLAR_S3_FILES_DOWNLOAD_SECRET = {
+      value = var.s3_files_download_secret
+    }
+    POLAR_LOGFIRE_PROJECT_NAME = {
+      value     = "polar"
+      sensitive = false
+    }
+    POLAR_LOGFIRE_TOKEN = {
+      value = var.logfire_token
+    }
+    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_URL = {
+      value     = "${var.grafana_cloud_prometheus_url}/api/prom/push"
+      sensitive = false
+    }
+    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_USERNAME = {
+      value = var.grafana_cloud_prometheus_username
+    }
+    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_PASSWORD = {
+      value = var.grafana_cloud_prometheus_password
+    }
+    POLAR_GRAFANA_CLOUD_PROMETHEUS_WRITE_INTERVAL = {
+      value     = "60"
+      sensitive = false
+    }
+    POLAR_POLAR_ACCESS_TOKEN = {
+      value = var.polar_access_token
+    }
+    POLAR_POLAR_WEBHOOK_SECRET = {
+      value = var.polar_webhook_secret
+    }
+    POLAR_POLAR_ORGANIZATION_ID = {
+      value     = var.polar_organization_id
+      sensitive = false
+    }
+    POLAR_POLAR_FREE_PRODUCT_ID = {
+      value     = var.polar_free_product_id
+      sensitive = false
+    }
+    POLAR_POLAR_SCALE_PRODUCT_ID = {
+      value     = var.polar_scale_product_id
+      sensitive = false
+    }
+    POLAR_POLAR_API_URL = {
+      value     = "https://test-api.polar.sh"
+      sensitive = false
+    }
+    POLAR_TINYBIRD_API_URL = {
+      value     = "https://api.us-east.aws.tinybird.co"
+      sensitive = false
+    }
+    POLAR_TINYBIRD_CLICKHOUSE_URL = {
+      value     = "https://clickhouse.us-east.aws.tinybird.co"
+      sensitive = false
+    }
+    POLAR_TINYBIRD_API_TOKEN = {
+      value = var.tinybird_api_token
+    }
+    POLAR_TINYBIRD_READ_TOKEN = {
+      value = var.tinybird_read_token
+    }
+    POLAR_TINYBIRD_CLICKHOUSE_USERNAME = {
+      value = var.tinybird_clickhouse_username
+    }
+    POLAR_TINYBIRD_CLICKHOUSE_TOKEN = {
+      value = var.tinybird_clickhouse_token
+    }
+    POLAR_TINYBIRD_WORKSPACE = {
+      value = var.tinybird_workspace
     }
   }
 
-  vercel_services_environment_variable_groups = merge(
-    local.vercel_services_base_environment_variable_groups,
+  vercel_services_environment_variables = merge(
+    local.vercel_services_base_environment_variables,
     local.test_enabled ? {
-      secrets_kms = {
-        POLAR_AWS_KMS_KEY_ID = {
-          value = module.secrets_kms[0].key_arn
-        }
+      POLAR_AWS_KMS_KEY_ID = {
+        value = module.secrets_kms[0].key_arn
       }
     } : {},
   )
@@ -453,7 +427,7 @@ module "vercel_services" {
     function_default_regions = ["cle1"]
   }
 
-  environment_variable_groups = local.vercel_services_environment_variable_groups
+  environment_variables = local.vercel_services_environment_variables
 }
 
 data "aws_iam_policy_document" "vercel_services_kms" {


### PR DESCRIPTION
## Summary

- add a reusable Terraform module for Vercel Services projects and their environment variables
- grant the account-wide Neon and Upstash integration installations access to projects created by the module
- provision a full-stack Vercel Services project for the test environment
- wire the existing test configuration and secrets into Vercel, including KMS permissions for the existing S3 application user

Postgres and Redis connection variables are intentionally omitted because Vercel Marketplace storage resources inject them when connected to the project. Connecting the individual `store_*` resources remains a manual step for this trial because the official Vercel Terraform provider does not currently model that relationship.

## Validation

- `terraform fmt -check terraform/modules/vercel_services terraform/test`
- `terraform -chdir=terraform/test validate`
- ADR compliance check: no violations


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

