### PR TITLE
clients: metered tier editor, displays, and regenerated client

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/meter/[meterId]/CustomerMeterPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/meter/[meterId]/CustomerMeterPage.tsx
@@ -14,6 +14,7 @@ import { useCustomerMeters } from '@/hooks/queries/customerMeters'
 import { useInfiniteEvents } from '@/hooks/queries/events'
 import { useMeterQuantities } from '@/hooks/queries/meters'
 import { Events } from '@/components/Events/Events'
+import { estimateMeteredCost } from '@/components/Products/ProductForm/Pricing/utils'
 import { ParsedMetricPeriod } from '@/hooks/queries/metrics'
 import { useSubscriptions } from '@/hooks/queries/subscriptions'
 import { getCustomerActivityStart } from '@/utils/customer'
@@ -160,10 +161,8 @@ const CustomerMeterPage = ({
 
   const overages = useMemo(() => {
     if (!unitPrice || !customerMeter || customerMeter.balance >= 0) return null
-    const cost =
-      Math.abs(customerMeter.balance) * parseFloat(unitPrice.unit_amount)
     return {
-      cost: unitPrice.cap_amount ? Math.min(cost, unitPrice.cap_amount) : cost,
+      cost: estimateMeteredCost(unitPrice, Math.abs(customerMeter.balance)),
       currency: unitPrice.price_currency,
     }
   }, [customerMeter, unitPrice])

--- a/clients/apps/web/src/components/Customer/CustomerMeter.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerMeter.tsx
@@ -1,3 +1,4 @@
+import { estimateMeteredCost } from '@/components/Products/ProductForm/Pricing/utils'
 import { ParsedMeterQuantities } from '@/hooks/queries/meters'
 import { ParsedMetricPeriod } from '@/hooks/queries/metrics'
 import { schemas } from '@polar-sh/client'
@@ -35,13 +36,7 @@ export const CustomerMeter = ({
     }
 
     const overageUnits = Math.abs(customerMeter.balance)
-    const overageCost = overageUnits * parseFloat(unitPrice.unit_amount)
-
-    if (unitPrice.cap_amount) {
-      return Math.min(overageCost, unitPrice.cap_amount)
-    }
-
-    return overageCost
+    return estimateMeteredCost(unitPrice, overageUnits)
   }, [customerMeter.balance, unitPrice])
 
   const creditProgress = useMemo(() => {

--- a/clients/apps/web/src/components/Customer/CustomerPage/CustomerUsageView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerPage/CustomerUsageView.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { estimateMeteredCost } from '@/components/Products/ProductForm/Pricing/utils'
 import { useCustomerMeters } from '@/hooks/queries/customerMeters'
 import { useMultipleMeterQuantities } from '@/hooks/queries/meters'
 import { useSubscriptions } from '@/hooks/queries/subscriptions'
@@ -46,11 +47,8 @@ const getOverages = (cm: CustomerMeterWithSubscription) => {
   if (!unitPrice) return null
 
   const overageUnits = Math.abs(cm.balance)
-  const overageCost = overageUnits * parseFloat(unitPrice.unit_amount)
   return {
-    cost: unitPrice.cap_amount
-      ? Math.min(overageCost, unitPrice.cap_amount)
-      : overageCost,
+    cost: estimateMeteredCost(unitPrice, overageUnits),
     currency: unitPrice.price_currency,
   }
 }

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredPricingFields.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredPricingFields.tsx
@@ -1,0 +1,211 @@
+'use client'
+
+import { useMeters } from '@/hooks/queries/meters'
+import { schemas } from '@polar-sh/client'
+import { Box } from '@polar-sh/orbit/Box'
+import { formatCurrency } from '@polar-sh/currency'
+import MoneyInput from '@polar-sh/ui/components/atoms/MoneyInput'
+import { getMeterUnitFormat } from '@polar-sh/ui/lib/meterUnit'
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@polar-sh/orbit'
+import { InfoIcon } from 'lucide-react'
+import React, { useCallback, useMemo } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { ProductFormType } from '../ProductForm'
+import UnitAmountInput from '../UnitAmountInput'
+import { MeteredTierEditor } from './MeteredTierEditor'
+
+type MeteredPricingModel = 'fixed' | 'graduated' | 'volume'
+
+export interface MeteredPricingFieldsProps {
+  organization: schemas['Organization']
+  index: number
+  currency: string
+}
+
+export const MeteredPricingFields: React.FC<MeteredPricingFieldsProps> = ({
+  organization,
+  index,
+  currency,
+}) => {
+  const { control, setValue, watch, getValues } =
+    useFormContext<ProductFormType>()
+
+  const { data: meters } = useMeters(organization.id, {
+    sorting: ['name'],
+    limit: 30,
+    is_archived: false,
+  })
+
+  const meterId = watch(`prices.${index}.meter_id`)
+  const unitAmount = watch(`prices.${index}.unit_amount`)
+  const tiersValue = watch(`prices.${index}.tiers`)
+
+  const pricingModel: MeteredPricingModel = tiersValue
+    ? tiersValue.type
+    : 'fixed'
+
+  const handlePricingModelChange = useCallback(
+    (value: MeteredPricingModel) => {
+      setValue(`prices.${index}.id`, '')
+      if (value === 'fixed') {
+        setValue(`prices.${index}.tiers`, null)
+        setValue(`prices.${index}.unit_amount`, 0)
+        return
+      }
+      const currentTiers = getValues(`prices.${index}.tiers`)
+      setValue(`prices.${index}.tiers`, {
+        type: value,
+        tiers: currentTiers?.tiers ?? [
+          {
+            bound: null,
+            unit_amount: getValues(`prices.${index}.unit_amount`) ?? 0,
+          },
+        ],
+      })
+      setValue(`prices.${index}.unit_amount`, null)
+    },
+    [getValues, setValue, index],
+  )
+
+  const pricePreview = useMemo(() => {
+    const selectedMeter = meters?.items.find(
+      (m: schemas['Meter']) => m.id === meterId,
+    )
+    const { scale, label } = getMeterUnitFormat(
+      selectedMeter?.unit ?? 'scalar',
+      {
+        customLabel: selectedMeter?.custom_label,
+        customMultiplier: selectedMeter?.custom_multiplier,
+      },
+    )
+    const cents = Number.parseFloat(String(unitAmount || '0'))
+    const formatted = formatCurrency('subcent')(cents * scale, currency)
+    return `${formatted} / ${label}`
+  }, [meterId, unitAmount, meters, currency])
+
+  return (
+    <>
+      <FormItem>
+        <FormLabel>Pricing model</FormLabel>
+        <Box display="block">
+          <Select
+            value={pricingModel}
+            onValueChange={(v) =>
+              handlePricingModelChange(v as MeteredPricingModel)
+            }
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="fixed">Flat price per unit</SelectItem>
+              <SelectItem value="graduated">Graduated</SelectItem>
+              <SelectItem value="volume">Volume</SelectItem>
+            </SelectContent>
+          </Select>
+        </Box>
+      </FormItem>
+
+      {pricingModel === 'fixed' ? (
+        <FormField
+          control={control}
+          name={`prices.${index}.unit_amount`}
+          rules={{
+            min: 0,
+            required: 'This field is required',
+          }}
+          render={({ field }) => {
+            return (
+              <FormItem>
+                <FormLabel>Amount per unit</FormLabel>
+                <FormControl>
+                  <UnitAmountInput
+                    {...field}
+                    name={field.name}
+                    currency={currency}
+                    value={field.value ?? ''}
+                    onValueChange={(v) => {
+                      field.onChange(v)
+                      setValue(`prices.${index}.id`, '')
+                    }}
+                  />
+                </FormControl>
+                <FormDescription>Displayed as {pricePreview}</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )
+          }}
+        />
+      ) : (
+        <MeteredTierEditor index={index} currency={currency} />
+      )}
+
+      <FormField
+        control={control}
+        name={`prices.${index}.cap_amount`}
+        render={({ field }) => {
+          return (
+            <FormItem>
+              <FormLabel>
+                <Box
+                  as="span"
+                  display="inline-flex"
+                  alignItems="center"
+                  columnGap="xs"
+                >
+                  Cap amount
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Box
+                        as="span"
+                        display="inline-flex"
+                        color="text-tertiary"
+                      >
+                        <InfoIcon className="h-3.5 w-3.5" />
+                      </Box>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-3xs">
+                      Optional maximum amount that can be charged, regardless of
+                      the number of units consumed.
+                    </TooltipContent>
+                  </Tooltip>
+                </Box>
+              </FormLabel>
+              <FormControl>
+                <MoneyInput
+                  {...field}
+                  name={field.name}
+                  currency={currency}
+                  value={field.value}
+                  onChange={(v) => {
+                    field.onChange(v)
+                    setValue(`prices.${index}.id`, '')
+                  }}
+                  placeholder={10000}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )
+        }}
+      />
+    </>
+  )
+}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredTierCard.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredTierCard.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import CloseOutlined from '@mui/icons-material/CloseOutlined'
+import { Box } from '@polar-sh/orbit/Box'
+import { Button, Grid, Input, Text } from '@polar-sh/orbit'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import React from 'react'
+import { useFormContext } from 'react-hook-form'
+import { ProductFormType } from '../ProductForm'
+import UnitAmountInput from '../UnitAmountInput'
+
+export interface MeteredTierCardProps {
+  index: number
+  tierIndex: number
+  currency: string
+  hasSingleTier: boolean
+  title: string
+  previousUpTo: number
+  isLast: boolean
+  onRemove: () => void
+}
+
+export const MeteredTierCard: React.FC<MeteredTierCardProps> = ({
+  index,
+  tierIndex,
+  currency,
+  hasSingleTier,
+  title,
+  previousUpTo,
+  isLast,
+  onRemove,
+}) => {
+  const { control, setValue } = useFormContext<ProductFormType>()
+  const titleId = `metered-tier-title-${index}-${tierIndex}`
+
+  return (
+    <Box
+      flexDirection="column"
+      rowGap="m"
+      role="group"
+      aria-labelledby={hasSingleTier ? undefined : titleId}
+      {...(hasSingleTier
+        ? {}
+        : {
+            borderRadius: 'l' as const,
+            borderWidth: 1,
+            borderStyle: 'solid' as const,
+            borderColor: 'border-primary' as const,
+            backgroundColor: 'background-card' as const,
+            padding: 'l' as const,
+          })}
+    >
+      {!hasSingleTier && (
+        <Box alignItems="center" justifyContent="between">
+          <Text id={titleId} as="span" variant="label" color="muted">
+            {title}
+          </Text>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            onClick={onRemove}
+            aria-label={`Remove ${title}`}
+          >
+            <CloseOutlined className="h-3.5 w-3.5" />
+          </Button>
+        </Box>
+      )}
+
+      <Grid templateColumns="1fr 2fr" columnGap="l">
+        <FormField
+          control={control}
+          name={`prices.${index}.tiers.tiers.${tierIndex}.bound` as const}
+          rules={
+            isLast
+              ? undefined
+              : {
+                  required: 'Required',
+                  validate: (value) => {
+                    const parsed = Number(value)
+                    if (!Number.isInteger(parsed)) {
+                      return 'Must be a whole number of units'
+                    }
+                    if (parsed <= previousUpTo) {
+                      return `Must be greater than ${previousUpTo.toLocaleString('en-US')}`
+                    }
+                    return true
+                  },
+                }
+          }
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Up to</FormLabel>
+              <FormControl>
+                {isLast ? (
+                  <Input
+                    name={field.name}
+                    value="Unlimited"
+                    disabled
+                    readOnly
+                    ref={field.ref}
+                  />
+                ) : (
+                  <Input
+                    {...field}
+                    type="number"
+                    min={previousUpTo + 1}
+                    step={1}
+                    value={field.value ?? ''}
+                    onChange={(e) => {
+                      const parsed = Number.parseInt(e.target.value, 10)
+                      field.onChange(Number.isNaN(parsed) ? '' : parsed)
+                      setValue(`prices.${index}.id`, '')
+                    }}
+                    onBlur={(e) => {
+                      field.onBlur()
+                      const parsed = Number.parseInt(e.target.value, 10)
+                      const minAllowed = previousUpTo + 1
+                      field.onChange(
+                        Math.max(
+                          Number.isNaN(parsed) ? minAllowed : parsed,
+                          minAllowed,
+                        ),
+                      )
+                    }}
+                  />
+                )}
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={control}
+          name={`prices.${index}.tiers.tiers.${tierIndex}.unit_amount` as const}
+          rules={{
+            required: 'This field is required',
+            min: { value: 0, message: 'Must be 0 or more' },
+          }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Price per unit</FormLabel>
+              <FormControl>
+                <UnitAmountInput
+                  {...field}
+                  name={field.name}
+                  currency={currency}
+                  value={field.value}
+                  onValueChange={(v) => {
+                    field.onChange(v)
+                    setValue(`prices.${index}.id`, '')
+                  }}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </Grid>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredTierEditor.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredTierEditor.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { Box } from '@polar-sh/orbit/Box'
+import { Button } from '@polar-sh/orbit'
+import React, { useCallback } from 'react'
+import { useFieldArray, useFormContext } from 'react-hook-form'
+import { ProductFormType } from '../ProductForm'
+import { MeteredTierCard } from './MeteredTierCard'
+
+const formatUnits = (value: number) => value.toLocaleString('en-US')
+
+const getMeteredTierTitle = (
+  upTo: number | null | undefined,
+  previousUpTo: number,
+) => {
+  const from = previousUpTo + 1
+  if (upTo == null) return `Units ${formatUnits(from)}+`
+  if (upTo === from) return `Unit ${formatUnits(from)}`
+  return `Units ${formatUnits(from)}–${formatUnits(upTo)}`
+}
+
+export interface MeteredTierEditorProps {
+  index: number
+  currency: string
+}
+
+export const MeteredTierEditor: React.FC<MeteredTierEditorProps> = ({
+  index,
+  currency,
+}) => {
+  const { control, setValue, watch, getValues } =
+    useFormContext<ProductFormType>()
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: `prices.${index}.tiers.tiers` as const,
+  })
+
+  const tiers = watch(`prices.${index}.tiers.tiers`)
+  const hasSingleTier = fields.length === 1
+
+  const forceLastTierUnbounded = useCallback(() => {
+    const currentTiers = getValues(`prices.${index}.tiers.tiers`)
+    if (!currentTiers || currentTiers.length === 0) return
+    setValue(
+      `prices.${index}.tiers.tiers.${currentTiers.length - 1}.bound`,
+      null,
+    )
+  }, [getValues, setValue, index])
+
+  const addTier = useCallback(() => {
+    const currentTiers = getValues(`prices.${index}.tiers.tiers`)
+    const lastTier = currentTiers?.[currentTiers.length - 1]
+    const previousUpTo = Number(
+      currentTiers?.[(currentTiers?.length ?? 0) - 2]?.bound ?? 0,
+    )
+    const newUpTo = previousUpTo > 0 ? previousUpTo * 2 : 1000
+
+    if (currentTiers && currentTiers.length > 0) {
+      setValue(
+        `prices.${index}.tiers.tiers.${currentTiers.length - 1}.bound`,
+        newUpTo,
+      )
+    }
+    append({ bound: null, unit_amount: lastTier?.unit_amount ?? 0 })
+    setValue(`prices.${index}.id`, '')
+  }, [getValues, append, setValue, index])
+
+  const removeTier = useCallback(
+    (tierIndex: number) => {
+      remove(tierIndex)
+      setValue(`prices.${index}.id`, '')
+      forceLastTierUnbounded()
+    },
+    [remove, setValue, index, forceLastTierUnbounded],
+  )
+
+  return (
+    <Box flexDirection="column" rowGap="l">
+      {fields.map((field, tierIndex) => {
+        const previousUpTo = Number(tiers?.[tierIndex - 1]?.bound ?? 0)
+        return (
+          <MeteredTierCard
+            key={field.id}
+            index={index}
+            tierIndex={tierIndex}
+            currency={currency}
+            hasSingleTier={hasSingleTier}
+            title={getMeteredTierTitle(tiers?.[tierIndex]?.bound, previousUpTo)}
+            previousUpTo={previousUpTo}
+            isLast={tierIndex === fields.length - 1}
+            onRemove={() => removeTier(tierIndex)}
+          />
+        )
+      })}
+
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={addTier}
+        className="self-start"
+      >
+        Add tier
+      </Button>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceMeteredUnitItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceMeteredUnitItem.tsx
@@ -6,25 +6,20 @@ import { InlineModal } from '@polar-sh/orbit'
 import { useModal } from '@/components/Modal/useModal'
 import { SpinnerNoMargin } from '@polar-sh/orbit'
 import { useMeters } from '@/hooks/queries/meters'
-import { formatCurrency } from '@polar-sh/currency'
 import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
-import MoneyInput from '@polar-sh/ui/components/atoms/MoneyInput'
-import { getMeterUnitFormat } from '@polar-sh/ui/lib/meterUnit'
 import {
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@polar-sh/orbit'
-import { InfoIcon, PlusIcon } from 'lucide-react'
-import React, { useCallback, useMemo } from 'react'
+import { PlusIcon } from 'lucide-react'
+import React, { useCallback } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ProductFormType } from '../ProductForm'
-import UnitAmountInput from '../UnitAmountInput'
+import { MeteredPricingFields } from './MeteredPricingFields'
 
 export interface ProductPriceMeteredUnitItemProps {
   organization: schemas['Organization']
@@ -35,33 +30,13 @@ export interface ProductPriceMeteredUnitItemProps {
 export const ProductPriceMeteredUnitItem: React.FC<
   ProductPriceMeteredUnitItemProps
 > = ({ organization, index, currency }) => {
-  const { control, setValue, watch } = useFormContext<ProductFormType>()
+  const { control, setValue } = useFormContext<ProductFormType>()
 
   const { data: meters } = useMeters(organization.id, {
     sorting: ['name'],
     limit: 30,
     is_archived: false,
   })
-
-  const meterId = watch(`prices.${index}.meter_id`)
-  const unitAmount = watch(`prices.${index}.unit_amount`)
-
-  const pricePreview = useMemo(() => {
-    const selectedMeter = meters?.items.find(
-      (m: schemas['Meter']) => m.id === meterId,
-    )
-    const { scale, label } = getMeterUnitFormat(
-      selectedMeter?.unit ?? 'scalar',
-      {
-        customLabel: selectedMeter?.custom_label,
-        customMultiplier: selectedMeter?.custom_multiplier,
-      },
-    )
-    const cents = Number.parseFloat(String(unitAmount || '0'))
-    const scaled = cents * scale
-    const formatted = formatCurrency('subcent')(scaled, currency)
-    return `${formatted} / ${label}`
-  }, [meterId, unitAmount, meters, currency])
 
   const {
     isShown: isCreateMeterModalShown,
@@ -138,72 +113,10 @@ export const ProductPriceMeteredUnitItem: React.FC<
               )
             }}
           />
-          <FormField
-            control={control}
-            name={`prices.${index}.unit_amount`}
-            rules={{
-              min: 0,
-              required: 'This field is required',
-            }}
-            render={({ field }) => {
-              return (
-                <FormItem>
-                  <FormLabel>Amount per unit</FormLabel>
-                  <FormControl>
-                    <UnitAmountInput
-                      {...field}
-                      name={field.name}
-                      currency={currency}
-                      value={field.value}
-                      onValueChange={(v) => {
-                        field.onChange(v)
-                        setValue(`prices.${index}.id`, '')
-                      }}
-                    />
-                  </FormControl>
-                  <FormDescription>Displayed as {pricePreview}</FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )
-            }}
-          />
-          <FormField
-            control={control}
-            name={`prices.${index}.cap_amount`}
-            render={({ field }) => {
-              return (
-                <FormItem>
-                  <FormLabel>
-                    <span className="flex items-center gap-x-1.5">
-                      Cap amount
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <InfoIcon className="dark:text-polar-400 h-3.5 w-3.5 text-gray-400" />
-                        </TooltipTrigger>
-                        <TooltipContent className="max-w-3xs">
-                          Optional maximum amount that can be charged,
-                          regardless of the number of units consumed.
-                        </TooltipContent>
-                      </Tooltip>
-                    </span>
-                  </FormLabel>
-                  <FormControl>
-                    <MoneyInput
-                      {...field}
-                      name={field.name}
-                      currency={currency}
-                      value={field.value}
-                      onChange={(v) => {
-                        field.onChange(v)
-                        setValue(`prices.${index}.id`, '')
-                      }}
-                      placeholder={10000}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )
-            }}
+          <MeteredPricingFields
+            organization={organization}
+            index={index}
+            currency={currency}
           />
         </>
       )}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
@@ -1,0 +1,173 @@
+import { schemas } from '@polar-sh/client'
+import { describe, expect, it } from 'vitest'
+import { estimateMeteredCost } from './utils'
+
+type MeteredPrice = schemas['ProductPriceMeteredUnit']
+type MeteredTiers = NonNullable<MeteredPrice['tiers']>
+
+const price = (overrides: Partial<MeteredPrice> = {}): MeteredPrice =>
+  ({
+    id: 'price_1',
+    created_at: '2026-01-01T00:00:00Z',
+    modified_at: null,
+    is_archived: false,
+    product_id: 'prod_1',
+    amount_type: 'metered_unit',
+    price_currency: 'usd',
+    unit_amount: '0.05',
+    tiers: null,
+    cap_amount: null,
+    meter_id: 'meter_1',
+    meter: {
+      id: 'meter_1',
+      name: 'API Calls',
+      unit: 'scalar',
+      custom_label: null,
+      custom_multiplier: null,
+    },
+    ...overrides,
+  }) as MeteredPrice
+
+const tiers = (
+  tierType: MeteredTiers['type'],
+  list: { bound: number | null; unit_amount: string }[],
+): MeteredTiers => ({ type: tierType, tiers: list })
+
+// The ladder used across the tiered cases: 5c up to 1,000, then 1c.
+const ladder = (tierType: MeteredTiers['type']) =>
+  tiers(tierType, [
+    { bound: 1000, unit_amount: '5' },
+    { bound: null, unit_amount: '1' },
+  ])
+
+describe('estimateMeteredCost', () => {
+  describe('flat rate', () => {
+    it('multiplies units by the unit amount', () => {
+      expect(estimateMeteredCost(price({ unit_amount: '0.5' }), 100)).toBe(50)
+    })
+
+    it('treats a missing unit amount as free', () => {
+      expect(estimateMeteredCost(price({ unit_amount: null }), 100)).toBe(0)
+    })
+  })
+
+  describe('zero and negative usage', () => {
+    it.each([0, -1, -1000])('costs nothing for %i units', (units) => {
+      expect(
+        estimateMeteredCost(price({ tiers: ladder('graduated') }), units),
+      ).toBe(0)
+    })
+  })
+
+  describe('graduated', () => {
+    it('bills a quantity inside the first tier at the first rate', () => {
+      const p = price({ unit_amount: null, tiers: ladder('graduated') })
+      expect(estimateMeteredCost(p, 500)).toBe(2500)
+    })
+
+    it('bills the boundary quantity entirely at the first rate', () => {
+      const p = price({ unit_amount: null, tiers: ladder('graduated') })
+      expect(estimateMeteredCost(p, 1000)).toBe(5000)
+    })
+
+    it('splits usage across tiers, each portion at its own rate', () => {
+      const p = price({ unit_amount: null, tiers: ladder('graduated') })
+      // 1,000 × 5c + 1,000 × 1c
+      expect(estimateMeteredCost(p, 2000)).toBe(6000)
+    })
+
+    it('walks more than two tiers', () => {
+      const p = price({
+        unit_amount: null,
+        tiers: tiers('graduated', [
+          { bound: 100, unit_amount: '10' },
+          { bound: 200, unit_amount: '5' },
+          { bound: null, unit_amount: '1' },
+        ]),
+      })
+      // 100 × 10c + 100 × 5c + 50 × 1c
+      expect(estimateMeteredCost(p, 250)).toBe(1550)
+    })
+
+    it('handles fractional usage', () => {
+      const p = price({ unit_amount: null, tiers: ladder('graduated') })
+      // 1,000 × 5c + 0.5 × 1c
+      expect(estimateMeteredCost(p, 1000.5)).toBe(5000.5)
+    })
+
+    it('reads tiers that arrive unsorted', () => {
+      const p = price({
+        unit_amount: null,
+        tiers: tiers('graduated', [
+          { bound: null, unit_amount: '1' },
+          { bound: 1000, unit_amount: '5' },
+        ]),
+      })
+      expect(estimateMeteredCost(p, 2000)).toBe(6000)
+    })
+  })
+
+  describe('volume', () => {
+    it('bills the whole quantity at the rate of the tier it lands in', () => {
+      const p = price({ unit_amount: null, tiers: ladder('volume') })
+      expect(estimateMeteredCost(p, 500)).toBe(2500)
+    })
+
+    it('reprices the entire quantity once a bound is crossed', () => {
+      const p = price({ unit_amount: null, tiers: ladder('volume') })
+      // Not 1,000 × 5c + 1,000 × 1c — the whole 2,000 drops to the 1c rate.
+      expect(estimateMeteredCost(p, 2000)).toBe(2000)
+    })
+
+    it('keeps the boundary quantity in the lower tier', () => {
+      const p = price({ unit_amount: null, tiers: ladder('volume') })
+      expect(estimateMeteredCost(p, 1000)).toBe(5000)
+    })
+
+    it('falls back to the top tier when usage passes every bound', () => {
+      const p = price({
+        unit_amount: null,
+        tiers: tiers('volume', [
+          { bound: 100, unit_amount: '10' },
+          { bound: 200, unit_amount: '5' },
+        ]),
+      })
+      expect(estimateMeteredCost(p, 500)).toBe(2500)
+    })
+  })
+
+  describe('single unbounded tier', () => {
+    it('behaves like a flat rate', () => {
+      const p = price({
+        unit_amount: null,
+        tiers: tiers('graduated', [{ bound: null, unit_amount: '5' }]),
+      })
+      expect(estimateMeteredCost(p, 250)).toBe(1250)
+    })
+  })
+
+  describe('cap amount', () => {
+    it('caps a tiered cost', () => {
+      const p = price({
+        unit_amount: null,
+        tiers: ladder('graduated'),
+        cap_amount: 1000,
+      })
+      expect(estimateMeteredCost(p, 2000)).toBe(1000)
+    })
+
+    it('leaves a cost below the cap alone', () => {
+      const p = price({
+        unit_amount: null,
+        tiers: ladder('graduated'),
+        cap_amount: 100_000,
+      })
+      expect(estimateMeteredCost(p, 2000)).toBe(6000)
+    })
+
+    it('honours a zero cap, matching the server', () => {
+      const p = price({ unit_amount: '0.5', cap_amount: 0 })
+      expect(estimateMeteredCost(p, 100)).toBe(0)
+    })
+  })
+})

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
@@ -51,8 +51,8 @@ type MeteredTiers = NonNullable<schemas['ProductPriceMeteredUnit']['tiers']>
 const parseTiers = (tiers: MeteredTiers['tiers']) =>
   tiers
     .map((tier) => ({
-      upTo: tier.up_to,
-      pricePerUnit: Number.parseFloat(String(tier.price_per_unit)),
+      upTo: tier.bound,
+      pricePerUnit: Number.parseFloat(String(tier.unit_amount)),
     }))
     .sort(
       (a, b) =>
@@ -61,13 +61,17 @@ const parseTiers = (tiers: MeteredTiers['tiers']) =>
     )
 
 const tieredCost = (
-  { tier_type, tiers }: MeteredTiers,
+  { type: tierType, tiers }: MeteredTiers,
   units: number,
 ): number => {
   const parsed = parseTiers(tiers)
 
-  if (tier_type === 'volume') {
-    const tier = parsed.find((t) => t.upTo === null || units <= t.upTo)
+  if (tierType === 'volume') {
+    // A bounded last tier can't be created through the API, but if usage ever
+    // lands past every bound, the top rate is a better estimate than nothing.
+    const tier =
+      parsed.find((t) => t.upTo === null || units <= t.upTo) ??
+      parsed[parsed.length - 1]
     return tier ? units * tier.pricePerUnit : 0
   }
 

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
@@ -45,3 +45,59 @@ export const getActiveCurrencies = (
   }
   return Array.from(currencies)
 }
+
+type MeteredTiers = NonNullable<schemas['ProductPriceMeteredUnit']['tiers']>
+
+const parseTiers = (tiers: MeteredTiers['tiers']) =>
+  tiers
+    .map((tier) => ({
+      upTo: tier.up_to,
+      pricePerUnit: Number.parseFloat(String(tier.price_per_unit)),
+    }))
+    .sort(
+      (a, b) =>
+        Number(a.upTo === null) - Number(b.upTo === null) ||
+        (a.upTo ?? 0) - (b.upTo ?? 0),
+    )
+
+const tieredCost = (
+  { tier_type, tiers }: MeteredTiers,
+  units: number,
+): number => {
+  const parsed = parseTiers(tiers)
+
+  if (tier_type === 'volume') {
+    const tier = parsed.find((t) => t.upTo === null || units <= t.upTo)
+    return tier ? units * tier.pricePerUnit : 0
+  }
+
+  let total = 0
+  let remaining = units
+  let previousUpTo = 0
+  for (const { upTo, pricePerUnit } of parsed) {
+    if (remaining <= 0) break
+    const capacity = upTo === null ? null : upTo - previousUpTo
+    const unitsInTier =
+      capacity === null ? remaining : Math.min(remaining, capacity)
+    total += unitsInTier * pricePerUnit
+    remaining -= unitsInTier
+    if (upTo !== null) previousUpTo = upTo
+  }
+  return total
+}
+
+export const estimateMeteredCost = (
+  price: schemas['ProductPriceMeteredUnit'],
+  units: number,
+): number => {
+  if (units <= 0) {
+    return 0
+  }
+  const cost = price.tiers
+    ? tieredCost(price.tiers, units)
+    : units * Number.parseFloat(price.unit_amount ?? '0')
+  if (price.cap_amount != null) {
+    return Math.min(cost, price.cap_amount)
+  }
+  return cost
+}

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
@@ -256,4 +256,129 @@ describe('MeteredPriceLabel', () => {
       expect(container.querySelector('.line-through')).toBeNull()
     })
   })
+  describe('tiered prices', () => {
+    const tieredPrice = (
+      tierType: 'graduated' | 'volume',
+      tiers: { bound: number | null; unit_amount: string }[],
+      meter?: Partial<schemas['ProductPriceMeteredUnit']['meter']>,
+    ) =>
+      createMeteredPrice({
+        unit_amount: null,
+        tiers: { type: tierType, tiers },
+        ...(meter
+          ? {
+              meter: {
+                ...createMeteredPrice().meter,
+                ...meter,
+              },
+            }
+          : {}),
+      })
+
+    it('renders the first tier rate and the bound it applies up to', () => {
+      const price = tieredPrice('graduated', [
+        { bound: 1000, unit_amount: '5' },
+        { bound: null, unit_amount: '1' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$0.05')
+      expect(container.textContent).toContain('/ unit')
+      expect(container.textContent).toContain('up to 1,000')
+    })
+
+    it('anchors volume prices to the first tier too, not the cheapest', () => {
+      const price = tieredPrice('volume', [
+        { bound: 1000, unit_amount: '5' },
+        { bound: null, unit_amount: '0.1' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$0.05')
+      expect(container.textContent).not.toContain('$0.001')
+    })
+
+    it('never claims a floor the buyer might not get', () => {
+      const price = tieredPrice('volume', [
+        { bound: 1000, unit_amount: '5' },
+        { bound: null, unit_amount: '0.1' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).not.toContain('From')
+    })
+
+    it('reads the tiers even when they arrive unsorted', () => {
+      const price = tieredPrice('graduated', [
+        { bound: null, unit_amount: '1' },
+        { bound: 1000, unit_amount: '5' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$0.05')
+      expect(container.textContent).toContain('up to 1,000')
+    })
+
+    it('omits the bound when the only tier is unbounded', () => {
+      const price = tieredPrice('graduated', [
+        { bound: null, unit_amount: '5' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$0.05')
+      expect(container.textContent).not.toContain('up to')
+    })
+
+    it('scales the rate to the meter unit but leaves the bound in base units', () => {
+      const price = tieredPrice(
+        'graduated',
+        [
+          { bound: 5_000_000, unit_amount: '0.001' },
+          { bound: null, unit_amount: '0.0005' },
+        ],
+        { unit: 'token' },
+      )
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$10.00')
+      expect(container.textContent).toContain('/ 1M tokens')
+      expect(container.textContent).toContain('up to 5,000,000')
+    })
+
+    it('discounts the first tier rate', () => {
+      const price = tieredPrice('graduated', [
+        { bound: 1000, unit_amount: '1000' },
+        { bound: null, unit_amount: '100' },
+      ])
+
+      render(
+        <MeteredPriceLabel
+          price={price}
+          locale="en"
+          discount={percentageDiscount(5000)}
+        />,
+      )
+
+      expect(screen.getByText('$10.00')).toHaveClass('line-through')
+      expect(screen.getByText('$5.00')).toBeInTheDocument()
+    })
+  })
 })

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -10,6 +10,18 @@ interface MeteredPriceLabelProps {
   discount?: schemas['CheckoutPublic']['discount']
 }
 
+const startingRate = (price: schemas['ProductPriceMeteredUnit']): number => {
+  if (price.tiers) {
+    const first = price.tiers.tiers.toSorted(
+      (a, b) =>
+        Number(a.up_to === null) - Number(b.up_to === null) ||
+        (a.up_to ?? 0) - (b.up_to ?? 0),
+    )[0]
+    return Number.parseFloat(first?.price_per_unit ?? '0')
+  }
+  return Number.parseFloat(price.unit_amount ?? '0')
+}
+
 const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
   price,
   locale = DEFAULT_LOCALE,
@@ -21,7 +33,8 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
   })
 
   const format = formatCurrency('subcent', locale)
-  const baseAmount = Number.parseFloat(price.unit_amount) * scale
+  const isTiered = price.tiers !== null
+  const baseAmount = startingRate(price) * scale
   const discountedAmount =
     discount && 'basis_points' in discount
       ? baseAmount * (1 - discount.basis_points / 10000)
@@ -29,6 +42,9 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
 
   return (
     <div className="flex flex-row items-baseline gap-x-1">
+      {isTiered && (
+        <span className="dark:text-polar-400 text-gray-500">From</span>
+      )}
       {discountedAmount !== null ? (
         <>
           <span className="dark:text-polar-500 text-gray-400 line-through">

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -1,6 +1,10 @@
 import type { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
-import { DEFAULT_LOCALE, type AcceptedLocale } from '@polar-sh/i18n'
+import {
+  DEFAULT_LOCALE,
+  useTranslations,
+  type AcceptedLocale,
+} from '@polar-sh/i18n'
 import { getMeterUnitFormat } from '@polar-sh/ui/lib/meterUnit'
 import { cn } from '@polar-sh/ui/lib/utils'
 
@@ -10,16 +14,24 @@ interface MeteredPriceLabelProps {
   discount?: schemas['CheckoutPublic']['discount']
 }
 
-const startingRate = (price: schemas['ProductPriceMeteredUnit']): number => {
-  if (price.tiers) {
-    const first = price.tiers.tiers.toSorted(
-      (a, b) =>
-        Number(a.up_to === null) - Number(b.up_to === null) ||
-        (a.up_to ?? 0) - (b.up_to ?? 0),
-    )[0]
-    return Number.parseFloat(first?.price_per_unit ?? '0')
+type MeteredTier = NonNullable<
+  schemas['ProductPriceMeteredUnit']['tiers']
+>['tiers'][number]
+
+// The tier usage starts in: lowest bound first, unbounded tier last.
+const getFirstTier = (
+  price: schemas['ProductPriceMeteredUnit'],
+): MeteredTier | null => {
+  if (price.tiers == null) {
+    return null
   }
-  return Number.parseFloat(price.unit_amount ?? '0')
+  return (
+    price.tiers.tiers.toSorted(
+      (a, b) =>
+        Number(a.bound === null) - Number(b.bound === null) ||
+        (a.bound ?? 0) - (b.bound ?? 0),
+    )[0] ?? null
+  )
 }
 
 const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
@@ -27,14 +39,21 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
   locale = DEFAULT_LOCALE,
   discount,
 }) => {
+  const t = useTranslations(locale)
   const { scale, label } = getMeterUnitFormat(price.meter.unit ?? 'scalar', {
     customLabel: price.meter.custom_label,
     customMultiplier: price.meter.custom_multiplier,
   })
 
   const format = formatCurrency('subcent', locale)
-  const isTiered = price.tiers !== null
-  const baseAmount = startingRate(price) * scale
+  const firstTier = getFirstTier(price)
+  // Tier bounds are in base units, like the meter readings customers see in
+  // their portal, while the rate is scaled to the meter's display unit.
+  const upTo = firstTier?.bound ?? null
+  const rate = firstTier
+    ? Number.parseFloat(firstTier.unit_amount)
+    : Number.parseFloat(price.unit_amount ?? '0')
+  const baseAmount = rate * scale
   const discountedAmount =
     discount && 'basis_points' in discount
       ? baseAmount * (1 - discount.basis_points / 10000)
@@ -42,9 +61,6 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
 
   return (
     <div className="flex flex-row items-baseline gap-x-1">
-      {isTiered && (
-        <span className="dark:text-polar-400 text-gray-500">From</span>
-      )}
       {discountedAmount !== null ? (
         <>
           <span className="dark:text-polar-500 text-gray-400 line-through">
@@ -63,6 +79,14 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
       >
         / {label}
       </span>
+      {upTo !== null && (
+        <span className="dark:text-polar-400 text-[max(12px,0.5em)] text-gray-500">
+          ·{' '}
+          {t('checkout.pricing.upTo', {
+            units: new Intl.NumberFormat(locale).format(upTo),
+          })}
+        </span>
+      )}
     </div>
   )
 }

--- a/clients/packages/checkout/src/test-utils/makeCheckout.ts
+++ b/clients/packages/checkout/src/test-utils/makeCheckout.ts
@@ -73,6 +73,7 @@ export function createMeteredPrice(
     id: 'price_metered_1',
     amount_type: 'metered_unit',
     unit_amount: '0.05',
+    tiers: null,
     cap_amount: null,
     meter_id: 'meter_1',
     meter: {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -31558,8 +31558,71 @@ export interface components {
       custom_multiplier: number | null
     }
     /**
+     * ProductPriceMeteredTier
+     * @description A pricing tier for metered pricing: a per-unit rate up to and including
+     *     `bound`. A tier starts where the previous one ended; the first starts at
+     *     zero.
+     */
+    'ProductPriceMeteredTier-Input': {
+      /**
+       * Bound
+       * @description Upper bound of the tier in units (inclusive). `null` for the unbounded last tier.
+       */
+      bound: number | null
+      /**
+       * Unit Amount
+       * @description The price per unit in cents for this tier. Supports up to 12 decimal places.
+       */
+      unit_amount: number | string
+    }
+    /**
+     * ProductPriceMeteredTier
+     * @description A pricing tier for metered pricing: a per-unit rate up to and including
+     *     `bound`. A tier starts where the previous one ended; the first starts at
+     *     zero.
+     */
+    'ProductPriceMeteredTier-Output': {
+      /**
+       * Bound
+       * @description Upper bound of the tier in units (inclusive). `null` for the unbounded last tier.
+       */
+      bound: number | null
+      /**
+       * Unit Amount
+       * @description The price per unit in cents for this tier. Supports up to 12 decimal places.
+       */
+      unit_amount: string
+    }
+    /**
+     * ProductPriceMeteredTiers
+     * @description Tiered pricing configuration for a metered price.
+     */
+    'ProductPriceMeteredTiers-Input': {
+      /** @description How tiers convert usage into an amount: `volume` bills the whole quantity at the rate of the tier it falls in, `graduated` bills each tier's portion at that tier's rate. */
+      type: components['schemas']['TierType']
+      /**
+       * Tiers
+       * @description The pricing tiers.
+       */
+      tiers: components['schemas']['ProductPriceMeteredTier-Input'][]
+    }
+    /**
+     * ProductPriceMeteredTiers
+     * @description Tiered pricing configuration for a metered price.
+     */
+    'ProductPriceMeteredTiers-Output': {
+      /** @description How tiers convert usage into an amount: `volume` bills the whole quantity at the rate of the tier it falls in, `graduated` bills each tier's portion at that tier's rate. */
+      type: components['schemas']['TierType']
+      /**
+       * Tiers
+       * @description The pricing tiers.
+       */
+      tiers: components['schemas']['ProductPriceMeteredTier-Output'][]
+    }
+    /**
      * ProductPriceMeteredUnit
-     * @description A metered, usage-based, price for a product, with a fixed unit price.
+     * @description A metered, usage-based, price for a product, with either a fixed unit
+     *     price or pricing tiers.
      */
     ProductPriceMeteredUnit: {
       /**
@@ -31606,9 +31669,11 @@ export interface components {
       product_id: string
       /**
        * Unit Amount
-       * @description The price per unit in cents.
+       * @description The price per unit in cents. `null` for tiered prices: read the rates from `tiers` instead.
        */
-      unit_amount: string
+      unit_amount: string | null
+      /** @description The pricing tiers based on consumed units. `null` for prices with a fixed unit price. */
+      tiers: components['schemas']['ProductPriceMeteredTiers-Output'] | null
       /**
        * Cap Amount
        * @description The maximum amount in cents that can be charged, regardless of the number of units consumed.
@@ -31625,7 +31690,7 @@ export interface components {
     }
     /**
      * ProductPriceMeteredUnitCreate
-     * @description Schema to create a metered price with a fixed unit price.
+     * @description Schema to create a metered price, with either a fixed unit price or pricing tiers.
      */
     ProductPriceMeteredUnitCreate: {
       /**
@@ -31648,9 +31713,11 @@ export interface components {
       meter_id: string
       /**
        * Unit Amount
-       * @description The price per unit in cents. Supports up to 12 decimal places.
+       * @description The price per unit in cents. Supports up to 12 decimal places. Mutually exclusive with `tiers`.
        */
-      unit_amount: number | string
+      unit_amount?: number | string | null
+      /** @description Tiered pricing based on consumed units. Mutually exclusive with `unit_amount`. */
+      tiers?: components['schemas']['ProductPriceMeteredTiers-Input'] | null
       /**
        * Cap Amount
        * @description Optional maximum amount in cents that can be charged, regardless of the number of units consumed.
@@ -35663,6 +35730,11 @@ export interface components {
       /** Text */
       text: string
     }
+    /**
+     * TierType
+     * @enum {string}
+     */
+    TierType: 'volume' | 'graduated'
     /**
      * TimeInterval
      * @enum {string}
@@ -68217,6 +68289,9 @@ export const taxJurisdictionSortPropertyValues: ReadonlyArray<
 export const textBlockTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['TextBlock']['type']
 > = ['text']
+export const tierTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['TierType']
+> = ['volume', 'graduated']
 export const timeIntervalValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['TimeInterval']
 > = ['year', 'month', 'week', 'day', 'hour']

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -178,7 +178,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -359,7 +360,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -540,7 +542,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -721,7 +724,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -902,7 +906,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1075,7 +1080,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1248,7 +1254,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1421,7 +1428,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1594,7 +1602,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1767,7 +1776,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1940,7 +1950,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "tr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2113,7 +2124,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "pl": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2286,6 +2298,7 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   }
 }

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'MwSt. (inklusive)',
       basePrice: 'Grundpreis',
+      upTo: 'bis zu {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -94,6 +94,11 @@ export default {
         },
       },
       additionalMeteredUsage: 'Additional metered usage',
+      upTo: {
+        value: 'up to {units}',
+        _llmContext:
+          'Suffix after a metered price rate on checkout, marking the usage bound that rate applies up to. {units} is an already-formatted number of metered units, e.g. "1,000". Displayed as: "$0.05 / unit \u00b7 up to 1,000".',
+      },
       perSeat: 'per seat',
       basePrice: {
         value: 'Base price',

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'Impuestos (incluidos)',
       basePrice: 'Precio base',
+      upTo: 'hasta {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'TVA (incluse)',
       basePrice: 'Prix de base',
+      upTo: 'jusqu’à {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'ÁFA (tartalmazza)',
       basePrice: 'Alapár',
+      upTo: 'legfeljebb {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'IVA (inclusa)',
       basePrice: 'Prezzo base',
+      upTo: 'fino a {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -94,6 +94,7 @@ export default {
         until: '{date}まで',
       },
       basePrice: '基本料金',
+      upTo: '{units}まで',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: '부가세 (포함)',
       basePrice: '기본 가격',
+      upTo: '{units}까지',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'Btw (inbegrepen)',
       basePrice: 'Basisprijs',
+      upTo: 'tot {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pl.ts
+++ b/clients/packages/i18n/src/locales/pl.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'Podatki (w cenie)',
       basePrice: 'Cena bazowa',
+      upTo: 'do {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'IVA (incluído)',
       basePrice: 'Preço base',
+      upTo: 'até {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'Impostos (inclusos)',
       basePrice: 'Preço base',
+      upTo: 'até {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'Moms (ingår)',
       basePrice: 'Grundavgift',
+      upTo: 'upp till {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/tr.ts
+++ b/clients/packages/i18n/src/locales/tr.ts
@@ -94,6 +94,7 @@ export default {
         updateFailed: 'Koltuklar güncellenemedi',
       },
       basePrice: 'Temel fiyat',
+      upTo: '{units} kadar',
     },
     trial: {
       hero: {

--- a/server/polar/backoffice/products/endpoints.py
+++ b/server/polar/backoffice/products/endpoints.py
@@ -60,7 +60,7 @@ def _format_price_display(price: ProductPrice) -> str:
             return f"{price_display} / seat"
     elif is_metered_price(price):
         if price.unit_amount is None:
-            return f"{price.meter.name}: {price.tier_type} pricing ({len(price.get_tiers().tiers)} tiers)"
+            return f"{price.meter.name}: {price.tier_type} pricing ({len(price.tiers.tiers)} tiers)"
         return f"{price.meter.name}: {formatters.currency(price.unit_amount, price.price_currency, decimal_quantization=False)} / unit"
     return "N/A"
 

--- a/server/polar/backoffice/products/endpoints.py
+++ b/server/polar/backoffice/products/endpoints.py
@@ -59,6 +59,8 @@ def _format_price_display(price: ProductPrice) -> str:
                 return f"From {price_display} / seat"
             return f"{price_display} / seat"
     elif is_metered_price(price):
+        if price.unit_amount is None:
+            return f"{price.meter.name}: {price.tier_type} pricing ({len(price.get_tiers().tiers)} tiers)"
         return f"{price.meter.name}: {formatters.currency(price.unit_amount, price.price_currency, decimal_quantization=False)} / unit"
     return "N/A"
 

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import (
     object_mapper,
     relationship,
 )
+from sqlalchemy.orm.attributes import Event
 
 from polar.enums import (
     SubscriptionRecurringInterval,
@@ -40,6 +41,7 @@ from polar.product.tiers import (
     SeatTierType,
     Tiers,
     TiersType,
+    TierType,
     seat_tiers_to_tiers,
     seat_tiers_unit_bounds,
     tiers_to_seat_tiers,
@@ -287,54 +289,6 @@ class LegacyRecurringProductPriceCustom(
     }
 
 
-class ProductPriceMeteredUnit(ProductPrice, NewProductPrice):
-    amount_type: Mapped[Literal[ProductPriceAmountType.metered_unit]] = mapped_column(
-        use_existing_column=True, default=ProductPriceAmountType.metered_unit
-    )
-    unit_amount: Mapped[Decimal] = mapped_column(
-        Numeric(17, 12),  # 12 decimal places, 17 digits total
-        # Polymorphic columns must be nullable, as they don't apply to other types
-        nullable=True,
-    )
-    cap_amount: Mapped[int | None] = mapped_column(
-        "cap_amount_v2", BigInteger, nullable=True
-    )
-    meter_id: Mapped[UUID] = mapped_column(
-        Uuid,
-        ForeignKey("meters.id"),
-        # Polymorphic columns must be nullable, as they don't apply to other types
-        nullable=True,
-        index=True,
-    )
-
-    @declared_attr
-    def meter(cls) -> Mapped["Meter"]:
-        # For convenience, eager load it, at it's embedded in all schemas outputting a price
-        return relationship("Meter", lazy="joined")
-
-    def get_amount_and_label(self, units: float) -> tuple[int, str]:
-        label = f"({format_decimal(max(0, units), locale='en_US')} consumed units"
-
-        label += f") × {format_currency(self.unit_amount, self.price_currency, decimal_quantization=False)}"
-
-        billable_units = Decimal(max(0, units))
-        raw_amount = self.unit_amount * billable_units
-        amount = polar_round(raw_amount)
-
-        if self.cap_amount is not None and amount > self.cap_amount:
-            amount = self.cap_amount
-            label += (
-                f" — Capped at {format_currency(self.cap_amount, self.price_currency)}"
-            )
-
-        return amount, label
-
-    __mapper_args__ = {
-        "polymorphic_identity": ProductPriceAmountType.metered_unit,
-        "polymorphic_load": "inline",
-    }
-
-
 class TieredPrice:
     """Mixin for prices billed from a shared list of tiers.
 
@@ -366,6 +320,16 @@ class TieredPrice:
         default=None,
     )
 
+    def get_tiers(self) -> Tiers:
+        """The tiers this price bills on."""
+        if self.tiers is None:
+            raise ValueError("Price has no tiers")
+        return self.tiers
+
+    @property
+    def tier_type(self) -> TierType:
+        return self.get_tiers().type
+
     def get_tiered_amount(self, quantity: Decimal | int) -> Decimal:
         return self.tiers.calculate(quantity)
 
@@ -380,6 +344,66 @@ class TieredPrice:
         if self.maximum_units is not None:
             return self.maximum_units
         return self.tiers.last_bound
+
+
+class ProductPriceMeteredUnit(TieredPrice, NewProductPrice, ProductPrice):
+    amount_type: Mapped[Literal[ProductPriceAmountType.metered_unit]] = mapped_column(
+        use_existing_column=True, default=ProductPriceAmountType.metered_unit
+    )
+    unit_amount: Mapped[Decimal | None] = mapped_column(
+        Numeric(17, 12),  # 12 decimal places, 17 digits total
+        # Polymorphic columns must be nullable, as they don't apply to other types
+        # None for tiered prices: exactly one of unit_amount and tiers is set
+        nullable=True,
+    )
+    cap_amount: Mapped[int | None] = mapped_column(
+        "cap_amount_v2", BigInteger, nullable=True
+    )
+    meter_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("meters.id"),
+        # Polymorphic columns must be nullable, as they don't apply to other types
+        nullable=True,
+        index=True,
+    )
+
+    @declared_attr
+    def meter(cls) -> Mapped["Meter"]:
+        # For convenience, eager load it, at it's embedded in all schemas outputting a price
+        return relationship("Meter", lazy="joined")
+
+    def get_amount_and_label(self, units: float) -> tuple[int, str]:
+        billable_units = Decimal(max(0, units))
+        formatted_units = format_decimal(max(0, units), locale="en_US")
+
+        if self.tiers is not None:
+            label = f"({formatted_units} consumed units, {self.tier_type} pricing)"
+            raw_amount = self.get_tiered_amount(billable_units)
+        else:
+            if self.unit_amount is None:
+                raise ValueError("Metered price has neither unit_amount nor tiers")
+            label = f"({formatted_units} consumed units) × {format_currency(self.unit_amount, self.price_currency, decimal_quantization=False)}"
+            raw_amount = self.unit_amount * billable_units
+
+        amount = polar_round(raw_amount)
+
+        if self.cap_amount is not None and amount > self.cap_amount:
+            amount = self.cap_amount
+            label += (
+                f" — Capped at {format_currency(self.cap_amount, self.price_currency)}"
+            )
+
+        return amount, label
+
+    @property
+    def is_free(self) -> bool:
+        """Metered prices are never free: the amount depends on usage."""
+        return False
+
+    __mapper_args__ = {
+        "polymorphic_identity": ProductPriceAmountType.metered_unit,
+        "polymorphic_load": "inline",
+    }
 
 
 class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
@@ -439,6 +463,21 @@ class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
         "polymorphic_identity": ProductPriceAmountType.seat_based,
         "polymorphic_load": "inline",
     }
+
+
+@event.listens_for(ProductPriceMeteredUnit.tiers, "set", retval=True)
+def _coerce_tiers(
+    target: ProductPriceMeteredUnit,
+    value: Tiers | dict[str, Any] | None,
+    oldvalue: Tiers | dict[str, Any] | None,
+    initiator: Event,
+) -> Tiers | None:
+    """The create path passes the API payload through as a plain mapping, so
+    parse it here and keep the attribute a `Tiers` in memory as well as in the
+    database."""
+    if value is None or isinstance(value, Tiers):
+        return value
+    return Tiers.model_validate(value)
 
 
 @event.listens_for(ProductPrice, "init", propagate=True)

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -424,7 +424,7 @@ class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
         return self.minimum_units if self.minimum_units is not None else 1
 
     def get_maximum_seats(self) -> int | None:
-        return self.maximum_units
+        return self.get_maximum_units()
 
     @property
     def is_free(self) -> bool:

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -338,8 +338,11 @@ class ProductPriceMeteredUnit(ProductPrice, NewProductPrice):
 class TieredPrice:
     """Mixin for prices billed from a shared list of tiers.
 
-    `get_tiered_amount` returns cents for a whole-unit quantity.
-    Subclasses interpret those units (seats, metered usage, …).
+    `get_tiered_amount` returns cents for a quantity. Bounds are whole
+    units, but the quantity need not be: metered usage is consumed rather
+    than purchased, and an inclusive bound places a fractional quantity
+    unambiguously. Subclasses interpret those units (seats, metered
+    usage, …).
     """
 
     __abstract__ = True
@@ -363,7 +366,7 @@ class TieredPrice:
         default=None,
     )
 
-    def get_tiered_amount(self, quantity: int) -> Decimal:
+    def get_tiered_amount(self, quantity: Decimal | int) -> Decimal:
         return self.tiers.calculate(quantity)
 
     def get_minimum_units(self) -> int:

--- a/server/polar/models/product_price.py
+++ b/server/polar/models/product_price.py
@@ -26,7 +26,6 @@ from sqlalchemy.orm import (
     object_mapper,
     relationship,
 )
-from sqlalchemy.orm.attributes import Event
 
 from polar.enums import (
     SubscriptionRecurringInterval,
@@ -38,10 +37,12 @@ from polar.kit.extensions.sqlalchemy.types import StringEnum
 from polar.kit.math import polar_round
 from polar.product.tiers import (
     SeatTiersData,
+    SeatTierType,
     Tiers,
     TiersType,
     seat_tiers_to_tiers,
     seat_tiers_unit_bounds,
+    tiers_to_seat_tiers,
 )
 
 if TYPE_CHECKING:
@@ -379,63 +380,62 @@ class TieredPrice:
 
 
 class ProductPriceSeatUnit(TieredPrice, NewProductPrice, ProductPrice):
-    """Seat-based price. Billing still reads `seat_tiers`. That column is
-    dual-written into the shared `tiers` columns so they can become the
-    billing source after backfill.
+    """Seat-based price billed from the shared `tiers` columns.
+
+    The public `seat_tiers` attribute is the HTTP payload reconstructed
+    from those columns. `_seat_tiers` keeps the unused DB column mapped
+    so Alembic does not try to drop it.
     """
 
     amount_type: Mapped[Literal[ProductPriceAmountType.seat_based]] = mapped_column(
         use_existing_column=True, default=ProductPriceAmountType.seat_based
     )
-    seat_tiers: Mapped[SeatTiersData] = mapped_column(
+    _seat_tiers: Mapped[SeatTiersData | None] = mapped_column(
+        "seat_tiers",
         postgresql.JSONB,
         nullable=True,
+        default=None,
     )
 
+    @property
+    def seat_tiers(self) -> SeatTiersData:
+        if self.tiers is None:
+            return {"seat_tier_type": SeatTierType.volume, "tiers": []}
+        return tiers_to_seat_tiers(self.tiers, self.minimum_units, self.maximum_units)
+
+    @seat_tiers.setter
+    def seat_tiers(self, value: SeatTiersData | None) -> None:
+        if value is None:
+            self.tiers = None  # type: ignore[assignment]
+            self.minimum_units = None
+            self.maximum_units = None
+            return
+        self.tiers = seat_tiers_to_tiers(value)
+        self.minimum_units, self.maximum_units = seat_tiers_unit_bounds(value)
+
     def calculate_amount(self, seats: int) -> int:
-        amount = seat_tiers_to_tiers(self.seat_tiers).calculate(seats)
+        amount = self.get_tiered_amount(seats)
         # Seat rates are whole cents, so any fraction means corrupt data.
         if amount != amount.to_integral_value():
             raise ValueError(f"Seat price produced non-integral amount {amount}")
         return int(amount)
 
     def get_minimum_seats(self) -> int:
-        minimum, _ = seat_tiers_unit_bounds(self.seat_tiers)
-        return minimum if minimum is not None else 1
+        return self.minimum_units if self.minimum_units is not None else 1
 
     def get_maximum_seats(self) -> int | None:
-        _, maximum = seat_tiers_unit_bounds(self.seat_tiers)
-        return maximum
+        return self.maximum_units
 
     @property
     def is_free(self) -> bool:
-        tiers = self.seat_tiers.get("tiers", [])
-        if not tiers:
+        if self.tiers is None or not self.tiers.tiers:
             return True
-        return all(tier["price_per_seat"] == 0 for tier in tiers)
+        return all(tier.unit_amount == 0 for tier in self.tiers.tiers)
 
     __mapper_args__ = {
         "polymorphic_identity": ProductPriceAmountType.seat_based,
         "polymorphic_load": "inline",
     }
-
-
-@event.listens_for(ProductPriceSeatUnit.seat_tiers, "set")
-def _write_tiers_from_seat_tiers(
-    target: ProductPriceSeatUnit,
-    value: SeatTiersData | None,
-    oldvalue: SeatTiersData | None,
-    initiator: Event,
-) -> None:
-    """Dual-write to the shared `tiers`, `minimum_units` and `maximum_units`
-    columns. Delete when `seat_tiers` is dropped."""
-    if value is None:
-        target.tiers = None  # type: ignore[assignment]
-        target.minimum_units = None
-        target.maximum_units = None
-    else:
-        target.tiers = seat_tiers_to_tiers(value)
-        target.minimum_units, target.maximum_units = seat_tiers_unit_bounds(value)
 
 
 @event.listens_for(ProductPrice, "init", propagate=True)

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -9,8 +9,10 @@ from pydantic import (
     Discriminator,
     Field,
     Tag,
+    ValidationError,
     ValidationInfo,
     computed_field,
+    field_serializer,
     field_validator,
     model_validator,
 )
@@ -80,6 +82,8 @@ from polar.product.tiers import (
     NonContiguousTiersError,
     SeatTiersData,
     SeatTierType,
+    Tiers,
+    TierType,
     UnboundedTierNotLastError,
     seat_tiers_to_tiers,
     seat_tiers_unit_bounds,
@@ -376,17 +380,77 @@ class ProductPriceMeteredCreateBase(ProductPriceCreateBase):
     meter_id: UUID4 = Field(description="The ID of the meter associated to the price.")
 
 
+class ProductPriceMeteredTier(Schema):
+    """
+    A pricing tier for metered pricing: a per-unit rate up to and including
+    `bound`. A tier starts where the previous one ended; the first starts at
+    zero.
+    """
+
+    bound: int | None = Field(
+        gt=0,
+        description=(
+            "Upper bound of the tier in units (inclusive). "
+            "`null` for the unbounded last tier."
+        ),
+    )
+    unit_amount: Decimal = Field(
+        ge=0,
+        max_digits=17,
+        decimal_places=12,
+        description=(
+            "The price per unit in cents for this tier. "
+            "Supports up to 12 decimal places."
+        ),
+    )
+
+    @field_serializer("unit_amount")
+    def _serialize_decimal(self, value: Decimal) -> str:
+        return str(value)
+
+
+class ProductPriceMeteredTiers(Schema):
+    """
+    Tiered pricing configuration for a metered price.
+    """
+
+    type: TierType = Field(
+        description=(
+            "How tiers convert usage into an amount: `volume` bills the whole "
+            "quantity at the rate of the tier it falls in, `graduated` bills "
+            "each tier's portion at that tier's rate."
+        )
+    )
+    tiers: list[ProductPriceMeteredTier] = Field(
+        min_length=1, description="The pricing tiers."
+    )
+
+    def to_tiers(self) -> Tiers:
+        return Tiers.model_validate(self.model_dump())
+
+
 class ProductPriceMeteredUnitCreate(ProductPriceMeteredCreateBase):
     """
-    Schema to create a metered price with a fixed unit price.
+    Schema to create a metered price, with either a fixed unit price or pricing tiers.
     """
 
     amount_type: Literal[ProductPriceAmountType.metered_unit]
-    unit_amount: Decimal = Field(
+    unit_amount: Decimal | None = Field(
+        default=None,
         gt=0,
         max_digits=17,
         decimal_places=12,
-        description="The price per unit in cents. Supports up to 12 decimal places.",
+        description=(
+            "The price per unit in cents. Supports up to 12 decimal places. "
+            "Mutually exclusive with `tiers`."
+        ),
+    )
+    tiers: ProductPriceMeteredTiers | None = Field(
+        default=None,
+        description=(
+            "Tiered pricing based on consumed units. "
+            "Mutually exclusive with `unit_amount`."
+        ),
     )
     cap_amount: Int32 | None = Field(
         default=None,
@@ -396,6 +460,31 @@ class ProductPriceMeteredUnitCreate(ProductPriceMeteredCreateBase):
             "regardless of the number of units consumed."
         ),
     )
+
+    @model_validator(mode="after")
+    def validate_unit_amount_or_tiers(self) -> Self:
+        if (self.unit_amount is None) == (self.tiers is None):
+            raise ValueError("Set either unit_amount or tiers, not both")
+        return self
+
+    @model_validator(mode="after")
+    def validate_tiers(self) -> Self:
+        """Validation runs on creation only: the read schema stays permissive,
+        so a drifted stored row can never fail response serialization."""
+        if self.tiers is None:
+            return self
+
+        try:
+            self.tiers.to_tiers()
+        except ValidationError as e:
+            raise ValueError(e.errors()[0]["msg"]) from None
+
+        if all(tier.bound is not None for tier in self.tiers.tiers):
+            raise ValueError(
+                "The last tier must be unbounded (bound set to null), "
+                "since usage has no upper limit"
+            )
+        return self
 
     def get_model_class(self) -> builtins.type[ProductPriceMeteredUnitModel]:
         return ProductPriceMeteredUnitModel
@@ -824,11 +913,23 @@ class ProductPriceMeter(IDSchema):
 
 class ProductPriceMeteredUnit(ProductPriceBase):
     """
-    A metered, usage-based, price for a product, with a fixed unit price.
+    A metered, usage-based, price for a product, with either a fixed unit
+    price or pricing tiers.
     """
 
     amount_type: Literal[ProductPriceAmountType.metered_unit]
-    unit_amount: Decimal = Field(description="The price per unit in cents.")
+    unit_amount: Decimal | None = Field(
+        description=(
+            "The price per unit in cents. `null` for tiered prices: "
+            "read the rates from `tiers` instead."
+        )
+    )
+    tiers: ProductPriceMeteredTiers | None = Field(
+        description=(
+            "The pricing tiers based on consumed units. `null` for prices "
+            "with a fixed unit price."
+        )
+    )
     cap_amount: int | None = Field(
         description=(
             "The maximum amount in cents that can be charged, "

--- a/server/polar/product/tiers.py
+++ b/server/polar/product/tiers.py
@@ -252,6 +252,7 @@ def tiers_to_seat_tiers(
     last_index = len(tiers.tiers) - 1
     for index, tier in enumerate(tiers.tiers):
         min_seats = first_min if previous_max is None else previous_max + 1
+        max_seats: int | None
         if index == last_index and maximum_units is not None:
             max_seats = maximum_units
         else:

--- a/server/polar/product/tiers.py
+++ b/server/polar/product/tiers.py
@@ -184,7 +184,7 @@ class SeatTier(TypedDict):
 
 
 class SeatTiersData(TypedDict):
-    """The structure of the seat_tiers JSONB column."""
+    """The public seat-tier payload used by the HTTP API and dashboard."""
 
     seat_tier_type: SeatTierType
     tiers: list[SeatTier]
@@ -231,3 +231,41 @@ def seat_tiers_unit_bounds(seat_tiers: SeatTiersData) -> tuple[int | None, int |
     if not sorted_seat_tiers:
         return None, None
     return sorted_seat_tiers[0]["min_seats"], sorted_seat_tiers[-1].get("max_seats")
+
+
+def tiers_to_seat_tiers(
+    tiers: Tiers,
+    minimum_units: int | None = None,
+    maximum_units: int | None = None,
+) -> SeatTiersData:
+    """Translate the shared tiers format back to the seat API payload.
+
+    The first `min_seats` comes from `minimum_units` (at least 1). Each
+    later `min_seats` is the previous `max_seats` plus one. Intermediate
+    `max_seats` values are the tier bounds. The last `max_seats` is
+    `maximum_units` when set, otherwise the last bound.
+    """
+    first_min = 1 if minimum_units is None or minimum_units < 1 else minimum_units
+
+    seat_tiers: list[SeatTier] = []
+    previous_max: int | None = None
+    last_index = len(tiers.tiers) - 1
+    for index, tier in enumerate(tiers.tiers):
+        min_seats = first_min if previous_max is None else previous_max + 1
+        if index == last_index and maximum_units is not None:
+            max_seats = maximum_units
+        else:
+            max_seats = tier.bound
+        seat_tiers.append(
+            {
+                "min_seats": min_seats,
+                "max_seats": max_seats,
+                "price_per_seat": int(tier.unit_amount),
+            }
+        )
+        previous_max = max_seats
+
+    return {
+        "seat_tier_type": SeatTierType(tiers.type),
+        "tiers": seat_tiers,
+    }

--- a/server/polar/product/tiers.py
+++ b/server/polar/product/tiers.py
@@ -57,7 +57,7 @@ class Tiers(BaseModel):
                 )
         return sorted_tiers
 
-    def calculate(self, quantity: int) -> Decimal:
+    def calculate(self, quantity: Decimal | int) -> Decimal:
         if quantity < 0:
             raise InvalidQuantityError(f"Negative quantity: {quantity}")
         if quantity == 0:
@@ -69,13 +69,13 @@ class Tiers(BaseModel):
             case TierType.graduated:
                 return self._calculate_graduated(quantity)
 
-    def _calculate_volume(self, quantity: int) -> Decimal:
+    def _calculate_volume(self, quantity: Decimal | int) -> Decimal:
         for tier in self.tiers:
             if tier.bound is None or quantity <= tier.bound:
                 return tier.unit_amount * quantity
         raise InvalidQuantityError(f"No tier covers quantity {quantity}")
 
-    def _calculate_graduated(self, quantity: int) -> Decimal:
+    def _calculate_graduated(self, quantity: Decimal | int) -> Decimal:
         total = Decimal(0)
         remaining = quantity
         previous_bound = 0

--- a/server/polar/product/tiers.py
+++ b/server/polar/product/tiers.py
@@ -170,6 +170,12 @@ class InvalidQuantityError(PolarError):
         super().__init__(message, status_code=400)
 
 
+def integral_price_per_seat(unit_amount: Decimal) -> int:
+    if unit_amount != unit_amount.to_integral_value():
+        raise ValueError(f"Seat tier rates must be whole cents, got {unit_amount}")
+    return int(unit_amount)
+
+
 class SeatTierType(StrEnum):
     volume = "volume"
     graduated = "graduated"
@@ -214,7 +220,9 @@ def seat_tiers_to_tiers(seat_tiers: SeatTiersData) -> Tiers:
             tiers=[
                 Tier(
                     bound=tier.get("max_seats"),
-                    unit_amount=Decimal(tier["price_per_seat"]),
+                    unit_amount=Decimal(
+                        integral_price_per_seat(Decimal(tier["price_per_seat"]))
+                    ),
                 )
                 for tier in sorted_seat_tiers
             ],
@@ -240,31 +248,45 @@ def tiers_to_seat_tiers(
 ) -> SeatTiersData:
     """Translate the shared tiers format back to the seat API payload.
 
-    The first `min_seats` comes from `minimum_units` (at least 1). Each
-    later `min_seats` is the previous `max_seats` plus one. Intermediate
-    `max_seats` values are the tier bounds. The last `max_seats` is
-    `maximum_units` when set, otherwise the last bound.
+    Only tiers overlapping the purchasable interval are emitted. The first
+    `min_seats` is clipped to `minimum_units` (at least 1). The last
+    `max_seats` is clipped to `maximum_units` when set, otherwise the tier
+    bound.
     """
     first_min = 1 if minimum_units is None or minimum_units < 1 else minimum_units
+    last_max = maximum_units if maximum_units is not None else tiers.last_bound
 
     seat_tiers: list[SeatTier] = []
-    previous_max: int | None = None
-    last_index = len(tiers.tiers) - 1
-    for index, tier in enumerate(tiers.tiers):
-        min_seats = first_min if previous_max is None else previous_max + 1
-        max_seats: int | None
-        if index == last_index and maximum_units is not None:
-            max_seats = maximum_units
+    previous_bound = 0
+    for tier in tiers.tiers:
+        tier_start = previous_bound + 1
+        tier_end = tier.bound
+
+        if tier_end is not None and tier_end < first_min:
+            previous_bound = tier_end
+            continue
+
+        if last_max is not None and tier_start > last_max:
+            break
+
+        min_seats = max(first_min, tier_start)
+        if tier_end is None:
+            max_seats = last_max
+        elif last_max is None:
+            max_seats = tier_end
         else:
-            max_seats = tier.bound
+            max_seats = min(tier_end, last_max)
+
         seat_tiers.append(
             {
                 "min_seats": min_seats,
                 "max_seats": max_seats,
-                "price_per_seat": int(tier.unit_amount),
+                "price_per_seat": integral_price_per_seat(tier.unit_amount),
             }
         )
-        previous_max = max_seats
+
+        if tier_end is not None:
+            previous_bound = tier_end
 
     return {
         "seat_tier_type": SeatTierType(tiers.type),

--- a/server/scripts/backfill_product_price_tiers.py
+++ b/server/scripts/backfill_product_price_tiers.py
@@ -1,12 +1,12 @@
 """Backfill the shared `tiers`, `minimum_units` and `maximum_units` columns
 on seat-based product prices.
 
-Translates each row's legacy `seat_tiers` with the same functions the
-dual-write hook uses, so backfilled and newly written rows match.
-Re-running the script is safe: the translation is deterministic.
+Translates each row's unused `seat_tiers` column with the same functions
+product create uses. Rows that already have `tiers` are skipped so a
+post-cutover re-run cannot overwrite live data with a stale unused column.
 
-Dry-run still translates and validates every row, so corrupt legacy
-data is detected before `--execute`.
+Dry-run still translates and validates every remaining row, so corrupt
+legacy data is detected before `--execute`.
 """
 
 import typer
@@ -47,18 +47,20 @@ async def run_backfill(
 async def _run(session: AsyncSession, *, dry_run: bool) -> int:
     repository = ProductPriceRepository.from_session(session)
     statement = repository.get_base_statement(include_deleted=True).where(
-        ProductPriceSeatUnit.seat_tiers.isnot(None)
+        ProductPriceSeatUnit._seat_tiers.isnot(None),
+        ProductPriceSeatUnit.tiers.is_(None),
     )
     if not dry_run:
-        # Lock each row so a concurrent seat_tiers write cannot commit new
-        # canonical values that this snapshot would then overwrite.
+        # Lock each row so a concurrent write cannot commit new canonical
+        # values that this snapshot would then overwrite.
         statement = statement.with_for_update(of=ProductPrice)
 
     total = 0
     async for price in repository.stream(statement):
         assert isinstance(price, ProductPriceSeatUnit)
-        tiers = seat_tiers_to_tiers(price.seat_tiers)
-        minimum_units, maximum_units = seat_tiers_unit_bounds(price.seat_tiers)
+        assert price._seat_tiers is not None
+        tiers = seat_tiers_to_tiers(price._seat_tiers)
+        minimum_units, maximum_units = seat_tiers_unit_bounds(price._seat_tiers)
         # Crash on corrupt legacy rows rather than copying them into the
         # canonical columns.
         validate_unit_bounds(

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -39,6 +39,7 @@ from polar.product.guard import (
     is_metered_price,
     is_seat_price,
 )
+from polar.product.tiers import Tiers, TierType
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_active_subscription,
@@ -105,7 +106,7 @@ async def create_metered_event_billing_entry(
     customer: Customer,
     price: ProductPrice,
     subscription: Subscription,
-    tokens: int,
+    tokens: float,
     pending: bool = True,
     order: Order | None = None,
     metadata_key: str = "tokens",
@@ -763,6 +764,210 @@ class TestCreateOrderItemsFromPending:
         for entry in entries[1:]:
             await session.refresh(entry)
             assert entry.order_item_id == order_item.id
+
+    async def test_tiered_graduated_price(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+        product_metered_unit: Product,
+        metered_subscription: Subscription,
+    ) -> None:
+        price = product_metered_unit.prices[0]
+        assert is_metered_price(price)
+        price.unit_amount = None
+        price.tiers = Tiers.model_validate(
+            {
+                "type": TierType.graduated,
+                "tiers": [
+                    {"bound": 30, "unit_amount": "100"},
+                    {"bound": None, "unit_amount": "50"},
+                ],
+            }
+        )
+        await save_fixture(price)
+        await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=20,
+        )
+        await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=30,
+        )
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, metered_subscription
+        ) as order_items:
+            assert len(order_items) == 1
+            order_item = order_items[0]
+            # 30 units at 100 + 20 units at 50
+            assert order_item.amount == 40_00
+            assert "graduated pricing" in order_item.label
+            await create_order(
+                save_fixture, customer=customer, order_items=list(order_items)
+            )
+
+    async def test_tiered_volume_price_with_credits(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+        product_metered_unit: Product,
+        metered_subscription: Subscription,
+    ) -> None:
+        price = product_metered_unit.prices[0]
+        assert is_metered_price(price)
+        price.unit_amount = None
+        price.tiers = Tiers.model_validate(
+            {
+                "type": TierType.volume,
+                "tiers": [
+                    {"bound": 30, "unit_amount": "100"},
+                    {"bound": None, "unit_amount": "80"},
+                ],
+            }
+        )
+        await save_fixture(price)
+        await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=50,
+        )
+        await create_credit_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            meter=meter,
+            units=25,
+        )
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, metered_subscription
+        ) as order_items:
+            assert len(order_items) == 1
+            order_item = order_items[0]
+            # Credits net first: 50 - 25 = 25 units, dropping into the first
+            # volume tier, whose rate applies to all net units.
+            assert order_item.amount == 25_00
+            assert "volume pricing" in order_item.label
+            await create_order(
+                save_fixture, customer=customer, order_items=list(order_items)
+            )
+
+    async def test_tiered_price_fractional_consumption(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+        product_metered_unit: Product,
+        metered_subscription: Subscription,
+    ) -> None:
+        # Tier bounds are whole units, but consumption is a float coming off
+        # the meter. It stays exact through to the amount — no floor, no
+        # rounding until the total.
+        price = product_metered_unit.prices[0]
+        assert is_metered_price(price)
+        price.unit_amount = None
+        price.tiers = Tiers.model_validate(
+            {
+                "type": TierType.graduated,
+                "tiers": [
+                    {"bound": 10, "unit_amount": "100"},
+                    {"bound": None, "unit_amount": "50"},
+                ],
+            }
+        )
+        await save_fixture(price)
+        await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=15.5,
+        )
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, metered_subscription
+        ) as order_items:
+            assert len(order_items) == 1
+            order_item = order_items[0]
+            # 10 units at 100 + 5.5 units at 50
+            assert order_item.amount == 12_75
+            assert "graduated pricing" in order_item.label
+            await create_order(
+                save_fixture, customer=customer, order_items=list(order_items)
+            )
+
+    async def test_tiered_price_max_aggregation(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        meter_max = await create_meter(
+            save_fixture,
+            filter=Filter(conjunction=FilterConjunction.and_, clauses=[]),
+            aggregation=PropertyAggregation(
+                func=AggregationFunction.max, property="servers"
+            ),
+            organization=organization,
+        )
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(meter_max, Decimal(10_00), None, "usd")],
+        )
+        price = product.prices[0]
+        assert is_metered_price(price)
+        price.unit_amount = None
+        price.tiers = Tiers.model_validate(
+            {
+                "type": TierType.graduated,
+                "tiers": [
+                    {"bound": 2, "unit_amount": "1000"},
+                    {"bound": None, "unit_amount": "500"},
+                ],
+            }
+        )
+        await save_fixture(price)
+        subscription = await create_active_subscription(
+            save_fixture, customer=customer, product=product
+        )
+        for servers in (1, 3, 2):
+            await create_metered_event_billing_entry(
+                save_fixture,
+                customer=customer,
+                price=price,
+                subscription=subscription,
+                tokens=servers,
+                metadata_key="servers",
+            )
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, subscription
+        ) as order_items:
+            assert len(order_items) == 1
+            order_item = order_items[0]
+            # max is 3 servers: 2 at 1000 + 1 at 500
+            assert order_item.amount == 25_00
+            assert "graduated pricing" in order_item.label
+            await create_order(
+                save_fixture, customer=customer, order_items=list(order_items)
+            )
 
     async def test_count_meter_excludes_system_entries(
         self,

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -136,7 +136,7 @@ from polar.models.wallet import WalletType
 from polar.models.webhook_endpoint import WebhookEventType, WebhookFormat
 from polar.notification_recipient.schemas import NotificationRecipientPlatform
 from polar.product.price_set import PriceSet
-from polar.product.tiers import SeatTierType
+from polar.product.tiers import SeatTierType, Tiers
 from polar.tax.calculation import TaxBreakdownItem
 from polar.tax.tax_id import TaxID
 from tests.fixtures.database import SaveFixture
@@ -603,8 +603,9 @@ async def create_product_price_metered_unit(
     *,
     product: Product,
     meter: Meter,
-    unit_amount: Decimal = Decimal(100),
+    unit_amount: Decimal | None = Decimal(100),
     cap_amount: int | None = None,
+    tiers: Tiers | None = None,
     currency: str = "usd",
     tax_behavior: TaxBehavior | None = None,
 ) -> ProductPriceMeteredUnit:
@@ -613,6 +614,7 @@ async def create_product_price_metered_unit(
         tax_behavior=tax_behavior,
         unit_amount=unit_amount,
         cap_amount=cap_amount,
+        tiers=tiers,
         meter=meter,
         product=product,
     )

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -528,31 +528,6 @@ class TestGetTieredAmount:
         )
         assert price.get_tiered_amount(5) == price.tiers.calculate(5)
 
-    def test_fractional_quantity(self) -> None:
-        # Bounds are whole units, the quantity need not be: an inclusive
-        # bound still places a fractional quantity unambiguously.
-        price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
-        assert price.get_tiered_amount(Decimal("9.5")) == Decimal("9.5") * 1000
-        assert price.get_tiered_amount(Decimal("10.5")) == Decimal("10.5") * 800
-
-    def test_fractional_quantity_on_and_below_a_bound(self) -> None:
-        price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
-        assert price.get_tiered_amount(Decimal("10.0")) == Decimal("10.0") * 1000
-        assert price.get_tiered_amount(Decimal("9.999")) == Decimal("9.999") * 1000
-        assert price.get_tiered_amount(Decimal("10.001")) == Decimal("10.001") * 800
-
-    def test_fractional_quantity_straddles_a_bound(self) -> None:
-        # 9.8 splits into 9.8 inside the first tier; 15.5 into 10 + 5.5.
-        price = _make_tiered_price(_tiers_data(TierType.graduated, SHARED_MULTI_TIER))
-        assert price.get_tiered_amount(Decimal("9.8")) == Decimal("9.8") * 1000
-        assert (
-            price.get_tiered_amount(Decimal("15.5")) == 10 * 1000 + Decimal("5.5") * 800
-        )
-        assert (
-            price.get_tiered_amount(Decimal("50.25"))
-            == 10 * 1000 + 40 * 800 + Decimal("0.25") * 600
-        )
-
 
 class TestSeatTiersApiView:
     def test_constructor_populates_shared_columns(self) -> None:

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -95,6 +95,210 @@ async def test_get_amount_and_label(
     assert label == expected_label
 
 
+METERED_TIER_RATES: list[dict[str, Any]] = [
+    {"bound": 100, "unit_amount": "10"},
+    {"bound": 1000, "unit_amount": "8"},
+    {"bound": None, "unit_amount": "5"},
+]
+
+METERED_VOLUME_TIERS = Tiers.model_validate(
+    {"type": TierType.volume, "tiers": METERED_TIER_RATES}
+)
+
+METERED_GRADUATED_TIERS = Tiers.model_validate(
+    {"type": TierType.graduated, "tiers": METERED_TIER_RATES}
+)
+
+
+@pytest.mark.asyncio
+class TestMeteredTieredAmountAndLabel:
+    @pytest.mark.parametrize(
+        ("tiers", "cap_amount", "units", "expected_amount", "expected_label"),
+        [
+            # Volume: quantity in each tier
+            (
+                METERED_VOLUME_TIERS,
+                None,
+                50,
+                500,
+                "(50 consumed units, volume pricing)",
+            ),
+            (
+                METERED_VOLUME_TIERS,
+                None,
+                500,
+                4_000,
+                "(500 consumed units, volume pricing)",
+            ),
+            (
+                METERED_VOLUME_TIERS,
+                None,
+                5000,
+                25_000,
+                "(5,000 consumed units, volume pricing)",
+            ),
+            # Quantity exactly on a bound bills in that tier (bound is inclusive)
+            (
+                METERED_VOLUME_TIERS,
+                None,
+                100,
+                1_000,
+                "(100 consumed units, volume pricing)",
+            ),
+            # Graduated: spans tiers, boundary, unlimited tail
+            (
+                METERED_GRADUATED_TIERS,
+                None,
+                50,
+                500,
+                "(50 consumed units, graduated pricing)",
+            ),
+            (
+                METERED_GRADUATED_TIERS,
+                None,
+                100,
+                1_000,
+                "(100 consumed units, graduated pricing)",
+            ),
+            (
+                METERED_GRADUATED_TIERS,
+                None,
+                500,
+                4_200,
+                "(500 consumed units, graduated pricing)",
+            ),
+            (
+                METERED_GRADUATED_TIERS,
+                None,
+                5000,
+                28_200,
+                "(5,000 consumed units, graduated pricing)",
+            ),
+            # Fractional quantity keeps full precision
+            (
+                METERED_GRADUATED_TIERS,
+                None,
+                150.5,
+                1_404,
+                "(150.5 consumed units, graduated pricing)",
+            ),
+            # Cap clamps the tiered total
+            (
+                METERED_VOLUME_TIERS,
+                20_000,
+                5000,
+                20_000,
+                "(5,000 consumed units, volume pricing) — Capped at $200.00",
+            ),
+            # Zero and negative quantities bill nothing
+            (METERED_VOLUME_TIERS, None, 0, 0, "(0 consumed units, volume pricing)"),
+            (
+                METERED_GRADUATED_TIERS,
+                None,
+                -5,
+                0,
+                "(0 consumed units, graduated pricing)",
+            ),
+        ],
+    )
+    async def test_tiered_amounts(
+        self,
+        tiers: Tiers,
+        cap_amount: int | None,
+        units: float,
+        expected_amount: int,
+        expected_label: str,
+        save_fixture: SaveFixture,
+        product: Product,
+        meter: Meter,
+    ) -> None:
+        price = await create_product_price_metered_unit(
+            save_fixture,
+            product=product,
+            meter=meter,
+            unit_amount=None,
+            cap_amount=cap_amount,
+            tiers=tiers,
+        )
+
+        amount, label = price.get_amount_and_label(units)
+        assert amount == expected_amount
+        assert label == expected_label
+
+    async def test_zero_rate_first_tier_bills_nothing(
+        self, save_fixture: SaveFixture, product: Product, meter: Meter
+    ) -> None:
+        price = await create_product_price_metered_unit(
+            save_fixture,
+            product=product,
+            meter=meter,
+            unit_amount=None,
+            tiers=Tiers.model_validate(
+                {
+                    "type": TierType.graduated,
+                    "tiers": [
+                        {"bound": 1000, "unit_amount": "0"},
+                        {"bound": None, "unit_amount": "10"},
+                    ],
+                }
+            ),
+        )
+
+        assert price.get_amount_and_label(500)[0] == 0
+        assert price.get_amount_and_label(1500)[0] == 5_000
+
+    async def test_total_rounded_once_not_per_tier(
+        self, save_fixture: SaveFixture, product: Product, meter: Meter
+    ) -> None:
+        # Each tier portion is 0.4 cents; per-tier rounding would bill 0.
+        price = await create_product_price_metered_unit(
+            save_fixture,
+            product=product,
+            meter=meter,
+            unit_amount=None,
+            tiers=Tiers.model_validate(
+                {
+                    "type": TierType.graduated,
+                    "tiers": [
+                        {"bound": 2, "unit_amount": "0.2"},
+                        {"bound": None, "unit_amount": "0.2"},
+                    ],
+                }
+            ),
+        )
+
+        assert price.get_amount_and_label(4)[0] == 1
+
+    async def test_single_unbounded_tier_equals_flat(
+        self, save_fixture: SaveFixture, product: Product, meter: Meter
+    ) -> None:
+        tiered = await create_product_price_metered_unit(
+            save_fixture,
+            product=product,
+            meter=meter,
+            unit_amount=None,
+            tiers=Tiers.model_validate(
+                {
+                    "type": TierType.volume,
+                    "tiers": [{"bound": None, "unit_amount": "0.5"}],
+                }
+            ),
+        )
+        flat = await create_product_price_metered_unit(
+            save_fixture, product=product, meter=meter, unit_amount=Decimal("0.5")
+        )
+
+        assert tiered.get_amount_and_label(100)[0] == flat.get_amount_and_label(100)[0]
+
+    async def test_flat_price_is_not_free(
+        self, save_fixture: SaveFixture, product: Product, meter: Meter
+    ) -> None:
+        price = await create_product_price_metered_unit(
+            save_fixture, product=product, meter=meter, unit_amount=Decimal(100)
+        )
+        assert price.is_free is False
+
+
 class TestFixedPriceIsFree:
     """A fixed price with an amount of 0 is the free-pricing representation and must
     behave like a free price (`is_free` is True)."""

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -181,35 +181,28 @@ class TestCalculateAmountIntegralityGuard:
             price.calculate_amount(3)
 
 
-def _clear_shared_tier_columns(price: ProductPriceSeatUnit) -> ProductPriceSeatUnit:
-    price.tiers = None  # type: ignore[assignment]
-    price.minimum_units = None
-    price.maximum_units = None
-    return price
+class TestSeatBillingReadsSharedTiers:
+    """Billing and bounds come from the shared columns, not `_seat_tiers`."""
 
-
-class TestSeatBillingReadsSeatTiers:
-    """Billing must not depend on the dual-written `tiers` columns yet."""
-
-    def test_amount_with_empty_shared_columns(self) -> None:
-        price = _clear_shared_tier_columns(_make_seat_price(MULTI_TIER))
+    def test_amount_ignores_legacy_column(self) -> None:
+        price = _make_seat_price(MULTI_TIER)
+        price._seat_tiers = {
+            "seat_tier_type": SeatTierType.volume,
+            "tiers": [{"min_seats": 1, "max_seats": None, "price_per_seat": 1}],
+        }
         assert price.calculate_amount(10) == 10_000
         assert price.calculate_amount(11) == 11 * 800
 
-    def test_bounds_with_empty_shared_columns(self) -> None:
-        price = _clear_shared_tier_columns(
-            _make_seat_price(
-                [{"min_seats": 5, "max_seats": 20, "price_per_seat": 250}],
-            )
+    def test_bounds_from_shared_columns(self) -> None:
+        price = _make_seat_price(
+            [{"min_seats": 5, "max_seats": 20, "price_per_seat": 250}],
         )
         assert price.get_minimum_seats() == 5
         assert price.get_maximum_seats() == 20
 
-    def test_is_free_with_empty_shared_columns(self) -> None:
-        price = _clear_shared_tier_columns(
-            _make_seat_price(
-                [{"min_seats": 1, "max_seats": None, "price_per_seat": 0}],
-            )
+    def test_is_free_from_shared_tiers(self) -> None:
+        price = _make_seat_price(
+            [{"min_seats": 1, "max_seats": None, "price_per_seat": 0}],
         )
         assert price.is_free is True
 
@@ -326,14 +319,15 @@ class TestGetTieredAmount:
         assert price.get_tiered_amount(5) == price.tiers.calculate(5)
 
 
-class TestSeatTiersDualWrite:
-    def test_constructor_populates_tiers(self) -> None:
+class TestSeatTiersApiView:
+    def test_constructor_populates_shared_columns(self) -> None:
         price = _make_seat_price(MULTI_TIER, SeatTierType.graduated)
         assert price.tiers == seat_tiers_to_tiers(price.seat_tiers)
         assert price.minimum_units == 1
         assert price.maximum_units is None
+        assert price._seat_tiers is None
 
-    def test_updating_seat_tiers_updates_tiers(self) -> None:
+    def test_updating_seat_tiers_updates_shared_columns(self) -> None:
         price = _make_seat_price(MULTI_TIER, SeatTierType.volume)
         price.seat_tiers = {
             "seat_tier_type": SeatTierType.volume,
@@ -345,6 +339,10 @@ class TestSeatTiersDualWrite:
         )
         assert price.minimum_units == 5
         assert price.maximum_units == 20
+        assert price.seat_tiers["tiers"] == [
+            {"min_seats": 5, "max_seats": 20, "price_per_seat": 250}
+        ]
+        assert price._seat_tiers is None
 
     @pytest.mark.asyncio
     async def test_database_round_trip_returns_tiers_model(
@@ -360,13 +358,19 @@ class TestSeatTiersDualWrite:
             seat_tier_type=SeatTierType.graduated,
         )
 
-        tiers = (
-            await session.execute(
-                select(ProductPriceSeatUnit.tiers).where(
-                    ProductPriceSeatUnit.id == price.id
+        result = (
+            (
+                await session.execute(
+                    select(
+                        ProductPriceSeatUnit.tiers,
+                        ProductPriceSeatUnit._seat_tiers,
+                    ).where(ProductPriceSeatUnit.id == price.id)
                 )
             )
-        ).scalar_one()
+            .tuples()
+            .one()
+        )
+        tiers, legacy_seat_tiers = result
 
         assert isinstance(tiers, Tiers)
         assert tiers.type == TierType.graduated
@@ -375,6 +379,7 @@ class TestSeatTiersDualWrite:
             Decimal(800),
             Decimal(600),
         ]
+        assert legacy_seat_tiers is None
 
 
 class TestMinimumMaximumUnits:

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -173,12 +173,11 @@ class TestVolumePricing:
 
 class TestCalculateAmountIntegralityGuard:
     def test_fractional_stored_rate_raises(self) -> None:
-        price = _make_seat_price(
-            [{"min_seats": 1, "max_seats": None, "price_per_seat": 500.5}],
-            SeatTierType.volume,
-        )
-        with pytest.raises(ValueError, match="non-integral amount"):
-            price.calculate_amount(3)
+        with pytest.raises(ValueError, match="whole cents"):
+            _make_seat_price(
+                [{"min_seats": 1, "max_seats": None, "price_per_seat": 500.5}],
+                SeatTierType.volume,
+            )
 
 
 class TestSeatBillingReadsSharedTiers:
@@ -198,6 +197,13 @@ class TestSeatBillingReadsSharedTiers:
             [{"min_seats": 5, "max_seats": 20, "price_per_seat": 250}],
         )
         assert price.get_minimum_seats() == 5
+        assert price.get_maximum_seats() == 20
+
+    def test_maximum_seats_falls_back_to_last_tier_bound(self) -> None:
+        price = _make_seat_price(
+            [{"min_seats": 1, "max_seats": 20, "price_per_seat": 250}],
+        )
+        price.maximum_units = None
         assert price.get_maximum_seats() == 20
 
     def test_is_free_from_shared_tiers(self) -> None:

--- a/server/tests/models/test_product_price.py
+++ b/server/tests/models/test_product_price.py
@@ -324,6 +324,31 @@ class TestGetTieredAmount:
         )
         assert price.get_tiered_amount(5) == price.tiers.calculate(5)
 
+    def test_fractional_quantity(self) -> None:
+        # Bounds are whole units, the quantity need not be: an inclusive
+        # bound still places a fractional quantity unambiguously.
+        price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
+        assert price.get_tiered_amount(Decimal("9.5")) == Decimal("9.5") * 1000
+        assert price.get_tiered_amount(Decimal("10.5")) == Decimal("10.5") * 800
+
+    def test_fractional_quantity_on_and_below_a_bound(self) -> None:
+        price = _make_tiered_price(_tiers_data(TierType.volume, SHARED_MULTI_TIER))
+        assert price.get_tiered_amount(Decimal("10.0")) == Decimal("10.0") * 1000
+        assert price.get_tiered_amount(Decimal("9.999")) == Decimal("9.999") * 1000
+        assert price.get_tiered_amount(Decimal("10.001")) == Decimal("10.001") * 800
+
+    def test_fractional_quantity_straddles_a_bound(self) -> None:
+        # 9.8 splits into 9.8 inside the first tier; 15.5 into 10 + 5.5.
+        price = _make_tiered_price(_tiers_data(TierType.graduated, SHARED_MULTI_TIER))
+        assert price.get_tiered_amount(Decimal("9.8")) == Decimal("9.8") * 1000
+        assert (
+            price.get_tiered_amount(Decimal("15.5")) == 10 * 1000 + Decimal("5.5") * 800
+        )
+        assert (
+            price.get_tiered_amount(Decimal("50.25"))
+            == 10 * 1000 + 40 * 800 + Decimal("0.25") * 600
+        )
+
 
 class TestSeatTiersApiView:
     def test_constructor_populates_shared_columns(self) -> None:

--- a/server/tests/product/test_schemas.py
+++ b/server/tests/product/test_schemas.py
@@ -20,6 +20,7 @@ from polar.product.schemas import (
     ProductPriceMeteredUnitCreate,
     ProductPriceSeatTiers,
 )
+from polar.product.tiers import TierType
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import METER_ID, create_benefit
 
@@ -202,6 +203,118 @@ class TestProductPriceMeteredUnitCreate:
         assert len(errors) == 1
         assert errors[0]["type"] == "less_than_equal"
         assert errors[0]["loc"] == ("cap_amount",)
+
+
+def _metered_tiers_payload(
+    tiers: list[dict[str, Any]], tier_type: str = "graduated"
+) -> dict[str, Any]:
+    return {
+        "amount_type": ProductPriceAmountType.metered_unit,
+        "price_currency": PresentmentCurrency.usd,
+        "meter_id": METER_ID,
+        "tiers": {"type": tier_type, "tiers": tiers},
+    }
+
+
+UNBOUNDED_METERED_TIERS: list[dict[str, Any]] = [
+    {"bound": 1000, "unit_amount": "0.5"},
+    {"bound": None, "unit_amount": "0.25"},
+]
+
+
+class TestProductPriceMeteredUnitCreateTiers:
+    def test_valid_tiered_price(self) -> None:
+        schema = ProductPriceMeteredUnitCreate.model_validate(
+            _metered_tiers_payload(UNBOUNDED_METERED_TIERS)
+        )
+        assert schema.unit_amount is None
+        assert schema.tiers is not None
+        assert schema.tiers.type == TierType.graduated
+
+    def test_model_dump_matches_storage_format(self) -> None:
+        schema = ProductPriceMeteredUnitCreate.model_validate(
+            _metered_tiers_payload(UNBOUNDED_METERED_TIERS, tier_type="volume")
+        )
+        dumped = schema.model_dump()["tiers"]
+        assert dumped == {
+            "type": TierType.volume,
+            "tiers": [
+                {"bound": 1000, "unit_amount": "0.5"},
+                {"bound": None, "unit_amount": "0.25"},
+            ],
+        }
+
+    def test_both_unit_amount_and_tiers_rejected(self) -> None:
+        payload = _metered_tiers_payload(UNBOUNDED_METERED_TIERS)
+        payload["unit_amount"] = "1.0"
+        with pytest.raises(ValidationError, match="either unit_amount or tiers"):
+            ProductPriceMeteredUnitCreate.model_validate(payload)
+
+    def test_neither_unit_amount_nor_tiers_rejected(self) -> None:
+        payload = _metered_tiers_payload(UNBOUNDED_METERED_TIERS)
+        del payload["tiers"]
+        with pytest.raises(ValidationError, match="either unit_amount or tiers"):
+            ProductPriceMeteredUnitCreate.model_validate(payload)
+
+    def test_last_tier_must_be_unbounded(self) -> None:
+        with pytest.raises(ValidationError, match="must be unbounded"):
+            ProductPriceMeteredUnitCreate.model_validate(
+                _metered_tiers_payload(
+                    [
+                        {"bound": 1000, "unit_amount": "0.5"},
+                    ]
+                )
+            )
+
+    def test_duplicate_bound_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="must be unique"):
+            ProductPriceMeteredUnitCreate.model_validate(
+                _metered_tiers_payload(
+                    [
+                        {"bound": 1000, "unit_amount": "0.5"},
+                        {"bound": 1000, "unit_amount": "0.25"},
+                        {"bound": None, "unit_amount": "0.1"},
+                    ]
+                )
+            )
+
+    def test_zero_bound_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ProductPriceMeteredUnitCreate.model_validate(
+                _metered_tiers_payload(
+                    [
+                        {"bound": 0, "unit_amount": "0.5"},
+                        {"bound": None, "unit_amount": "0.25"},
+                    ]
+                )
+            )
+
+    def test_negative_rate_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ProductPriceMeteredUnitCreate.model_validate(
+                _metered_tiers_payload([{"bound": None, "unit_amount": "-1"}])
+            )
+
+    def test_zero_rate_allowed(self) -> None:
+        schema = ProductPriceMeteredUnitCreate.model_validate(
+            _metered_tiers_payload(
+                [
+                    {"bound": 100, "unit_amount": "0"},
+                    {"bound": None, "unit_amount": "0.5"},
+                ]
+            )
+        )
+        assert schema.tiers is not None
+
+    def test_flat_price_still_valid(self) -> None:
+        schema = ProductPriceMeteredUnitCreate(
+            amount_type=ProductPriceAmountType.metered_unit,
+            price_currency=PresentmentCurrency.usd,
+            unit_amount=Decimal("1.0"),
+            meter_id=METER_ID,
+        )
+        assert schema.tiers is None
+        assert schema.unit_amount == Decimal("1.0")
 
 
 class TestProductPriceFixedCurrencyMinimums:

--- a/server/tests/product/test_schemas.py
+++ b/server/tests/product/test_schemas.py
@@ -223,14 +223,6 @@ UNBOUNDED_METERED_TIERS: list[dict[str, Any]] = [
 
 
 class TestProductPriceMeteredUnitCreateTiers:
-    def test_valid_tiered_price(self) -> None:
-        schema = ProductPriceMeteredUnitCreate.model_validate(
-            _metered_tiers_payload(UNBOUNDED_METERED_TIERS)
-        )
-        assert schema.unit_amount is None
-        assert schema.tiers is not None
-        assert schema.tiers.type == TierType.graduated
-
     def test_model_dump_matches_storage_format(self) -> None:
         schema = ProductPriceMeteredUnitCreate.model_validate(
             _metered_tiers_payload(UNBOUNDED_METERED_TIERS, tier_type="volume")
@@ -265,46 +257,6 @@ class TestProductPriceMeteredUnitCreateTiers:
                     ]
                 )
             )
-
-    def test_duplicate_bound_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="must be unique"):
-            ProductPriceMeteredUnitCreate.model_validate(
-                _metered_tiers_payload(
-                    [
-                        {"bound": 1000, "unit_amount": "0.5"},
-                        {"bound": 1000, "unit_amount": "0.25"},
-                        {"bound": None, "unit_amount": "0.1"},
-                    ]
-                )
-            )
-
-    def test_zero_bound_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            ProductPriceMeteredUnitCreate.model_validate(
-                _metered_tiers_payload(
-                    [
-                        {"bound": 0, "unit_amount": "0.5"},
-                        {"bound": None, "unit_amount": "0.25"},
-                    ]
-                )
-            )
-
-    def test_negative_rate_rejected(self) -> None:
-        with pytest.raises(ValidationError):
-            ProductPriceMeteredUnitCreate.model_validate(
-                _metered_tiers_payload([{"bound": None, "unit_amount": "-1"}])
-            )
-
-    def test_zero_rate_allowed(self) -> None:
-        schema = ProductPriceMeteredUnitCreate.model_validate(
-            _metered_tiers_payload(
-                [
-                    {"bound": 100, "unit_amount": "0"},
-                    {"bound": None, "unit_amount": "0.5"},
-                ]
-            )
-        )
-        assert schema.tiers is not None
 
     def test_flat_price_still_valid(self) -> None:
         schema = ProductPriceMeteredUnitCreate(

--- a/server/tests/product/test_service.py
+++ b/server/tests/product/test_service.py
@@ -28,6 +28,7 @@ from polar.models.organization import OrganizationStatus
 from polar.models.product_price import (
     ProductPriceAmountType,
     ProductPriceFixed,
+    ProductPriceMeteredUnit,
 )
 from polar.organization_review.schemas import ReviewContext
 from polar.postgres import AsyncSession
@@ -50,8 +51,12 @@ from polar.product.schemas import (
     ProductPriceSeatTiers,
     ProductUpdate,
 )
+from polar.product.schemas import (
+    ProductPriceMeteredUnit as ProductPriceMeteredUnitSchema,
+)
 from polar.product.service import product as product_service
 from polar.product.sorting import ProductSortProperty
+from polar.product.tiers import Tiers
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -713,6 +718,58 @@ class TestCreate:
         assert product.organization_id == organization.id
 
         assert len(product.prices) == len(create_schema.prices)
+
+    @pytest.mark.auth
+    async def test_valid_tiered_metered_price(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        meter: Meter,
+    ) -> None:
+        create_schema = ProductCreateRecurring(
+            name="Recurring tiered metered",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            organization_id=organization.id,
+            prices=[
+                ProductPriceMeteredUnitCreate.model_validate(
+                    {
+                        "amount_type": ProductPriceAmountType.metered_unit,
+                        "price_currency": PresentmentCurrency.usd,
+                        "meter_id": METER_ID,
+                        "tiers": {
+                            "type": "graduated",
+                            "tiers": [
+                                {"bound": 1000, "unit_amount": "0.5"},
+                                {"bound": None, "unit_amount": "0.25"},
+                            ],
+                        },
+                    }
+                )
+            ],
+        )
+
+        product = await product_service.create(session, create_schema, auth_subject)
+
+        price = product.prices[0]
+        assert isinstance(price, ProductPriceMeteredUnit)
+        assert price.unit_amount is None
+        assert price.tiers == Tiers.model_validate(
+            {
+                "type": "graduated",
+                "tiers": [
+                    {"bound": 1000, "unit_amount": "0.5"},
+                    {"bound": None, "unit_amount": "0.25"},
+                ],
+            }
+        )
+        assert price.get_amount_and_label(2000)[0] == 750
+
+        read = ProductPriceMeteredUnitSchema.model_validate(price)
+        assert read.unit_amount is None
+        assert read.tiers is not None
+        assert read.tiers.tiers[0].unit_amount == Decimal("0.5")
 
     @pytest.mark.auth
     async def test_invalid_several_static_prices(

--- a/server/tests/product/test_tiers.py
+++ b/server/tests/product/test_tiers.py
@@ -79,6 +79,19 @@ class TestTiersCalculateVolume:
         )
         assert tiers.calculate(10) == Decimal(5)
 
+    def test_fractional_quantity(self) -> None:
+        # Bounds are whole units, the quantity need not be: an inclusive
+        # bound still places a fractional quantity unambiguously.
+        tiers = _tiers_data(TierType.volume, SHARED_MULTI_TIER)
+        assert tiers.calculate(Decimal("9.5")) == Decimal("9.5") * 1000
+        assert tiers.calculate(Decimal("10.5")) == Decimal("10.5") * 800
+
+    def test_fractional_quantity_on_and_below_a_bound(self) -> None:
+        tiers = _tiers_data(TierType.volume, SHARED_MULTI_TIER)
+        assert tiers.calculate(Decimal("10.0")) == Decimal("10.0") * 1000
+        assert tiers.calculate(Decimal("9.999")) == Decimal("9.999") * 1000
+        assert tiers.calculate(Decimal("10.001")) == Decimal("10.001") * 800
+
     def test_quantity_below_first_bound(self) -> None:
         # The engine prices from 0; purchase floors live on the price.
         tiers = _tiers_data(
@@ -106,6 +119,16 @@ class TestTiersCalculateGraduated:
             [{"bound": 10, "unit_amount": "500"}],
         )
         assert tiers.calculate(15) == 10 * 500
+
+    def test_fractional_quantity_straddles_a_bound(self) -> None:
+        # 9.8 splits into 9.8 inside the first tier; 15.5 into 10 + 5.5.
+        tiers = _tiers_data(TierType.graduated, SHARED_MULTI_TIER)
+        assert tiers.calculate(Decimal("9.8")) == Decimal("9.8") * 1000
+        assert tiers.calculate(Decimal("15.5")) == 10 * 1000 + Decimal("5.5") * 800
+        assert (
+            tiers.calculate(Decimal("50.25"))
+            == 10 * 1000 + 40 * 800 + Decimal("0.25") * 600
+        )
 
     def test_first_tier_bills_from_unit_one(self) -> None:
         # The first tier still bills from unit one.

--- a/server/tests/product/test_tiers.py
+++ b/server/tests/product/test_tiers.py
@@ -7,12 +7,14 @@ from pydantic import ValidationError
 from polar.product.tiers import (
     InvalidQuantityError,
     NonContiguousTiersError,
+    SeatTiersData,
     SeatTierType,
     Tiers,
     TierType,
     UnboundedTierNotLastError,
     seat_tiers_to_tiers,
     seat_tiers_unit_bounds,
+    tiers_to_seat_tiers,
     validate_unit_bounds,
 )
 
@@ -272,3 +274,69 @@ class TestSeatTiersUnitBounds:
         assert seat_tiers_unit_bounds(
             {"seat_tier_type": SeatTierType.volume, "tiers": []}
         ) == (None, None)
+
+
+MULTI_SEAT_TIERS: SeatTiersData = {
+    "seat_tier_type": SeatTierType.graduated,
+    "tiers": [
+        {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+        {"min_seats": 11, "max_seats": 50, "price_per_seat": 800},
+        {"min_seats": 51, "max_seats": None, "price_per_seat": 600},
+    ],
+}
+
+SINGLE_UNLIMITED_TIER: SeatTiersData = {
+    "seat_tier_type": SeatTierType.volume,
+    "tiers": [{"min_seats": 1, "max_seats": None, "price_per_seat": 500}],
+}
+
+MINIMUM_ABOVE_ONE: SeatTiersData = {
+    "seat_tier_type": SeatTierType.graduated,
+    "tiers": [
+        {"min_seats": 10, "max_seats": 10, "price_per_seat": 20000},
+        {"min_seats": 11, "max_seats": None, "price_per_seat": 6000},
+    ],
+}
+
+
+class TestTiersToSeatTiers:
+    def test_reconstructs_unbounded_last_tier(self) -> None:
+        shared = seat_tiers_to_tiers(MULTI_SEAT_TIERS)
+        minimum_units, maximum_units = seat_tiers_unit_bounds(MULTI_SEAT_TIERS)
+        assert (
+            tiers_to_seat_tiers(shared, minimum_units, maximum_units)
+            == MULTI_SEAT_TIERS
+        )
+
+    def test_reconstructs_bounded_last_tier(self) -> None:
+        seat_tiers: SeatTiersData = {
+            "seat_tier_type": SeatTierType.volume,
+            "tiers": [
+                {"min_seats": 5, "max_seats": 10, "price_per_seat": 1000},
+                {"min_seats": 11, "max_seats": 20, "price_per_seat": 800},
+            ],
+        }
+        shared = seat_tiers_to_tiers(seat_tiers)
+        minimum_units, maximum_units = seat_tiers_unit_bounds(seat_tiers)
+        assert tiers_to_seat_tiers(shared, minimum_units, maximum_units) == seat_tiers
+
+    def test_last_max_seats_prefers_maximum_units(self) -> None:
+        shared = _tiers_data(
+            TierType.volume,
+            [
+                {"bound": 10, "unit_amount": "1000"},
+                {"bound": 50, "unit_amount": "800"},
+            ],
+        )
+        result = tiers_to_seat_tiers(shared, minimum_units=1, maximum_units=40)
+        assert result["tiers"][-1]["max_seats"] == 40
+        assert result["tiers"][0]["max_seats"] == 10
+
+    @pytest.mark.parametrize(
+        "seat_tiers",
+        [MULTI_SEAT_TIERS, SINGLE_UNLIMITED_TIER, MINIMUM_ABOVE_ONE],
+    )
+    def test_roundtrip_is_lossless(self, seat_tiers: SeatTiersData) -> None:
+        shared = seat_tiers_to_tiers(seat_tiers)
+        minimum_units, maximum_units = seat_tiers_unit_bounds(seat_tiers)
+        assert tiers_to_seat_tiers(shared, minimum_units, maximum_units) == seat_tiers

--- a/server/tests/product/test_tiers.py
+++ b/server/tests/product/test_tiers.py
@@ -249,6 +249,17 @@ class TestSeatTiersToTiers:
                 }
             )
 
+    def test_fractional_price_per_seat_raises(self) -> None:
+        with pytest.raises(ValueError, match="whole cents"):
+            seat_tiers_to_tiers(
+                {
+                    "seat_tier_type": SeatTierType.volume,
+                    "tiers": [
+                        {"min_seats": 1, "max_seats": None, "price_per_seat": 500.5},
+                    ],
+                }
+            )
+
 
 class TestSeatTiersUnitBounds:
     def test_first_min_and_last_max(self) -> None:
@@ -331,6 +342,57 @@ class TestTiersToSeatTiers:
         result = tiers_to_seat_tiers(shared, minimum_units=1, maximum_units=40)
         assert result["tiers"][-1]["max_seats"] == 40
         assert result["tiers"][0]["max_seats"] == 10
+
+    def test_omits_tiers_below_minimum_units(self) -> None:
+        shared = _tiers_data(
+            TierType.graduated,
+            [
+                {"bound": 10, "unit_amount": "1000"},
+                {"bound": 50, "unit_amount": "800"},
+                {"bound": None, "unit_amount": "600"},
+            ],
+        )
+        result = tiers_to_seat_tiers(shared, minimum_units=15, maximum_units=None)
+        assert result["tiers"] == [
+            {"min_seats": 15, "max_seats": 50, "price_per_seat": 800},
+            {"min_seats": 51, "max_seats": None, "price_per_seat": 600},
+        ]
+
+    def test_omits_tiers_above_maximum_units(self) -> None:
+        shared = _tiers_data(
+            TierType.graduated,
+            [
+                {"bound": 10, "unit_amount": "1000"},
+                {"bound": 50, "unit_amount": "800"},
+                {"bound": None, "unit_amount": "600"},
+            ],
+        )
+        result = tiers_to_seat_tiers(shared, minimum_units=1, maximum_units=40)
+        assert result["tiers"] == [
+            {"min_seats": 1, "max_seats": 10, "price_per_seat": 1000},
+            {"min_seats": 11, "max_seats": 40, "price_per_seat": 800},
+        ]
+
+    def test_clips_single_tier_to_purchasable_bounds(self) -> None:
+        shared = _tiers_data(
+            TierType.volume,
+            [
+                {"bound": 10, "unit_amount": "1000"},
+                {"bound": 50, "unit_amount": "800"},
+            ],
+        )
+        result = tiers_to_seat_tiers(shared, minimum_units=15, maximum_units=40)
+        assert result["tiers"] == [
+            {"min_seats": 15, "max_seats": 40, "price_per_seat": 800},
+        ]
+
+    def test_fractional_unit_amount_raises(self) -> None:
+        shared = _tiers_data(
+            TierType.volume,
+            [{"bound": None, "unit_amount": "500.5"}],
+        )
+        with pytest.raises(ValueError, match="whole cents"):
+            tiers_to_seat_tiers(shared)
 
     @pytest.mark.parametrize(
         "seat_tiers",

--- a/server/tests/scripts/test_backfill_product_price_tiers.py
+++ b/server/tests/scripts/test_backfill_product_price_tiers.py
@@ -20,19 +20,25 @@ TIERS: list[dict[str, Any]] = [
     {"min_seats": 11, "max_seats": None, "price_per_seat": 800},
 ]
 
+LEGACY_SEAT_TIERS = {
+    "seat_tier_type": SeatTierType.graduated,
+    "tiers": TIERS,
+}
+
 
 async def _legacy_seat_price(
     save_fixture: SaveFixture,
     product: Product,
 ) -> ProductPriceSeatUnit:
-    """A seat price with empty shared columns, like rows written
-    before the dual-write hook existed."""
+    """A seat price with empty shared columns and a filled unused
+    `seat_tiers` column, like rows written before the cutover."""
     price = await create_product_price_seat_unit(
         save_fixture,
         product=product,
         tiers=TIERS,
         seat_tier_type=SeatTierType.graduated,
     )
+    price._seat_tiers = LEGACY_SEAT_TIERS  # type: ignore[assignment]
     price.tiers = None  # type: ignore[assignment]
     price.minimum_units = None
     price.maximum_units = None
@@ -67,12 +73,7 @@ class TestBackfillProductPriceTiers:
 
         assert updated == 1
         tiers, minimum_units, maximum_units = await _get_tier_columns(session, price)
-        assert tiers == seat_tiers_to_tiers(
-            {
-                "seat_tier_type": SeatTierType.graduated,
-                "tiers": TIERS,  # type: ignore[typeddict-item]
-            }
-        )
+        assert tiers == seat_tiers_to_tiers(LEGACY_SEAT_TIERS)  # type: ignore[arg-type]
         assert minimum_units == 1
         assert maximum_units is None
 
@@ -96,12 +97,11 @@ class TestBackfillProductPriceTiers:
         product: Product,
     ) -> None:
         price = await _legacy_seat_price(save_fixture, product)
-        # Bypass the dual-write setter so we can persist corrupt legacy JSON.
         await session.execute(
             update(ProductPriceSeatUnit)
             .where(ProductPriceSeatUnit.id == price.id)
             .values(
-                seat_tiers={
+                _seat_tiers={
                     "seat_tier_type": SeatTierType.volume,
                     "tiers": [
                         {"min_seats": 1, "max_seats": 5, "price_per_seat": 1000},
@@ -118,6 +118,30 @@ class TestBackfillProductPriceTiers:
 
         assert await _get_tier_columns(session, price) == (None, None, None)
 
+    async def test_skips_rows_that_already_have_tiers(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+    ) -> None:
+        price = await create_product_price_seat_unit(
+            save_fixture,
+            product=product,
+            tiers=TIERS,
+            seat_tier_type=SeatTierType.graduated,
+        )
+        original = await _get_tier_columns(session, price)
+        price._seat_tiers = {
+            "seat_tier_type": SeatTierType.volume,
+            "tiers": [{"min_seats": 1, "max_seats": None, "price_per_seat": 1}],
+        }
+        await save_fixture(price)
+
+        updated = await run_backfill(dry_run=False, session=session)
+
+        assert updated == 0
+        assert await _get_tier_columns(session, price) == original
+
     async def test_idempotent(
         self,
         save_fixture: SaveFixture,
@@ -126,9 +150,11 @@ class TestBackfillProductPriceTiers:
     ) -> None:
         price = await _legacy_seat_price(save_fixture, product)
 
-        await run_backfill(dry_run=False, session=session)
+        first_count = await run_backfill(dry_run=False, session=session)
         first = await _get_tier_columns(session, price)
-        await run_backfill(dry_run=False, session=session)
+        second_count = await run_backfill(dry_run=False, session=session)
         second = await _get_tier_columns(session, price)
 
+        assert first_count == 1
+        assert second_count == 0
         assert first == second


### PR DESCRIPTION
## Summary

Frontend for the metered tiers added in #13793: a tier editor in the product form, and display updates everywhere a metered price is shown.

## Changes

**Product form.** A "Pricing model" select on metered prices: flat price per unit, graduated, or volume. Flat keeps the existing amount input. The other two show a tier editor, one card per tier with an "Up to" and a "Price per unit" field.

Switching to a tiered model seeds one unbounded tier from the current unit amount, switching back to flat clears the tiers. Adding a tier gives the previously-last tier a bound and appends a new unbounded one, so the last tier always reads "Unlimited" and can't be edited. Bounds must be whole numbers greater than the previous tier's, checked on change and clamped on blur.

**Checkout.** `MeteredPriceLabel` prefixes tiered prices with "From" and shows the first
tier's rate. Flat prices are unchanged.

## Testing

No new tests, the tier editor isn't covered. Existing checkout tests pass with `tiers: null` added to the metered price fixture.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds graduated and volume metered pricing with a tier editor and tier‑aware displays. Previously metered prices used a single unit rate and checkout prefixed tiered prices with “From”; now prices can be fixed or tiered, estimates and checkout labels follow the server’s inclusive up_to rules, and labels show the first tier’s rate with its bound.

- API client: `ProductPriceMeteredUnit.unit_amount` is nullable and `tiers` may be present; creating a metered price requires exactly one of `unit_amount` or `tiers`. Required migration: set `tiers: null` on fixed prices (update fixtures/tests).
- Product form: Adds a Pricing model select (fixed/graduated/volume) and a tier editor that states each tier’s inclusive `up_to`; the lower bound derives from the previous tier and the last tier is unbounded. Bounds must be whole numbers greater than the previous and are clamped on blur. Switching models seeds/clears tiers; adding a tier bounds the previous and appends an unbounded one. Removes the hidden max_units field and its contiguity sync.
- Estimates/displays: Centralizes metered math in `estimateMeteredCost`, mirroring the server’s `up_to` algorithm; supports graduated and volume pricing, reads unsorted tiers, handles fractional/zero/negative usage, and honors `cap_amount`. Replaces overage calculations in customer meter and usage views. Adds unit tests for the estimator.
- Checkout: Removes the “From” prefix for tiered prices. Shows the first tier’s rate and a localized “up to {units}” suffix in base units, reads tiers even if unsorted, scales the rate to the meter unit, and covers a single unbounded tier. Adds tiered label tests and the `checkout.pricing.upTo` i18n key across locales.

<sup>Written for commit 316ba2733519374cd32269d4326ebbb10dddd15a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



