### PR TITLE
license_keys: remove arbitrary activation limit caps

### DIFF
--- a/server/polar/benefit/strategies/license_keys/schemas.py
+++ b/server/polar/benefit/strategies/license_keys/schemas.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from pydantic import Field, model_validator
 
-from polar.kit.schemas import EmptyStrToNone, Schema
+from polar.kit.schemas import EmptyStrToNone, Int32, Schema
 from polar.models.benefit import BenefitType
 
 from ..base.schemas import (
@@ -35,7 +35,7 @@ class BenefitLicenseKeyExpirationProperties(Schema):
 
 
 class BenefitLicenseKeyActivationCreateProperties(Schema):
-    limit: int = Field(gt=0, le=50)
+    limit: Int32 = Field(gt=0)
     enable_customer_admin: bool
 
 

--- a/server/polar/license_key/schemas.py
+++ b/server/polar/license_key/schemas.py
@@ -183,7 +183,7 @@ class LicenseKeyActivationRead(LicenseKeyActivationBase):
 class LicenseKeyUpdate(Schema):
     status: LicenseKeyStatus | None = None
     usage: Int32 = 0
-    limit_activations: Int32 | None = Field(gt=0, le=1000, default=None)
+    limit_activations: Int32 | None = Field(gt=0, default=None)
     limit_usage: Int32 | None = Field(gt=0, default=None)
     expires_at: datetime | None = None
 


### PR DESCRIPTION
## Summary

Removes two arbitrary upper bounds on license-key activation limits. The Int32 column bound is sufficient protection in both cases.

## What

- `LicenseKeyUpdate.limit_activations`: `Field(gt=0, le=1000)` → `Field(gt=0)`
- `BenefitLicenseKeyActivationCreateProperties.limit`: `int = Field(gt=0, le=50)` → `Int32 = Field(gt=0)`

## Why

The `le=50` on the benefit's activation properties is exactly the **"50 activations limit on a benefit grant"** merchants were reporting — it capped how many activations a merchant could offer when configuring a license-key benefit. That value flows straight into each granted key's `limit_activations` (via `LicenseKeyCreate.build`), which itself was separately capped at `le=1000` on direct updates.

Both values ultimately land in the Int32 `limit_activations` column, so `Int32` is the right, sufficient bound — the smaller caps were arbitrary and only got in merchants' way.

## How

- Dropped `le=1000` from `limit_activations`, leaving it identical to the neighbouring `limit_usage` field (`Int32 | None = Field(gt=0, default=None)`).
- Changed the benefit `limit` from a bare `int` to `Int32` while dropping `le=50`, so it's explicitly bounded to the same Int32 range as the column it feeds.

No generated-client change: `openapi-typescript` doesn't encode numeric `maximum`/`minimum` bounds in `clients/packages/client/src/v1.ts`, so it stays byte-identical (verified) and the OpenAPI regeneration check passes.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests — no new behaviour; this only widens existing validation bounds
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`) — couldn't run in this environment; `py_compile` passes on both files
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwLRYwzezcHZ5LKiJ88ukH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwLRYwzezcHZ5LKiJ88ukH)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

