### PR TITLE
products: let recurring products set a meter cycle

### DIFF
--- a/clients/apps/web/src/components/Products/CreateProductPage.tsx
+++ b/clients/apps/web/src/components/Products/CreateProductPage.tsx
@@ -62,6 +62,11 @@ export const CreateProductPage = ({
     [enabledBenefits],
   )
 
+  const hasMeterCreditBenefit = useMemo(
+    () => enabledBenefits.some((b) => b.type === 'meter_credit'),
+    [enabledBenefits],
+  )
+
   const getDefaultValues = () => {
     if (sourceProduct) {
       return productToCreateForm(sourceProduct)
@@ -228,6 +233,7 @@ export const CreateProductPage = ({
             <ProductForm
               organization={organization}
               update={false}
+              hasMeterCreditBenefit={hasMeterCreditBenefit}
               benefitsSlot={
                 <Benefits
                   organization={organization}

--- a/clients/apps/web/src/components/Products/EditProductPage.tsx
+++ b/clients/apps/web/src/components/Products/EditProductPage.tsx
@@ -59,6 +59,11 @@ export const EditProductPage = ({
     [enabledBenefits],
   )
 
+  const hasMeterCreditBenefit = useMemo(
+    () => enabledBenefits.some((b) => b.type === 'meter_credit'),
+    [enabledBenefits],
+  )
+
   const form = useForm<ProductEditOrCreateForm>({
     defaultValues: {
       ...product,
@@ -244,6 +249,7 @@ export const EditProductPage = ({
             <ProductForm
               organization={organization}
               update={true}
+              hasMeterCreditBenefit={hasMeterCreditBenefit}
               benefitsSlot={
                 <Benefits
                   organization={organization}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.test.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { ReactNode } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@polar-sh/orbit/Box', () => ({
+  Box: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@polar-sh/orbit', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+  Switch: ({
+    id,
+    checked,
+    disabled,
+    onCheckedChange,
+  }: {
+    id?: string
+    checked?: boolean
+    disabled?: boolean
+    onCheckedChange?: (checked: boolean) => void
+  }) => (
+    <input
+      type="checkbox"
+      role="switch"
+      id={id}
+      checked={checked}
+      disabled={disabled}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+    />
+  ),
+  Text: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  Select: ({
+    children,
+    value,
+    disabled,
+  }: {
+    children: ReactNode
+    value?: string
+    disabled?: boolean
+  }) => (
+    <div
+      data-testid="meter-interval"
+      data-value={value ?? ''}
+      data-disabled={disabled ? 'true' : 'false'}
+    >
+      {children}
+    </div>
+  ),
+  SelectContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectValue: () => null,
+}))
+
+const { MeterCycleField } = await import('./MeterCycleField')
+
+type Values = {
+  recurring_interval: 'day' | 'week' | 'month' | 'year' | null
+  recurring_interval_count: number | null
+  meter_interval?: 'day' | 'week' | 'month' | 'year' | null
+  meter_interval_count?: number | null
+}
+
+const Harness = ({
+  values,
+  disabled,
+}: {
+  values: Values
+  disabled?: boolean
+}) => {
+  const form = useForm<Values>({ defaultValues: values })
+  return (
+    <FormProvider {...form}>
+      <MeterCycleField disabled={disabled} />
+    </FormProvider>
+  )
+}
+
+const yearly: Values = {
+  recurring_interval: 'year',
+  recurring_interval_count: 1,
+}
+
+describe('MeterCycleField', () => {
+  afterEach(cleanup)
+
+  it('hides the interval inputs until the meter cycle is enabled', () => {
+    render(<Harness values={yearly} />)
+
+    expect(screen.queryByTestId('meter-interval')).toBeNull()
+  })
+
+  it('defaults to a monthly meter cycle on yearly billing', () => {
+    render(<Harness values={yearly} />)
+
+    fireEvent.click(screen.getByRole('switch'))
+
+    expect(screen.getByTestId('meter-interval').dataset.value).toBe('month')
+  })
+
+  it('reports a meter cycle that does not divide the billing cycle', () => {
+    render(
+      <Harness
+        values={{ ...yearly, meter_interval: 'month', meter_interval_count: 5 }}
+      />,
+    )
+
+    expect(
+      screen.getByText(/must evenly divide the billing cycle/),
+    ).toBeTruthy()
+  })
+
+  it('accepts a meter cycle that divides the billing cycle', () => {
+    render(
+      <Harness
+        values={{ ...yearly, meter_interval: 'month', meter_interval_count: 6 }}
+      />,
+    )
+
+    expect(
+      screen.queryByText(/must evenly divide the billing cycle/),
+    ).toBeNull()
+  })
+
+  it('locks the inputs on an existing product', () => {
+    render(
+      <Harness
+        values={{ ...yearly, meter_interval: 'month', meter_interval_count: 1 }}
+        disabled
+      />,
+    )
+
+    expect(screen.getByRole('switch').hasAttribute('disabled')).toBe(true)
+    expect(screen.getByTestId('meter-interval').dataset.disabled).toBe('true')
+  })
+})

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.test.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react'
 import { ReactNode } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -105,7 +111,7 @@ describe('MeterCycleField', () => {
     expect(screen.getByTestId('meter-interval').dataset.value).toBe('month')
   })
 
-  it('reports a meter cycle that does not divide the billing cycle', () => {
+  it('reports a meter cycle that does not divide the billing cycle', async () => {
     render(
       <Harness
         values={{ ...yearly, meter_interval: 'month', meter_interval_count: 5 }}
@@ -113,20 +119,22 @@ describe('MeterCycleField', () => {
     )
 
     expect(
-      screen.getByText(/must evenly divide the billing cycle/),
+      await screen.findByText(/must evenly divide the billing cycle/),
     ).toBeTruthy()
   })
 
-  it('accepts a meter cycle that divides the billing cycle', () => {
+  it('accepts a meter cycle that divides the billing cycle', async () => {
     render(
       <Harness
         values={{ ...yearly, meter_interval: 'month', meter_interval_count: 6 }}
       />,
     )
 
-    expect(
-      screen.queryByText(/must evenly divide the billing cycle/),
-    ).toBeNull()
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/must evenly divide the billing cycle/),
+      ).toBeNull(),
+    )
   })
 
   it('locks the inputs on an existing product', () => {

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.tsx
@@ -16,7 +16,12 @@ import {
   Text,
 } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import { FormField } from '@polar-sh/ui/components/ui/form'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ProductFormType } from '../ProductForm'
@@ -91,8 +96,10 @@ export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
       </Box>
       {enabled && (
         <Box flexDirection="column" rowGap="s">
-          <Box alignItems="center" columnGap="m">
-            <Text variant="caption">Every</Text>
+          <Box alignItems="start" columnGap="m">
+            <Box height={40} alignItems="center">
+              <Text variant="caption">Every</Text>
+            </Box>
             <FormField
               control={control}
               name="meter_interval_count"
@@ -105,17 +112,28 @@ export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
                 },
               }}
               render={({ field }) => (
-                <Input
-                  type="text"
-                  pattern="\d*"
-                  value={field.value ?? ''}
-                  onChange={(e) => {
-                    const parsedValue = parseInt(e.target.value)
-                    field.onChange(isNaN(parsedValue) ? '' : parsedValue)
-                  }}
-                  disabled={disabled}
-                  className="min-w-12"
-                />
+                <FormItem className="flex-1">
+                  <FormControl>
+                    <Input
+                      type="text"
+                      inputMode="numeric"
+                      pattern="\d*"
+                      value={field.value ?? ''}
+                      // Digits only, and keep every one the merchant typed: parsing a
+                      // partial entry would store a cadence they didn't ask for.
+                      onChange={(e) => {
+                        const entered = e.target.value
+                        if (!/^\d*$/.test(entered)) {
+                          return
+                        }
+                        field.onChange(entered === '' ? null : Number(entered))
+                      }}
+                      disabled={disabled}
+                      className="min-w-12"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
             />
             <FormField

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.tsx
@@ -21,8 +21,7 @@ import { useCallback } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ProductFormType } from '../ProductForm'
 
-const INVALID_MESSAGE =
-  'The meter cycle must evenly divide the billing cycle, so it re-aligns at every renewal'
+const INVALID_MESSAGE = 'The meter cycle must evenly divide the billing cycle'
 
 export interface MeterCycleFieldProps {
   disabled?: boolean
@@ -87,9 +86,9 @@ export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
             Separate meter cycle
           </Text>
           <Text as="span" variant="caption" color="muted">
-            Reset meters, grant meter credits and bill usage on their own
-            cadence instead of the billing cycle — like yearly billing with
-            monthly credits.
+            Reset meters, grant meter credits and bill usage at a different pace
+            than normal subscription renewal, like for instance yearly
+            subscription renewals with monthly meter cycling
           </Text>
         </Box>
         <Switch

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import {
+  defaultMeterInterval,
+  meterIntervalDividesBillingInterval,
+} from '@/utils/meterInterval'
+import { enums, schemas } from '@polar-sh/client'
+import {
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+  Text,
+} from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { FormField } from '@polar-sh/ui/components/ui/form'
+import { useCallback } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { ProductFormType } from '../ProductForm'
+
+const INVALID_MESSAGE =
+  'The meter cycle must evenly divide the billing cycle, so it re-aligns at every renewal'
+
+export interface MeterCycleFieldProps {
+  disabled?: boolean
+}
+
+export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
+  const { control, setValue, watch } = useFormContext<ProductFormType>()
+
+  const billingInterval = watch('recurring_interval')
+  const billingIntervalCount = watch('recurring_interval_count')
+  const meterInterval = watch('meter_interval')
+  const meterIntervalCount = watch('meter_interval_count')
+
+  const enabled = !!meterInterval
+
+  const onToggle = useCallback(
+    (checked: boolean) => {
+      if (!checked) {
+        setValue('meter_interval', null)
+        setValue('meter_interval_count', null)
+        return
+      }
+      setValue(
+        'meter_interval',
+        defaultMeterInterval(billingInterval ?? 'month'),
+      )
+      setValue('meter_interval_count', 1)
+    },
+    [setValue, billingInterval],
+  )
+
+  const validate = useCallback(
+    (value: schemas['RecurringInterval'] | null | undefined) => {
+      if (!value || !billingInterval) {
+        return true
+      }
+      return (
+        meterIntervalDividesBillingInterval(
+          value,
+          Number(meterIntervalCount ?? 1),
+          billingInterval,
+          Number(billingIntervalCount ?? 1),
+        ) || INVALID_MESSAGE
+      )
+    },
+    [billingInterval, billingIntervalCount, meterIntervalCount],
+  )
+
+  const invalid = enabled && validate(meterInterval) !== true
+
+  return (
+    <Box flexDirection="column" rowGap="l">
+      <Box alignItems="center" justifyContent="between" columnGap="l">
+        <Box
+          as="label"
+          htmlFor="meter-cycle-enable"
+          display="flex"
+          flexDirection="column"
+          rowGap="xs"
+        >
+          <Text as="span" variant="label">
+            Separate meter cycle
+          </Text>
+          <Text as="span" variant="caption" color="muted">
+            Reset meters, grant meter credits and bill usage on their own
+            cadence instead of the billing cycle — like yearly billing with
+            monthly credits.
+          </Text>
+        </Box>
+        <Switch
+          id="meter-cycle-enable"
+          checked={enabled}
+          onCheckedChange={onToggle}
+          disabled={disabled}
+        />
+      </Box>
+      {enabled && (
+        <Box flexDirection="column" rowGap="s">
+          <Box alignItems="center" columnGap="m">
+            <Text variant="caption">Every</Text>
+            <FormField
+              control={control}
+              name="meter_interval_count"
+              rules={{
+                required: 'This field is required when a meter cycle is set',
+                min: { value: 1, message: 'Interval count must be at least 1' },
+                max: {
+                  value: 999,
+                  message: 'Interval count cannot exceed 999',
+                },
+              }}
+              render={({ field }) => (
+                <Input
+                  type="text"
+                  pattern="\d*"
+                  value={field.value ?? ''}
+                  onChange={(e) => {
+                    const parsedValue = parseInt(e.target.value)
+                    field.onChange(isNaN(parsedValue) ? '' : parsedValue)
+                  }}
+                  disabled={disabled}
+                  className="min-w-12"
+                />
+              )}
+            />
+            <FormField
+              control={control}
+              name="meter_interval"
+              rules={{ validate }}
+              render={({ field }) => (
+                <Box>
+                  <Select
+                    onValueChange={field.onChange}
+                    value={field.value ?? ''}
+                    disabled={disabled}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select a meter cycle" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {enums.recurringIntervalValues.map((value) => (
+                        <SelectItem key={value} value={value}>
+                          {value}
+                          {meterIntervalCount !== 1 ? 's' : ''}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Box>
+              )}
+            />
+          </Box>
+          {invalid && (
+            <Text variant="caption" color="error">
+              {INVALID_MESSAGE}
+            </Text>
+          )}
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.tsx
@@ -4,7 +4,7 @@ import {
   defaultMeterInterval,
   meterIntervalDividesBillingInterval,
 } from '@/utils/meterInterval'
-import { enums, schemas } from '@polar-sh/client'
+import { enums } from '@polar-sh/client'
 import {
   Input,
   Select,
@@ -53,24 +53,15 @@ export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
     [setValue, billingInterval],
   )
 
-  const validate = useCallback(
-    (value: schemas['RecurringInterval'] | null | undefined) => {
-      if (!value || !billingInterval) {
-        return true
-      }
-      return (
-        meterIntervalDividesBillingInterval(
-          value,
-          Number(meterIntervalCount ?? 1),
-          billingInterval,
-          Number(billingIntervalCount ?? 1),
-        ) || INVALID_MESSAGE
-      )
-    },
-    [billingInterval, billingIntervalCount, meterIntervalCount],
-  )
-
-  const invalid = enabled && validate(meterInterval) !== true
+  const dividesBillingCycle =
+    !meterInterval ||
+    !billingInterval ||
+    meterIntervalDividesBillingInterval(
+      meterInterval,
+      Number(meterIntervalCount ?? 1),
+      billingInterval,
+      Number(billingIntervalCount ?? 1),
+    )
 
   return (
     <Box flexDirection="column" rowGap="l">
@@ -130,7 +121,7 @@ export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
             <FormField
               control={control}
               name="meter_interval"
-              rules={{ validate }}
+              rules={{ validate: () => dividesBillingCycle || INVALID_MESSAGE }}
               render={({ field }) => (
                 <Box>
                   <Select
@@ -154,7 +145,7 @@ export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
               )}
             />
           </Box>
-          {invalid && (
+          {!dividesBillingCycle && (
             <Text variant="caption" color="error">
               {INVALID_MESSAGE}
             </Text>

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeterCycleField.tsx
@@ -13,16 +13,16 @@ import {
   SelectTrigger,
   SelectValue,
   Switch,
-  Text,
 } from '@polar-sh/orbit'
-import { Box } from '@polar-sh/orbit/Box'
 import {
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
+  FormLabel,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ProductFormType } from '../ProductForm'
 
@@ -33,7 +33,8 @@ export interface MeterCycleFieldProps {
 }
 
 export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
-  const { control, setValue, watch } = useFormContext<ProductFormType>()
+  const { control, setValue, trigger, watch } =
+    useFormContext<ProductFormType>()
 
   const billingInterval = watch('recurring_interval')
   const billingIntervalCount = watch('recurring_interval_count')
@@ -68,38 +69,41 @@ export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
       Number(billingIntervalCount ?? 1),
     )
 
+  // Both cycles feed the divisibility rule, so re-run it whenever either moves —
+  // otherwise a billing cycle edited after the meter cycle only surfaces on submit.
+  useEffect(() => {
+    if (enabled) {
+      trigger('meter_interval')
+    }
+  }, [
+    enabled,
+    meterInterval,
+    meterIntervalCount,
+    billingInterval,
+    billingIntervalCount,
+    trigger,
+  ])
+
   return (
-    <Box flexDirection="column" rowGap="l">
-      <Box alignItems="center" justifyContent="between" columnGap="l">
-        <Box
-          as="label"
-          htmlFor="meter-cycle-enable"
-          display="flex"
-          flexDirection="column"
-          rowGap="xs"
-        >
-          <Text as="span" variant="label">
-            Separate meter cycle
-          </Text>
-          <Text as="span" variant="caption" color="muted">
-            Reset meters, grant meter credits and bill usage at a different pace
-            than normal subscription renewal, like for instance yearly
-            subscription renewals with monthly meter cycling
-          </Text>
-        </Box>
-        <Switch
-          id="meter-cycle-enable"
-          checked={enabled}
-          onCheckedChange={onToggle}
-          disabled={disabled}
-        />
-      </Box>
-      {enabled && (
-        <Box flexDirection="column" rowGap="s">
-          <Box alignItems="start" columnGap="m">
-            <Box height={40} alignItems="center">
-              <Text variant="caption">Every</Text>
-            </Box>
+    <div>
+      <div className="flex flex-col gap-4">
+        <FormItem>
+          <div className="flex flex-row items-center justify-between space-y-0 space-x-2">
+            <FormLabel htmlFor="meter-cycle-enable">
+              Separate meter cycle
+            </FormLabel>
+            <FormControl>
+              <Switch
+                id="meter-cycle-enable"
+                checked={enabled}
+                onCheckedChange={onToggle}
+                disabled={disabled}
+              />
+            </FormControl>
+          </div>
+        </FormItem>
+        {enabled && (
+          <div className="flex w-full flex-col gap-2 lg:flex-row">
             <FormField
               control={control}
               name="meter_interval_count"
@@ -112,12 +116,13 @@ export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
                 },
               }}
               render={({ field }) => (
-                <FormItem className="flex-1">
+                <FormItem className="w-full space-y-0 lg:w-1/3">
                   <FormControl>
                     <Input
-                      type="text"
-                      inputMode="numeric"
-                      pattern="\d*"
+                      type="number"
+                      min={1}
+                      max={999}
+                      step={1}
                       value={field.value ?? ''}
                       // Digits only, and keep every one the merchant typed: parsing a
                       // partial entry would store a cadence they didn't ask for.
@@ -129,7 +134,6 @@ export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
                         field.onChange(entered === '' ? null : Number(entered))
                       }}
                       disabled={disabled}
-                      className="min-w-12"
                     />
                   </FormControl>
                   <FormMessage />
@@ -141,35 +145,40 @@ export const MeterCycleField = ({ disabled }: MeterCycleFieldProps) => {
               name="meter_interval"
               rules={{ validate: () => dividesBillingCycle || INVALID_MESSAGE }}
               render={({ field }) => (
-                <Box>
-                  <Select
-                    onValueChange={field.onChange}
-                    value={field.value ?? ''}
-                    disabled={disabled}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select a meter cycle" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {enums.recurringIntervalValues.map((value) => (
-                        <SelectItem key={value} value={value}>
-                          {value}
-                          {meterIntervalCount !== 1 ? 's' : ''}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </Box>
+                <FormItem className="w-full space-y-0 lg:w-2/3">
+                  <FormControl>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value ?? ''}
+                      disabled={disabled}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a meter cycle" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {enums.recurringIntervalValues.map((value) => (
+                          <SelectItem key={value} value={value}>
+                            {value}
+                            {meterIntervalCount !== 1 ? 's' : ''}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
             />
-          </Box>
-          {!dividesBillingCycle && (
-            <Text variant="caption" color="error">
-              {INVALID_MESSAGE}
-            </Text>
-          )}
-        </Box>
-      )}
-    </Box>
+          </div>
+        )}
+      </div>
+      <div className="mt-4">
+        <FormDescription>
+          Reset meters, grant meter credits and bill usage at a different pace
+          than normal subscription renewal, like for instance yearly
+          subscription renewals with monthly meter cycling
+        </FormDescription>
+      </div>
+    </div>
   )
 }

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowMeterCycle } from './utils'
+
+const base = {
+  isRecurring: true,
+  hasMeteredPrice: false,
+  hasMeterCreditBenefit: false,
+  hasSavedMeterCycle: false,
+}
+
+describe('shouldShowMeterCycle', () => {
+  it('stays hidden on a recurring product with nothing metered', () => {
+    expect(shouldShowMeterCycle(base)).toBe(false)
+  })
+
+  it('shows once a metered price is added', () => {
+    expect(shouldShowMeterCycle({ ...base, hasMeteredPrice: true })).toBe(true)
+  })
+
+  it('shows for a meter-credit benefit without any metered price', () => {
+    expect(shouldShowMeterCycle({ ...base, hasMeterCreditBenefit: true })).toBe(
+      true,
+    )
+  })
+
+  it('shows a saved meter cycle even once its trigger is gone', () => {
+    expect(shouldShowMeterCycle({ ...base, hasSavedMeterCycle: true })).toBe(
+      true,
+    )
+  })
+
+  it('stays hidden on a one-time product', () => {
+    expect(
+      shouldShowMeterCycle({
+        isRecurring: false,
+        hasMeteredPrice: true,
+        hasMeterCreditBenefit: true,
+        hasSavedMeterCycle: true,
+      }),
+    ).toBe(false)
+  })
+})

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { shouldShowMeterCycle } from './utils'
 
 const base = {
+  isEnabledForOrganization: true,
   isRecurring: true,
   hasMeteredPrice: false,
   hasMeterCreditBenefit: false,
@@ -23,15 +24,37 @@ describe('shouldShowMeterCycle', () => {
     )
   })
 
+  it('stays hidden for an organization without the feature', () => {
+    expect(
+      shouldShowMeterCycle({
+        ...base,
+        isEnabledForOrganization: false,
+        hasMeteredPrice: true,
+        hasMeterCreditBenefit: true,
+      }),
+    ).toBe(false)
+  })
+
   it('shows a saved meter cycle even once its trigger is gone', () => {
     expect(shouldShowMeterCycle({ ...base, hasSavedMeterCycle: true })).toBe(
       true,
     )
   })
 
+  it('shows a saved meter cycle even if the feature is turned back off', () => {
+    expect(
+      shouldShowMeterCycle({
+        ...base,
+        isEnabledForOrganization: false,
+        hasSavedMeterCycle: true,
+      }),
+    ).toBe(true)
+  })
+
   it('stays hidden on a one-time product', () => {
     expect(
       shouldShowMeterCycle({
+        isEnabledForOrganization: true,
         isRecurring: false,
         hasMeteredPrice: true,
         hasMeterCreditBenefit: true,

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
@@ -9,6 +9,24 @@ export type ProductPriceCreate =
 export type AnyPrice = NonNullable<ProductFormType['prices']>[number]
 export type PriceEntry = { price: AnyPrice; index: number }
 
+// The meter cycle governs meter resets, meter-credit grants and overage settlement, so it
+// only earns its place once the product has something metered — a metered price or a
+// meter-credit benefit. An existing product shows its saved cycle regardless: the API
+// accepts `meter_interval` on create only, so there it's a read-only fact, not a choice.
+export const shouldShowMeterCycle = ({
+  isRecurring,
+  hasMeteredPrice,
+  hasMeterCreditBenefit,
+  hasSavedMeterCycle,
+}: {
+  isRecurring: boolean
+  hasMeteredPrice: boolean
+  hasMeterCreditBenefit: boolean
+  hasSavedMeterCycle: boolean
+}): boolean =>
+  isRecurring &&
+  (hasMeteredPrice || hasMeterCreditBenefit || hasSavedMeterCycle)
+
 export const hasPriceCurrency = (
   price: AnyPrice,
 ): price is AnyPrice & { price_currency: string } => {

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
@@ -11,21 +11,32 @@ export type PriceEntry = { price: AnyPrice; index: number }
 
 // The meter cycle governs meter resets, meter-credit grants and overage settlement, so it
 // only earns its place once the product has something metered — a metered price or a
-// meter-credit benefit. An existing product shows its saved cycle regardless: the API
-// accepts `meter_interval` on create only, so there it's a read-only fact, not a choice.
+// meter-credit benefit — in an organization the feature is rolled out to. An existing
+// product shows its saved cycle regardless: the API accepts `meter_interval` on create
+// only, so there it's a read-only fact, not a choice, and hiding it would hide a setting
+// the product is already billing on.
 export const shouldShowMeterCycle = ({
+  isEnabledForOrganization,
   isRecurring,
   hasMeteredPrice,
   hasMeterCreditBenefit,
   hasSavedMeterCycle,
 }: {
+  isEnabledForOrganization: boolean
   isRecurring: boolean
   hasMeteredPrice: boolean
   hasMeterCreditBenefit: boolean
   hasSavedMeterCycle: boolean
-}): boolean =>
-  isRecurring &&
-  (hasMeteredPrice || hasMeterCreditBenefit || hasSavedMeterCycle)
+}): boolean => {
+  if (hasSavedMeterCycle) {
+    return isRecurring
+  }
+  return (
+    isEnabledForOrganization &&
+    isRecurring &&
+    (hasMeteredPrice || hasMeterCreditBenefit)
+  )
+}
 
 export const hasPriceCurrency = (
   price: AnyPrice,

--- a/clients/apps/web/src/components/Products/ProductForm/ProductForm.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductForm.tsx
@@ -46,16 +46,22 @@ const ProductForm = ({
   organization,
   update,
   benefitsSlot,
+  hasMeterCreditBenefit,
 }: {
   organization: schemas['Organization']
   update?: boolean
   benefitsSlot: React.ReactNode
+  hasMeterCreditBenefit?: boolean
 }) => {
   return (
     <div className="dark:divide-polar-700 flex flex-col divide-y">
       <ProductInfoSection />
 
-      <ProductPricingSection organization={organization} update={update} />
+      <ProductPricingSection
+        organization={organization}
+        update={update}
+        hasMeterCreditBenefit={hasMeterCreditBenefit}
+      />
 
       {benefitsSlot}
 

--- a/clients/apps/web/src/components/Products/ProductForm/ProductForm.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductForm.tsx
@@ -25,11 +25,19 @@ type ApiProductFormPrice = NonNullable<
 
 export type ProductFormPrice = ApiProductFormPrice | FreeProductPriceCreate
 
+// The meter cycle only exists on recurring creates, so it isn't part of the keys shared by
+// the union members — carry it explicitly.
+export type ProductMeterCycleMixin = Pick<
+  schemas['ProductCreateRecurring'],
+  'meter_interval' | 'meter_interval_count'
+>
+
 export type ProductFormType = Omit<
   schemas['ProductCreate'] | schemas['ProductUpdate'],
   'metadata' | 'prices'
 > &
-  ProductFullMediasMixin & {
+  ProductFullMediasMixin &
+  ProductMeterCycleMixin & {
     metadata: { key: string; value: string | number | boolean }[]
     prices: ProductFormPrice[]
   }

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -150,6 +150,8 @@ export const ProductPricingSection = ({
   const meterInterval = watch('meter_interval')
 
   const showMeterCycle = shouldShowMeterCycle({
+    isEnabledForOrganization:
+      organization.feature_settings?.meter_cycling_enabled ?? false,
     isRecurring: productType === 'recurring',
     hasMeteredPrice: (watchedPrices ?? []).some((price) =>
       isMeteredPrice(price as ProductPrice),

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -29,6 +29,7 @@ import { useFieldArray, useFormContext } from 'react-hook-form'
 import { twMerge } from 'tailwind-merge'
 import { Section } from '../../Layout/Section'
 import { CurrencyTabs } from './Pricing/CurrencyTabs'
+import { MeterCycleField } from './Pricing/MeterCycleField'
 import { ProductPriceItem } from './Pricing/ProductPriceItem'
 import { useAutoSwitchToErroredPriceTab } from './Pricing/useAutoSwitchToErroredPriceTab'
 import {
@@ -99,6 +100,8 @@ export const ProductPricingSection = ({
     }
 
     setValue('recurring_interval_count', null)
+    setValue('meter_interval', null)
+    setValue('meter_interval_count', null)
     const currentPrices = getValues('prices')
     if (!currentPrices) return
     const filteredPrices = currentPrices.filter(
@@ -545,6 +548,7 @@ export const ProductPricingSection = ({
               />
             </div>
           )}
+          {productType === 'recurring' && <MeterCycleField disabled={update} />}
         </div>
 
         <CurrencyTabs

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -103,8 +103,6 @@ export const ProductPricingSection = ({
     }
 
     setValue('recurring_interval_count', null)
-    setValue('meter_interval', null)
-    setValue('meter_interval_count', null)
     const currentPrices = getValues('prices')
     if (!currentPrices) return
     const filteredPrices = currentPrices.filter(
@@ -160,12 +158,13 @@ export const ProductPricingSection = ({
     hasSavedMeterCycle: !!update && !!meterInterval,
   })
 
+  // Covers the one-time switch too: a one-time product never shows the meter cycle.
   useEffect(() => {
-    if (!showMeterCycle && getValues('meter_interval')) {
+    if (!showMeterCycle && meterInterval) {
       setValue('meter_interval', null)
       setValue('meter_interval_count', null)
     }
-  }, [showMeterCycle, getValues, setValue])
+  }, [showMeterCycle, meterInterval, setValue])
 
   const handleAmountTypeChange = useCallback(
     (

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -38,6 +38,7 @@ import {
   hasPriceCurrency,
   ProductPrice,
   ProductPriceCreate,
+  shouldShowMeterCycle,
 } from './Pricing/utils'
 import { ProductFormType } from './ProductForm'
 
@@ -46,6 +47,7 @@ export interface ProductPricingSectionProps {
   className?: string
   update?: boolean
   compact?: boolean
+  hasMeterCreditBenefit?: boolean
 }
 
 export const ProductPricingSection = ({
@@ -53,6 +55,7 @@ export const ProductPricingSection = ({
   className,
   update,
   compact,
+  hasMeterCreditBenefit,
 }: ProductPricingSectionProps) => {
   const { control, setValue, watch, getValues } =
     useFormContext<ProductFormType>()
@@ -144,6 +147,25 @@ export const ProductPricingSection = ({
       }),
     [pricesByCurrency, validatedSelectedCurrency],
   )
+
+  const watchedPrices = watch('prices')
+  const meterInterval = watch('meter_interval')
+
+  const showMeterCycle = shouldShowMeterCycle({
+    isRecurring: productType === 'recurring',
+    hasMeteredPrice: (watchedPrices ?? []).some((price) =>
+      isMeteredPrice(price as ProductPrice),
+    ),
+    hasMeterCreditBenefit: !!hasMeterCreditBenefit,
+    hasSavedMeterCycle: !!update && !!meterInterval,
+  })
+
+  useEffect(() => {
+    if (!showMeterCycle && getValues('meter_interval')) {
+      setValue('meter_interval', null)
+      setValue('meter_interval_count', null)
+    }
+  }, [showMeterCycle, getValues, setValue])
 
   const handleAmountTypeChange = useCallback(
     (
@@ -548,7 +570,6 @@ export const ProductPricingSection = ({
               />
             </div>
           )}
-          {productType === 'recurring' && <MeterCycleField disabled={update} />}
         </div>
 
         <CurrencyTabs
@@ -628,6 +649,12 @@ export const ProductPricingSection = ({
             )
           })}
         </div>
+
+        {showMeterCycle && (
+          <div className="flex flex-col py-6">
+            <MeterCycleField disabled={update} />
+          </div>
+        )}
 
         {recurringInterval && (
           <div className="flex flex-col py-6">

--- a/clients/apps/web/src/utils/meterInterval.test.ts
+++ b/clients/apps/web/src/utils/meterInterval.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import {
+  defaultMeterInterval,
+  meterIntervalDividesBillingInterval,
+} from './meterInterval'
+
+describe('meterIntervalDividesBillingInterval', () => {
+  it('accepts a monthly meter cycle on yearly billing', () => {
+    expect(meterIntervalDividesBillingInterval('month', 1, 'year', 1)).toBe(
+      true,
+    )
+    expect(meterIntervalDividesBillingInterval('month', 6, 'year', 1)).toBe(
+      true,
+    )
+    expect(meterIntervalDividesBillingInterval('month', 8, 'year', 2)).toBe(
+      true,
+    )
+  })
+
+  it('rejects a monthly meter cycle that leaves a partial period', () => {
+    expect(meterIntervalDividesBillingInterval('month', 5, 'year', 1)).toBe(
+      false,
+    )
+  })
+
+  it('accepts a meter cycle dividing the same interval unit', () => {
+    expect(meterIntervalDividesBillingInterval('month', 2, 'month', 6)).toBe(
+      true,
+    )
+    expect(meterIntervalDividesBillingInterval('day', 5, 'day', 10)).toBe(true)
+    expect(meterIntervalDividesBillingInterval('week', 2, 'week', 4)).toBe(true)
+  })
+
+  it('rejects a meter cycle coarser than the billing cycle', () => {
+    expect(meterIntervalDividesBillingInterval('year', 1, 'month', 6)).toBe(
+      false,
+    )
+    expect(meterIntervalDividesBillingInterval('month', 12, 'month', 6)).toBe(
+      false,
+    )
+  })
+
+  it('converts days into weeks', () => {
+    expect(meterIntervalDividesBillingInterval('day', 7, 'week', 1)).toBe(true)
+    expect(meterIntervalDividesBillingInterval('day', 2, 'week', 2)).toBe(true)
+    expect(meterIntervalDividesBillingInterval('day', 5, 'week', 1)).toBe(false)
+  })
+
+  it('only allows a daily meter cycle on month or year billing', () => {
+    expect(meterIntervalDividesBillingInterval('day', 1, 'month', 1)).toBe(true)
+    expect(meterIntervalDividesBillingInterval('day', 1, 'year', 1)).toBe(true)
+    expect(meterIntervalDividesBillingInterval('day', 2, 'month', 1)).toBe(
+      false,
+    )
+  })
+
+  it('rejects week and month cycles across interval families', () => {
+    expect(meterIntervalDividesBillingInterval('week', 1, 'month', 1)).toBe(
+      false,
+    )
+    expect(meterIntervalDividesBillingInterval('month', 1, 'week', 4)).toBe(
+      false,
+    )
+  })
+
+  it('rejects counts that are not positive integers', () => {
+    expect(meterIntervalDividesBillingInterval('month', 0, 'year', 1)).toBe(
+      false,
+    )
+    expect(meterIntervalDividesBillingInterval('month', 1.5, 'year', 1)).toBe(
+      false,
+    )
+    expect(meterIntervalDividesBillingInterval('month', 1, 'year', NaN)).toBe(
+      false,
+    )
+  })
+})
+
+describe('defaultMeterInterval', () => {
+  it('picks an interval that divides the billing interval', () => {
+    expect(defaultMeterInterval('year')).toBe('month')
+    expect(defaultMeterInterval('month')).toBe('month')
+    expect(defaultMeterInterval('week')).toBe('day')
+    expect(defaultMeterInterval('day')).toBe('day')
+  })
+})

--- a/clients/apps/web/src/utils/meterInterval.ts
+++ b/clients/apps/web/src/utils/meterInterval.ts
@@ -1,0 +1,46 @@
+import { schemas } from '@polar-sh/client'
+
+type RecurringInterval = schemas['RecurringInterval']
+
+// Mirrors `meter_interval_divides_billing_interval` on the backend: the meter cycle has to
+// re-align with the billing cycle at every renewal, so the meter interval must divide the
+// billing interval cleanly. Day/week are commensurable with each other, month/year with
+// each other, but the two families don't convert — only a daily meter interval re-aligns
+// on a month/year boundary.
+export const meterIntervalDividesBillingInterval = (
+  meterInterval: RecurringInterval,
+  meterIntervalCount: number,
+  billingInterval: RecurringInterval,
+  billingIntervalCount: number,
+): boolean => {
+  const m = meterIntervalCount
+  const n = billingIntervalCount
+
+  if (!Number.isInteger(m) || !Number.isInteger(n) || m < 1 || n < 1) {
+    return false
+  }
+
+  switch (`${meterInterval}:${billingInterval}`) {
+    case 'day:day':
+    case 'week:week':
+    case 'month:month':
+    case 'year:year':
+      return n % m === 0
+    case 'day:week':
+      return (n * 7) % m === 0
+    case 'day:month':
+    case 'day:year':
+      return m === 1
+    case 'month:year':
+      return (n * 12) % m === 0
+    default:
+      return false
+  }
+}
+
+// The coarsest meter interval that always divides the given billing interval, used as the
+// default when the meter cycle is enabled.
+export const defaultMeterInterval = (
+  billingInterval: RecurringInterval,
+): RecurringInterval =>
+  billingInterval === 'month' || billingInterval === 'year' ? 'month' : 'day'

--- a/clients/apps/web/src/utils/meterInterval.ts
+++ b/clients/apps/web/src/utils/meterInterval.ts
@@ -38,8 +38,9 @@ export const meterIntervalDividesBillingInterval = (
   }
 }
 
-// The coarsest meter interval that always divides the given billing interval, used as the
-// default when the meter cycle is enabled.
+// The cadence the meter cycle starts on when it's enabled: monthly under month/year
+// billing, daily under day/week billing. Both divide their family's billing intervals, and
+// both are finer than the billing cycle — a meter cycle equal to it would be a no-op.
 export const defaultMeterInterval = (
   billingInterval: RecurringInterval,
 ): RecurringInterval =>

--- a/clients/apps/web/src/utils/product.ts
+++ b/clients/apps/web/src/utils/product.ts
@@ -1,6 +1,7 @@
 import {
   FreeProductPriceCreate,
   ProductFullMediasMixin,
+  ProductMeterCycleMixin,
 } from '@/components/Products/ProductForm/ProductForm'
 import { Client, schemas, unwrap } from '@polar-sh/client'
 import { notFound } from 'next/navigation'
@@ -93,7 +94,8 @@ export type ProductEditOrCreateForm = Omit<
   schemas['ProductCreate'],
   'metadata' | 'prices'
 > &
-  ProductFullMediasMixin & {
+  ProductFullMediasMixin &
+  ProductMeterCycleMixin & {
     metadata: { key: string; value: string | number | boolean }[]
     prices: (
       | schemas['ProductCreate']['prices'][number]

--- a/clients/packages/client/src/enums.ts
+++ b/clients/packages/client/src/enums.ts
@@ -11,6 +11,7 @@ export {
   orderStatusValues,
   presentmentCurrencyValues,
   propertyAggregationFuncValues,
+  recurringIntervalValues,
   refundReasonValues,
   stripeAccountCountryValues,
   subscriptionExportColumnValues,


### PR DESCRIPTION
# Summary

Last step in meter cycling: Bring the frontend parts to allow merchants to create recurring products with meter cycling different from the normal subscription cycling.

## Screenshots

### Toggle not visible because product neither has metered price nor meter credit benefit
<img width="1532" height="1592" alt="1-hidden-until-something-is-metered" src="https://github.com/user-attachments/assets/03ae99b0-44d3-4055-b567-d24b60486ea2" />

### Toggle off
<img width="1532" height="2130" alt="2-revealed-by-metered-price" src="https://github.com/user-attachments/assets/4ee2c59f-0a09-4d9a-96c7-e0c9f2b06de7" />

### Toggle on
<img width="1532" height="2242" alt="3-monthly-meters-on-yearly-billing" src="https://github.com/user-attachments/assets/f5b22627-670a-4b62-b608-78670834d3d4" />

### Invalid cadence configured
<img width="1532" height="2282" alt="4-invalid-combination" src="https://github.com/user-attachments/assets/e9614f0c-dcb4-464d-8d90-4432f655e692" />

### Disabled when editing
<img width="1532" height="2248" alt="6-locked-on-an-existing-product" src="https://github.com/user-attachments/assets/d6034ba6-a5c5-4b28-bcfa-c437f17d6850" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let recurring products set a separate meter cycle so resets, meter‑credit grants, and overage settlement can run on a different cadence. Previously the meter cycle always matched the billing cycle; now you can opt into a cycle that must evenly divide the billing cycle. This is accepted on create only and gated by an organization feature flag.

- UI/behavior:
  - Toggle appears under Price Configuration next to the free trial when the product is recurring, the org’s meter cycling feature is enabled, and the product has a metered price or a meter‑credit benefit; existing products always show a saved cycle read‑only even if the flag later turns off.
  - Enabling defaults to monthly for month/year billing and daily for day/week; turning the toggle off, switching to one‑time, removing the last metered trigger, or otherwise losing the gate clears `meter_interval` and `meter_interval_count`. Field is disabled on update.
  - Client‑side rule mirrors the backend divisibility check and updates inline on changes; the count input is digits‑only, stores null on empty, and enforces required/min/max with clear messages.

- Dev notes:
  - Exports `recurringIntervalValues` from `@polar-sh/client`; adds a `ProductMeterCycleMixin` to carry `meter_interval` fields in `ProductForm` types and passes `hasMeterCreditBenefit` through `ProductForm`.
  - Adds `meterIntervalDividesBillingInterval`, `defaultMeterInterval`, and `shouldShowMeterCycle` utilities and frontend tests for divisibility, defaults, gating (including saved cycles), and validation.

<sup>Written for commit bdfe684fca83131ba7de995efa5215caf21c8cf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





