### PR TITLE
Use native anchors for external links in Landing components

### DIFF
--- a/clients/apps/web/src/components/Landing/LogoGrid.tsx
+++ b/clients/apps/web/src/components/Landing/LogoGrid.tsx
@@ -1,6 +1,5 @@
 import { Grid, GridItem } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import Link from 'next/link'
 import { JSX } from 'react'
 import { Confidence, FastAPICloud, StillaAIWordmark, Tailwind } from './Logos'
 
@@ -35,7 +34,12 @@ export const LogoGrid = () => (
   >
     {LOGOS.map((logo) => (
       <GridItem key={logo.link}>
-        <Link href={logo.link} target="_blank" className="flex w-full">
+        <a
+          href={logo.link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex w-full"
+        >
           <Box
             width="100%"
             alignItems="center"
@@ -53,7 +57,7 @@ export const LogoGrid = () => (
               {logo.icon}
             </div>
           </Box>
-        </Link>
+        </a>
       </GridItem>
     ))}
   </Grid>

--- a/clients/apps/web/src/components/Landing/Testimonials.tsx
+++ b/clients/apps/web/src/components/Landing/Testimonials.tsx
@@ -56,8 +56,10 @@ const TESTIMONIALS: Testimonial[] = [
   },
 ]
 
-const TestimonialRow = ({ testimonial }: { testimonial: Testimonial }) => (
-  <Link href={testimonial.link} target="_blank" className="flex w-full">
+const isExternalLink = (link: string) => /^https?:\/\//.test(link)
+
+const TestimonialRow = ({ testimonial }: { testimonial: Testimonial }) => {
+  const content = (
     <Grid
       width="100%"
       templateColumns={{ base: '1fr', lg: 'repeat(2, 1fr)' }}
@@ -92,8 +94,27 @@ const TestimonialRow = ({ testimonial }: { testimonial: Testimonial }) => (
         ))}
       </Box>
     </Grid>
-  </Link>
-)
+  )
+
+  if (isExternalLink(testimonial.link)) {
+    return (
+      <a
+        href={testimonial.link}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex w-full"
+      >
+        {content}
+      </a>
+    )
+  }
+
+  return (
+    <Link href={testimonial.link} target="_blank" className="flex w-full">
+      {content}
+    </Link>
+  )
+}
 
 export const Testimonials = () => (
   <Chapter


### PR DESCRIPTION
## Summary

Replace Next.js `Link` components with native HTML `<a>` tags for external links in the Landing page components, and add proper security attributes.

## What

- Modified `Testimonials.tsx` to conditionally use native `<a>` tags for external links (those matching `https?://`) and `Link` components for internal routes
- Modified `LogoGrid.tsx` to replace `Link` with native `<a>` tags for external logo links
- Added `rel="noopener noreferrer"` security attributes to all external anchor tags
- Removed unused `next/link` import from `LogoGrid.tsx`

## Why

Next.js `Link` component is designed for internal navigation within the application. Using it for external URLs is semantically incorrect and can cause unnecessary overhead. Native `<a>` tags are the appropriate choice for external links and provide better browser behavior (e.g., proper context menu handling, keyboard navigation).

## How

- Created `isExternalLink()` utility function to detect external URLs
- Refactored `TestimonialRow` to conditionally render either `<a>` or `Link` based on the link type
- Replaced all external link `Link` components with native `<a>` tags
- Added security attributes (`rel="noopener noreferrer"`) to prevent potential security vulnerabilities with external links

## Checklist

- [x] This PR addresses a single concern (refactoring external link handling)
- [x] The diff is reasonably sized and easy to review
- [x] No new functionality requiring tests
- [x] No unrelated changes included

https://claude.ai/code/session_018oP39wEwSuUBh1h3SwNszQ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

