### PR TITLE
tinybird: Use server-side bound parameters for ClickHouse queries

### DIFF
--- a/server/polar/integrations/tinybird/service.py
+++ b/server/polar/integrations/tinybird/service.py
@@ -11,6 +11,7 @@ import logfire
 import sqlalchemy
 import structlog
 from clickhouse_connect.cc_sqlalchemy.dialect import ClickHouseDialect
+from clickhouse_connect.cc_sqlalchemy.sql.compiler import ChStatementCompiler
 from sqlalchemy import (
     Column,
     ColumnClause,
@@ -44,7 +45,56 @@ from .schemas import TinybirdEvent
 
 log: Logger = structlog.get_logger()
 
-clickhouse_dialect = ClickHouseDialect()
+
+def _ch_bind_type(type_: Any) -> str:
+    if isinstance(type_, DateTime):
+        return "DateTime64(3)"
+    if isinstance(type_, Float):
+        return "Float64"
+    if isinstance(type_, sqlalchemy.Integer):
+        return "Int64"
+    return "String"
+
+
+class _ChBindCompiler(ChStatementCompiler):
+    """Render values as ClickHouse bound parameters (``{name:Type}``), never inlined."""
+
+    _expanding_ch_type: str = "String"
+
+    @property
+    def bindtemplate(self) -> str:
+        return f"{{%(name)s:{self._expanding_ch_type}}}"
+
+    @bindtemplate.setter
+    def bindtemplate(self, value: str) -> None:
+        pass
+
+    def bindparam_string(  # type: ignore[override]
+        self, name: str, post_compile: bool = False, expanding: bool = False, **kw: Any
+    ) -> str:
+        if expanding:
+            return super().bindparam_string(
+                name, post_compile=post_compile, expanding=expanding, **kw
+            )
+        bind = self.binds.get(name)
+        ch_type = _ch_bind_type(bind.type) if bind is not None else "String"
+        return f"{{{name}:{ch_type}}}"
+
+    def _literal_execute_expanding_parameter(
+        self, name: str, parameter: Any, values: Any
+    ) -> Any:
+        self._expanding_ch_type = _ch_bind_type(parameter.type)
+        try:
+            return super()._literal_execute_expanding_parameter(name, parameter, values)
+        finally:
+            self._expanding_ch_type = "String"
+
+
+class _ClickHouseDialect(ClickHouseDialect):
+    statement_compiler = _ChBindCompiler
+
+
+clickhouse_dialect = _ClickHouseDialect()
 
 
 def _contains(column: Any, value: str) -> ColumnElement[bool]:
@@ -415,8 +465,8 @@ async def get_first_user_event_at(
 
     timestamps: list[datetime] = []
     for statement in statements:
-        sql, template = _compile(statement)
-        rows = await client.query(sql, db_statement=template)
+        sql, params = _compile(statement)
+        rows = await client.query(sql, parameters=params, db_statement=sql)
         timestamps.extend(
             _parse_datetime(value)
             for row in rows
@@ -435,15 +485,11 @@ def _finite(value: Any, default: float = 0.0) -> float:
     return result if math.isfinite(result) else default
 
 
-def _compile(statement: Select[Any]) -> tuple[str, str]:
-    compiled = statement.compile(dialect=clickhouse_dialect)
-    template = str(compiled)
-    literal = str(
-        statement.compile(
-            dialect=clickhouse_dialect, compile_kwargs={"literal_binds": True}
-        )
+def _compile(statement: Select[Any]) -> tuple[str, dict[str, Any]]:
+    compiled = statement.compile(
+        dialect=clickhouse_dialect, compile_kwargs={"render_postcompile": True}
     )
-    return literal, template
+    return str(compiled), dict(compiled.params)
 
 
 def _parse_datetime(value: datetime | date | str) -> datetime:
@@ -758,10 +804,10 @@ class TinybirdEventsQuery:
         else:
             statement = statement.order_by(func.max(events_table.c.timestamp).desc())
 
-        sql, template = _compile(statement)
+        sql, params = _compile(statement)
 
         try:
-            rows = await client.query(sql, db_statement=template)
+            rows = await client.query(sql, parameters=params, db_statement=sql)
             return _parse_event_type_stats(rows)
         except Exception as e:
             log.error("tinybird.get_event_type_stats.failed", error=str(e))
@@ -795,13 +841,17 @@ class TinybirdEventsQuery:
         for f in self._filters:
             ids_statement = ids_statement.where(f)
 
-        count_sql, count_template = _compile(count_statement)
-        ids_sql, ids_template = _compile(ids_statement)
+        count_sql, count_params = _compile(count_statement)
+        ids_sql, ids_params = _compile(ids_statement)
 
-        count_rows = await client.query(count_sql, db_statement=count_template)
+        count_rows = await client.query(
+            count_sql, parameters=count_params, db_statement=count_sql
+        )
         total = count_rows[0]["total"] if count_rows else 0
 
-        id_rows = await client.query(ids_sql, db_statement=ids_template)
+        id_rows = await client.query(
+            ids_sql, parameters=ids_params, db_statement=ids_sql
+        )
         event_ids = [str(row["id"]) for row in id_rows]
 
         return event_ids, total
@@ -823,11 +873,15 @@ class TinybirdEventsQuery:
             customer_statement = customer_statement.where(f)
             external_statement = external_statement.where(f)
 
-        customer_sql, customer_template = _compile(customer_statement)
-        external_sql, external_template = _compile(external_statement)
+        customer_sql, customer_params = _compile(customer_statement)
+        external_sql, external_params = _compile(external_statement)
 
-        customer_rows = await client.query(customer_sql, db_statement=customer_template)
-        external_rows = await client.query(external_sql, db_statement=external_template)
+        customer_rows = await client.query(
+            customer_sql, parameters=customer_params, db_statement=customer_sql
+        )
+        external_rows = await client.query(
+            external_sql, parameters=external_params, db_statement=external_sql
+        )
 
         return (
             [str(row["customer_id"]) for row in customer_rows],
@@ -852,7 +906,7 @@ class TinybirdEventsQuery:
             label = field_path.replace(".", "_")
             ae_col = self._get_agg_col_for_table(ae, field_path)
             agg_columns.append(
-                func.coalesce(func.sum(ae_col), 0).label(f"{label}_total")
+                func.coalesce(func.sum(ae_col), 0.0).label(f"{label}_total")
             )
 
         org_filter_values = self._organization_ids
@@ -980,8 +1034,8 @@ class TinybirdEventsQuery:
             .order_by(bucket, per_root.c.organization_id, per_root.c.root_name)
         )
 
-        sql, template = _compile(statement)
-        rows = await client.query(sql, db_statement=template)
+        sql, params = _compile(statement)
+        rows = await client.query(sql, parameters=params, db_statement=sql)
 
         results = []
         for row in rows:
@@ -1024,8 +1078,8 @@ class TinybirdEventsQuery:
             .group_by(per_root.c.organization_id, per_root.c.root_name)
         )
 
-        sql, template = _compile(statement)
-        rows = await client.query(sql, db_statement=template)
+        sql, params = _compile(statement)
+        rows = await client.query(sql, parameters=params, db_statement=sql)
 
         results = []
         for row in rows:
@@ -1071,8 +1125,8 @@ class TinybirdEventsQuery:
         for f in self._filters:
             statement = statement.where(f)
 
-        sql, template = _compile(statement)
-        rows = await client.query(sql, db_statement=template)
+        sql, params = _compile(statement)
+        rows = await client.query(sql, parameters=params, db_statement=sql)
 
         if not rows:
             return 0, {f.replace(".", "_"): 0.0 for f in aggregate_fields}
@@ -1123,8 +1177,8 @@ class TinybirdEventsQuery:
             statement = statement.where(f)
         statement = statement.group_by(literal_column("matched_ancestor"))
 
-        sql, template = _compile(statement)
-        rows = await client.query(sql, db_statement=template)
+        sql, params = _compile(statement)
+        rows = await client.query(sql, parameters=params, db_statement=sql)
 
         result: dict[str, tuple[int, dict[str, float]]] = {}
         for row in rows:
@@ -1193,8 +1247,8 @@ class TinybirdEventsQuery:
 
         statement = statement.limit(limit)
 
-        sql, template = _compile(statement)
-        rows = await client.query(sql, db_statement=template)
+        sql, params = _compile(statement)
+        rows = await client.query(sql, parameters=params, db_statement=sql)
 
         results = []
         for row in rows:
@@ -1253,8 +1307,8 @@ class TinybirdEventsQuery:
             sqlalchemy.select(customer_sums, share_col).order_by(order_col).limit(limit)
         )
 
-        sql, template = _compile(statement)
-        rows = await client.query(sql, db_statement=template)
+        sql, params = _compile(statement)
+        rows = await client.query(sql, parameters=params, db_statement=sql)
 
         results = []
         for row in rows:
@@ -1343,8 +1397,8 @@ class TinybirdEventsQuery:
             .limit(limit)
         )
 
-        sql, template = _compile(statement)
-        rows = await client.query(sql, db_statement=template)
+        sql, params = _compile(statement)
+        rows = await client.query(sql, parameters=params, db_statement=sql)
 
         results = []
         for row in rows:

--- a/server/scripts/backfill_customer_first_user_event_at.py
+++ b/server/scripts/backfill_customer_first_user_event_at.py
@@ -90,8 +90,8 @@ async def organization_ids_with_user_events() -> set[UUID]:
             .where(table.c.source == EventSource.user)
             .group_by(table.c.organization_id)
         )
-        sql, template = _compile(statement)
-        rows = await tinybird_client.query(sql, db_statement=template)
+        sql, params = _compile(statement)
+        rows = await tinybird_client.query(sql, parameters=params, db_statement=sql)
         organization_ids.update(_parse_uuid(row["organization_id"]) for row in rows)
 
     return organization_ids
@@ -126,8 +126,8 @@ async def _pages_by_key(
             .order_by(key_column)
             .limit(PAGE_SIZE)
         )
-        sql, template = _compile(statement)
-        rows = await tinybird_client.query(sql, db_statement=template)
+        sql, params = _compile(statement)
+        rows = await tinybird_client.query(sql, parameters=params, db_statement=sql)
 
         if not rows:
             break

--- a/server/tests/integrations/tinybird/test_service.py
+++ b/server/tests/integrations/tinybird/test_service.py
@@ -7,6 +7,7 @@ from typing import Any
 import httpx
 import pytest
 import respx
+from sqlalchemy import select
 
 from polar.integrations.tinybird.client import (
     MAX_RETRIES,
@@ -18,12 +19,18 @@ from polar.integrations.tinybird.service import (
     DATASOURCE_EVENTS,
     TinybirdEventsQuery,
     TinybirdEventTypesQuery,
+    _compile,
     _event_to_tinybird,
     clickhouse_dialect,
     count_user_events_by_organization,
     events_table,
 )
-from polar.meter.filter import FilterClause, FilterOperator
+from polar.meter.filter import (
+    Filter,
+    FilterClause,
+    FilterConjunction,
+    FilterOperator,
+)
 from polar.models import Event
 from polar.models.event import EventSource
 from tests.fixtures.tinybird import tinybird_available
@@ -136,67 +143,123 @@ class TestEventToTinybird:
         assert result["amount"] is None
 
 
-def compile_clause(clause: Any) -> str:
-    return str(
-        clause.compile(
-            dialect=clickhouse_dialect, compile_kwargs={"literal_binds": True}
-        )
+def compile_clause(clause: Any) -> tuple[str, dict[str, Any]]:
+    compiled = clause.compile(
+        dialect=clickhouse_dialect, compile_kwargs={"render_postcompile": True}
     )
+    return str(compiled), dict(compiled.params)
 
 
 class TestQueryWildcardsAreLiteral:
     def test_filter_name_query(self) -> None:
         query = TinybirdEventsQuery([uuid.uuid4()]).filter_name_query("ai_gen%")
-        compiled = compile_clause(query._filters[-1])
-        assert (
-            compiled
-            == "positionCaseInsensitiveUTF8(`events_by_timestamp`.`name`, 'ai_gen%') > 0"
-        )
+        sql, params = compile_clause(query._filters[-1])
+        assert "positionCaseInsensitiveUTF8(`events_by_timestamp`.`name`," in sql
+        assert "like" not in sql.lower()
+        assert "ai_gen%" in params.values()
 
     def test_filter_by_query(self) -> None:
         query = TinybirdEventsQuery([uuid.uuid4()]).filter_by_query("100%_x")
-        compiled = compile_clause(query._filters[-1])
+        sql, params = compile_clause(query._filters[-1])
         for column in ("name", "source", "user_metadata"):
             assert (
-                f"positionCaseInsensitiveUTF8(`events_by_timestamp`.`{column}`, '100%_x') > 0"
-                in compiled
+                f"positionCaseInsensitiveUTF8(`events_by_timestamp`.`{column}`," in sql
             )
+        assert list(params.values()).count("100%_x") == 3
 
     def test_like_operator(self) -> None:
         clause = FilterClause(
             property="name", operator=FilterOperator.like, value="api_test"
         )
-        compiled = compile_clause(
+        sql, params = compile_clause(
             TinybirdEventsQuery._ch_comparison(events_table.c.name, clause)
         )
-        assert (
-            compiled
-            == "position(toString(`events_by_timestamp`.`name`), 'api_test') > 0"
-        )
+        assert "position(toString(`events_by_timestamp`.`name`)," in sql
+        assert "api_test" in params.values()
 
     def test_not_like_operator(self) -> None:
         clause = FilterClause(
             property="name", operator=FilterOperator.not_like, value="api_test"
         )
-        compiled = compile_clause(
+        sql, params = compile_clause(
             TinybirdEventsQuery._ch_comparison(events_table.c.name, clause)
         )
-        assert (
-            compiled
-            == "position(toString(`events_by_timestamp`.`name`), 'api_test') <= 0"
-        )
+        assert "position(toString(`events_by_timestamp`.`name`)," in sql
+        assert "<= " in sql
+        assert "api_test" in params.values()
 
     def test_like_operator_numeric_column(self) -> None:
         clause = FilterClause(
             property="_cost.amount", operator=FilterOperator.like, value=10
         )
-        compiled = compile_clause(
+        sql, params = compile_clause(
             TinybirdEventsQuery._ch_comparison(events_table.c.cost_amount, clause)
         )
-        assert (
-            compiled
-            == "position(toString(`events_by_timestamp`.`cost_amount`), '10') > 0"
+        assert "position(toString(`events_by_timestamp`.`cost_amount`)," in sql
+        assert "10" in params.values()
+
+
+class TestQueryBindsValuesInsteadOfInlining:
+    def _compile_filters(
+        self, query: TinybirdEventsQuery
+    ) -> tuple[str, dict[str, Any]]:
+        statement = select(events_table.c.name).where(query._get_organization_filter())
+        for f in query._filters:
+            statement = statement.where(f)
+        return _compile(statement)
+
+    def test_injection_payloads_never_reach_the_sql_string(self) -> None:
+        query = TinybirdEventsQuery([uuid.uuid4()])
+        query.filter_name_query("aaa\\")
+        query.filter_customer(external_customer_ids=["e\\", "e2"])
+        query.filter_by_query("uniontest")
+        query.filter_by_filter(
+            Filter(
+                conjunction=FilterConjunction.and_,
+                clauses=[
+                    FilterClause(
+                        property="name",
+                        operator=FilterOperator.eq,
+                        value="') UNION SELECT customer_email FROM events --",
+                    )
+                ],
+            )
         )
+        sql, params = self._compile_filters(query)
+
+        for injected in (
+            "UNION SELECT",
+            "customer_email",
+            "--",
+            "e\\",
+            "aaa\\",
+        ):
+            assert injected not in sql
+        assert "') UNION SELECT customer_email FROM events --" in params.values()
+
+    def test_value_is_a_typed_placeholder(self) -> None:
+        query = TinybirdEventsQuery([uuid.uuid4()]).filter_by_filter(
+            Filter(
+                conjunction=FilterConjunction.and_,
+                clauses=[
+                    FilterClause(
+                        property="name", operator=FilterOperator.eq, value="O'Brien"
+                    )
+                ],
+            )
+        )
+        sql, params = self._compile_filters(query)
+        assert "{name_1:String}" in sql
+        assert "O'Brien" in params.values()
+
+    def test_in_list_placeholders_are_typed_by_column(self) -> None:
+        statement = select(events_table.c.name).where(
+            events_table.c.organization_id.in_(["a", "b"]),
+            events_table.c.cost_amount.in_([1.5, 2.5]),
+        )
+        sql, _ = _compile(statement)
+        assert "{organization_id_1_1:String}" in sql
+        assert "{cost_amount_1_1:Float64}" in sql
 
 
 @pytest.mark.skipif(not tinybird_available(), reason="Tinybird not running")
@@ -394,6 +457,133 @@ class TestTinybirdEventsQuery:
             stats_by_key[(org_2, "shared.event", EventSource.system)].occurrences == 1
         )
         assert stats_by_key[(org_2, "org2.only", EventSource.user)].occurrences == 1
+
+    async def test_statistics_methods_execute_with_bound_params(
+        self, tinybird_client: TinybirdClient
+    ) -> None:
+        org_id = uuid.uuid4()
+        customer_id = uuid.uuid4()
+        events = []
+        for i in range(4):
+            event = create_test_event(
+                organization_id=org_id,
+                name="llm.request",
+                source=EventSource.user,
+                user_metadata={
+                    "_cost": {"amount": float(i + 1), "currency": "usd"},
+                    "_llm": {"model": "gpt-4", "vendor": "openai"},
+                },
+            )
+            event.customer_id = customer_id
+            events.append(event)
+
+        tinybird_events = [_event_to_tinybird(e) for e in events]
+        await tinybird_client.ingest(DATASOURCE_EVENTS, tinybird_events, wait=True)
+
+        property_stats = await TinybirdEventsQuery([org_id]).get_property_group_stats(
+            "_llm.model", ["_cost.amount"]
+        )
+        timeseries = await TinybirdEventsQuery([org_id]).get_timeseries_stats(
+            "day", "UTC", ["_cost.amount"]
+        )
+        customer_stats = await TinybirdEventsQuery([org_id]).get_customer_stats(
+            ["_cost.amount"]
+        )
+        variance = await TinybirdEventsQuery([org_id]).get_variance_events(
+            ["_cost.amount"]
+        )
+
+        assert property_stats[0].value == "gpt-4"
+        assert property_stats[0].occurrences == 4
+        assert property_stats[0].totals["_cost_amount"] == 10.0
+        assert timeseries[0].occurrences == 4
+        assert timeseries[0].customers == 1
+        assert customer_stats[0].occurrences == 4
+        assert len(variance) >= 1
+
+
+@pytest.mark.skipif(not tinybird_available(), reason="Tinybird not running")
+@pytest.mark.asyncio
+class TestSearchBehaviorAndInjectionSafety:
+    async def _ingest(self, tinybird_client: TinybirdClient, org_id: uuid.UUID) -> None:
+        events = [
+            create_test_event(
+                organization_id=org_id,
+                name="checkout.completed",
+                source=EventSource.user,
+            ),
+            create_test_event(
+                organization_id=org_id, name="checkout.failed", source=EventSource.user
+            ),
+            create_test_event(
+                organization_id=org_id, name="login.success", source=EventSource.system
+            ),
+            create_test_event(
+                organization_id=org_id, name="weird'na\\me", source=EventSource.system
+            ),
+        ]
+        await tinybird_client.ingest(
+            DATASOURCE_EVENTS, [_event_to_tinybird(e) for e in events], wait=True
+        )
+
+    async def test_searches_return_correct_results(
+        self, tinybird_client: TinybirdClient
+    ) -> None:
+        org_id = uuid.uuid4()
+        await self._ingest(tinybird_client, org_id)
+
+        async def count(query: TinybirdEventsQuery) -> int:
+            _, total = await query.get_event_ids_and_count(100, 0)
+            return total
+
+        assert await count(TinybirdEventsQuery([org_id])) == 4
+        assert (
+            await count(TinybirdEventsQuery([org_id]).filter_name_query("checkout"))
+            == 2
+        )
+        assert (
+            await count(TinybirdEventsQuery([org_id]).filter_name_query("CHECKOUT"))
+            == 2
+        )
+        assert (
+            await count(TinybirdEventsQuery([org_id]).filter_source(EventSource.system))
+            == 2
+        )
+        assert (
+            await count(TinybirdEventsQuery([org_id]).filter_name_query("d'na\\m")) == 1
+        )
+
+    async def test_wildcards_are_literal_not_operators(
+        self, tinybird_client: TinybirdClient
+    ) -> None:
+        org_id = uuid.uuid4()
+        await self._ingest(tinybird_client, org_id)
+        _, total = await (
+            TinybirdEventsQuery([org_id])
+            .filter_name_query("check%")
+            .get_event_ids_and_count(100, 0)
+        )
+        assert total == 0
+
+    async def test_injection_payloads_are_inert(
+        self, tinybird_client: TinybirdClient
+    ) -> None:
+        org_id = uuid.uuid4()
+        await self._ingest(tinybird_client, org_id)
+
+        _, breakout_total = await (
+            TinybirdEventsQuery([org_id])
+            .filter_name_query("' OR 1=1 -- ")
+            .get_event_ids_and_count(100, 0)
+        )
+        assert breakout_total == 0
+
+        _, throwif_total = await (
+            TinybirdEventsQuery([org_id])
+            .filter_name_query("z' OR throwIf(1=1) -- ")
+            .get_event_ids_and_count(100, 0)
+        )
+        assert throwif_total == 0
 
 
 @pytest.mark.skipif(not tinybird_available(), reason="Tinybird not running")

--- a/server/tests/scripts/test_backfill_customer_first_user_event_at.py
+++ b/server/tests/scripts/test_backfill_customer_first_user_event_at.py
@@ -169,10 +169,9 @@ class TestPagesByKey:
         assert [len(page) for page in pages] == [2, 1]
         # The second page resumes after the last key of the first, cast so
         # ClickHouse compares UUIDs rather than a UUID against a string.
-        assert (
-            f"customer_id` > toUUID('{customer_ids[1]}')"
-            in query_mock.await_args_list[1].args[0]
-        )
+        second_call = query_mock.await_args_list[1]
+        assert "`customer_id` > toUUID(" in second_call.args[0]
+        assert str(customer_ids[1]) in second_call.kwargs["parameters"].values()
 
     async def test_pages_the_external_customer_id_view(
         self, mocker: MockerFixture
@@ -202,11 +201,11 @@ class TestPagesByKey:
         ]
 
         assert [len(page) for page in pages] == [2, 1]
-        # This view keys on a String, so the cursor is a plain literal rather than
-        # the toUUID() cast the customer id view needs.
-        assert (
-            "external_customer_id` > 'EXT_2'" in query_mock.await_args_list[1].args[0]
-        )
+        # This view keys on a String, so the cursor is bound directly rather than
+        # wrapped in the toUUID() cast the customer id view needs.
+        second_call = query_mock.await_args_list[1]
+        assert "`external_customer_id` > {" in second_call.args[0]
+        assert "EXT_2" in second_call.kwargs["parameters"].values()
 
     async def test_no_rows(self, mocker: MockerFixture) -> None:
         mocker.patch(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Send ClickHouse queries to Tinybird with server-side bound parameters instead of inlined literals. This prevents injection, treats wildcard characters literally in search, and ensures correct typing for all values.

- Introduces a custom `_ClickHouseDialect` with `_ChBindCompiler` to render `{name:Type}` placeholders (String, Int64, Float64, DateTime64(3)) and type-aware expanding params.
- `_compile` now returns `(sql, params)` and uses `render_postcompile`; callers pass `parameters=params` and `db_statement=sql` to `TinybirdClient.query`.
- Updates all Tinybird query call sites and the backfill script to use bound params; sets float aggregates’ defaults to `0.0` to avoid int/float mixing.
- Adds tests ensuring values are never inlined in SQL, injection payloads are inert, wildcards (%) and (_) are treated as literals in search, and bound parameters execute across statistics methods.

**Migration**
- If you call `_compile` elsewhere, update usage to accept `(sql, params)` and pass `parameters=params` to `TinybirdClient.query`.

<sup>Written for commit 2879b8c87169526a12af4596b458c96206dfb715. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

