### PR TITLE
feat(organization): support partial updates of settings groups

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -17917,6 +17917,11 @@ export interface components {
       /** Allow Email Change */
       allow_email_change?: boolean
     }
+    /** CustomerPortalCustomerSettingsUpdate */
+    CustomerPortalCustomerSettingsUpdate: {
+      /** Allow Email Change */
+      allow_email_change?: boolean | null
+    }
     /** CustomerPortalCustomerUpdate */
     CustomerPortalCustomerUpdate: {
       /** Billing Name */
@@ -18019,10 +18024,24 @@ export interface components {
       /** Pause */
       pause?: boolean
     }
+    /** CustomerPortalSubscriptionSettingsUpdate */
+    CustomerPortalSubscriptionSettingsUpdate: {
+      /** Update Seats */
+      update_seats?: boolean | null
+      /** Update Plan */
+      update_plan?: boolean | null
+      /** Pause */
+      pause?: boolean | null
+    }
     /** CustomerPortalUsageSettings */
     CustomerPortalUsageSettings: {
       /** Show */
       show: boolean
+    }
+    /** CustomerPortalUsageSettingsUpdate */
+    CustomerPortalUsageSettingsUpdate: {
+      /** Show */
+      show?: boolean | null
     }
     /**
      * CustomerProduct
@@ -27456,11 +27475,64 @@ export interface components {
       /** Subscription Updated */
       subscription_updated: boolean
     }
+    /**
+     * OrganizationCustomerEmailSettingsUpdate
+     * @description Partial update for customer email settings.
+     *
+     *     Every field is optional: only the flags provided are changed, the rest keep
+     *     their current value.
+     */
+    OrganizationCustomerEmailSettingsUpdate: {
+      /** Order Confirmation */
+      order_confirmation?: boolean | null
+      /** Payment Method Expiration Reminder */
+      payment_method_expiration_reminder?: boolean | null
+      /** Subscription Cancellation */
+      subscription_cancellation?: boolean | null
+      /** Subscription Confirmation */
+      subscription_confirmation?: boolean | null
+      /** Subscription Cycled */
+      subscription_cycled?: boolean | null
+      /** Subscription Cycled After Trial */
+      subscription_cycled_after_trial?: boolean | null
+      /** Subscription Past Due */
+      subscription_past_due?: boolean | null
+      /** Subscription Paused */
+      subscription_paused?: boolean | null
+      /** Subscription Resumed */
+      subscription_resumed?: boolean | null
+      /** Subscription Renewal Reminder */
+      subscription_renewal_reminder?: boolean | null
+      /** Subscription Revoked */
+      subscription_revoked?: boolean | null
+      /** Subscription Trial Conversion Reminder */
+      subscription_trial_conversion_reminder?: boolean | null
+      /** Subscription Uncanceled */
+      subscription_uncanceled?: boolean | null
+      /** Subscription Updated */
+      subscription_updated?: boolean | null
+    }
     /** OrganizationCustomerPortalSettings */
     OrganizationCustomerPortalSettings: {
       usage: components['schemas']['CustomerPortalUsageSettings']
       subscription: components['schemas']['CustomerPortalSubscriptionSettings']
       customer?: components['schemas']['CustomerPortalCustomerSettings']
+    }
+    /**
+     * OrganizationCustomerPortalSettingsUpdate
+     * @description Partial update for customer portal settings.
+     *
+     *     Every field is optional and merged into the current settings: only the
+     *     nested keys provided are changed, the rest keep their current value.
+     */
+    OrganizationCustomerPortalSettingsUpdate: {
+      usage?: components['schemas']['CustomerPortalUsageSettingsUpdate'] | null
+      subscription?:
+        | components['schemas']['CustomerPortalSubscriptionSettingsUpdate']
+        | null
+      customer?:
+        | components['schemas']['CustomerPortalCustomerSettingsUpdate']
+        | null
     }
     /** OrganizationCustomerSession */
     OrganizationCustomerSession: {
@@ -28829,6 +28901,24 @@ export interface components {
       /** Allow Customer Updates */
       allow_customer_updates: boolean
     }
+    /**
+     * OrganizationSubscriptionSettingsUpdate
+     * @description Partial update for subscription settings.
+     *
+     *     Every field is optional: only the fields provided are changed, the rest keep
+     *     their current value.
+     */
+    OrganizationSubscriptionSettingsUpdate: {
+      /** Allow Multiple Subscriptions */
+      allow_multiple_subscriptions?: boolean | null
+      proration_behavior?: ('invoice' | 'prorate' | 'next_period') | null
+      /** Benefit Revocation Grace Period */
+      benefit_revocation_grace_period?: number | null
+      /** Prevent Trial Abuse */
+      prevent_trial_abuse?: boolean | null
+      /** Allow Customer Updates */
+      allow_customer_updates?: boolean | null
+    }
     /** OrganizationSubscriptionUpdate */
     OrganizationSubscriptionUpdate: {
       /**
@@ -29137,13 +29227,13 @@ export interface components {
         | components['schemas']['OrganizationFeatureSettingsUpdate']
         | null
       subscription_settings?:
-        | components['schemas']['OrganizationSubscriptionSettings']
+        | components['schemas']['OrganizationSubscriptionSettingsUpdate']
         | null
       customer_email_settings?:
-        | components['schemas']['OrganizationCustomerEmailSettings']
+        | components['schemas']['OrganizationCustomerEmailSettingsUpdate']
         | null
       customer_portal_settings?:
-        | components['schemas']['OrganizationCustomerPortalSettings']
+        | components['schemas']['OrganizationCustomerPortalSettingsUpdate']
         | null
       dispute_settings?:
         | components['schemas']['OrganizationDisputeSettingsUpdate']
@@ -66921,6 +67011,9 @@ export const organizationStatusValues: ReadonlyArray<
 ]
 export const organizationSubscriptionSettingsProration_behaviorValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationSubscriptionSettings']['proration_behavior']
+> = ['invoice', 'prorate', 'next_period']
+export const organizationSubscriptionSettingsUpdateProration_behaviorAnyOf0Values: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['OrganizationSubscriptionSettingsUpdate']['proration_behavior']
 > = ['invoice', 'prorate', 'next_period']
 export const organizationUpdateCountryAnyOf0Values: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationUpdate']['country']

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -13,7 +13,7 @@ from pydantic import (
     computed_field,
     model_validator,
 )
-from pydantic.json_schema import SkipJsonSchema
+from pydantic.json_schema import SkipJsonSchema, WithJsonSchema
 from pydantic.networks import HttpUrl
 
 from polar.auth.permission import ROLE_PERMISSIONS, OrganizationPermission
@@ -399,6 +399,81 @@ CustomerEmailSettings = Annotated[
 ]
 
 
+class OrganizationCustomerEmailSettingsUpdate(Schema):
+    """Partial update for customer email settings.
+
+    Every field is optional: only the flags provided are changed, the rest keep
+    their current value.
+    """
+
+    order_confirmation: bool | None = None
+    payment_method_expiration_reminder: bool | None = None
+    subscription_cancellation: bool | None = None
+    subscription_confirmation: bool | None = None
+    subscription_cycled: bool | None = None
+    subscription_cycled_after_trial: bool | None = None
+    subscription_past_due: bool | None = None
+    subscription_paused: bool | None = None
+    subscription_resumed: bool | None = None
+    subscription_renewal_reminder: bool | None = None
+    subscription_revoked: bool | None = None
+    subscription_trial_conversion_reminder: bool | None = None
+    subscription_uncanceled: bool | None = None
+    subscription_updated: bool | None = None
+
+
+PublicProrationBehavior = Annotated[
+    SubscriptionProrationBehavior,
+    WithJsonSchema(
+        {
+            "enum": ["invoice", "prorate", "next_period"],
+            "title": "PublicSubscriptionProrationBehavior",
+            "type": "string",
+        }
+    ),
+]
+
+
+class OrganizationSubscriptionSettingsUpdate(Schema):
+    """Partial update for subscription settings.
+
+    Every field is optional: only the fields provided are changed, the rest keep
+    their current value.
+    """
+
+    allow_multiple_subscriptions: bool | None = None
+    proration_behavior: PublicProrationBehavior | None = None
+    benefit_revocation_grace_period: int | None = None
+    prevent_trial_abuse: bool | None = None
+    allow_customer_updates: bool | None = None
+
+
+class CustomerPortalUsageSettingsUpdate(Schema):
+    show: bool | None = None
+
+
+class CustomerPortalSubscriptionSettingsUpdate(Schema):
+    update_seats: bool | None = None
+    update_plan: bool | None = None
+    pause: bool | None = None
+
+
+class CustomerPortalCustomerSettingsUpdate(Schema):
+    allow_email_change: bool | None = None
+
+
+class OrganizationCustomerPortalSettingsUpdate(Schema):
+    """Partial update for customer portal settings.
+
+    Every field is optional and merged into the current settings: only the
+    nested keys provided are changed, the rest keep their current value.
+    """
+
+    usage: CustomerPortalUsageSettingsUpdate | None = None
+    subscription: CustomerPortalSubscriptionSettingsUpdate | None = None
+    customer: CustomerPortalCustomerSettingsUpdate | None = None
+
+
 class OrganizationBase(IDSchema, TimestampedSchema):
     name: str = Field(
         description="Organization name shown in checkout, customer portal, emails etc.",
@@ -712,9 +787,9 @@ class OrganizationUpdate(Schema):
     )
 
     feature_settings: OrganizationFeatureSettingsUpdate | None = None
-    subscription_settings: OrganizationSubscriptionSettings | None = None
-    customer_email_settings: OrganizationCustomerEmailSettings | None = None
-    customer_portal_settings: OrganizationCustomerPortalSettings | None = None
+    subscription_settings: OrganizationSubscriptionSettingsUpdate | None = None
+    customer_email_settings: OrganizationCustomerEmailSettingsUpdate | None = None
+    customer_portal_settings: OrganizationCustomerPortalSettingsUpdate | None = None
     dispute_settings: OrganizationDisputeSettingsUpdate | None = None
     embed_hosts: EmbedHostsInput | None = None
     default_presentment_currency: PresentmentCurrency | None = Field(

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -56,7 +56,6 @@ from polar.models.organization import (
     STATUS_CAPABILITIES,
     CapabilityName,
     OrganizationCapabilities,
-    OrganizationCustomerEmailSettings,
     OrganizationCustomerPortalSettings,
     OrganizationDetails,
     OrganizationDisputeSettings,
@@ -585,16 +584,17 @@ class OrganizationService:
             )
 
         if update_schema.customer_email_settings is not None:
-            organization.customer_email_settings = cast(
-                OrganizationCustomerEmailSettings,
-                {
-                    **resolve_default_customer_email_settings(
-                        organization.customer_email_settings
-                    ),
-                    **update_schema.customer_email_settings.model_dump(
-                        mode="json", exclude_unset=True, exclude_none=True
-                    ),
-                },
+            merged_email_settings = {
+                **organization.customer_email_settings,
+                **update_schema.customer_email_settings.model_dump(
+                    mode="json", exclude_unset=True, exclude_none=True
+                ),
+            }
+            # Resolve defaults after merging so a legacy organization that lacks
+            # `payment_method_expiration_reminder` derives its fallback from the
+            # `subscription_cycled` value set in this same request, not the old one.
+            organization.customer_email_settings = (
+                resolve_default_customer_email_settings(merged_email_settings)
             )
 
         if update_schema.customer_portal_settings is not None:

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -56,10 +56,14 @@ from polar.models.organization import (
     STATUS_CAPABILITIES,
     CapabilityName,
     OrganizationCapabilities,
+    OrganizationCustomerEmailSettings,
+    OrganizationCustomerPortalSettings,
     OrganizationDetails,
     OrganizationDisputeSettings,
     OrganizationStatus,
+    OrganizationSubscriptionSettings,
     SnoozeType,
+    resolve_default_customer_email_settings,
 )
 from polar.models.organization_review import OrganizationReview
 from polar.models.transaction import TransactionType
@@ -550,7 +554,7 @@ class OrganizationService:
 
         if update_schema.subscription_settings is not None:
             if (
-                update_schema.subscription_settings.get("proration_behavior")
+                update_schema.subscription_settings.proration_behavior
                 == SubscriptionProrationBehavior.reset
                 and not organization.feature_settings.get(
                     "reset_proration_behavior_enabled"
@@ -566,13 +570,47 @@ class OrganizationService:
                                 "proration_behavior",
                             ),
                             "msg": "The 'reset' proration behavior is not enabled for this organization.",
-                            "input": update_schema.subscription_settings[
-                                "proration_behavior"
-                            ],
+                            "input": update_schema.subscription_settings.proration_behavior,
                         }
                     ]
                 )
-            organization.subscription_settings = update_schema.subscription_settings
+            organization.subscription_settings = cast(
+                OrganizationSubscriptionSettings,
+                {
+                    **organization.subscription_settings,
+                    **update_schema.subscription_settings.model_dump(
+                        mode="json", exclude_unset=True, exclude_none=True
+                    ),
+                },
+            )
+
+        if update_schema.customer_email_settings is not None:
+            organization.customer_email_settings = cast(
+                OrganizationCustomerEmailSettings,
+                {
+                    **resolve_default_customer_email_settings(
+                        organization.customer_email_settings
+                    ),
+                    **update_schema.customer_email_settings.model_dump(
+                        mode="json", exclude_unset=True, exclude_none=True
+                    ),
+                },
+            )
+
+        if update_schema.customer_portal_settings is not None:
+            portal_update = update_schema.customer_portal_settings.model_dump(
+                mode="json", exclude_unset=True, exclude_none=True
+            )
+            merged_portal_settings = {**organization.customer_portal_settings}
+            for key, value in portal_update.items():
+                existing = merged_portal_settings.get(key)
+                if isinstance(value, dict) and isinstance(existing, dict):
+                    merged_portal_settings[key] = {**existing, **value}
+                else:
+                    merged_portal_settings[key] = value
+            organization.customer_portal_settings = cast(
+                OrganizationCustomerPortalSettings, merged_portal_settings
+            )
 
         if update_schema.dispute_settings is not None:
             if (
@@ -606,6 +644,8 @@ class OrganizationService:
                 "profile_settings",
                 "feature_settings",
                 "subscription_settings",
+                "customer_email_settings",
+                "customer_portal_settings",
                 "dispute_settings",
                 "details",
             },

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import UTC, datetime
+from typing import cast
 
 import pytest
 from httpx import AsyncClient
@@ -13,6 +14,7 @@ from polar.models.account import Account
 from polar.models.organization import (
     EMBED_HOSTS_ENFORCED_FROM,
     Organization,
+    OrganizationCustomerEmailSettings,
     OrganizationStatus,
 )
 from polar.models.organization_sso_connection import (
@@ -539,6 +541,34 @@ class TestUpdateOrganization:
         email_settings = second.json()["customer_email_settings"]
         assert email_settings["order_confirmation"] is False
         assert email_settings["subscription_confirmation"] is False
+
+    @pytest.mark.auth
+    async def test_partial_update_customer_email_settings_reminder_follows_new_cycle(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # A legacy organization without an explicit
+        # `payment_method_expiration_reminder`: its fallback is derived from
+        # `subscription_cycled`. Changing the cycle in the same request must
+        # re-derive the persisted reminder from the new value, not the old one.
+        organization.customer_email_settings = cast(
+            OrganizationCustomerEmailSettings,
+            {"subscription_cycled": True},
+        )
+        await save_fixture(organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"customer_email_settings": {"subscription_cycled": False}},
+        )
+
+        assert response.status_code == 200
+        email_settings = response.json()["customer_email_settings"]
+        assert email_settings["subscription_cycled"] is False
+        assert email_settings["payment_method_expiration_reminder"] is False
 
     @pytest.mark.auth
     async def test_update_customer_email_settings_full_object(

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -512,6 +512,115 @@ class TestUpdateOrganization:
         assert settings["customer"]["allow_email_change"] is True
 
     @pytest.mark.auth
+    async def test_partial_update_customer_email_settings(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Turn one flag off, then turn a different flag off in a separate
+        # request: the first change must survive the second, proving the
+        # settings are merged rather than replaced wholesale.
+        first = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"customer_email_settings": {"subscription_confirmation": False}},
+        )
+        assert first.status_code == 200
+        assert (
+            first.json()["customer_email_settings"]["subscription_confirmation"]
+            is False
+        )
+
+        second = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"customer_email_settings": {"order_confirmation": False}},
+        )
+        assert second.status_code == 200
+        email_settings = second.json()["customer_email_settings"]
+        assert email_settings["order_confirmation"] is False
+        assert email_settings["subscription_confirmation"] is False
+
+    @pytest.mark.auth
+    async def test_update_customer_email_settings_full_object(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "customer_email_settings": {
+                    "order_confirmation": False,
+                    "payment_method_expiration_reminder": False,
+                    "subscription_cancellation": False,
+                    "subscription_confirmation": False,
+                    "subscription_cycled": False,
+                    "subscription_cycled_after_trial": False,
+                    "subscription_past_due": False,
+                    "subscription_paused": False,
+                    "subscription_resumed": False,
+                    "subscription_renewal_reminder": False,
+                    "subscription_revoked": False,
+                    "subscription_trial_conversion_reminder": False,
+                    "subscription_uncanceled": False,
+                    "subscription_updated": False,
+                }
+            },
+        )
+        assert response.status_code == 200
+        email_settings = response.json()["customer_email_settings"]
+        assert all(value is False for value in email_settings.values())
+
+    @pytest.mark.auth
+    async def test_partial_update_subscription_settings(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        first = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"subscription_settings": {"allow_multiple_subscriptions": True}},
+        )
+        assert first.status_code == 200
+        assert (
+            first.json()["subscription_settings"]["allow_multiple_subscriptions"]
+            is True
+        )
+
+        second = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"subscription_settings": {"prevent_trial_abuse": True}},
+        )
+        assert second.status_code == 200
+        subscription_settings = second.json()["subscription_settings"]
+        assert subscription_settings["prevent_trial_abuse"] is True
+        # The field set by the first request is preserved by the second.
+        assert subscription_settings["allow_multiple_subscriptions"] is True
+
+    @pytest.mark.auth
+    async def test_partial_update_customer_portal_settings_deep_merge(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # A nested partial update must deep-merge: changing one key of
+        # `subscription` leaves the sibling keys and the other groups intact.
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "customer_portal_settings": {"subscription": {"update_seats": False}}
+            },
+        )
+        assert response.status_code == 200
+        portal_settings = response.json()["customer_portal_settings"]
+        assert portal_settings["subscription"]["update_seats"] is False
+        assert portal_settings["subscription"]["update_plan"] is True
+        assert portal_settings["usage"]["show"] is True
+
+    @pytest.mark.auth
     async def test_submit_for_review_requires_relevant_fields(
         self,
         client: AsyncClient,


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

`PATCH /v1/organizations/{id}` couldn't partially update the `customer_email_settings`, `subscription_settings`, or `customer_portal_settings` groups: callers had to send each group in full. This makes them behave like `feature_settings` and `dispute_settings`, which already support partial merges.

## What

- Added dedicated partial-update schemas — `OrganizationCustomerEmailSettingsUpdate`, `OrganizationSubscriptionSettingsUpdate`, and `OrganizationCustomerPortalSettingsUpdate` (with nested `CustomerPortalUsageSettingsUpdate` / `CustomerPortalSubscriptionSettingsUpdate` / `CustomerPortalCustomerSettingsUpdate`) — where every field is optional.
- `OrganizationUpdate` now references these `*Update` variants instead of the full model TypedDicts.
- The service merges each group into the organization's current settings instead of replacing it wholesale. `customer_portal_settings` is deep-merged so a nested group (e.g. `subscription`) can be changed without resending its siblings.
- Regenerated the TypeScript client (`clients/packages/client/src/v1.ts`).

## Why

Previously these three groups were typed as their full TypedDicts and written by wholesale assignment. Because those TypedDicts require every key, omitting any nested field returned a `422`, and there was no way to toggle a single flag (e.g. turning off one `customer_email` notification) without re-sending the whole object. `feature_settings` and `dispute_settings` already merge partial input; this brings the remaining settings groups in line.

## How

- Each `*Update` schema mirrors its settings model but with all fields `| None = None`, so a subset validates. `subscription_settings.proration_behavior` keeps its public JSON-schema restriction (`invoice` / `prorate` / `next_period`), so the generated client surface is unchanged.
- In `OrganizationService.update`, each group is merged with `model_dump(mode="json", exclude_unset=True, exclude_none=True)` on top of the stored value, and the two newly-handled groups are excluded from the generic `update_dict` so they aren't re-applied. `customer_email_settings` is merged onto `resolve_default_customer_email_settings(...)` so the stored value stays complete.
- Full-object updates continue to work (a complete payload merges to the same result as before), so this is backwards compatible.

## Testing

- Added endpoint tests for partial `customer_email_settings`, `subscription_settings`, and deep-merged `customer_portal_settings` updates, plus a full-object `customer_email_settings` update.
- Ran `TestUpdateOrganization` (20 passed) and `tests/organization/test_service.py` + `test_schemas.py` (350 passed) against a local Postgres/Redis.
- `ruff check`, `ruff format --check`, and `mypy` pass on the changed files.

> Note: the DB-backed suite was run against a locally-installed Postgres because the sandbox couldn't pull the Docker images; the standard CI infra will re-run the full suite.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jfigrw4Jbz1MHSEMxgLBVY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jfigrw4Jbz1MHSEMxgLBVY)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

