### PR TITLE
Set Vercel team for test workspace

### DIFF
--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -9,4 +9,5 @@ provider "cloudflare" {
 }
 
 provider "vercel" {
+  team = "polar-sh"
 }


### PR DESCRIPTION
## Summary

- configure the test workspace's Vercel provider with the `polar-sh` team scope
- ensure new projects use the team's GitHub App installation and can resolve `polarsource/polar`

Without an explicit team, the provider can attempt project creation in the API token owner's personal scope, where the Polar GitHub organization repository is unavailable.

## Validation

- `terraform fmt -check terraform/test/main.tf`
- `terraform -chdir=terraform/test validate`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

