### PR TITLE
ecs: Set up pgbouncer in ECS/Fargate

### DIFF
--- a/terraform/modules/ecs_service/main.tf
+++ b/terraform/modules/ecs_service/main.tf
@@ -60,6 +60,38 @@ resource "aws_iam_role_policy_attachment" "execution" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+data "aws_iam_policy_document" "repository_credentials" {
+  count = var.repository_credentials == null ? 0 : 1
+
+  statement {
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [var.repository_credentials.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "repository_credentials" {
+  count  = var.repository_credentials == null ? 0 : 1
+  name   = "repository-credentials"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.repository_credentials[0].json
+}
+
+data "aws_iam_policy_document" "secrets" {
+  count = length(var.secrets) == 0 ? 0 : 1
+
+  statement {
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = values(var.secrets)
+  }
+}
+
+resource "aws_iam_role_policy" "secrets" {
+  count  = length(var.secrets) == 0 ? 0 : 1
+  name   = "secrets"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.secrets[0].json
+}
+
 resource "aws_ecs_task_definition" "this" {
   family                   = local.aws_names.task_family.value
   requires_compatibilities = ["FARGATE"]
@@ -71,26 +103,34 @@ resource "aws_ecs_task_definition" "this" {
   tags                     = var.tags
 
   container_definitions = jsonencode([
-    {
-      name      = local.full_name
-      image     = var.image
-      essential = true
-      command   = var.command
-      environment = [
-        for key, value in var.environment_variables : { name = key, value = value }
-      ]
-      portMappings = var.container_port == null ? [] : [
-        { containerPort = var.container_port, protocol = "tcp" }
-      ]
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          "awslogs-group"         = aws_cloudwatch_log_group.this.name
-          "awslogs-region"        = data.aws_region.current.name
-          "awslogs-stream-prefix" = local.full_name
+    merge(
+      {
+        name      = local.full_name
+        image     = var.image
+        essential = true
+        command   = var.command
+        environment = [
+          for key, value in var.environment_variables : { name = key, value = value }
+        ]
+        portMappings = var.container_port == null ? [] : [
+          { containerPort = var.container_port, protocol = "tcp" }
+        ]
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            "awslogs-group"         = aws_cloudwatch_log_group.this.name
+            "awslogs-region"        = data.aws_region.current.name
+            "awslogs-stream-prefix" = local.full_name
+          }
         }
-      }
-    }
+      },
+      var.repository_credentials == null ? {} : {
+        repositoryCredentials = { credentialsParameter = var.repository_credentials.arn }
+      },
+      length(var.secrets) == 0 ? {} : {
+        secrets = [for name, arn in var.secrets : { name = name, valueFrom = arn }]
+      },
+    )
   ])
 
   lifecycle {
@@ -124,5 +164,16 @@ resource "aws_ecs_service" "this" {
     security_groups = var.security_group_ids
   }
 
-  depends_on = [aws_iam_role_policy_attachment.execution]
+  dynamic "service_registries" {
+    for_each = var.service_registry == null ? [] : [var.service_registry.arn]
+    content {
+      registry_arn = service_registries.value
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.execution,
+    aws_iam_role_policy.repository_credentials,
+    aws_iam_role_policy.secrets,
+  ]
 }

--- a/terraform/modules/ecs_service/variables.tf
+++ b/terraform/modules/ecs_service/variables.tf
@@ -75,6 +75,12 @@ variable "environment_variables" {
   default     = {}
 }
 
+variable "secrets" {
+  description = "Environment variables injected from Secrets Manager, as name => secret ARN."
+  type        = map(string)
+  default     = {}
+}
+
 variable "subnet_ids" {
   description = "Subnets the tasks run in."
   type        = list(string)
@@ -89,6 +95,22 @@ variable "task_role_arn" {
   description = "IAM role assumed by the running task, if any."
   type        = string
   default     = null
+}
+
+variable "service_registry" {
+  description = "Cloud Map service the tasks register in, if any. Wrapped in an object so the null-check stays decidable when the ARN is computed."
+  type = object({
+    arn = string
+  })
+  default = null
+}
+
+variable "repository_credentials" {
+  description = "Secrets Manager secret with credentials for a private image registry, if any. Wrapped in an object so the null-check stays decidable when the ARN is computed."
+  type = object({
+    arn = string
+  })
+  default = null
 }
 
 variable "permissions_boundary_arn" {

--- a/terraform/modules/services/pgbouncer/main.tf
+++ b/terraform/modules/services/pgbouncer/main.tf
@@ -1,0 +1,83 @@
+locals {
+  port = 5432
+}
+
+resource "aws_secretsmanager_secret" "database_password" {
+  name = "polar-${var.environment}-pgbouncer-db-password"
+}
+
+resource "aws_secretsmanager_secret_version" "database_password" {
+  secret_id     = aws_secretsmanager_secret.database_password.id
+  secret_string = var.database.password
+}
+
+resource "aws_service_discovery_service" "this" {
+  name = "pgbouncer"
+
+  dns_config {
+    namespace_id   = var.namespace.id
+    routing_policy = "MULTIVALUE"
+
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_security_group" "this" {
+  name        = "polar-${var.environment}-pgbouncer"
+  description = "PgBouncer tasks fronting the Render database."
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port       = local.port
+    to_port         = local.port
+    protocol        = "tcp"
+    security_groups = var.client_security_group_ids
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+module "service" {
+  source = "../../ecs_service"
+
+  environment              = var.environment
+  name                     = "pgbouncer"
+  cluster_arn              = var.cluster_arn
+  image                    = var.image
+  profile                  = "tiny"
+  container_port           = local.port
+  subnet_ids               = var.subnet_ids
+  security_group_ids       = [aws_security_group.this.id]
+  permissions_boundary_arn = var.permissions_boundary_arn
+
+  service_registry = {
+    arn = aws_service_discovery_service.this.arn
+  }
+
+  repository_credentials = {
+    arn = var.repository_credentials_arn
+  }
+
+  environment_variables = {
+    DB_HOST            = var.database.host
+    DB_PORT            = var.database.port
+    DB_USER            = var.database.user
+    SERVER_TLS_SSLMODE = "require"
+  }
+
+  secrets = {
+    DB_PASSWORD = aws_secretsmanager_secret_version.database_password.arn
+  }
+}

--- a/terraform/modules/services/pgbouncer/outputs.tf
+++ b/terraform/modules/services/pgbouncer/outputs.tf
@@ -1,0 +1,14 @@
+output "host" {
+  description = "Private DNS name of the PgBouncer service"
+  value       = "${aws_service_discovery_service.this.name}.${var.namespace.name}"
+}
+
+output "port" {
+  description = "Port PgBouncer listens on"
+  value       = tostring(local.port)
+}
+
+output "security_group_id" {
+  description = "Security group attached to the PgBouncer tasks"
+  value       = aws_security_group.this.id
+}

--- a/terraform/modules/services/pgbouncer/terraform.tf
+++ b/terraform/modules/services/pgbouncer/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/terraform/modules/services/pgbouncer/variables.tf
+++ b/terraform/modules/services/pgbouncer/variables.tf
@@ -1,0 +1,64 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+
+  validation {
+    condition     = contains(["production", "sandbox", "test"], var.environment)
+    error_message = "Must be either \"production\", \"sandbox\" or \"test\"."
+  }
+}
+
+variable "vpc_id" {
+  description = "VPC the service runs in."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnets the tasks run in."
+  type        = list(string)
+}
+
+variable "cluster_arn" {
+  description = "ECS cluster the service runs in."
+  type        = string
+}
+
+variable "namespace" {
+  description = "Cloud Map private DNS namespace the service registers in."
+  type = object({
+    id   = string
+    name = string
+  })
+}
+
+variable "client_security_group_ids" {
+  description = "Security groups allowed to connect on port 5432."
+  type        = list(string)
+}
+
+variable "permissions_boundary_arn" {
+  description = "Permissions boundary for the task execution role."
+  type        = string
+}
+
+variable "repository_credentials_arn" {
+  description = "Secrets Manager secret with GHCR pull credentials."
+  type        = string
+}
+
+variable "image" {
+  description = "PgBouncer container image."
+  type        = string
+  default     = "ghcr.io/polarsource/polar-pgbouncer:latest"
+}
+
+variable "database" {
+  description = "Postgres endpoint PgBouncer proxies to."
+  type = object({
+    host     = string
+    port     = string
+    user     = string
+    password = string
+  })
+  sensitive = true
+}

--- a/terraform/sandbox/ecs.tf
+++ b/terraform/sandbox/ecs.tf
@@ -3,3 +3,46 @@ module "ecs_cluster" {
 
   environment = "sandbox"
 }
+
+# =============================================================================
+# PgBouncer for the Lambda worker
+# =============================================================================
+
+resource "aws_service_discovery_private_dns_namespace" "internal" {
+  name = "polar-sandbox.internal"
+  vpc  = module.vpc.vpc_id
+}
+
+resource "aws_secretsmanager_secret" "ghcr_pull" {
+  name = "polar-sandbox-ghcr-pull"
+}
+
+resource "aws_secretsmanager_secret_version" "ghcr_pull" {
+  secret_id     = aws_secretsmanager_secret.ghcr_pull.id
+  secret_string = jsonencode({ username = var.ghcr_username, password = var.ghcr_auth_token })
+}
+
+module "pgbouncer_aws" {
+  source = "../modules/services/pgbouncer"
+
+  environment = "sandbox"
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.private_subnet_ids
+  cluster_arn = module.ecs_cluster.cluster_arn
+
+  namespace = {
+    id   = aws_service_discovery_private_dns_namespace.internal.id
+    name = aws_service_discovery_private_dns_namespace.internal.name
+  }
+
+  client_security_group_ids  = [aws_security_group.lambda.id]
+  permissions_boundary_arn   = data.aws_iam_policy.permission_boundary.arn
+  repository_credentials_arn = aws_secretsmanager_secret_version.ghcr_pull.arn
+
+  database = {
+    host     = local.db_external_host
+    port     = local.db_port
+    user     = local.db_user
+    password = local.db_password
+  }
+}


### PR DESCRIPTION
This sets up pgbouncer in ECS to be used by the lambdas for now


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

