### PR TITLE
tf/athena: Set up log search for sandbox logs

### DIFF
--- a/terraform/organization/sandbox.tf
+++ b/terraform/organization/sandbox.tf
@@ -42,6 +42,16 @@ module "sandbox_application_access" {
   }
 }
 
+module "sandbox_athena_spans" {
+  source = "../modules/athena_spans"
+  providers = {
+    aws = aws.us_east_2
+  }
+
+  environment      = "sandbox"
+  logs_bucket_name = "polar-sandbox-logs"
+}
+
 data "aws_s3_object" "sandbox_image_resizer_package" {
   bucket = aws_s3_bucket.production_lambda_artifacts.id
   key    = "image-resizer/package.zip"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables Athena log search for sandbox by adding `sandbox_athena_spans` targeting `polar-sandbox-logs` in `us-east-2`. Previously sandbox logs were not queryable via Athena; now spans can be queried. No impact on production.

**Rollout and verification**
- Ensure provider alias `aws.us_east_2` is configured in this workspace.
- Verify S3 bucket `polar-sandbox-logs` exists and contains the expected sandbox logs.
- Run Terraform apply; confirm Athena database/tables are created in `us-east-2` and sample queries return results.

<sup>Written for commit 5c5ca61a333221c9b2948d4e7d43f1f31732ebaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

