### PR TITLE
fix(billing_entry): deterministic pending entry ordering

### DIFF
--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -219,7 +219,12 @@ class BillingEntryRepository(
                 BillingEntry.order_item_id.is_(None),
                 BillingEntry.subscription_id == subscription_id,
             )
-            .order_by(BillingEntry.product_price_id.asc())
+            .order_by(
+                BillingEntry.product_price_id.asc(),
+                BillingEntry.start_timestamp.asc(),
+                BillingEntry.created_at.asc(),
+                BillingEntry.id.asc(),
+            )
             .options(*options)
         )
         if cutoff is not None:


### PR DESCRIPTION
## Summary

Makes the pending billing entry scan deterministic. Must merge before #13784: the new index there changes the query plan, which exposed this latent ordering ambiguity and made three tests flaky in the merge queue ([failed run](https://github.com/polarsource/polar/actions/runs/32109370122/job/95625359097)).

## What

- `get_pending_by_subscription_statement` now orders by `product_price_id, start_timestamp, created_at` instead of `product_price_id` alone.

## Why

Same-price rows came back in plan-dependent order. Any index change can flip it, and it flips per run. This decides the order of static line items on invoices, and tests unpack entries positionally. Checked prod data: 349 subscription/price groups currently have an ambiguous order; `start_timestamp` plus `created_at` disambiguates all of them.

## How

Tie-break in the query, not in the tests, so invoice line order is stable too: chronological by billing period, then by creation time. The previously flaky tests pass 10/10 runs with the #13784 index applied on top of this change.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

