### PR TITLE
fix(web): stop dashboard content from clipping beside the sidebar

### DIFF
--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -59,7 +59,7 @@ const DashboardLayout = (
         </div>
         <div
           className={twMerge(
-            'relative flex h-full w-full flex-col',
+            'relative flex h-full min-w-0 flex-1 flex-col',
             props.className,
           )}
         >


### PR DESCRIPTION
The main pane was w-full in a flex row with the sidebar, so the layout was sidebar + 100% viewport. That overflowed and got clipped (discounts table, New button, pagination) and would prevent horizontal scrolling correctly.

The pane now uses flex-1 min-w-0 so it only takes the remaining width and still letting scroll the table all the way.

Fixes more than the discount page on mid to small devices. Customer page for example.

**Related Ticket**: https://app.plain.com/workspace/w_01JE9TRRX9KT61D8P2CH77XDQM/thread/th_01M07B4VNFH1CQAW291EYDWKDC/

| Before | After |
|---|---|
| <img width="1223" height="639" alt="Screenshot 2026-08-17 at 14 45 40" src="https://github.com/user-attachments/assets/a5a06416-a8fb-4c0b-a5c6-a744d904ebec" /> | <img width="1176" height="642" alt="Screenshot 2026-08-17 at 14 46 03" src="https://github.com/user-attachments/assets/b6463465-0573-494a-8583-8111b85d3fa7" /> |
| <img width="1276" height="605" alt="Screenshot 2026-08-17 at 14 47 26" src="https://github.com/user-attachments/assets/d13fc89f-4313-48b2-8035-fe6e264e7c3b" /> | <img width="1225" height="570" alt="Screenshot 2026-08-17 at 14 47 58" src="https://github.com/user-attachments/assets/624104aa-0877-4057-8f3a-ff211bb24a23" /> |




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

