### PR TITLE
tf: Reintroduce pgbouncer in sandbox + test

### DIFF
--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -105,14 +105,18 @@ module "sandbox" {
   registry_credential_id = render_registry_credential.ghcr.id
 
   postgres_config = {
-    host          = local.db_internal_host
-    port          = local.db_port
-    user          = local.db_user
-    password      = local.db_password
-    read_host     = local.read_replica.id
-    read_port     = local.db_port
-    read_user     = local.db_user
-    read_password = local.db_password
+    host               = module.pgbouncer.host
+    port               = module.pgbouncer.port
+    user               = local.db_user
+    password           = local.db_password
+    host_fallback      = local.db_internal_host
+    port_fallback      = local.db_port
+    read_host          = module.pgbouncer_read.host
+    read_port          = module.pgbouncer_read.port
+    read_user          = local.db_user
+    read_password      = local.db_password
+    read_host_fallback = local.read_replica.id
+    read_port_fallback = local.db_port
   }
 
   redis_config = {

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -119,14 +119,18 @@ module "test" {
   registry_credential_id = render_registry_credential.ghcr.id
 
   postgres_config = {
-    host          = local.db_internal_host
-    port          = local.db_port
-    user          = local.db_user
-    password      = local.db_password
-    read_host     = local.read_replica.id
-    read_port     = local.db_port
-    read_user     = local.db_user
-    read_password = local.db_password
+    host               = module.pgbouncer[0].host
+    port               = module.pgbouncer[0].port
+    user               = local.db_user
+    password           = local.db_password
+    host_fallback      = local.db_internal_host
+    port_fallback      = local.db_port
+    read_host          = module.pgbouncer_read[0].host
+    read_port          = module.pgbouncer_read[0].port
+    read_user          = local.db_user
+    read_password      = local.db_password
+    read_host_fallback = local.read_replica.id
+    read_port_fallback = local.db_port
   }
 
   redis_config = {


### PR DESCRIPTION
This will hopefully work now that we've fixed the masking bug


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes sandbox and test Postgres connections through PgBouncer with direct-DB fallbacks to restore pooling and reduce connection pressure. Previously, services connected directly to primary and read replica; now they go via PgBouncer and fall back to direct hosts if PgBouncer is unavailable.

**Review and rollout**
- Updates `postgres_config` in `terraform/sandbox/render.tf` and `terraform/test/render.tf` to use `module.pgbouncer`/`module.pgbouncer_read` for `host`/`port`, and adds `host_fallback`/`port_fallback` and `read_host_fallback`/`read_port_fallback` to the direct DB hosts.
- Test env references `module.pgbouncer[0]` and `module.pgbouncer_read[0]`; verify these modules are created when applying in test.
- Apply in sandbox and test; expect service reconfiguration only (no DB schema changes).

<sup>Written for commit 1fb9b33007f92b726847292d4c05f9e7b3ade8c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

