### PR TITLE
Tweak OAuth settings UI

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/account/developer/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/account/developer/page.tsx
@@ -14,7 +14,7 @@ export default function Page() {
       <Section id="oauth">
         <SectionDescription
           title="OAuth Applications"
-          description="Your configured OAuth Applications"
+          description="Your configured OAuth applications"
         />
 
         <OAuthSettings />

--- a/clients/apps/web/src/components/Settings/OAuth/OAuthForm.tsx
+++ b/clients/apps/web/src/components/Settings/OAuth/OAuthForm.tsx
@@ -15,6 +15,7 @@ import {
   FormLabel,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
+import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
 
 import AddOutlined from '@mui/icons-material/AddOutlined'
 import ClearOutlined from '@mui/icons-material/ClearOutlined'
@@ -97,10 +98,7 @@ export const FieldClientID = ({ clientId }: { clientId: string }) => {
   return (
     <FormItem>
       <FormLabel>Client ID</FormLabel>
-      <FormControl>
-        <Input value={clientId} placeholder="Client ID" readOnly />
-      </FormControl>
-      <FormMessage />
+      <CopyToClipboardInput value={clientId} variant="mono" />
     </FormItem>
   )
 }
@@ -113,10 +111,7 @@ export const FieldClientSecret = ({
   return (
     <FormItem>
       <FormLabel>Client Secret</FormLabel>
-      <FormControl>
-        <Input value={clientSecret} placeholder="Client Secret" readOnly />
-      </FormControl>
-      <FormMessage />
+      <CopyToClipboardInput value={clientSecret} variant="mono" />
       <FormDescription>
         This is a sensitive value. Don&apos;t embed it in a public client like a
         SPA or mobile app.{' '}

--- a/clients/apps/web/src/components/Settings/OAuth/OAuthForm.tsx
+++ b/clients/apps/web/src/components/Settings/OAuth/OAuthForm.tsx
@@ -34,10 +34,8 @@ export const FieldName = () => {
         required: 'This field is required',
       }}
       render={({ field }) => (
-        <FormItem className="flex flex-col gap-4">
-          <div className="flex flex-row items-center justify-between">
-            <FormLabel>Application Name</FormLabel>
-          </div>
+        <FormItem>
+          <FormLabel>Application Name</FormLabel>
           <FormControl>
             <Input {...field} placeholder="My OAuth Application" />
           </FormControl>
@@ -97,10 +95,8 @@ export const FieldClientType = () => {
 
 export const FieldClientID = ({ clientId }: { clientId: string }) => {
   return (
-    <FormItem className="flex flex-col gap-4">
-      <div className="flex flex-row items-center justify-between">
-        <FormLabel>Client ID</FormLabel>
-      </div>
+    <FormItem>
+      <FormLabel>Client ID</FormLabel>
       <FormControl>
         <Input value={clientId} placeholder="Client ID" readOnly />
       </FormControl>
@@ -115,10 +111,8 @@ export const FieldClientSecret = ({
   clientSecret: string
 }) => {
   return (
-    <FormItem className="flex flex-col gap-4">
-      <div className="flex flex-row items-center justify-between">
-        <FormLabel>Client Secret</FormLabel>
-      </div>
+    <FormItem>
+      <FormLabel>Client Secret</FormLabel>
       <FormControl>
         <Input value={clientSecret} placeholder="Client Secret" readOnly />
       </FormControl>
@@ -153,11 +147,11 @@ export const FieldRedirectURIs = () => {
   })
 
   return (
-    <div className="flex flex-col gap-y-4">
+    <div>
       <div className="flex flex-row items-center justify-between gap-x-4">
         <FormLabel>Redirect URIs</FormLabel>
         <Button
-          className="aspect-square w-8"
+          className="aspect-square h-8 w-8"
           size="icon"
           variant="secondary"
           onClick={(e) => {
@@ -253,10 +247,8 @@ export const FieldClientURI = () => {
         required: 'A URL to your homepage is required',
       }}
       render={({ field }) => (
-        <FormItem className="flex flex-col gap-4">
-          <div className="flex flex-row items-center justify-between">
-            <FormLabel>Homepage URL</FormLabel>
-          </div>
+        <FormItem>
+          <FormLabel>Homepage URL</FormLabel>
           <FormControl>
             <Input
               {...field}
@@ -279,10 +271,8 @@ export const FieldTOS = () => {
       control={control}
       name="tos_uri"
       render={({ field }) => (
-        <FormItem className="flex flex-col gap-4">
-          <div className="flex flex-row items-center justify-between">
-            <FormLabel>Terms of Service</FormLabel>
-          </div>
+        <FormItem>
+          <FormLabel>Terms of Service</FormLabel>
           <FormControl>
             <Input
               {...field}
@@ -305,10 +295,8 @@ export const FieldPrivacy = () => {
       control={control}
       name="policy_uri"
       render={({ field }) => (
-        <FormItem className="flex flex-col gap-4">
-          <div className="flex flex-row items-center justify-between">
-            <FormLabel>Privacy Policy</FormLabel>
-          </div>
+        <FormItem>
+          <FormLabel>Privacy Policy</FormLabel>
           <FormControl>
             <Input
               {...field}

--- a/clients/apps/web/src/components/Settings/OAuth/OAuthSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OAuth/OAuthSettings.tsx
@@ -62,14 +62,15 @@ const OAuthSettings = () => {
       ) : (
         <ListGroup.Item>
           <p className="dark:text-polar-400 text-sm text-gray-500">
-            You don&apos;t have any configured OAuth Applications
+            You haven&rsquo;t created any OAuth applications yet. Create one to
+            get started.
           </p>
         </ListGroup.Item>
       )}
       <ListGroup.Item>
         <div className="flex flex-row items-center gap-x-4">
           <Button asChild onClick={showNewOAuthClientModal}>
-            New OAuth App
+            Create OAuth App
           </Button>
         </div>
       </ListGroup.Item>


### PR DESCRIPTION
## Summary

Polish the OAuth applications settings UI and copy.

## What

- Normalize OAuth form field spacing and label markup
- Improve empty-state and create-button copy
- Align the redirect URI add button dimensions

## Why

Make the OAuth settings experience clearer and more visually consistent.

## How

Simplify redundant form wrappers and adjust user-facing labels without changing behavior.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

