### PR TITLE
fix(subscription): delay final settlement of cancelled subscriptions

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1235,16 +1235,14 @@ class SubscriptionService:
         else:
             billing_reason = OrderBillingReasonInternal.subscription_cycle
 
-        # A cancelled subscription has no later invoice to carry usage onto, so its
-        # final settlement waits an hour for the entry fan-out to catch up with the
-        # window it is billing. The cutoff is explicit, so waiting changes when the
-        # window is computed, not which window.
+        # Delay the job 15 minutes when the subscription has been revoked to allow for
+        # late arrival usage events to be included.
         enqueue_job(
             "order.create_subscription_order",
             subscription.id,
             billing_reason,
             cutoff=cycle_at.isoformat(),
-            delay=60 * 60 * 1000 if revoke else None,
+            delay=15 * 60 * 1000 if revoke else None,
         )
 
         return subscription

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1235,11 +1235,16 @@ class SubscriptionService:
         else:
             billing_reason = OrderBillingReasonInternal.subscription_cycle
 
+        # A cancelled subscription has no later invoice to carry usage onto, so its
+        # final settlement waits an hour for the entry fan-out to catch up with the
+        # window it is billing. The cutoff is explicit, so waiting changes when the
+        # window is computed, not which window.
         enqueue_job(
             "order.create_subscription_order",
             subscription.id,
             billing_reason,
             cutoff=cycle_at.isoformat(),
+            delay=60 * 60 * 1000 if revoke else None,
         )
 
         return subscription

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1345,7 +1345,7 @@ class TestCycle:
 
     @pytest.mark.parametrize(
         ("cancel_at_period_end", "expected_delay"),
-        [(False, None), (True, 60 * 60 * 1000)],
+        [(False, None), (True, 15 * 60 * 1000)],
     )
     async def test_delays_settlement_only_when_cancelling(
         self,
@@ -1835,7 +1835,7 @@ class TestCycle:
             subscription.id,
             OrderBillingReasonInternal.subscription_cancel,
             cutoff=previous_current_period_end.isoformat(),
-            delay=60 * 60 * 1000,
+            delay=15 * 60 * 1000,
         )
 
         assert_webhook_not_sent(
@@ -2022,7 +2022,7 @@ class TestCycle:
             subscription.id,
             OrderBillingReasonInternal.subscription_cancel,
             cutoff=previous_current_period_end.isoformat(),
-            delay=60 * 60 * 1000,
+            delay=15 * 60 * 1000,
         )
         # The after-trial billing reason must NOT have been enqueued.
         for mock_call in enqueue_job_mock.call_args_list:

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1343,6 +1343,44 @@ class TestCycle:
             session, updated_subscription, reset_at=utc_now()
         )
 
+    @pytest.mark.parametrize(
+        ("cancel_at_period_end", "expected_delay"),
+        [(False, None), (True, 60 * 60 * 1000)],
+    )
+    async def test_delays_settlement_only_when_cancelling(
+        self,
+        cancel_at_period_end: bool,
+        expected_delay: int | None,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product_recurring_metered: Product,
+        customer: Customer,
+    ) -> None:
+        """A cancellation has no later invoice, so it waits for the entry fan-out
+        before settling; a renewal has one and does not."""
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product_recurring_metered,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+            cancel_at_period_end=cancel_at_period_end,
+        )
+        enqueue_job_mock = mocker.patch("polar.subscription.service.enqueue_job")
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.cycle(session, ctx, subscription)
+
+        order_calls = [
+            call
+            for call in enqueue_job_mock.call_args_list
+            if call.args and call.args[0] == "order.create_subscription_order"
+        ]
+        assert len(order_calls) == 1
+        assert order_calls[0].kwargs["delay"] == expected_delay
+
     @freeze_time("2024-01-15 12:00:00")
     async def test_preserves_period_end_when_cycling_late(
         self,
@@ -1465,6 +1503,7 @@ class TestCycle:
             subscription.id,
             OrderBillingReasonInternal.subscription_cycle,
             cutoff=previous_current_period_end.isoformat(),
+            delay=None,
         )
 
         assert_webhook_sent_once(
@@ -1796,6 +1835,7 @@ class TestCycle:
             subscription.id,
             OrderBillingReasonInternal.subscription_cancel,
             cutoff=previous_current_period_end.isoformat(),
+            delay=60 * 60 * 1000,
         )
 
         assert_webhook_not_sent(
@@ -1888,6 +1928,7 @@ class TestCycle:
             subscription.id,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
             cutoff=previous_current_period_end.isoformat(),
+            delay=None,
         )
 
         assert_webhook_sent_once(
@@ -1981,6 +2022,7 @@ class TestCycle:
             subscription.id,
             OrderBillingReasonInternal.subscription_cancel,
             cutoff=previous_current_period_end.isoformat(),
+            delay=60 * 60 * 1000,
         )
         # The after-trial billing reason must NOT have been enqueued.
         for mock_call in enqueue_job_mock.call_args_list:
@@ -2274,6 +2316,7 @@ class TestCycle:
             subscription.id,
             OrderBillingReasonInternal.subscription_cycle,
             cutoff=previous_current_period_end.isoformat(),
+            delay=None,
         )
 
         enqueue_job_mock.assert_any_call(
@@ -2403,6 +2446,7 @@ class TestCycle:
             subscription.id,
             OrderBillingReasonInternal.subscription_cycle,
             cutoff=previous_current_period_end.isoformat(),
+            delay=None,
         )
 
         assert not any(
@@ -4819,6 +4863,7 @@ class TestUpdate:
             updated.id,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
             cutoff=ANY,
+            delay=None,
         )
 
     async def test_seats_update(
@@ -5094,6 +5139,7 @@ class TestUpdate:
             updated.id,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
             cutoff=ANY,
+            delay=None,
         )
 
         assert_webhook_sent_once(
@@ -5324,6 +5370,7 @@ class TestUpdateProduct:
             updated.id,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
             cutoff=ANY,
+            delay=None,
         )
 
     async def test_trial_to_no_trial_product_ends_trial(
@@ -5363,6 +5410,7 @@ class TestUpdateProduct:
             updated.id,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
             cutoff=ANY,
+            delay=None,
         )
 
     async def test_trial_product_change_skips_proration_billing(


### PR DESCRIPTION
A small thing I discovered while digging into subscription order creation: since billing entries are created on a cron schedule any last usage just before a subscription is cancelled is never billed.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Delay final settlement of cancelled subscriptions by one hour to include late-arriving metered usage. Previously we enqueued the final order immediately and could miss last-window entries; now we wait an hour while keeping the same explicit cutoff. Renewals and trials are unchanged.

**Review notes**
- In `cycle`, pass `delay=60 * 60 * 1000` to `enqueue_job("order.create_subscription_order", ...)` when cancelling; otherwise `delay=None`. The `cutoff` remains `cycle_at.isoformat()`.
- Tests assert the delay for cancellation and `None` for renewal/trial paths, preserving existing billing reasons and webhook behavior.
- No API or schema changes. Expect up to ~1h delay before the final cancellation order, invoice, and related webhooks.

<sup>Written for commit b05eb97639852d5b1c940fe1270d3bb8757dd360. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

