### PR TITLE
Fix read performance of meter quantities endpoint

### DIFF
--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -432,6 +432,43 @@ class CustomerRepository(
         result = await self.session.execute(statement)
         return {external_id: id for external_id, id in result.all()}
 
+    async def resolve_customer_identifiers(
+        self,
+        organization_id: UUID,
+        customer_ids: Sequence[UUID],
+        external_customer_ids: Sequence[str],
+    ) -> set[tuple[UUID | None, str | None]]:
+        if not customer_ids and not external_customer_ids:
+            return set()
+
+        statement = (
+            self.get_base_statement()
+            .with_only_columns(Customer.id, Customer.external_id)
+            .where(
+                Customer.organization_id == organization_id,
+                or_(
+                    Customer.id.in_(customer_ids),
+                    Customer.external_id.in_(external_customer_ids),
+                ),
+            )
+        )
+        result = await self.session.execute(statement)
+        resolved_identifiers: set[tuple[UUID | None, str | None]] = set(
+            result.tuples().all()
+        )
+
+        resolved_external_customer_ids = {
+            external_customer_id
+            for _, external_customer_id in resolved_identifiers
+            if external_customer_id is not None
+        }
+        resolved_identifiers.update(
+            (None, external_customer_id)
+            for external_customer_id in external_customer_ids
+            if external_customer_id not in resolved_external_customer_ids
+        )
+        return resolved_identifiers
+
     async def lower_first_user_event_at(
         self, timestamps: Mapping[UUID, datetime]
     ) -> None:

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -21,7 +21,7 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.dialects.postgresql import aggregate_order_by, insert
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import aliased, joinedload
 
 from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import RepositoryBase, RepositoryIDMixin
@@ -289,26 +289,57 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         return result.scalar_one_or_none()
 
     def get_customer_id_filter_clause(
-        self, customer_id: Sequence[UUID]
+        self, organization_id: UUID, customer_id: Sequence[UUID]
     ) -> ColumnElement[bool]:
-        return or_(
-            Event.customer_id.in_(customer_id),
-            Event.external_customer_id.in_(
-                select(Customer.external_id).where(Customer.id.in_(customer_id))
-            ),
+        event_by_customer_id = aliased(Event)
+        event_by_external_customer_id = aliased(Event)
+        external_customer_ids = select(Customer.external_id).where(
+            Customer.organization_id == organization_id,
+            Customer.id.in_(customer_id),
+            Customer.external_id.is_not(None),
         )
+        matching_event_ids = (
+            select(event_by_customer_id.id)
+            .where(
+                event_by_customer_id.organization_id == organization_id,
+                event_by_customer_id.customer_id.in_(customer_id),
+            )
+            .union_all(
+                select(event_by_external_customer_id.id).where(
+                    event_by_external_customer_id.organization_id == organization_id,
+                    event_by_external_customer_id.external_customer_id.in_(
+                        external_customer_ids
+                    ),
+                )
+            )
+        )
+        return Event.id.in_(matching_event_ids)
 
     def get_external_customer_id_filter_clause(
-        self, external_customer_id: Sequence[str]
+        self, organization_id: UUID, external_customer_id: Sequence[str]
     ) -> ColumnElement[bool]:
-        return or_(
-            Event.external_customer_id.in_(external_customer_id),
-            Event.customer_id.in_(
-                select(Customer.id).where(
-                    Customer.external_id.in_(external_customer_id)
-                )
-            ),
+        event_by_external_customer_id = aliased(Event)
+        event_by_customer_id = aliased(Event)
+        customer_ids = select(Customer.id).where(
+            Customer.organization_id == organization_id,
+            Customer.external_id.in_(external_customer_id),
         )
+        matching_event_ids = (
+            select(event_by_external_customer_id.id)
+            .where(
+                event_by_external_customer_id.organization_id == organization_id,
+                event_by_external_customer_id.external_customer_id.in_(
+                    external_customer_id
+                ),
+            )
+            .union_all(
+                select(event_by_customer_id.id).where(
+                    event_by_customer_id.organization_id == organization_id,
+                    event_by_customer_id.customer_id.in_(customer_ids),
+                )
+            )
+        )
+        return Event.id.in_(matching_event_ids)
 
     def get_meter_clause(self, meter: Meter) -> ColumnExpressionArgument[bool]:
         return and_(

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from datetime import datetime, timedelta
 from typing import Any
 from uuid import UUID
@@ -288,46 +288,19 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         result = await self.session.execute(statement)
         return result.scalar_one_or_none()
 
-    def get_customer_id_filter_clause(
-        self, organization_id: UUID, customer_id: Sequence[UUID]
+    def get_customer_filter_clause(
+        self,
+        organization_id: UUID,
+        customer_id: Collection[UUID],
+        external_customer_id: Collection[str],
     ) -> ColumnElement[bool]:
-        external_customer_ids = select(Customer.external_id).where(
-            Customer.organization_id == organization_id,
-            Customer.id.in_(customer_id),
-            Customer.external_id.is_not(None),
-        )
-        events_by_customer_id = select(Event.id).where(
+        return and_(
             Event.organization_id == organization_id,
-            Event.customer_id.in_(customer_id),
+            or_(
+                Event.customer_id.in_(customer_id),
+                Event.external_customer_id.in_(external_customer_id),
+            ),
         )
-        events_by_external_customer_id = select(Event.id).where(
-            Event.organization_id == organization_id,
-            Event.external_customer_id.in_(external_customer_ids),
-        )
-        matching_event_ids = events_by_customer_id.union_all(
-            events_by_external_customer_id
-        )
-        return Event.id.in_(matching_event_ids)
-
-    def get_external_customer_id_filter_clause(
-        self, organization_id: UUID, external_customer_id: Sequence[str]
-    ) -> ColumnElement[bool]:
-        customer_ids = select(Customer.id).where(
-            Customer.organization_id == organization_id,
-            Customer.external_id.in_(external_customer_id),
-        )
-        events_by_external_customer_id = select(Event.id).where(
-            Event.organization_id == organization_id,
-            Event.external_customer_id.in_(external_customer_id),
-        )
-        events_by_customer_id = select(Event.id).where(
-            Event.organization_id == organization_id,
-            Event.customer_id.in_(customer_ids),
-        )
-        matching_event_ids = events_by_external_customer_id.union_all(
-            events_by_customer_id
-        )
-        return Event.id.in_(matching_event_ids)
 
     def get_meter_clause(self, meter: Meter) -> ColumnExpressionArgument[bool]:
         return and_(

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -21,7 +21,7 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.dialects.postgresql import aggregate_order_by, insert
-from sqlalchemy.orm import aliased, joinedload
+from sqlalchemy.orm import joinedload
 
 from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import RepositoryBase, RepositoryIDMixin
@@ -291,53 +291,41 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
     def get_customer_id_filter_clause(
         self, organization_id: UUID, customer_id: Sequence[UUID]
     ) -> ColumnElement[bool]:
-        event_by_customer_id = aliased(Event)
-        event_by_external_customer_id = aliased(Event)
         external_customer_ids = select(Customer.external_id).where(
             Customer.organization_id == organization_id,
             Customer.id.in_(customer_id),
             Customer.external_id.is_not(None),
         )
-        matching_event_ids = (
-            select(event_by_customer_id.id)
-            .where(
-                event_by_customer_id.organization_id == organization_id,
-                event_by_customer_id.customer_id.in_(customer_id),
-            )
-            .union_all(
-                select(event_by_external_customer_id.id).where(
-                    event_by_external_customer_id.organization_id == organization_id,
-                    event_by_external_customer_id.external_customer_id.in_(
-                        external_customer_ids
-                    ),
-                )
-            )
+        events_by_customer_id = select(Event.id).where(
+            Event.organization_id == organization_id,
+            Event.customer_id.in_(customer_id),
+        )
+        events_by_external_customer_id = select(Event.id).where(
+            Event.organization_id == organization_id,
+            Event.external_customer_id.in_(external_customer_ids),
+        )
+        matching_event_ids = events_by_customer_id.union_all(
+            events_by_external_customer_id
         )
         return Event.id.in_(matching_event_ids)
 
     def get_external_customer_id_filter_clause(
         self, organization_id: UUID, external_customer_id: Sequence[str]
     ) -> ColumnElement[bool]:
-        event_by_external_customer_id = aliased(Event)
-        event_by_customer_id = aliased(Event)
         customer_ids = select(Customer.id).where(
             Customer.organization_id == organization_id,
             Customer.external_id.in_(external_customer_id),
         )
-        matching_event_ids = (
-            select(event_by_external_customer_id.id)
-            .where(
-                event_by_external_customer_id.organization_id == organization_id,
-                event_by_external_customer_id.external_customer_id.in_(
-                    external_customer_id
-                ),
-            )
-            .union_all(
-                select(event_by_customer_id.id).where(
-                    event_by_customer_id.organization_id == organization_id,
-                    event_by_customer_id.customer_id.in_(customer_ids),
-                )
-            )
+        events_by_external_customer_id = select(Event.id).where(
+            Event.organization_id == organization_id,
+            Event.external_customer_id.in_(external_customer_id),
+        )
+        events_by_customer_id = select(Event.id).where(
+            Event.organization_id == organization_id,
+            Event.customer_id.in_(customer_ids),
+        )
+        matching_event_ids = events_by_external_customer_id.union_all(
+            events_by_customer_id
         )
         return Event.id.in_(matching_event_ids)
 

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -327,16 +327,30 @@ class MeterService:
             Event.organization_id == meter.organization_id,
         ]
         event_repository = EventRepository.from_session(session)
-        if customer_id is not None:
-            event_clauses.append(
-                event_repository.get_customer_id_filter_clause(
-                    meter.organization_id, customer_id
+        customer_repository = CustomerRepository.from_session(session)
+        if customer_id is not None or external_customer_id is not None:
+            resolved_customer_identifiers = (
+                await customer_repository.resolve_customer_identifiers(
+                    meter.organization_id,
+                    customer_id or (),
+                    external_customer_id or (),
                 )
             )
-        if external_customer_id is not None:
+            resolved_customer_ids = {
+                customer_id
+                for customer_id, _ in resolved_customer_identifiers
+                if customer_id is not None
+            }
+            resolved_external_customer_ids = {
+                external_customer_id
+                for _, external_customer_id in resolved_customer_identifiers
+                if external_customer_id is not None
+            }
             event_clauses.append(
-                event_repository.get_external_customer_id_filter_clause(
-                    meter.organization_id, external_customer_id
+                event_repository.get_customer_filter_clause(
+                    meter.organization_id,
+                    resolved_customer_ids,
+                    resolved_external_customer_ids,
                 )
             )
         if metadata is not None:

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -329,12 +329,14 @@ class MeterService:
         event_repository = EventRepository.from_session(session)
         if customer_id is not None:
             event_clauses.append(
-                event_repository.get_customer_id_filter_clause(customer_id)
+                event_repository.get_customer_id_filter_clause(
+                    meter.organization_id, customer_id
+                )
             )
         if external_customer_id is not None:
             event_clauses.append(
                 event_repository.get_external_customer_id_filter_clause(
-                    external_customer_id
+                    meter.organization_id, external_customer_id
                 )
             )
         if metadata is not None:

--- a/server/tests/customer/test_repository.py
+++ b/server/tests/customer/test_repository.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import timedelta
 from unittest.mock import call
 
@@ -33,6 +34,49 @@ async def test_get_by_id(
 
     result = await repository.get_by_id(customer.id, include_deleted=True)
     assert result == customer
+
+
+@pytest.mark.asyncio
+async def test_resolve_customer_identifiers(
+    save_fixture: SaveFixture,
+    repository: CustomerRepository,
+    organization: Organization,
+    organization_second: Organization,
+) -> None:
+    external_customer = await create_customer(
+        save_fixture,
+        organization=organization,
+        external_id="external-customer",
+        email="external-customer@example.com",
+    )
+    customer = await create_customer(
+        save_fixture,
+        organization=organization,
+        email="customer@example.com",
+    )
+    await create_customer(
+        save_fixture,
+        organization=organization_second,
+        external_id="other-organization-customer",
+    )
+    unknown_customer_id = uuid.uuid4()
+
+    result = await repository.resolve_customer_identifiers(
+        organization.id,
+        [external_customer.id, customer.id, unknown_customer_id],
+        [
+            "external-customer",
+            "unknown-external-customer",
+            "other-organization-customer",
+        ],
+    )
+
+    assert result == {
+        (external_customer.id, "external-customer"),
+        (customer.id, None),
+        (None, "unknown-external-customer"),
+        (None, "other-organization-customer"),
+    }
 
 
 @pytest.mark.asyncio

--- a/server/tests/event/test_repository.py
+++ b/server/tests/event/test_repository.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime, timedelta
 
 import pytest
+from sqlalchemy import select
 
 from polar.event.repository import EventRepository
 from polar.kit.utils import utc_now
@@ -9,6 +10,7 @@ from polar.models import Event, Organization
 from polar.models.event import EventSource
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_customer
 
 
 async def _create_event(
@@ -20,6 +22,8 @@ async def _create_event(
     source: EventSource = EventSource.user,
     name: str = "test_event",
     user_metadata: dict[str, object] | None = None,
+    customer_id: uuid.UUID | None = None,
+    external_customer_id: str | None = None,
 ) -> Event:
     event_id = uuid.uuid4()
     event = Event(
@@ -31,9 +35,92 @@ async def _create_event(
         organization=organization,
         root_id=event_id,
         user_metadata=user_metadata or {},
+        customer_id=customer_id,
+        external_customer_id=external_customer_id,
     )
     await save_fixture(event)
     return event
+
+
+@pytest.mark.asyncio
+class TestCustomerFilterClause:
+    async def test_customer_id_resolves_external_id_within_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        external_id = "shared-external-id"
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id=external_id,
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            external_id=external_id,
+        )
+        matching_event = await _create_event(
+            save_fixture,
+            organization=organization,
+            ingested_at=utc_now(),
+            external_customer_id=external_id,
+        )
+        await _create_event(
+            save_fixture,
+            organization=organization_second,
+            ingested_at=utc_now(),
+            external_customer_id=external_id,
+        )
+
+        repository = EventRepository.from_session(session)
+        clause = repository.get_customer_id_filter_clause(
+            organization.id, [customer.id]
+        )
+        result = await session.scalars(select(Event).where(clause))
+
+        assert list(result) == [matching_event]
+
+    async def test_external_customer_id_resolves_customer_within_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        external_id = "shared-external-id"
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id=external_id,
+        )
+        other_customer = await create_customer(
+            save_fixture,
+            organization=organization_second,
+            external_id=external_id,
+        )
+        matching_event = await _create_event(
+            save_fixture,
+            organization=organization,
+            ingested_at=utc_now(),
+            customer_id=customer.id,
+        )
+        await _create_event(
+            save_fixture,
+            organization=organization_second,
+            ingested_at=utc_now(),
+            customer_id=other_customer.id,
+        )
+
+        repository = EventRepository.from_session(session)
+        clause = repository.get_external_customer_id_filter_clause(
+            organization.id, [external_id]
+        )
+        result = await session.scalars(select(Event).where(clause))
+
+        assert list(result) == [matching_event]
 
 
 @pytest.mark.asyncio

--- a/server/tests/event/test_repository.py
+++ b/server/tests/event/test_repository.py
@@ -44,7 +44,7 @@ async def _create_event(
 
 @pytest.mark.asyncio
 class TestCustomerFilterClause:
-    async def test_customer_id_resolves_external_id_within_organization(
+    async def test_customer_id_matches_external_id_within_organization(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -76,14 +76,14 @@ class TestCustomerFilterClause:
         )
 
         repository = EventRepository.from_session(session)
-        clause = repository.get_customer_id_filter_clause(
-            organization.id, [customer.id]
+        clause = repository.get_customer_filter_clause(
+            organization.id, [customer.id], [external_id]
         )
         result = await session.scalars(select(Event).where(clause))
 
         assert list(result) == [matching_event]
 
-    async def test_external_customer_id_resolves_customer_within_organization(
+    async def test_external_customer_id_matches_customer_within_organization(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -115,8 +115,8 @@ class TestCustomerFilterClause:
         )
 
         repository = EventRepository.from_session(session)
-        clause = repository.get_external_customer_id_filter_clause(
-            organization.id, [external_id]
+        clause = repository.get_customer_filter_clause(
+            organization.id, [customer.id], [external_id]
         )
         result = await session.scalars(select(Event).where(clause))
 

--- a/server/tests/meter/test_service.py
+++ b/server/tests/meter/test_service.py
@@ -1155,8 +1155,10 @@ class TestGetQuantities:
         assert result.quantities[0].quantity == 3
         assert result.total == 3
 
-    async def test_external_customer_id_filter_resolves_customer(
+    @pytest.mark.parametrize("use_external_customer_id", [False, True])
+    async def test_customer_filter_resolves_both_identifiers(
         self,
+        use_external_customer_id: bool,
         save_fixture: SaveFixture,
         session: AsyncSession,
         customer_external_id: Customer,
@@ -1197,7 +1199,10 @@ class TestGetQuantities:
         result = await meter_service.get_quantities(
             session,
             meter,
-            external_customer_id=[customer.external_id],
+            customer_id=None if use_external_customer_id else [customer.id],
+            external_customer_id=(
+                [customer.external_id] if use_external_customer_id else None
+            ),
             start_timestamp=timestamp,
             end_timestamp=timestamp,
             interval=TimeInterval.day,

--- a/server/tests/meter/test_service.py
+++ b/server/tests/meter/test_service.py
@@ -1109,6 +1109,105 @@ class TestGetQuantities:
         assert quantity.quantity == expected_value
         assert result.total == expected_value
 
+    async def test_external_customer_id_filter_without_customer_record(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+    ) -> None:
+        timestamp = utc_now()
+        external_customer_id = "unresolved-external-customer"
+        for _ in range(3):
+            await create_event(
+                save_fixture,
+                timestamp=timestamp,
+                organization=customer.organization,
+                external_customer_id=external_customer_id,
+                metadata={"model": "lite"},
+            )
+
+        meter = await create_meter(
+            save_fixture,
+            name="Lite Model Usage",
+            filter=Filter(
+                conjunction=FilterConjunction.and_,
+                clauses=[
+                    FilterClause(
+                        property="model", operator=FilterOperator.eq, value="lite"
+                    )
+                ],
+            ),
+            aggregation=CountAggregation(),
+            organization=customer.organization,
+        )
+
+        result = await meter_service.get_quantities(
+            session,
+            meter,
+            external_customer_id=[external_customer_id],
+            start_timestamp=timestamp,
+            end_timestamp=timestamp,
+            interval=TimeInterval.day,
+            timezone=ZoneInfo("UTC"),
+        )
+
+        assert len(result.quantities) == 1
+        assert result.quantities[0].quantity == 3
+        assert result.total == 3
+
+    async def test_external_customer_id_filter_resolves_customer(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer_external_id: Customer,
+    ) -> None:
+        customer = customer_external_id
+        assert customer.external_id is not None
+        timestamp = utc_now()
+        await create_event(
+            save_fixture,
+            timestamp=timestamp,
+            organization=customer.organization,
+            customer=customer,
+            metadata={"model": "lite"},
+        )
+        await create_event(
+            save_fixture,
+            timestamp=timestamp,
+            organization=customer.organization,
+            external_customer_id=customer.external_id,
+            metadata={"model": "lite"},
+        )
+
+        meter = await create_meter(
+            save_fixture,
+            name="Lite Model Usage",
+            filter=Filter(
+                conjunction=FilterConjunction.and_,
+                clauses=[
+                    FilterClause(
+                        property="model", operator=FilterOperator.eq, value="lite"
+                    )
+                ],
+            ),
+            aggregation=CountAggregation(),
+            organization=customer.organization,
+        )
+
+        result = await meter_service.get_quantities(
+            session,
+            meter,
+            external_customer_id=[customer.external_id],
+            start_timestamp=timestamp,
+            end_timestamp=timestamp,
+            interval=TimeInterval.day,
+            timezone=ZoneInfo("UTC"),
+        )
+
+        assert len(result.quantities) == 1
+        assert result.quantities[0].quantity == 2
+        assert result.total == 2
+
 
 @pytest.mark.asyncio
 class TestGetQuantity:


### PR DESCRIPTION
Bug fix: customer and external customer filters could match events across organizations sharing the same external ID.

Performance improvement: resolve the passed in customer ID's first to a list of tuples (customer_id, external_customer_id), then find events for those ID's. This path avoids sequential scans throughout.