### PR TITLE
perf: keyset-paginate pending billing entry linking

### DIFF
--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -1,10 +1,9 @@
 from collections.abc import AsyncGenerator, Sequence
 from datetime import datetime
 from itertools import batched
-from typing import cast
 from uuid import UUID
 
-from sqlalchemy import CursorResult, Select, and_, func, or_, select, update
+from sqlalchemy import Select, and_, func, or_, select, update
 from sqlalchemy.orm.strategy_options import contains_eager, joinedload
 
 from polar.config import settings
@@ -159,36 +158,51 @@ class BillingEntryRepository(
         *,
         cutoff: datetime,
     ) -> None:
-        pending_ids = select(BillingEntry.id).where(
-            BillingEntry.subscription_id == subscription_id,
-            BillingEntry.deleted_at.is_(None),
-            BillingEntry.order_item_id.is_(None),
-            BillingEntry.product_price_id.in_(
-                select(ProductPriceMeteredUnit.id).where(
-                    ProductPriceMeteredUnit.meter_id == meter_id
-                )
-            ),
-            BillingEntry.start_timestamp < cutoff,
-            BillingEntry.created_at <= cutoff,
+        # `ix_billing_entry_pending_link` serves the id-ordered scan for one
+        # price at a time.
+        price_ids = await self.session.scalars(
+            select(ProductPriceMeteredUnit.id).where(
+                ProductPriceMeteredUnit.meter_id == meter_id
+            )
         )
-        await self._link_pending(pending_ids, order_item_id)
+        for product_price_id in price_ids:
+            await self.link_pending_by_subscription_and_price(
+                subscription_id, product_price_id, order_item_id, cutoff=cutoff
+            )
 
     async def _link_pending(
         self, pending_ids: Select[tuple[UUID]], order_item_id: UUID
     ) -> None:
-        batch_ids = pending_ids.limit(_LINK_PENDING_BATCH_SIZE)
-        statement = (
-            update(BillingEntry)
-            .where(BillingEntry.id.in_(batch_ids))
-            .values(order_item_id=order_item_id)
-            .execution_options(synchronize_session=False)
-        )
+        # Keyset pagination: a bare `LIMIT` restart would re-scan rows already
+        # updated in this transaction, making the loop quadratic.
+        last_id: UUID | None = None
         while True:
-            result = cast(
-                CursorResult[BillingEntry], await self.session.execute(statement)
+            batch_ids = pending_ids
+            if last_id is not None:
+                batch_ids = batch_ids.where(BillingEntry.id > last_id)
+            batch_ids = batch_ids.order_by(BillingEntry.id).limit(
+                _LINK_PENDING_BATCH_SIZE
             )
-            if result.rowcount < _LINK_PENDING_BATCH_SIZE:
+            updated = (
+                update(BillingEntry)
+                .where(BillingEntry.id.in_(batch_ids))
+                .values(order_item_id=order_item_id)
+                .returning(BillingEntry.id)
+                .cte("updated_billing_entry")
+            )
+            # Postgres has no max(uuid), hence the ordered scalar subquery.
+            statement = select(
+                func.count(),
+                select(updated.c.id)
+                .order_by(updated.c.id.desc())
+                .limit(1)
+                .scalar_subquery(),
+            ).select_from(updated)
+            updated_count, batch_last_id = (await self.session.execute(statement)).one()
+            if updated_count < _LINK_PENDING_BATCH_SIZE:
                 break
+            assert batch_last_id is not None
+            last_id = batch_last_id
 
     async def lock_pending_by_subscription(self, subscription_id: UUID) -> None:
         """

--- a/server/polar/observability/invariants/rules/subscriptions_locked_invariant.py
+++ b/server/polar/observability/invariants/rules/subscriptions_locked_invariant.py
@@ -33,7 +33,9 @@ class SubscriptionsLockedInvariant(Invariant):
     Failure of this invariant indicate there is an issue with the subscription cycle process.
     """
 
-    LEEWAY = timedelta(minutes=5)
+    # Must exceed `subscription.cycle`'s 600s time_limit: it holds
+    # `scheduler_locked_at` for its whole run.
+    LEEWAY = timedelta(minutes=15)
     LIMIT = 10
 
     async def check(self) -> None:

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -71,7 +71,12 @@ async def order_created(order_id: uuid.UUID) -> None:
             raise OrderDoesNotExist(order_id)
 
 
-@actor(actor_name="order.create_subscription_order", priority=TaskPriority.LOW)
+@actor(
+    actor_name="order.create_subscription_order",
+    priority=TaskPriority.LOW,
+    # Linking a whole cycle of pending billing entries doesn't fit the default 60s.
+    time_limit=600_000,
+)
 async def create_subscription_order(
     subscription_id: uuid.UUID,
     order_reason: OrderBillingReasonInternal,

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -43,7 +43,12 @@ class SubscriptionTierDoesNotExist(SubscriptionTaskError):
         super().__init__(message)
 
 
-@actor(actor_name="subscription.cycle", priority=TaskPriority.LOW)
+@actor(
+    actor_name="subscription.cycle",
+    priority=TaskPriority.LOW,
+    # The meter-only branch links pending billing entries inline; doesn't fit 60s.
+    time_limit=600_000,
+)
 async def subscription_cycle(subscription_id: uuid.UUID, force: bool = False) -> None:
     async with AsyncSessionMaker() as session:
         repository = SubscriptionRepository.from_session(session)

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 import pytest
 import pytest_asyncio
 from pytest_mock import MockerFixture
-from sqlalchemy import Update
+from sqlalchemy import Select
 
 from polar.billing_entry.service import billing_entry as billing_entry_service
 from polar.enums import SubscriptionProrationBehavior, SubscriptionRecurringInterval
@@ -622,11 +622,20 @@ class TestCreateOrderItemsFromPending:
         billing_entry_updates = [
             call.args[0]
             for call in execute_spy.call_args_list
-            if isinstance(call.args[0], Update)
-            and getattr(call.args[0].table, "name", None) == BillingEntry.__tablename__
+            if isinstance(call.args[0], Select)
+            and f"UPDATE {BillingEntry.__tablename__}" in str(call.args[0])
         ]
         assert len(billing_entry_updates) > len(order_items)
-        assert all("LIMIT" in str(statement) for statement in billing_entry_updates)
+        # The batch LIMIT and the last-id subquery LIMIT.
+        assert all(
+            str(statement).count("LIMIT") == 2 for statement in billing_entry_updates
+        )
+        keyset_statements = [
+            statement
+            for statement in billing_entry_updates
+            if f"{BillingEntry.__tablename__}.id > " in str(statement)
+        ]
+        assert len(keyset_statements) >= len(order_items)
 
     @pytest.mark.parametrize(
         ("entry_type", "new_seats", "expected_transition"),

--- a/server/tests/observability/invariants/rules/test_subscriptions_locked_invariant.py
+++ b/server/tests/observability/invariants/rules/test_subscriptions_locked_invariant.py
@@ -32,7 +32,7 @@ async def test_failure(
         status=SubscriptionStatus.active,
         product=product,
         customer=customer,
-        scheduler_locked_at=utc_now() - timedelta(minutes=10),
+        scheduler_locked_at=utc_now() - timedelta(minutes=20),
     )
 
     with pytest.raises(SubscriptionsLockedInvariantError) as exc_info:
@@ -56,7 +56,7 @@ async def test_failure_over_limit(
             status=SubscriptionStatus.active,
             product=product,
             customer=customer,
-            scheduler_locked_at=utc_now() - timedelta(minutes=10),
+            scheduler_locked_at=utc_now() - timedelta(minutes=20),
         )
 
     with pytest.raises(SubscriptionsLockedInvariantError) as exc_info:


### PR DESCRIPTION
## Summary

Fixes subscription renewals that time out on high-volume metered subscriptions.

**Merge order: #13796, then #13784, then this.**

## What

- `_link_pending` now walks pending entries in `id` order and resumes each batch after the last linked id, instead of restarting a bare `LIMIT` scan.
- Each batch returns only a count and the last id, computed server-side in a CTE.
- Meter linking runs one price at a time so the scan stays on the new index.
- `order.create_subscription_order` and `subscription.cycle` get a 600s time limit. Both run this loop on whole-cycle backlogs.
- The locked-subscription invariant leeway goes from 5 to 15 minutes so healthy long runs don't page.

## Why

The old loop re-issued the same `UPDATE ... LIMIT` statement until done. Rows updated earlier in the transaction stay visible to the scan until commit, so each batch re-scanned everything already linked. With hundreds of thousands of pending entries the task could not finish inside the 60s worker limit. The rollback threw away all progress, so every retry started from zero and failed the same way. Production traces show 16 attempts in a row killed at exactly 60s with no progress.

## How

Keyset pagination on `id`, served by `ix_billing_entry_pending_link` from #13784. Each batch does bounded work, so batch time stays flat instead of growing.

Measured, not estimated: on a local database seeded with 600,000 pending entries for one subscription (schema built from the models, so all production indexes are present), the real repository code links the full set in about 24 seconds. EXPLAIN confirms the new index serves the scan with the cursor as an index condition. Production adds load and cold caches, but the 600s budget leaves wide headroom. Not measured end to end in production yet; the first real cycle after deploy will confirm.

The linking stays in one transaction, so billing semantics do not change: amounts are computed from the pending set before linking, and partial progress is never committed.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)