### PR TITLE
fix: stop the auto-offboard cron from timing out

### DIFF
--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -229,41 +229,24 @@ class OrganizationRepository(
     async def get_offboarding_past_period(
         self, cutoff: datetime, *, limit: int = OFFBOARD_EXPIRED_BATCH_SIZE
     ) -> Sequence[Organization]:
-        """Offboarding orgs whose offboarding period has elapsed.
+        """Offboarding orgs past the merchant wind-down floor.
 
-        Anchor = the later of (a) the most recent paid order that hasn't been
-        fully refunded — the post-chargeback-risk window, and (b) when the org
-        entered offboarding (``status_updated_at``) — the merchant wind-down
-        floor. Both gates must clear, so a merchant freshly put into
-        offboarding always gets the full wind-down period even if their last
-        payment is already past the chargeback window. Orgs with no paid
-        orders use ``status_updated_at`` alone (PostgreSQL ``GREATEST`` skips
-        NULLs).
-
-        ``FOR UPDATE`` on the org row: a concurrent admin status change either
-        commits before our SELECT (and the row falls out of the WHERE clause)
-        or waits behind our lock — eliminating the read/transition race.
+        Floor = when the org entered offboarding (``status_updated_at``,
+        falling back to ``created_at``). The last-paid-order / chargeback
+        gate is checked per org by the follow-up task, not here: a joined
+        ``MAX(orders.created_at)`` timed out the production cron.
         """
-        last_paid_order_at = (
-            select(func.max(Order.created_at))
-            .where(
-                Order.organization_id == Organization.id,
-                Order.status.in_(OrderStatus.paid_statuses()),
-                Order.deleted_at.is_(None),
-            )
-            .correlate(Organization)
-            .scalar_subquery()
+        status_entered_at = func.coalesce(
+            Organization.status_updated_at, Organization.created_at
         )
-        anchor = func.greatest(last_paid_order_at, Organization.status_updated_at)
         statement = (
             self.get_base_statement()
             .where(
                 Organization.status == OrganizationStatus.OFFBOARDING,
-                anchor <= cutoff,
+                status_entered_at <= cutoff,
             )
-            .order_by(anchor.asc())
+            .order_by(status_entered_at.asc())
             .limit(limit)
-            .with_for_update(of=Organization)
         )
         return await self.get_all(statement)
 
@@ -307,9 +290,8 @@ class OrganizationRepository(
     async def get_last_paid_order_at(self, organization_id: UUID) -> datetime | None:
         """Most recent paid (not fully refunded) order date for an org.
 
-        Same chargeback-risk anchor as ``get_offboarding_past_period``, but for
-        a single organization — lets the backoffice surface how much of the
-        offboarding wind-down period remains before an auto-offboard.
+        Chargeback-risk anchor for a single organization — used by the
+        per-org auto-offboard task and the backoffice remaining-window UI.
         """
         statement = select(func.max(Order.created_at)).where(
             Order.organization_id == organization_id,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -98,7 +98,11 @@ from polar.webhook.repository import WebhookEndpointRepository
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job
 
-from .repository import OrganizationRepository, OrganizationReviewRepository
+from .repository import (
+    OFFBOARD_EXPIRED_BATCH_SIZE,
+    OrganizationRepository,
+    OrganizationReviewRepository,
+)
 from .schemas import (
     OrganizationCreate,
     OrganizationDeletionBlockedReason,
@@ -1566,6 +1570,14 @@ class OrganizationService:
             count=len(candidates),
             cutoff=cutoff.isoformat(),
         )
+        # Orgs blocked by a recent payment stay in the candidate set until their
+        # chargeback window closes, so a saturated batch could keep newly
+        # eligible orgs waiting behind them.
+        if len(candidates) == OFFBOARD_EXPIRED_BATCH_SIZE:
+            log.warning(
+                "offboard_expired.batch_saturated",
+                limit=OFFBOARD_EXPIRED_BATCH_SIZE,
+            )
         for organization in candidates:
             enqueue_job(
                 "organization.offboard_expired_one",
@@ -1592,14 +1604,12 @@ class OrganizationService:
 
         cutoff = datetime.now(UTC) - settings.ORGANIZATION_OFFBOARDING_PERIOD
         last_paid_order_at = await repository.get_last_paid_order_at(organization.id)
-        anchors = [
-            d
-            for d in (last_paid_order_at, organization.status_updated_at)
-            if d is not None
-        ]
-        if not anchors:
-            anchors = [organization.created_at]
-        anchor = max(anchors)
+        status_entered_at = organization.status_updated_at or organization.created_at
+        anchor = (
+            max(last_paid_order_at, status_entered_at)
+            if last_paid_order_at is not None
+            else status_entered_at
+        )
         if anchor > cutoff:
             log.info(
                 "offboard_expired.skipped_recent_order",

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1551,28 +1551,71 @@ class OrganizationService:
     async def offboard_expired_organizations(
         self, session: AsyncSession
     ) -> Sequence[Organization]:
-        """Auto-transition offboarding orgs to the terminal offboarded state.
+        """Enqueue a per-org job for each offboarding org past the wind-down floor.
 
-        Run periodically by a worker once the offboarding period has elapsed
-        since both the org's last paid order (chargeback safety) and its
-        entry into offboarding (merchant wind-down floor). Returns the orgs
-        transitioned.
+        The cron only filters on when the org entered offboarding. Each
+        follow-up job re-checks the last paid order so a payment still inside
+        the chargeback window blocks the terminal transition. Returns the
+        organizations enqueued.
         """
         repository = OrganizationRepository.from_session(session)
         cutoff = datetime.now(UTC) - settings.ORGANIZATION_OFFBOARDING_PERIOD
-        # The candidate query takes FOR UPDATE on each org row, so a concurrent
-        # admin status change either falls out of the WHERE clause or waits
-        # behind our lock — no per-row re-check needed.
         candidates = await repository.get_offboarding_past_period(cutoff)
-        transitioned: list[Organization] = []
+        log.info(
+            "offboard_expired.candidates",
+            count=len(candidates),
+            cutoff=cutoff.isoformat(),
+        )
         for organization in candidates:
-            self._transition_to_offboarded(
-                session,
-                organization,
-                "Automatically offboarded after the offboarding period elapsed.",
+            enqueue_job(
+                "organization.offboard_expired_one",
+                organization_id=organization.id,
             )
-            transitioned.append(organization)
-        return transitioned
+        return candidates
+
+    async def complete_expired_offboarding(
+        self, session: AsyncSession, organization_id: UUID
+    ) -> Organization | None:
+        """Transition one offboarding org to offboarded if both gates have elapsed.
+
+        Locks the org row. Skips if status changed, or if the later of last
+        paid (not fully refunded) order and offboarding-entry is still inside
+        the offboarding period.
+        """
+        repository = OrganizationRepository.from_session(session)
+        organization = await repository.get_by_id(organization_id, for_update=True)
+        if (
+            organization is None
+            or organization.status != OrganizationStatus.OFFBOARDING
+        ):
+            return None
+
+        cutoff = datetime.now(UTC) - settings.ORGANIZATION_OFFBOARDING_PERIOD
+        last_paid_order_at = await repository.get_last_paid_order_at(organization.id)
+        anchors = [
+            d
+            for d in (last_paid_order_at, organization.status_updated_at)
+            if d is not None
+        ]
+        if not anchors:
+            anchors = [organization.created_at]
+        anchor = max(anchors)
+        if anchor > cutoff:
+            log.info(
+                "offboard_expired.skipped_recent_order",
+                organization_id=str(organization.id),
+                last_paid_order_at=(
+                    last_paid_order_at.isoformat() if last_paid_order_at else None
+                ),
+            )
+            return None
+
+        self._transition_to_offboarded(
+            session,
+            organization,
+            "Automatically offboarded after the offboarding period elapsed.",
+        )
+        return organization
 
     async def cancel_expired_organizations_subscriptions(
         self, session: AsyncSession

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -97,9 +97,21 @@ async def organization_unsnooze_expired() -> None:
     max_retries=0,
 )
 async def organization_offboard_expired() -> None:
-    """Auto-transition offboarding orgs to offboarded once the period elapses."""
+    """Enqueue a per-org job for each offboarding org past the wind-down floor."""
     async with AsyncSessionMaker() as session:
         await organization_service.offboard_expired_organizations(session)
+
+
+@actor(
+    actor_name="organization.offboard_expired_one",
+    priority=TaskPriority.LOW,
+)
+async def organization_offboard_expired_one(organization_id: uuid.UUID) -> None:
+    """Complete offboarding for one org if the chargeback window has also elapsed."""
+    async with AsyncSessionMaker() as session:
+        await organization_service.complete_expired_offboarding(
+            session, organization_id
+        )
 
 
 @actor(

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -4656,6 +4656,91 @@ class TestOffboardExpiredOrganizations:
         )
         await save_fixture(organization)
 
+    async def test_past_status_floor_enqueues(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        await self._make_offboarding(
+            save_fixture, organization, status_updated_days_ago=121
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            status=OrderStatus.paid,
+            created_at=datetime.now(UTC) - timedelta(days=10),
+        )
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert len(result) == 1
+        assert result[0].id == organization.id
+        assert result[0].status == OrganizationStatus.OFFBOARDING
+        enqueue_job_mock.assert_called_once_with(
+            "organization.offboard_expired_one",
+            organization_id=organization.id,
+        )
+
+    async def test_recent_offboarding_not_enqueued(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        await self._make_offboarding(
+            save_fixture, organization, status_updated_days_ago=4
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            status=OrderStatus.paid,
+            created_at=datetime.now(UTC) - timedelta(days=149),
+        )
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert result == []
+        assert organization.status == OrganizationStatus.OFFBOARDING
+        enqueue_job_mock.assert_not_called()
+
+    async def test_recent_offboarding_no_orders_not_enqueued(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        await self._make_offboarding(
+            save_fixture, organization, status_updated_days_ago=10
+        )
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert result == []
+        assert organization.status == OrganizationStatus.OFFBOARDING
+
+
+@pytest.mark.asyncio
+class TestCompleteExpiredOffboarding:
+    async def _make_offboarding(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        *,
+        status_updated_days_ago: int,
+    ) -> None:
+        organization.status = OrganizationStatus.OFFBOARDING
+        organization.status_updated_at = datetime.now(UTC) - timedelta(
+            days=status_updated_days_ago
+        )
+        await save_fixture(organization)
+
     async def test_both_anchors_old_transitions(
         self,
         mocker: MockerFixture,
@@ -4664,8 +4749,6 @@ class TestOffboardExpiredOrganizations:
         organization: Organization,
         customer: Customer,
     ) -> None:
-        # Both gates clear: chargeback window expired and merchant has had
-        # their wind-down period in offboarding.
         await self._make_offboarding(
             save_fixture, organization, status_updated_days_ago=121
         )
@@ -4677,11 +4760,12 @@ class TestOffboardExpiredOrganizations:
         )
         enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
-        result = await organization_service.offboard_expired_organizations(session)
+        result = await organization_service.complete_expired_offboarding(
+            session, organization.id
+        )
 
-        assert len(result) == 1
-        assert result[0].id == organization.id
-        assert result[0].status == OrganizationStatus.OFFBOARDED
+        assert result is not None
+        assert result.status == OrganizationStatus.OFFBOARDED
         enqueue_job_mock.assert_called_once_with(
             "organization.offboarded", organization_id=organization.id
         )
@@ -4693,9 +4777,6 @@ class TestOffboardExpiredOrganizations:
         organization: Organization,
         customer: Customer,
     ) -> None:
-        # Regression: an org freshly put into offboarding must still get its
-        # full wind-down period even if its last payment is already past the
-        # chargeback window. Anchor = MAX(last_paid, status_updated_at).
         await self._make_offboarding(
             save_fixture, organization, status_updated_days_ago=4
         )
@@ -4706,9 +4787,11 @@ class TestOffboardExpiredOrganizations:
             created_at=datetime.now(UTC) - timedelta(days=149),
         )
 
-        result = await organization_service.offboard_expired_organizations(session)
+        result = await organization_service.complete_expired_offboarding(
+            session, organization.id
+        )
 
-        assert result == []
+        assert result is None
         assert organization.status == OrganizationStatus.OFFBOARDING
 
     async def test_recent_paid_order_skipped(
@@ -4718,7 +4801,6 @@ class TestOffboardExpiredOrganizations:
         organization: Organization,
         customer: Customer,
     ) -> None:
-        # Old offboarding date, but a recent paid order anchors the window.
         await self._make_offboarding(
             save_fixture, organization, status_updated_days_ago=200
         )
@@ -4729,9 +4811,11 @@ class TestOffboardExpiredOrganizations:
             created_at=datetime.now(UTC) - timedelta(days=10),
         )
 
-        result = await organization_service.offboard_expired_organizations(session)
+        result = await organization_service.complete_expired_offboarding(
+            session, organization.id
+        )
 
-        assert result == []
+        assert result is None
         assert organization.status == OrganizationStatus.OFFBOARDING
 
     async def test_partially_refunded_recent_order_skipped(
@@ -4741,7 +4825,6 @@ class TestOffboardExpiredOrganizations:
         organization: Organization,
         customer: Customer,
     ) -> None:
-        # Partially refunded orders still count as paid-and-not-fully-refunded.
         await self._make_offboarding(
             save_fixture, organization, status_updated_days_ago=200
         )
@@ -4752,9 +4835,11 @@ class TestOffboardExpiredOrganizations:
             created_at=datetime.now(UTC) - timedelta(days=10),
         )
 
-        result = await organization_service.offboard_expired_organizations(session)
+        result = await organization_service.complete_expired_offboarding(
+            session, organization.id
+        )
 
-        assert result == []
+        assert result is None
         assert organization.status == OrganizationStatus.OFFBOARDING
 
     async def test_fully_refunded_order_falls_back_to_status_updated_at(
@@ -4765,8 +4850,6 @@ class TestOffboardExpiredOrganizations:
         organization: Organization,
         customer: Customer,
     ) -> None:
-        # A fully refunded order is ignored, so the window falls back to the
-        # offboarding-entry date, which is old enough here.
         await self._make_offboarding(
             save_fixture, organization, status_updated_days_ago=121
         )
@@ -4778,10 +4861,12 @@ class TestOffboardExpiredOrganizations:
         )
         enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
-        result = await organization_service.offboard_expired_organizations(session)
+        result = await organization_service.complete_expired_offboarding(
+            session, organization.id
+        )
 
-        assert len(result) == 1
-        assert result[0].status == OrganizationStatus.OFFBOARDED
+        assert result is not None
+        assert result.status == OrganizationStatus.OFFBOARDED
         enqueue_job_mock.assert_called_once_with(
             "organization.offboarded", organization_id=organization.id
         )
@@ -4798,28 +4883,15 @@ class TestOffboardExpiredOrganizations:
         )
         enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
-        result = await organization_service.offboard_expired_organizations(session)
+        result = await organization_service.complete_expired_offboarding(
+            session, organization.id
+        )
 
-        assert len(result) == 1
-        assert result[0].status == OrganizationStatus.OFFBOARDED
+        assert result is not None
+        assert result.status == OrganizationStatus.OFFBOARDED
         enqueue_job_mock.assert_called_once_with(
             "organization.offboarded", organization_id=organization.id
         )
-
-    async def test_recent_offboarding_no_orders_skipped(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        organization: Organization,
-    ) -> None:
-        await self._make_offboarding(
-            save_fixture, organization, status_updated_days_ago=10
-        )
-
-        result = await organization_service.offboard_expired_organizations(session)
-
-        assert result == []
-        assert organization.status == OrganizationStatus.OFFBOARDING
 
     async def test_old_offboarding_recent_paid_order_skipped(
         self,
@@ -4828,9 +4900,6 @@ class TestOffboardExpiredOrganizations:
         organization: Organization,
         customer: Customer,
     ) -> None:
-        # Mirror of the resumeset case: chargeback gate clears (offboarding is
-        # ancient) but the merchant just took a payment, so we must wait
-        # another 120 days from that payment before the terminal transition.
         await self._make_offboarding(
             save_fixture, organization, status_updated_days_ago=200
         )
@@ -4841,10 +4910,24 @@ class TestOffboardExpiredOrganizations:
             created_at=datetime.now(UTC) - timedelta(days=4),
         )
 
-        result = await organization_service.offboard_expired_organizations(session)
+        result = await organization_service.complete_expired_offboarding(
+            session, organization.id
+        )
 
-        assert result == []
+        assert result is None
         assert organization.status == OrganizationStatus.OFFBOARDING
+
+    async def test_not_offboarding_is_noop(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        result = await organization_service.complete_expired_offboarding(
+            session, organization.id
+        )
+
+        assert result is None
+        assert organization.status != OrganizationStatus.OFFBOARDED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The daily `organization.offboard_expired` cron timed out every morning, so no organization was ever auto-offboarded.

## Why

The cron ran one `MAX(orders.created_at)` subquery per row across every offboarding organization, and took `FOR UPDATE` on the whole batch. That went over the 30 second database command timeout. The task uses `max_retries=0`, so it just died each run.

## How

Split the work the same way subscription cancellation already does it.

- The cron now filters only on when an organization entered offboarding. This query is cheap and joins nothing.
- For each match it enqueues a new per-organization job.
- That job locks its own row, re-checks the status, and looks up the last paid order with an indexed single-organization `MAX` before making the terminal transition.

An organization that took a payment recently gets a cheap no-op job each day until its chargeback window closes. A warning is logged if a run fills the batch limit.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

