### PR TITLE
Redirect authenticated users away from auth page

### DIFF
--- a/clients/apps/web/src/app/(main)/auth/page.tsx
+++ b/clients/apps/web/src/app/(main)/auth/page.tsx
@@ -20,16 +20,25 @@ export default async function Page(props: {
     error?: string
     return_to?: string
     from?: string
+    refresh?: string
   }>
 }) {
+  const searchParams = await props.searchParams
+
+  // Already-authenticated users have no reason to see the login form, so send
+  // them into the app. The exception is a re-authentication flow (see
+  // SessionRefreshModal), which sets `refresh` and expects the form to render
+  // so the user can sign in again for a sensitive action.
   const user = await getAuthenticatedUser()
-  if (user) {
-    redirect('/start')
+  if (user && searchParams.refresh === undefined) {
+    const { return_to } = searchParams
+    const isSafeReturnTo =
+      !!return_to && return_to.startsWith('/') && !return_to.startsWith('//')
+    redirect(isSafeReturnTo ? return_to : '/start')
   }
 
   const api = await getServerSideAPI()
   const authenticationSession = await checkAuthenticationSession(api)
-  const searchParams = await props.searchParams
 
   const redirectPath = getAuthenticationSessionRedirectPath(
     authenticationSession,

--- a/clients/apps/web/src/app/(main)/auth/page.tsx
+++ b/clients/apps/web/src/app/(main)/auth/page.tsx
@@ -8,6 +8,7 @@ import {
   getAuthenticationSessionRedirectPath,
   type LoginMethod,
 } from '@/utils/auth'
+import { getAuthenticatedUser } from '@/utils/user'
 import { redirect } from 'next/navigation'
 
 export const metadata: Metadata = {
@@ -21,6 +22,11 @@ export default async function Page(props: {
     from?: string
   }>
 }) {
+  const user = await getAuthenticatedUser()
+  if (user) {
+    redirect('/start')
+  }
+
   const api = await getServerSideAPI()
   const authenticationSession = await checkAuthenticationSession(api)
   const searchParams = await props.searchParams

--- a/clients/apps/web/src/components/SessionRefresh/SessionRefreshModal.tsx
+++ b/clients/apps/web/src/components/SessionRefresh/SessionRefreshModal.tsx
@@ -22,7 +22,9 @@ export const SessionRefreshModal = () => {
       description="For your security, this action requires that you signed in recently. Sign in again to continue."
       onConfirm={() => {
         const returnTo = `${window.location.pathname}${window.location.search}`
-        router.push(`/auth?return_to=${encodeURIComponent(returnTo)}`)
+        router.push(
+          `/auth?return_to=${encodeURIComponent(returnTo)}&refresh`,
+        )
       }}
     />
   )


### PR DESCRIPTION
 - Pass on `?refresh` from the session refresh modal to opt out of redirect behavior
 - Redirect to existing `?return_to`, if any, only fall back to `/start`