### PR TITLE
tf: Add Grafana AWS scrape job

### DIFF
--- a/terraform/global/production.tf
+++ b/terraform/global/production.tf
@@ -628,3 +628,11 @@ resource "tfe_variable" "turnstile_secret_production" {
   sensitive       = true
   variable_set_id = tfe_variable_set.production.id
 }
+
+resource "tfe_variable" "grafana_cloud_aws_external_id_production" {
+  key             = "grafana_cloud_aws_external_id"
+  value           = "2341705"
+  category        = "terraform"
+  description     = "External ID for the Grafana Cloud CloudWatch scrape IAM role trust policy"
+  variable_set_id = tfe_variable_set.production.id
+}

--- a/terraform/global/sandbox.tf
+++ b/terraform/global/sandbox.tf
@@ -542,3 +542,11 @@ resource "tfe_variable" "turnstile_secret_sandbox" {
   sensitive       = true
   variable_set_id = tfe_variable_set.sandbox.id
 }
+
+resource "tfe_variable" "grafana_cloud_aws_external_id_sandbox" {
+  key             = "grafana_cloud_aws_external_id"
+  value           = "2341705"
+  category        = "terraform"
+  description     = "External ID for the Grafana Cloud CloudWatch scrape IAM role trust policy"
+  variable_set_id = tfe_variable_set.sandbox.id
+}

--- a/terraform/global/test.tf
+++ b/terraform/global/test.tf
@@ -528,3 +528,11 @@ resource "tfe_variable" "turnstile_secret_test" {
   sensitive       = true
   variable_set_id = tfe_variable_set.test.id
 }
+
+resource "tfe_variable" "grafana_cloud_aws_external_id_test" {
+  key             = "grafana_cloud_aws_external_id"
+  value           = "2341705"
+  category        = "terraform"
+  description     = "External ID for the Grafana Cloud CloudWatch scrape IAM role trust policy"
+  variable_set_id = tfe_variable_set.test.id
+}

--- a/terraform/modules/grafana_cloudwatch_role/main.tf
+++ b/terraform/modules/grafana_cloudwatch_role/main.tf
@@ -1,0 +1,43 @@
+data "aws_iam_policy_document" "assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::008923505280:root"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "sts:ExternalId"
+      values   = [var.external_id]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+  name                 = var.name
+  assume_role_policy   = data.aws_iam_policy_document.assume.json
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = var.tags
+}
+
+data "aws_iam_policy_document" "cloudwatch_read" {
+  statement {
+    sid    = "CloudWatchRead"
+    effect = "Allow"
+    actions = [
+      "cloudwatch:GetMetricData",
+      "cloudwatch:ListMetrics",
+      "tag:GetResources",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "cloudwatch_read" {
+  name   = "cloudwatch-read"
+  role   = aws_iam_role.this.id
+  policy = data.aws_iam_policy_document.cloudwatch_read.json
+}

--- a/terraform/modules/grafana_cloudwatch_role/outputs.tf
+++ b/terraform/modules/grafana_cloudwatch_role/outputs.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+  description = "ARN of the IAM role Grafana Cloud assumes."
+  value       = aws_iam_role.this.arn
+}

--- a/terraform/modules/grafana_cloudwatch_role/terraform.tf
+++ b/terraform/modules/grafana_cloudwatch_role/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/terraform/modules/grafana_cloudwatch_role/variables.tf
+++ b/terraform/modules/grafana_cloudwatch_role/variables.tf
@@ -1,0 +1,21 @@
+variable "name" {
+  description = "IAM role name."
+  type        = string
+}
+
+variable "external_id" {
+  description = "sts:ExternalId Grafana Cloud presents when assuming the IAM role."
+  type        = string
+}
+
+variable "permissions_boundary_arn" {
+  description = "Permissions boundary applied to the IAM role."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags applied to all created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -102,6 +102,11 @@ locals {
   lambda_worker_name                 = "default"
   lambda_worker_reserved_concurrency = null
 
+  lambda_worker_tags = {
+    Environment = "production"
+    Service     = "task-worker"
+  }
+
   lambda_worker_queues = {
     "high-priority"         = { timeout_seconds = 120 }
     "medium-priority"       = { timeout_seconds = 120 }
@@ -121,6 +126,7 @@ module "lambda_worker" {
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
   enabled                  = true
   reserved_concurrency     = local.lambda_worker_reserved_concurrency
+  tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
@@ -139,6 +145,7 @@ module "lambda_worker_queue" {
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
   enabled                  = true
   timeout_seconds          = each.value.timeout_seconds
+  tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
@@ -243,4 +250,13 @@ module "guardduty_scan_events" {
   queue_url         = module.lambda_worker.queue_url
   dlq_arn           = module.lambda_worker.dlq_arn
   dlq_url           = module.lambda_worker.dlq_url
+}
+
+module "grafana_cloudwatch_role" {
+  source = "../modules/grafana_cloudwatch_role"
+
+  name                     = "polar-production-grafana-cloudwatch"
+  external_id              = var.grafana_cloud_aws_external_id
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+  tags                     = local.lambda_worker_tags
 }

--- a/terraform/production/outputs.tf
+++ b/terraform/production/outputs.tf
@@ -27,3 +27,8 @@ output "redis_endpoint_service_name" {
   description = "VPC endpoint service name for the worker Redis. Provide to Render when creating the private link."
   value       = module.redis_private_link.service_name
 }
+
+output "grafana_cloudwatch_role_arn" {
+  description = "IAM role ARN to provide in the Grafana Cloud CloudWatch scrape setup."
+  value       = module.grafana_cloudwatch_role.role_arn
+}

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -550,3 +550,8 @@ variable "redis_private_link_host" {
   description = "DNS name of the Render private link to the production worker Redis"
   type        = string
 }
+
+variable "grafana_cloud_aws_external_id" {
+  description = "External ID for the Grafana Cloud CloudWatch scrape IAM role trust policy"
+  type        = string
+}

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -121,6 +121,11 @@ locals {
   lambda_worker_name                 = "default"
   lambda_worker_reserved_concurrency = null
 
+  lambda_worker_tags = {
+    Environment = "sandbox"
+    Service     = "task-worker"
+  }
+
   lambda_worker_queues = {
     "high-priority"         = { timeout_seconds = 120 }
     "medium-priority"       = { timeout_seconds = 120 }
@@ -140,6 +145,7 @@ module "lambda_worker" {
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
   enabled                  = true
   reserved_concurrency     = local.lambda_worker_reserved_concurrency
+  tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
@@ -158,6 +164,7 @@ module "lambda_worker_queue" {
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
   enabled                  = true
   timeout_seconds          = each.value.timeout_seconds
+  tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
@@ -272,4 +279,13 @@ module "guardduty_scan_events" {
   queue_url         = module.lambda_worker.queue_url
   dlq_arn           = module.lambda_worker.dlq_arn
   dlq_url           = module.lambda_worker.dlq_url
+}
+
+module "grafana_cloudwatch_role" {
+  source = "../modules/grafana_cloudwatch_role"
+
+  name                     = "polar-sandbox-grafana-cloudwatch"
+  external_id              = var.grafana_cloud_aws_external_id
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+  tags                     = local.lambda_worker_tags
 }

--- a/terraform/sandbox/outputs.tf
+++ b/terraform/sandbox/outputs.tf
@@ -32,3 +32,8 @@ output "redis_endpoint_service_name_b" {
   description = "VPC endpoint service name for the worker Redis on the secondary subnets. Provide to Render when creating the private link."
   value       = module.redis_private_link_b.service_name
 }
+
+output "grafana_cloudwatch_role_arn" {
+  description = "IAM role ARN to provide in the Grafana Cloud CloudWatch scrape setup."
+  value       = module.grafana_cloudwatch_role.role_arn
+}

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -461,3 +461,8 @@ variable "redis_private_link_host" {
   description = "DNS name of the Render private link to the sandbox worker Redis"
   type        = string
 }
+
+variable "grafana_cloud_aws_external_id" {
+  description = "External ID for the Grafana Cloud CloudWatch scrape IAM role trust policy"
+  type        = string
+}

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -106,6 +106,11 @@ locals {
   lambda_worker_name                 = "default"
   lambda_worker_reserved_concurrency = null
 
+  lambda_worker_tags = {
+    Environment = "test"
+    Service     = "task-worker"
+  }
+
   lambda_worker_queues = {
     "high-priority"         = { timeout_seconds = 120 }
     "medium-priority"       = { timeout_seconds = 120 }
@@ -126,6 +131,7 @@ module "lambda_worker" {
   image_uri                = "${module.lambda_worker_ecr[0].repository_url}:latest"
   enabled                  = true
   reserved_concurrency     = local.lambda_worker_reserved_concurrency
+  tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
@@ -144,6 +150,7 @@ module "lambda_worker_queue" {
   image_uri                = "${module.lambda_worker_ecr[0].repository_url}:latest"
   enabled                  = true
   timeout_seconds          = each.value.timeout_seconds
+  tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
@@ -256,4 +263,14 @@ module "guardduty_scan_events" {
   queue_url         = module.lambda_worker[0].queue_url
   dlq_arn           = module.lambda_worker[0].dlq_arn
   dlq_url           = module.lambda_worker[0].dlq_url
+}
+
+module "grafana_cloudwatch_role" {
+  count  = local.test_enabled ? 1 : 0
+  source = "../modules/grafana_cloudwatch_role"
+
+  name                     = "polar-test-grafana-cloudwatch"
+  external_id              = var.grafana_cloud_aws_external_id
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+  tags                     = local.lambda_worker_tags
 }

--- a/terraform/test/outputs.tf
+++ b/terraform/test/outputs.tf
@@ -12,3 +12,8 @@ output "vercel_services_project_id" {
   description = "Vercel project ID for the full-stack Services test deployment."
   value       = module.vercel_services.project_id
 }
+
+output "grafana_cloudwatch_role_arn" {
+  description = "IAM role ARN to provide in the Grafana Cloud CloudWatch scrape setup."
+  value       = try(module.grafana_cloudwatch_role[0].role_arn, null)
+}

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -445,3 +445,8 @@ variable "redis_private_link_host" {
   description = "DNS name of the Render private link to the test worker Redis"
   type        = string
 }
+
+variable "grafana_cloud_aws_external_id" {
+  description = "External ID for the Grafana Cloud CloudWatch scrape IAM role trust policy"
+  type        = string
+}


### PR DESCRIPTION
To allow us to get metrics from CloudWatch in Grafana


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

