### PR TITLE
perf: add partial index for linking pending billing entries

### DIFF
--- a/server/migrations/versions/2026-08-17-1200_add_pending_link_billing_entry_index.py
+++ b/server/migrations/versions/2026-08-17-1200_add_pending_link_billing_entry_index.py
@@ -1,0 +1,50 @@
+"""add partial index for linking pending billing entries
+
+Revision ID: f3d81c25ab90
+Revises: d54b19ea954c
+Create Date: 2026-08-17 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "f3d81c25ab90"
+down_revision = "d54b19ea954c"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX_NAME = "ix_billing_entry_pending_link"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Drop any INVALID leftover from an interrupted concurrent build first.
+        op.drop_index(
+            INDEX_NAME,
+            table_name="billing_entry",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.create_index(
+            INDEX_NAME,
+            "billing_entry",
+            ["subscription_id", "product_price_id", "id"],
+            unique=False,
+            postgresql_where=sa.text("deleted_at IS NULL AND order_item_id IS NULL"),
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX_NAME,
+            table_name="billing_entry",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/server/polar/models/billing_entry.py
+++ b/server/polar/models/billing_entry.py
@@ -54,6 +54,16 @@ class BillingEntry(RecordModel):
                 "deleted_at IS NULL AND order_item_id IS NULL AND type != 'metered'"
             ),
         ),
+        # Keyset walk in `BillingEntryRepository._link_pending`, one price at a
+        # time: `id` last lets each batch resume with `id > last`. Only
+        # unlinked rows live here.
+        Index(
+            "ix_billing_entry_pending_link",
+            "subscription_id",
+            "product_price_id",
+            "id",
+            postgresql_where=text("deleted_at IS NULL AND order_item_id IS NULL"),
+        ),
     )
 
     start_timestamp: Mapped[datetime] = mapped_column(


### PR DESCRIPTION
## Summary

Adds a partial index on `billing_entry` to support keyset-batched linking of pending entries. Migration-only PR; the code that uses it lands in #13785, as ADR-0006 requires.

**Merge order: #13796 first, then this, then #13785.** The first merge-queue run of this PR failed: the index changes the plan of the pending scan, which exposed a latent plan-dependent row order and made three tests flaky. #13796 makes that ordering deterministic.

## What

- New partial index `ix_billing_entry_pending_link` on `(subscription_id, product_price_id, id)` where `deleted_at IS NULL AND order_item_id IS NULL`.
- Matching `Index` on the `BillingEntry` model.

## Why

Subscription renewals for high-volume metered subscriptions time out. The fix walks pending entries in `id` order, one price at a time, in batches that resume after the last linked id. That scan needs `id` in an index next to the subscription and price columns. Only unlinked rows live in the index, so it stays small and linking updates never write to it.

## How

`CREATE INDEX CONCURRENTLY` inside an autocommit block, with the usual drop of any INVALID leftover first. Same pattern as `ix_billing_entry_pending_static`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)