### PR TITLE
clients/web: fix search API path

### DIFF
--- a/clients/apps/web/src/components/Search/OmniSearch.tsx
+++ b/clients/apps/web/src/components/Search/OmniSearch.tsx
@@ -104,7 +104,10 @@ export const OmniSearch = ({
 
       const loadingTimer = setTimeout(() => setLoading(true), 150)
       try {
-        const url = new URL(`${getServerURL()}/search`, window.location.origin)
+        const url = new URL(
+          `${getServerURL()}/v1/search`,
+          window.location.origin,
+        )
         url.searchParams.set('organization_id', organization.id)
         url.searchParams.set('query', searchQuery)
         url.searchParams.set('limit', '5')

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -4,28 +4,6 @@
  */
 
 export interface paths {
-  '/search': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /**
-     * Search
-     * @description Internal search endpoint for dashboard.
-     *
-     *     **Scopes**: `customers:read` `customers:write` `orders:read` `products:read` `products:write` `subscriptions:read` `subscriptions:write`
-     */
-    get: operations['search:search']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   '/v1/users/me': {
     parameters: {
       query?: never
@@ -5984,6 +5962,28 @@ export interface paths {
      *     **Scopes**: `payouts:write`
      */
     post: operations['payouts:generate_invoice']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/search': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Search
+     * @description Internal search endpoint for dashboard.
+     *
+     *     **Scopes**: `customers:read` `customers:write` `orders:read` `products:read` `products:write` `subscriptions:read` `subscriptions:write`
+     */
+    get: operations['search:search']
+    put?: never
+    post?: never
     delete?: never
     options?: never
     head?: never
@@ -38070,42 +38070,6 @@ export interface components {
 }
 export type $defs = Record<string, never>
 export interface operations {
-  'search:search': {
-    parameters: {
-      query: {
-        /** @description Organization ID to search within */
-        organization_id: string
-        /** @description Search query string */
-        query: string
-        /** @description Maximum number of results */
-        limit?: number
-      }
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['SearchResults']
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['HTTPValidationError']
-        }
-      }
-    }
-  }
   'users:get_authenticated': {
     parameters: {
       query?: never
@@ -57592,6 +57556,42 @@ export interface operations {
         }
         content: {
           'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'search:search': {
+    parameters: {
+      query: {
+        /** @description Organization ID to search within */
+        organization_id: string
+        /** @description Search query string */
+        query: string
+        /** @description Maximum number of results */
+        limit?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SearchResults']
         }
       }
       /** @description Validation Error */

--- a/server/polar/api.py
+++ b/server/polar/api.py
@@ -57,6 +57,7 @@ from polar.payout_account.endpoints import router as payout_account_router
 from polar.personal_access_token.endpoints import router as pat_router
 from polar.product.endpoints import router as product_router
 from polar.refund.endpoints import router as refund_router
+from polar.search.endpoints import router as search_router
 from polar.sso.endpoints import router as sso_router
 from polar.subscription.endpoints import router as subscription_router
 from polar.support_case.endpoints import router as support_case_router
@@ -170,6 +171,8 @@ router.include_router(customer_meter_router)
 router.include_router(payment_router)
 # /payouts
 router.include_router(payout_router)
+# /search
+router.include_router(search_router)
 # /wallets
 router.include_router(wallet_router)
 # /integrations/resend

--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -68,7 +68,6 @@ from polar.postgres import (
 )
 from polar.posthog import configure_posthog
 from polar.redis import Redis, create_redis
-from polar.search.endpoints import router as search_router
 from polar.sentry import configure_sentry
 from polar.version import CURRENT_API_VERSION, APIVersionMiddleware
 from polar.webhook.webhooks import document_webhooks
@@ -251,9 +250,6 @@ def create_app() -> FastAPI:
 
     # /healthz
     app.include_router(health_router)
-
-    # /search
-    app.include_router(search_router)
 
     if settings.BACKOFFICE_HOST is None:
         app.mount("/backoffice", backoffice_app)

--- a/server/tests/search/test_endpoints.py
+++ b/server/tests/search/test_endpoints.py
@@ -22,7 +22,7 @@ from tests.fixtures.random_objects import (
 class TestSearch:
     async def test_anonymous(self, client: AsyncClient) -> None:
         response = await client.get(
-            "/search",
+            "/v1/search",
             params={
                 "organization_id": str(uuid.uuid4()),
                 "query": "test",
@@ -37,7 +37,7 @@ class TestSearch:
         organization: Organization,
     ) -> None:
         response = await client.get(
-            "/search",
+            "/v1/search",
             params={
                 "organization_id": str(organization.id),
                 "query": "test",
@@ -63,7 +63,7 @@ class TestSearch:
         )
 
         response = await client.get(
-            "/search",
+            "/v1/search",
             params={
                 "organization_id": str(organization.id),
                 "query": "Premium",
@@ -95,7 +95,7 @@ class TestSearch:
         await save_fixture(product)
 
         response = await client.get(
-            "/search",
+            "/v1/search",
             params={
                 "organization_id": str(organization.id),
                 "query": "free",
@@ -125,7 +125,7 @@ class TestSearch:
         )
 
         response = await client.get(
-            "/search",
+            "/v1/search",
             params={
                 "organization_id": str(organization.id),
                 "query": "test@example",
@@ -155,7 +155,7 @@ class TestSearch:
         )
 
         response = await client.get(
-            "/search",
+            "/v1/search",
             params={
                 "organization_id": str(organization.id),
                 "query": "Free",
@@ -190,7 +190,7 @@ class TestSearch:
         )
 
         response = await client.get(
-            "/search",
+            "/v1/search",
             params={
                 "organization_id": str(organization.id),
                 "query": "Test",
@@ -223,7 +223,7 @@ class TestSearch:
         )
 
         response = await client.get(
-            "/search",
+            "/v1/search",
             params={
                 "organization_id": str(organization.id),
                 "query": "test",
@@ -258,7 +258,7 @@ class TestSearch:
         )
 
         response = await client.get(
-            "/search",
+            "/v1/search",
             params={
                 "organization_id": str(organization.id),
                 "query": "search",
@@ -287,7 +287,7 @@ class TestSearch:
         )
 
         response = await client.get(
-            "/search",
+            "/v1/search",
             params={
                 "organization_id": str(organization.id),
                 "query": "Test",


### PR DESCRIPTION

- clients/web: fix search API path
- clients/packages/client: update OpenAPI client
- server/search: include search endpoint in the api module instead of main app

The search endpoint was included in the main app instead of the api module, which is a bit inconsistent with the rest of the endpoints. It also causes issues with versioning support of OpenAPI.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

