### PR TITLE
Remove Vercel KMS configuration

### DIFF
--- a/terraform/test/vercel-services.tf
+++ b/terraform/test/vercel-services.tf
@@ -5,7 +5,7 @@
 locals {
   # Vercel's Postgres and Redis integrations own POLAR_POSTGRES_URL_NON_POOLING
   # and POLAR_REDIS_URL. They are intentionally not duplicated here.
-  vercel_services_base_environment_variables = {
+  vercel_services_environment_variables = {
     SENTRY_ORG = {
       value     = "polar-sh"
       sensitive = false
@@ -406,15 +406,6 @@ locals {
       value = var.tinybird_workspace
     }
   }
-
-  vercel_services_environment_variables = merge(
-    local.vercel_services_base_environment_variables,
-    local.test_enabled ? {
-      POLAR_AWS_KMS_KEY_ID = {
-        value = module.secrets_kms[0].key_arn
-      }
-    } : {},
-  )
 }
 
 module "vercel_services" {
@@ -428,24 +419,4 @@ module "vercel_services" {
   }
 
   environment_variables = local.vercel_services_environment_variables
-}
-
-data "aws_iam_policy_document" "vercel_services_kms" {
-  count = local.test_enabled ? 1 : 0
-
-  statement {
-    actions = [
-      "kms:GenerateDataKey",
-      "kms:Decrypt",
-    ]
-    resources = [module.secrets_kms[0].key_arn]
-  }
-}
-
-resource "aws_iam_user_policy" "vercel_services_kms" {
-  count = local.test_enabled ? 1 : 0
-
-  name   = "polar-test-vercel-services-kms"
-  user   = "polar-test-files"
-  policy = data.aws_iam_policy_document.vercel_services_kms[0].json
 }


### PR DESCRIPTION
## Summary

- stop exposing `POLAR_AWS_KMS_KEY_ID` to the Vercel Services test project
- remove the Vercel-specific KMS IAM policy that attempted to attach to an IAM user in another AWS account
- keep the existing Render KMS configuration unchanged

KMS-backed secret encryption is intentionally deferred for the Vercel trial. The backend setting is optional, and this removes the invalid cross-account IAM configuration currently blocking the Terraform apply.

## Validation

- `terraform fmt -check terraform/test/vercel-services.tf`
- `terraform -chdir=terraform/test validate`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

