### PR TITLE
aws/lambda: Use pgbouncer for DB connections

### DIFF
--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -69,10 +69,10 @@ locals {
     POLAR_LOG_LEVEL                   = "INFO"
     POLAR_TESTING                     = "0"
     POLAR_POSTGRES_DATABASE           = "polar_sandbox"
-    POLAR_POSTGRES_HOST               = local.db_external_host
-    POLAR_POSTGRES_PORT               = local.db_port
+    POLAR_POSTGRES_HOST               = module.pgbouncer_aws.host
+    POLAR_POSTGRES_PORT               = module.pgbouncer_aws.port
     POLAR_POSTGRES_USER               = local.db_user
-    POLAR_POSTGRES_SSL                = "true"
+    POLAR_POSTGRES_SSL                = "false"
     POLAR_REDIS_HOST                  = module.redis.host
     POLAR_REDIS_PORT                  = tostring(module.redis.port)
     POLAR_REDIS_DB                    = "1"


### PR DESCRIPTION
This should allow us to scale up the concurrency


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route sandbox Lambda Postgres connections through pgbouncer to reduce direct RDS connections and allow higher concurrency. Previously Lambdas connected to `db_external_host:db_port` with `POLAR_POSTGRES_SSL=true`; now they use `module.pgbouncer_aws.host:port` with `POLAR_POSTGRES_SSL=false`.

- Apply Terraform to provision/update `module.pgbouncer_aws`, then redeploy the Lambda so the new env vars take effect.
- Ensure security groups permit Lambda → pgbouncer and pgbouncer → RDS traffic. Monitor RDS connection counts to verify pooling.

<sup>Written for commit de14667223ab750612534ccae9928806d9d6a26b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

