### PR TITLE
fix: truncate external IDs on members page.

### DIFF
--- a/clients/apps/web/src/components/Customer/CustomerPage/MembersSection.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerPage/MembersSection.tsx
@@ -14,6 +14,7 @@ import {
   Status,
   type StatusColor,
   Text,
+  Truncated,
 } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
@@ -176,7 +177,9 @@ export const MembersSection = ({
             header: 'External ID',
             accessorKey: 'external_id',
             cell: ({ row: { original } }) => (
-              <Text>{original.external_id ?? '—'}</Text>
+              <Truncated>
+                <Text>{original.external_id ?? '—'}</Text>
+              </Truncated>
             ),
           },
           {


### PR DESCRIPTION
## Summary

Extenral ID was overflowing to the next column, displaying it with `<Truncated />` fixes it.

### Before

<img width="1354" height="539" alt="image" src="https://github.com/user-attachments/assets/efec7c6e-fba6-4574-9fa3-c5d379c9e614" />


### After

<img width="1352" height="515" alt="image" src="https://github.com/user-attachments/assets/91d3eaf7-5111-43e4-97fc-8672bc3e9df1" />
