### PR TITLE
product: add tiers column to product prices

### DIFF
--- a/server/migrations/versions/2026-08-14-1000_add_tiers_to_product_prices.py
+++ b/server/migrations/versions/2026-08-14-1000_add_tiers_to_product_prices.py
@@ -1,0 +1,48 @@
+"""add tiers to product prices
+
+Revision ID: c7f2a91e4d38
+Revises: f3d81c25ab90
+Create Date: 2026-08-14 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "c7f2a91e4d38"
+down_revision = "f3d81c25ab90"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '30s'")
+    op.add_column(
+        "product_prices",
+        sa.Column(
+            "tiers",
+            postgresql.JSONB(none_as_null=True, astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "product_prices",
+        sa.Column("minimum_units", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "product_prices",
+        sa.Column("maximum_units", sa.BigInteger(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '30s'")
+    op.drop_column("product_prices", "maximum_units")
+    op.drop_column("product_prices", "minimum_units")
+    op.drop_column("product_prices", "tiers")

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -355,7 +355,7 @@ class ProductPriceSeatUnit(NewProductPrice, ProductPrice):
         nullable=True,
     )
     tiers: Mapped[dict[str, Any] | None] = mapped_column(
-        postgresql.JSONB,
+        postgresql.JSONB(none_as_null=True),
         nullable=True,
         default=None,
     )

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -354,6 +354,21 @@ class ProductPriceSeatUnit(NewProductPrice, ProductPrice):
         postgresql.JSONB,
         nullable=True,
     )
+    tiers: Mapped[dict[str, Any] | None] = mapped_column(
+        postgresql.JSONB,
+        nullable=True,
+        default=None,
+    )
+    minimum_units: Mapped[int | None] = mapped_column(
+        BigInteger,
+        nullable=True,
+        default=None,
+    )
+    maximum_units: Mapped[int | None] = mapped_column(
+        BigInteger,
+        nullable=True,
+        default=None,
+    )
 
     def get_tier_for_seats(self, seats: int) -> SeatTier:
         for tier in self.seat_tiers.get("tiers", []):


### PR DESCRIPTION
## Summary

Adds an empty `tiers` JSONB column to `product_prices`. Nothing reads or writes it yet, this is the schema step of the tiered-pricing stack, split out so the migration can be deployed and before any code depends on it.

## What

- Adds a nullable `tiers` JSONB column to `product_prices`.
- Maps it on `ProductPriceSeatUnit` as `dict[str, Any] | None`, defaulting to `None`.

No backfill, no reads, no writes, no API or schema changes.

## Why

Seat-based prices store their tiers in `seat_tiers`, with a shape that only works for
seats (`min_seats`/`max_seats`, integer `price_per_seat`). Other prices may need tiers too,
and their rates may go below a cent, so they can't reuse that shape.

`tiers` is the shared replacement, in `up_to` form:
```
{
    "tier_type": "graduated", "minimum_units": 1,
    "tiers": [{"up_to": 10, "price_per_unit": "1000"}, {"up_to": null, "price_per_unit": "800"}]
}
```
`up_to` and `minimum_units` are plain integers; `price_per_unit` is a
string-encoded decimal so sub-cent metered rates survive JSON without float rounding.
The purchase floor lives in `minimum_units` rather than in the first tier's lower bound.

## How

`op.add_column` with `SET LOCAL lock_timeout = '30s'` on both upgrade and downgrade, per
the repo's migration convention.

The follow-up PR (#13760) adds the validator, the engine, and the writes.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by test
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds nullable tiers, minimum_units, and maximum_units to product_prices for reusable tiered pricing. Absent tiers now persist as SQL NULL (was JSON null with the prior model mapping), avoiding nullness mismatches; nothing reads or writes these fields yet, so runtime behavior does not change.

- Migration: adds product_prices.tiers (JSONB with none_as_null), minimum_units (BIGINT), and maximum_units (BIGINT); sets lock_timeout to 30s on upgrade and downgrade; downgrade drops all three.
- Model: maps tiers with none_as_null=True so default None writes SQL NULL; adds optional BIGINT minimum_units and maximum_units; no reads, writes, backfill, or validation.
- Rollout: run the DB migration; safe to deploy ahead of follow-up pricing logic.

<sup>Written for commit 616bfbfc6b895bbcac65bbb48850270c037cceee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



