### PR TITLE
fix(events): filter event type counts by selected customers

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/EventsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/EventsPage.tsx
@@ -93,6 +93,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
   const { data } = useEventNames(organization.id, {
     sorting: ['name'],
     limit: 500,
+    customer_id: selectedCustomerIds ?? undefined,
   })
 
   const eventTypes = useMemo(


### PR DESCRIPTION
## Summary

Closes polarsource/feedback#388

The event type occurrence counts in the **System Events** / **Custom Events** filter list on the Events analytics page always showed the org-wide total, ignoring the customer selection.

## What

Forward the selected customer IDs from the Events page to the `useEventNames` (`GET /v1/event-types/`) call, so the occurrence counts shown next to each event type reflect the active customer filter.

```tsx
const { data } = useEventNames(organization.id, {
  sorting: ['name'],
  limit: 500,
  customer_id: selectedCustomerIds ?? undefined, // added
})
```

## Why

The backend `event-types:list` endpoint (and `event_type_service.list_with_stats`) already accepts a `customer_id` filter and scopes the `occurrences` stat by it via Tinybird. The frontend simply wasn't passing the selected customers, so the counts stayed at the org-wide total no matter which customers were selected — inconsistent with the events list below it, which is correctly filtered.

## How

`selectedCustomerIds` is already tracked as query state on the page and drives the events list. Passing it into `useEventNames` makes it part of the query key, so the event-type stats re-fetch and re-scope whenever the customer selection changes. When no customer is selected, `undefined` is passed and the totals display exactly as before.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests — display-only change that forwards an existing, already-tested filter param; no new behavior to unit test
- [ ] Linting and type checking pass — couldn't run locally (no `node_modules`; repo pins Node 24). The change is type-safe (`customer_id?: string | string[] | null` accepts `string[] | undefined`) and mirrors the existing `selectedCustomerIds ?? null` pattern in the same file; CI will verify
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)