### PR TITLE
feat(backoffice): open meter periods for a subscription

### DIFF
--- a/server/polar/backoffice/subscriptions/endpoints.py
+++ b/server/polar/backoffice/subscriptions/endpoints.py
@@ -9,10 +9,14 @@ from sqlalchemy import func, or_
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 from tagflow import classes, tag, text
 
+from polar.billing_entry.repository import BillingEntryRepository
 from polar.kit.pagination import PaginationParamsQuery
 from polar.kit.schemas import empty_str_to_none
+from polar.meter_period.repository import MeterPeriodRepository
+from polar.meter_period.service import meter_period as meter_period_service
 from polar.models import (
     Customer,
+    MeterPeriod,
     Order,
     Organization,
     Product,
@@ -23,6 +27,7 @@ from polar.models.subscription import SubscriptionStatus
 from polar.order.repository import OrderRepository
 from polar.order.service import order as order_service
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
+from polar.product.guard import is_metered_price
 from polar.subscription import sorting
 from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.service import SubscriptionUpdateContext
@@ -41,7 +46,12 @@ from ..layout import layout
 from ..orders.components import orders_datatable
 from ..responses import HXRedirectResponse
 from ..toast import add_toast
-from .forms import CancelForm, UpdateBillingPeriodEndForm, build_update_status_form
+from .forms import (
+    CancelForm,
+    OpenMeterPeriodForm,
+    UpdateBillingPeriodEndForm,
+    build_update_status_form,
+)
 
 router = APIRouter()
 
@@ -79,6 +89,17 @@ class OrganizationColumn(
         self.href_getter = lambda r, i: str(
             r.url_for("organizations:detail", organization_id=i.product.organization_id)
         )
+
+
+class MeterPeriodBilledAmountColumn(
+    datatable.DatatableCurrencyColumn[MeterPeriod, SubscriptionSortProperty]
+):
+    def __init__(self, currency: str) -> None:
+        super().__init__("billed_amount", "Billed")
+        self.currency = currency
+
+    def get_currency(self, item: MeterPeriod) -> str:
+        return self.currency
 
 
 class SubscriptionMeterAmountColumn(
@@ -254,6 +275,11 @@ async def get(
     )
     orders = await order_repository.get_all(orders_statement)
 
+    meter_period_repository = MeterPeriodRepository.from_session(session)
+    meter_periods = await meter_period_repository.get_by_subscription(
+        subscription.id, options=meter_period_repository.get_eager_options()
+    )
+
     with layout(
         request,
         [
@@ -319,6 +345,16 @@ async def get(
                             hx_target="#modal",
                         ):
                             text("Update Status")
+                    with button(
+                        hx_get=str(
+                            request.url_for(
+                                "subscriptions:open_meter_period",
+                                id=subscription.id,
+                            )
+                        ),
+                        hx_target="#modal",
+                    ):
+                        text("Open Meter Period")
 
             with tag.div(classes="grid grid-cols-1 lg:grid-cols-2 gap-4"):
                 # Subscription Details
@@ -438,6 +474,20 @@ async def get(
                     datatable.DatatableAttrColumn("credited_units", "Credited Units"),
                     SubscriptionMeterAmountColumn(subscription.currency),
                 ).render(request, subscription.meters):
+                    pass
+
+            with tag.div(classes="flex flex-col gap-4"):
+                with tag.h2(classes="text-2xl"):
+                    text("Meter Periods")
+                with datatable.Datatable[MeterPeriod, SubscriptionSortProperty](
+                    datatable.DatatableAttrColumn("meter.name", "Meter"),
+                    datatable.DatatableAttrColumn("status", "Status"),
+                    datatable.DatatableDateTimeColumn("starts_at", "Starts"),
+                    datatable.DatatableDateTimeColumn("ends_at", "Ends"),
+                    datatable.DatatableAttrColumn("quantity", "Quantity"),
+                    datatable.DatatableAttrColumn("credited_units", "Credited"),
+                    MeterPeriodBilledAmountColumn(subscription.currency),
+                ).render(request, meter_periods):
                     pass
 
             with tag.div(classes="flex flex-col gap-4"):
@@ -751,3 +801,88 @@ async def update_status(
                             text("Cancel")
                     with button(type="submit", variant="primary"):
                         text("Submit")
+
+
+@router.api_route(
+    "/{id}/open_meter_period",
+    name="subscriptions:open_meter_period",
+    methods=["GET", "POST"],
+)
+async def open_meter_period(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    subscription_repository = SubscriptionRepository.from_session(session)
+    subscription = await subscription_repository.get_by_id(
+        id, options=subscription_repository.get_eager_options()
+    )
+
+    if subscription is None:
+        raise HTTPException(status_code=404)
+
+    if not any(
+        is_metered_price(price.product_price)
+        for price in subscription.subscription_product_prices
+    ):
+        await add_toast(request, "This subscription has no metered price.", "error")
+        return
+
+    validation_error: ValidationError | None = None
+
+    if request.method == "POST":
+        data = await request.form()
+        try:
+            form = OpenMeterPeriodForm.model_validate_form(data)
+            periods = await meter_period_service.open_for_subscription(
+                session,
+                subscription,
+                starts_at=form.starts_at,
+                ends_at=form.ends_at,
+            )
+            await add_toast(
+                request, f"Opened {len(periods)} meter period(s).", "success"
+            )
+            return HXRedirectResponse(
+                request, str(request.url_for("subscriptions:get", id=id)), 303
+            )
+        except ValidationError as e:
+            validation_error = e
+
+    # Default to the window a pending settlement would be billing: from the oldest
+    # unbilled entry up to the boundary the current period started at.
+    billing_entry_repository = BillingEntryRepository.from_session(session)
+    earliest = await billing_entry_repository.get_earliest_pending_metered_start(
+        subscription.id
+    )
+    starts_at = earliest or subscription.current_period_start
+    ends_at = (
+        subscription.current_period_start
+        if earliest is not None
+        else subscription.current_period_end
+    )
+    prefill_data = {
+        "starts_at": starts_at.strftime("%Y-%m-%dT%H:%M"),
+        "ends_at": ends_at.strftime("%Y-%m-%dT%H:%M"),
+    }
+
+    with modal("Open meter period", open=True):
+        with tag.p(classes="text-sm opacity-70"):
+            text(
+                "Opens one period per metered price. Billing reads them only when "
+                "`metered_billing_periods_enabled` is set on the organization, and "
+                "a price that already has an accruing period is left as it is."
+            )
+        with OpenMeterPeriodForm.render(
+            data=prefill_data,
+            hx_post=str(request.url_for("subscriptions:open_meter_period", id=id)),
+            hx_target="#modal",
+            classes="flex flex-col",
+            validation_error=validation_error,
+        ):
+            with tag.div(classes="modal-action"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with button(type="submit", variant="primary"):
+                    text("Open")

--- a/server/polar/backoffice/subscriptions/forms.py
+++ b/server/polar/backoffice/subscriptions/forms.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import Annotated, Any
 
-from pydantic import Field, create_model, field_validator
+from pydantic import Field, ValidationInfo, create_model, field_validator
 
 from polar.kit.schemas import EmptyStrToNone
 from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
@@ -70,4 +70,32 @@ class UpdateBillingPeriodEndForm(forms.BaseForm):
     def ensure_utc_timezone(cls, v: object) -> object:
         if isinstance(v, str):
             return datetime.fromisoformat(v).replace(tzinfo=UTC)
+        return v
+
+
+class OpenMeterPeriodForm(forms.BaseForm):
+    starts_at: Annotated[
+        datetime,
+        forms.InputField("datetime-local"),
+        Field(title="Window start"),
+    ]
+    ends_at: Annotated[
+        datetime,
+        forms.InputField("datetime-local"),
+        Field(title="Window end"),
+    ]
+
+    @field_validator("starts_at", "ends_at", mode="before")
+    @classmethod
+    def ensure_utc_timezone(cls, v: object) -> object:
+        if isinstance(v, str):
+            return datetime.fromisoformat(v).replace(tzinfo=UTC)
+        return v
+
+    @field_validator("ends_at")
+    @classmethod
+    def ensure_after_start(cls, v: datetime, info: ValidationInfo) -> datetime:
+        starts_at = info.data.get("starts_at")
+        if starts_at is not None and v <= starts_at:
+            raise ValueError("Window end must be after window start.")
         return v

--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -46,6 +46,17 @@ class BillingEntryRepository(
             )
             await self.session.execute(statement)
 
+    async def get_earliest_pending_metered_start(
+        self, subscription_id: UUID
+    ) -> datetime | None:
+        statement = select(func.min(BillingEntry.start_timestamp)).where(
+            BillingEntry.subscription_id == subscription_id,
+            BillingEntry.deleted_at.is_(None),
+            BillingEntry.order_item_id.is_(None),
+            BillingEntry.type == BillingEntryType.metered,
+        )
+        return await self.session.scalar(statement)
+
     async def get_all_by_subscription(
         self, subscription_id: UUID
     ) -> Sequence[BillingEntry]:

--- a/server/tests/backoffice/subscriptions/test_endpoints.py
+++ b/server/tests/backoffice/subscriptions/test_endpoints.py
@@ -1,5 +1,7 @@
 import uuid
 from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from decimal import Decimal
 
 import httpx
 import pytest
@@ -8,8 +10,13 @@ from pytest_mock import MockerFixture
 
 from polar.backoffice import app as backoffice_app
 from polar.backoffice.dependencies import get_admin
+from polar.enums import SubscriptionRecurringInterval
 from polar.kit.utils import utc_now
-from polar.models import Customer, Product, User
+from polar.meter.aggregation import CountAggregation
+from polar.meter.filter import Filter, FilterConjunction
+from polar.meter_period.repository import MeterPeriodRepository
+from polar.models import Customer, Organization, Product, Subscription, User
+from polar.models.meter_period import MeterPeriodStatus
 from polar.models.order import OrderStatus
 from polar.models.subscription import SubscriptionStatus
 from polar.models.user_session import UserSession
@@ -17,9 +24,14 @@ from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_active_subscription,
+    create_meter,
     create_order,
+    create_product,
     create_subscription,
 )
+
+PERIOD_START = datetime(2026, 7, 1, tzinfo=UTC)
+PERIOD_END = datetime(2026, 8, 1, tzinfo=UTC)
 
 
 @pytest_asyncio.fixture
@@ -40,6 +52,107 @@ async def backoffice_client(
         backoffice_app.dependency_overrides.pop(get_db_session, None)
         backoffice_app.dependency_overrides.pop(get_db_read_session, None)
         backoffice_app.dependency_overrides.pop(get_admin, None)
+
+
+@pytest_asyncio.fixture
+async def metered_subscription(
+    save_fixture: SaveFixture, customer: Customer, organization: Organization
+) -> Subscription:
+    meter = await create_meter(
+        save_fixture,
+        organization=organization,
+        name="Tool Calls",
+        filter=Filter(conjunction=FilterConjunction.and_, clauses=[]),
+        aggregation=CountAggregation(),
+    )
+    product = await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=SubscriptionRecurringInterval.month,
+        prices=[(meter, Decimal(100), None, "usd")],
+    )
+    return await create_active_subscription(
+        save_fixture,
+        customer=customer,
+        product=product,
+        current_period_start=PERIOD_START,
+        current_period_end=PERIOD_END,
+    )
+
+
+@pytest_asyncio.fixture
+async def static_subscription(
+    save_fixture: SaveFixture, customer: Customer, product: Product
+) -> Subscription:
+    return await create_active_subscription(
+        save_fixture, customer=customer, product=product
+    )
+
+
+@pytest.mark.asyncio
+class TestOpenMeterPeriod:
+    async def test_returns_404_for_unknown_subscription(
+        self, backoffice_client: httpx.AsyncClient
+    ) -> None:
+        response = await backoffice_client.get(
+            f"/subscriptions/{uuid.uuid4()}/open_meter_period"
+        )
+
+        assert response.status_code == 404
+
+    async def test_opens_one_period_per_metered_price(
+        self,
+        session: AsyncSession,
+        backoffice_client: httpx.AsyncClient,
+        metered_subscription: Subscription,
+    ) -> None:
+        response = await backoffice_client.post(
+            f"/subscriptions/{metered_subscription.id}/open_meter_period",
+            data={
+                "starts_at": "2026-07-01T00:00",
+                "ends_at": "2026-08-01T00:00",
+            },
+        )
+
+        assert response.status_code == 303
+        repository = MeterPeriodRepository.from_session(session)
+        periods = await repository.get_by_subscription(metered_subscription.id)
+        assert len(periods) == 1
+        assert periods[0].starts_at == PERIOD_START
+        assert periods[0].ends_at == PERIOD_END
+        assert periods[0].status == MeterPeriodStatus.accruing
+
+    async def test_rejects_a_window_that_ends_before_it_starts(
+        self,
+        session: AsyncSession,
+        backoffice_client: httpx.AsyncClient,
+        metered_subscription: Subscription,
+    ) -> None:
+        response = await backoffice_client.post(
+            f"/subscriptions/{metered_subscription.id}/open_meter_period",
+            data={
+                "starts_at": "2026-08-01T00:00",
+                "ends_at": "2026-07-01T00:00",
+            },
+        )
+
+        assert response.status_code == 200
+        repository = MeterPeriodRepository.from_session(session)
+        assert await repository.get_by_subscription(metered_subscription.id) == []
+
+    async def test_declines_a_subscription_with_no_metered_price(
+        self,
+        session: AsyncSession,
+        backoffice_client: httpx.AsyncClient,
+        static_subscription: Subscription,
+    ) -> None:
+        response = await backoffice_client.get(
+            f"/subscriptions/{static_subscription.id}/open_meter_period"
+        )
+
+        assert response.status_code == 200
+        repository = MeterPeriodRepository.from_session(session)
+        assert await repository.get_by_subscription(static_subscription.id) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Let operators open meter periods for a subscription in Backoffice and view existing periods, enabling a move from sweep-based settlement (old) to period-based settlement over a chosen window (new). Billing behavior does not change unless the organization has metered_billing_periods_enabled.

- Adds “Open Meter Period” action on the subscription page (GET/POST /subscriptions/{id}/open_meter_period) with a modal that collects start/end (datetime-local) and requires end after start; 404 for unknown subscription; error toast if no metered price; success toast and redirect on success.
- Opens one period per metered price in the window; leaves any price with an existing accruing period unchanged.
- Prefills the window from the earliest unbilled metered entry up to the current period boundary; if none, defaults to current period start→end.
- Adds a “Meter Periods” table on the subscription page showing meter, status, starts, ends, quantity, credited units, and billed amount in the subscription currency.

<sup>Written for commit 7c720aab7d03910ee1b3e9f349b60c34cb3e8635. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

