### PR TITLE
server/auth: issue TOTP codes using SHA-1 instead of SHA-256

### DIFF
--- a/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
+++ b/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
@@ -24,7 +24,6 @@ export interface TOTPSetupModalProps {
 const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
   const [code, setCode] = useState('')
   const [error, setError] = useState<string | null>(null)
-  const [invalidCodeError, setInvalidCodeError] = useState<boolean>(false)
   const [enrollment, setEnrollment] = useState<
     schemas['TOTPEnrollment'] | null
   >(null)
@@ -118,13 +117,6 @@ const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
               {error}
             </Text>
           )}
-          {invalidCodeError && (
-            <Text color="danger" variant="caption" align="center">
-              Using Authy? It doesn&apos;t support the modern and secure
-              algorithms we use. We recommend choosing a different authenticator
-              app.
-            </Text>
-          )}
         </div>
       </div>
     )
@@ -145,7 +137,6 @@ const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
   }
 
   const handleVerify = async () => {
-    setInvalidCodeError(false)
     if (!code || code.length !== 6) {
       setError('Please enter a 6-digit code')
       return
@@ -155,7 +146,6 @@ const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
     if (error) {
       if (!isSessionNotFreshError(error)) {
         setError('Invalid code. Please try again.')
-        setInvalidCodeError(true)
       }
       return
     }

--- a/server/polar/auth/factors.py
+++ b/server/polar/auth/factors.py
@@ -166,7 +166,7 @@ class EmailOTPFactor(EmailOTPFactorBase):
 class TOTPFactor(TOTPFactorBase):
     def __init__(self, session: AsyncSession) -> None:
         self.session = session
-        super().__init__()
+        super().__init__(algorithm="sha1")
 
     async def get_by_identity_id(
         self, identity_id: uuid.UUID


### PR DESCRIPTION

Lot of shitty authenticator apps don't support SHA-256, and don't even issue a warning when the `algorithm` parameter is set to SHA-256. So they silently generates SHA-1 codes, which are invalid, and the user is left with a broken 2FA setup, not understanding why.

Thus, switch new enrollments to SHA-1 to maximize compatibility with existing authenticator apps. Since we store the algorithm in our enrollment database, existing enrollments will continue to work with SHA-256.

Remove the related warning that's no longer relevant in the TOTP setup modal.

Fix https://github.com/polarsource/feedback/issues/390


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

