### PR TITLE
worker/sqs: Add priority queues in AWS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -334,10 +334,12 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
       - name: Update test Lambda function code
         run: |
-          aws lambda update-function-code \
-            --function-name polar-test-worker-default \
-            --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-test-lambda-worker:sha-${{ github.sha }}" \
-            --publish
+          for name in default high-priority medium-priority low-priority webhooks tinybird invoices-and-receipts; do
+            aws lambda update-function-code \
+              --function-name "polar-test-worker-$name" \
+              --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-test-lambda-worker:sha-${{ github.sha }}" \
+              --publish
+          done
 
   deploy-lambda-sandbox:
     name: "Deploy Lambda Worker to Sandbox 🧪"
@@ -358,10 +360,12 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
       - name: Update sandbox Lambda function code
         run: |
-          aws lambda update-function-code \
-            --function-name polar-sandbox-worker-default \
-            --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:sha-${{ github.sha }}" \
-            --publish
+          for name in default high-priority medium-priority low-priority webhooks tinybird invoices-and-receipts; do
+            aws lambda update-function-code \
+              --function-name "polar-sandbox-worker-$name" \
+              --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:sha-${{ github.sha }}" \
+              --publish
+          done
 
   deploy-lambda-production:
     name: "Deploy Lambda Worker to Production 🚀"
@@ -382,10 +386,12 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
       - name: Update production Lambda function code
         run: |
-          aws lambda update-function-code \
-            --function-name polar-production-worker-default \
-            --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-production-lambda-worker:sha-${{ github.sha }}" \
-            --publish
+          for name in default high-priority medium-priority low-priority webhooks tinybird invoices-and-receipts; do
+            aws lambda update-function-code \
+              --function-name "polar-production-worker-$name" \
+              --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-production-lambda-worker:sha-${{ github.sha }}" \
+              --publish
+          done
 
   deploy-sandbox:
     name: "Deploy to Sandbox 🧪"

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 import boto3
+import dramatiq
 import structlog
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -95,8 +96,9 @@ def get_consumer_scheduler_client() -> "EventBridgeSchedulerClient":
 sqs_client = get_sqs_client()
 
 
-def actor_to_queue_name(_actor_name: str) -> str:
-    return f"{settings.WORKER_SQS_QUEUE_PREFIX}-default"
+def actor_to_queue_name(actor_name: str) -> str:
+    queue_name = dramatiq.get_broker().get_actor(actor_name).queue_name
+    return f"{settings.WORKER_SQS_QUEUE_PREFIX}-{queue_name.replace('_', '-')}"
 
 
 _queue_url_cache: dict[tuple[int, str], str] = {}
@@ -109,6 +111,22 @@ def get_queue_url(client: "SQSClient", queue_name: str) -> str:
         url = client.get_queue_url(QueueName=queue_name)["QueueUrl"]
         _queue_url_cache[cache_key] = url
     return url
+
+
+def resolve_queue_url(client: "SQSClient", queue_name: str) -> str:
+    """Fall back to the default queue while a per-queue rollout is in flight."""
+    try:
+        return get_queue_url(client, queue_name)
+    except client.exceptions.QueueDoesNotExist:
+        default_queue_name = f"{settings.WORKER_SQS_QUEUE_PREFIX}-default"
+        if queue_name == default_queue_name:
+            raise
+        log.warning(
+            "polar.worker.sqs_queue_missing_fallback",
+            queue=queue_name,
+            fallback=default_queue_name,
+        )
+        return get_queue_url(client, default_queue_name)
 
 
 def build_envelope(
@@ -221,7 +239,7 @@ def send_jobs_sync(jobs: list[Job]) -> None:
         entries.append(entry)
 
     for queue_name, entries in by_queue.items():
-        queue_url = get_queue_url(client, queue_name)
+        queue_url = resolve_queue_url(client, queue_name)
         for batch in itertools.batched(entries, SQS_BATCH_SIZE):
             response = client.send_message_batch(
                 QueueUrl=queue_url, Entries=list(batch)
@@ -247,6 +265,7 @@ __all__ = [
     "get_queue_url",
     "get_sqs_client",
     "parse_envelope",
+    "resolve_queue_url",
     "schedule_delayed_message",
     "send_jobs",
     "send_jobs_sync",

--- a/server/polar/worker/sqs.py
+++ b/server/polar/worker/sqs.py
@@ -9,7 +9,7 @@ from polar.config import settings
 from polar.logging import Logger
 
 from ._runner import bootstrap, run_task, shutdown
-from ._sqs import actor_to_queue_name, get_queue_url, parse_envelope, sqs_client
+from ._sqs import actor_to_queue_name, parse_envelope, resolve_queue_url, sqs_client
 
 log: Logger = structlog.get_logger()
 
@@ -33,7 +33,7 @@ def run(actor: str, body: str = typer.Argument("{}")) -> None:
 
 async def _poll_loop(actors: list[str], max_iterations: int) -> None:
     client = sqs_client
-    queue_urls = {a: get_queue_url(client, actor_to_queue_name(a)) for a in actors}
+    queue_urls = {a: resolve_queue_url(client, actor_to_queue_name(a)) for a in actors}
     iterations = 0
     try:
         while max_iterations == 0 or iterations < max_iterations:

--- a/server/tests/worker/test_enqueue_gate.py
+++ b/server/tests/worker/test_enqueue_gate.py
@@ -9,14 +9,42 @@ from polar.config import settings
 from polar.logging import CorrelationID
 from polar.redis import Redis
 from polar.worker import JobQueueManager
-from polar.worker._sqs import actor_to_queue_name
+from polar.worker._sqs import actor_to_queue_name, get_sqs_client, resolve_queue_url
 
 
-def test_actor_to_queue_name_uses_single_worker_queue(mocker: MockerFixture) -> None:
+def test_actor_to_queue_name_maps_dramatiq_queue(mocker: MockerFixture) -> None:
     mocker.patch.object(settings, "WORKER_SQS_QUEUE_PREFIX", "polar-test-tasks")
 
-    assert actor_to_queue_name("customer.state_changed") == "polar-test-tasks-default"
-    assert actor_to_queue_name("dummy") == "polar-test-tasks-default"
+    assert (
+        actor_to_queue_name("customer.state_changed")
+        == "polar-test-tasks-high-priority"
+    )
+    assert actor_to_queue_name("dummy") == "polar-test-tasks-low-priority"
+    assert actor_to_queue_name("webhook_event.send") == "polar-test-tasks-webhooks"
+    assert (
+        actor_to_queue_name("receipt.render")
+        == "polar-test-tasks-invoices-and-receipts"
+    )
+
+
+def test_resolve_queue_url_falls_back_to_default(mocker: MockerFixture) -> None:
+    mocker.patch.object(settings, "WORKER_SQS_QUEUE_PREFIX", "polar-test-tasks")
+    client = get_sqs_client()
+
+    def fake_get_queue_url(_client: object, queue_name: str) -> str:
+        if queue_name == "polar-test-tasks-default":
+            return "https://sqs.example.com/polar-test-tasks-default"
+        raise client.exceptions.QueueDoesNotExist(
+            {"Error": {"Code": "AWS.SimpleQueueService.NonExistentQueue"}},
+            "GetQueueUrl",
+        )
+
+    mocker.patch("polar.worker._sqs.get_queue_url", side_effect=fake_get_queue_url)
+
+    assert (
+        resolve_queue_url(client, "polar-test-tasks-high-priority")
+        == "https://sqs.example.com/polar-test-tasks-default"
+    )
 
 
 @pytest.mark.asyncio

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -101,6 +101,15 @@ locals {
 
   lambda_worker_name                 = "default"
   lambda_worker_reserved_concurrency = null
+
+  lambda_worker_queues = {
+    "high-priority"         = { timeout_seconds = 120 }
+    "medium-priority"       = { timeout_seconds = 120 }
+    "low-priority"          = { timeout_seconds = 660 }
+    "webhooks"              = { timeout_seconds = 120 }
+    "tinybird"              = { timeout_seconds = 120 }
+    "invoices-and-receipts" = { timeout_seconds = 240 }
+  }
 }
 
 module "lambda_worker" {
@@ -120,6 +129,24 @@ module "lambda_worker" {
   secret_environment_variables = local.lambda_worker_secrets
 }
 
+module "lambda_worker_queue" {
+  for_each = local.lambda_worker_queues
+  source   = "../modules/aws_task_worker"
+
+  environment              = "production"
+  name                     = each.key
+  queue_name               = "polar-production-tasks-${each.key}"
+  image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
+  enabled                  = true
+  timeout_seconds          = each.value.timeout_seconds
+  subnet_ids               = local.lambda_subnet_ids
+  security_group_ids       = local.lambda_security_group_ids
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+
+  environment_variables        = local.lambda_worker_environment
+  secret_environment_variables = local.lambda_worker_secrets
+}
+
 # =============================================================================
 # Task producer policy (SQS send-only, attached to the Render backend OIDC role)
 # =============================================================================
@@ -131,7 +158,10 @@ data "aws_iam_policy_document" "tasks_producer" {
       "sqs:SendMessage",
       "sqs:GetQueueUrl",
     ]
-    resources = [module.lambda_worker.queue_arn]
+    resources = concat(
+      [module.lambda_worker.queue_arn],
+      [for worker in module.lambda_worker_queue : worker.queue_arn],
+    )
   }
 }
 
@@ -169,9 +199,15 @@ data "aws_iam_policy_document" "lambda_worker_deploy" {
   }
 
   statement {
-    sid       = "UpdateFunctionCode"
-    actions   = ["lambda:UpdateFunctionCode"]
-    resources = ["arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${module.lambda_worker.function_name}"]
+    sid     = "UpdateFunctionCode"
+    actions = ["lambda:UpdateFunctionCode"]
+    resources = [
+      for function_name in concat(
+        [module.lambda_worker.function_name],
+        [for worker in module.lambda_worker_queue : worker.function_name],
+      ) :
+      "arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${function_name}"
+    ]
   }
 }
 

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -99,6 +99,15 @@ locals {
 
   lambda_worker_name                 = "default"
   lambda_worker_reserved_concurrency = null
+
+  lambda_worker_queues = {
+    "high-priority"         = { timeout_seconds = 120 }
+    "medium-priority"       = { timeout_seconds = 120 }
+    "low-priority"          = { timeout_seconds = 660 }
+    "webhooks"              = { timeout_seconds = 120 }
+    "tinybird"              = { timeout_seconds = 120 }
+    "invoices-and-receipts" = { timeout_seconds = 240 }
+  }
 }
 
 module "lambda_worker" {
@@ -110,6 +119,24 @@ module "lambda_worker" {
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
   enabled                  = true
   reserved_concurrency     = local.lambda_worker_reserved_concurrency
+  subnet_ids               = local.lambda_subnet_ids
+  security_group_ids       = local.lambda_security_group_ids
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+
+  environment_variables        = local.lambda_worker_environment
+  secret_environment_variables = local.lambda_worker_secrets
+}
+
+module "lambda_worker_queue" {
+  for_each = local.lambda_worker_queues
+  source   = "../modules/aws_task_worker"
+
+  environment              = "sandbox"
+  name                     = each.key
+  queue_name               = "polar-sandbox-tasks-${each.key}"
+  image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
+  enabled                  = true
+  timeout_seconds          = each.value.timeout_seconds
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
@@ -139,7 +166,10 @@ data "aws_iam_policy_document" "tasks_producer" {
       "sqs:SendMessage",
       "sqs:GetQueueUrl",
     ]
-    resources = [module.lambda_worker.queue_arn]
+    resources = concat(
+      [module.lambda_worker.queue_arn],
+      [for worker in module.lambda_worker_queue : worker.queue_arn],
+    )
   }
 }
 
@@ -177,9 +207,15 @@ data "aws_iam_policy_document" "lambda_worker_deploy" {
   }
 
   statement {
-    sid       = "UpdateFunctionCode"
-    actions   = ["lambda:UpdateFunctionCode"]
-    resources = ["arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${module.lambda_worker.function_name}"]
+    sid     = "UpdateFunctionCode"
+    actions = ["lambda:UpdateFunctionCode"]
+    resources = [
+      for function_name in concat(
+        [module.lambda_worker.function_name],
+        [for worker in module.lambda_worker_queue : worker.function_name],
+      ) :
+      "arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${function_name}"
+    ]
   }
 }
 

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -105,6 +105,15 @@ locals {
 
   lambda_worker_name                 = "default"
   lambda_worker_reserved_concurrency = null
+
+  lambda_worker_queues = {
+    "high-priority"         = { timeout_seconds = 120 }
+    "medium-priority"       = { timeout_seconds = 120 }
+    "low-priority"          = { timeout_seconds = 660 }
+    "webhooks"              = { timeout_seconds = 120 }
+    "tinybird"              = { timeout_seconds = 120 }
+    "invoices-and-receipts" = { timeout_seconds = 240 }
+  }
 }
 
 module "lambda_worker" {
@@ -117,6 +126,24 @@ module "lambda_worker" {
   image_uri                = "${module.lambda_worker_ecr[0].repository_url}:latest"
   enabled                  = true
   reserved_concurrency     = local.lambda_worker_reserved_concurrency
+  subnet_ids               = local.lambda_subnet_ids
+  security_group_ids       = local.lambda_security_group_ids
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+
+  environment_variables        = local.lambda_worker_environment
+  secret_environment_variables = local.lambda_worker_secrets
+}
+
+module "lambda_worker_queue" {
+  for_each = local.test_enabled ? local.lambda_worker_queues : {}
+  source   = "../modules/aws_task_worker"
+
+  environment              = "test"
+  name                     = each.key
+  queue_name               = "polar-test-tasks-${each.key}"
+  image_uri                = "${module.lambda_worker_ecr[0].repository_url}:latest"
+  enabled                  = true
+  timeout_seconds          = each.value.timeout_seconds
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
@@ -138,7 +165,10 @@ data "aws_iam_policy_document" "tasks_producer" {
       "sqs:SendMessage",
       "sqs:GetQueueUrl",
     ]
-    resources = [module.lambda_worker[0].queue_arn]
+    resources = concat(
+      [module.lambda_worker[0].queue_arn],
+      [for worker in module.lambda_worker_queue : worker.queue_arn],
+    )
   }
 }
 
@@ -179,9 +209,15 @@ data "aws_iam_policy_document" "lambda_worker_deploy" {
   }
 
   statement {
-    sid       = "UpdateFunctionCode"
-    actions   = ["lambda:UpdateFunctionCode"]
-    resources = ["arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${module.lambda_worker[0].function_name}"]
+    sid     = "UpdateFunctionCode"
+    actions = ["lambda:UpdateFunctionCode"]
+    resources = [
+      for function_name in concat(
+        [module.lambda_worker[0].function_name],
+        [for worker in module.lambda_worker_queue : worker.function_name],
+      ) :
+      "arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${function_name}"
+    ]
   }
 }
 


### PR DESCRIPTION
Try to write to the priority queue first. If it doesn't exist, fall back to the default queue. This is to protect during the roll out period


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

