### PR TITLE
feat(products): gate separate meter cycling behind feature flag

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27655,6 +27655,12 @@ export interface components {
        */
       off_session_charges_enabled: boolean
       /**
+       * Meter Cycling Enabled
+       * @description If this organization can set a separate meter cycle on recurring products (a meter interval independent of the billing interval).
+       * @default false
+       */
+      meter_cycling_enabled: boolean
+      /**
        * Slack Benefit Enabled
        * @description Enables the slack shared channel benefit
        * @default false

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -2163,6 +2163,12 @@ export interface components {
        */
       off_session_charges_enabled: boolean
       /**
+       * Meter Cycling Enabled
+       * @description If this organization can set a separate meter cycle on recurring products (a meter interval independent of the billing interval).
+       * @default false
+       */
+      meter_cycling_enabled: boolean
+      /**
        * Slack Benefit Enabled
        * @description Enables the slack shared channel benefit
        * @default false

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -200,6 +200,13 @@ class OrganizationFeatureSettings(Schema):
             "(off-session charges against a saved payment method)."
         ),
     )
+    meter_cycling_enabled: bool = Field(
+        False,
+        description=(
+            "If this organization can set a separate meter cycle on recurring "
+            "products (a meter interval independent of the billing interval)."
+        ),
+    )
     slack_benefit_enabled: bool = Field(
         False, description="Enables the slack shared channel benefit"
     )

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -198,6 +198,19 @@ class ProductService:
         )
         errors.extend(prices_errors)
 
+        meter_interval = getattr(create_schema, "meter_interval", None)
+        if meter_interval is not None and not organization.feature_settings.get(
+            "meter_cycling_enabled", False
+        ):
+            errors.append(
+                {
+                    "type": "value_error",
+                    "loc": ("body", "meter_interval"),
+                    "msg": "Separate meter cycling is not enabled for this organization.",
+                    "input": meter_interval,
+                }
+            )
+
         product = await repository.create(
             Product(
                 organization=organization,

--- a/server/tests/product/test_service.py
+++ b/server/tests/product/test_service.py
@@ -1190,6 +1190,85 @@ def _seat_price_create(
 
 
 @pytest.mark.asyncio
+class TestCreateMeterCycling:
+    """The separate meter cycle is gated behind ``meter_cycling_enabled``."""
+
+    @pytest_asyncio.fixture
+    async def meter_cycling_enabled(
+        self, session: AsyncSession, organization: Organization
+    ) -> None:
+        organization.feature_settings = {"meter_cycling_enabled": True}
+        session.add(organization)
+        await session.flush()
+
+    @pytest.mark.auth
+    async def test_meter_interval_rejected_without_flag(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await product_service.create(
+                session,
+                ProductCreateRecurring(
+                    name="Product",
+                    recurring_interval=SubscriptionRecurringInterval.year,
+                    recurring_interval_count=1,
+                    meter_interval=SubscriptionRecurringInterval.month,
+                    prices=[_fixed_price_create()],
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_no_meter_interval_allowed_without_flag(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        product = await product_service.create(
+            session,
+            ProductCreateRecurring(
+                name="Product",
+                recurring_interval=SubscriptionRecurringInterval.month,
+                prices=[_fixed_price_create()],
+                organization_id=organization.id,
+            ),
+            auth_subject,
+        )
+        assert product.meter_interval is None
+
+    @pytest.mark.auth
+    async def test_meter_interval_allowed_with_flag(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        meter_cycling_enabled: None,
+    ) -> None:
+        product = await product_service.create(
+            session,
+            ProductCreateRecurring(
+                name="Product",
+                recurring_interval=SubscriptionRecurringInterval.year,
+                recurring_interval_count=1,
+                meter_interval=SubscriptionRecurringInterval.month,
+                prices=[_fixed_price_create()],
+                organization_id=organization.id,
+            ),
+            auth_subject,
+        )
+        assert product.meter_interval == SubscriptionRecurringInterval.month
+        assert product.meter_interval_count == 1
+
+
+@pytest.mark.asyncio
 class TestCreateFixedSeatComposition:
     """Validation for composing a fixed price with a seat-based price."""
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Gate separate meter cycling on recurring products behind an organization feature flag. Previously the API accepted `meter_interval` on create for all orgs; now it accepts it only when `organization.feature_settings.meter_cycling_enabled` is true, otherwise it returns a request validation error.

- Add `meter_cycling_enabled` to `OrganizationFeatureSettings` (default false) and regenerate the `v1` API client and emails OpenAPI types to expose it.
- Validate on product creation: if `meter_interval` is provided without the flag, return a `value_error` at ("body", "meter_interval") with message "Separate meter cycling is not enabled for this organization." Tests cover rejection without the flag, creating without `meter_interval`, and acceptance with the flag.

**Rollout**
- Enable per organization via `organization.feature_settings.meter_cycling_enabled = true`.
- API clients must only send `meter_interval` when the flag is enabled; otherwise omit it.

<sup>Written for commit 41d098e855484373e7825b5815664d1d99767ed8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

