### PR TITLE
tf/aws: Move lambda to new subnets and setup new privatelink

### DIFF
--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -56,6 +56,27 @@ resource "aws_vpc_security_group_ingress_rule" "redis_nlb" {
   ip_protocol                  = "tcp"
 }
 
+module "redis_private_link_b" {
+  source = "../modules/redis_private_link"
+
+  name                     = "polar-sandbox-worker-redis-b"
+  vpc_id                   = module.vpc.vpc_id
+  subnet_ids               = module.vpc.secondary_private_subnet_ids
+  redis_host               = module.redis.host
+  redis_port               = module.redis.port
+  redis_arn                = module.redis.arn
+  allowed_principals       = ["arn:aws:iam::557508356783:root"]
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+}
+
+resource "aws_vpc_security_group_ingress_rule" "redis_nlb_b" {
+  security_group_id            = module.redis.security_group_id
+  referenced_security_group_id = module.redis_private_link_b.nlb_security_group_id
+  from_port                    = module.redis.port
+  to_port                      = module.redis.port
+  ip_protocol                  = "tcp"
+}
+
 locals {
   files_bucket_name        = "polar-sandbox-files"
   files_public_bucket_name = "polar-public-sandbox-files"

--- a/terraform/sandbox/network.tf
+++ b/terraform/sandbox/network.tf
@@ -31,6 +31,6 @@ resource "aws_security_group" "lambda" {
 }
 
 locals {
-  lambda_subnet_ids         = module.vpc.private_subnet_ids
+  lambda_subnet_ids         = module.vpc.secondary_private_subnet_ids
   lambda_security_group_ids = [aws_security_group.lambda.id]
 }

--- a/terraform/sandbox/outputs.tf
+++ b/terraform/sandbox/outputs.tf
@@ -27,3 +27,8 @@ output "redis_endpoint_service_name" {
   description = "VPC endpoint service name for the worker Redis. Provide to Render when creating the private link."
   value       = module.redis_private_link.service_name
 }
+
+output "redis_endpoint_service_name_b" {
+  description = "VPC endpoint service name for the worker Redis on the secondary subnets. Provide to Render when creating the private link."
+  value       = module.redis_private_link_b.service_name
+}


### PR DESCRIPTION
This will allow us to remove the previous privatelink after we've moved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the Lambda to secondary private subnets and creates a new Redis PrivateLink in those subnets. Previously the Lambda ran in `private_subnet_ids` and used the existing Redis PrivateLink; now it runs in `secondary_private_subnet_ids` with `redis_private_link_b`, enabling removal of the old PrivateLink after migration.

- Apply in sandbox, then create the Render PrivateLink using the new output `redis_endpoint_service_name_b`.
- Verify Lambda connectivity to Redis via the new PrivateLink.
- After verification, remove the previous PrivateLink and its related ingress rule.

<sup>Written for commit 329a4e76e207f28305c3d6a0c7493da45c60a7e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

