### PR TITLE
tf/redis: Switch production to use AWS Redis

### DIFF
--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -29,7 +29,7 @@ locals {
   read_replica = [for r in render_postgres.db.read_replicas : r if r.name == "polar-read"][0]
 
   # Redis connection info
-  redis_host = render_redis.redis.id
+  redis_host = var.redis_private_link_host
   redis_port = "6379"
 
   # Forwarded allow IPs: Cloudflare ranges + Render proxy
@@ -160,6 +160,7 @@ module "production" {
     plan                   = "pro_plus"
     web_concurrency        = "6"
     forwarded_allow_ips    = local.forwarded_allow_ips
+    redis_db               = "1"
   }
 
   postgres_config = {

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -545,3 +545,8 @@ variable "turnstile_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "redis_private_link_host" {
+  description = "DNS name of the Render private link to the production worker Redis"
+  type        = string
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches production to AWS Redis via PrivateLink and sets Redis DB to 1. Previously we connected to Render Redis by resource ID and used the default DB; now we read the host from `redis_private_link_host` and target DB 1.

- Set `redis_private_link_host` in the production Terraform workspace before apply; the plan will fail if unset.
- Expect a service redeploy to pick up the new host/DB; brief Redis reconnects are possible.
- Moving from DB 0 to DB 1 invalidates existing cache entries; no data migration is required.
- Scope is production only; staging is unchanged.

<sup>Written for commit 9394c259f5c9e5a5ff6e6ee1678511831d74d422. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

