### PR TITLE
aws/ecs: Roll out pgbouncer in test env

### DIFF
--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -75,10 +75,10 @@ locals {
     POLAR_LOG_LEVEL                   = "INFO"
     POLAR_TESTING                     = "0"
     POLAR_POSTGRES_DATABASE           = local.db_name
-    POLAR_POSTGRES_HOST               = local.db_external_host
-    POLAR_POSTGRES_PORT               = local.db_port
+    POLAR_POSTGRES_HOST               = module.pgbouncer_aws[0].host
+    POLAR_POSTGRES_PORT               = module.pgbouncer_aws[0].port
     POLAR_POSTGRES_USER               = local.db_user
-    POLAR_POSTGRES_SSL                = "true"
+    POLAR_POSTGRES_SSL                = "false"
     POLAR_REDIS_HOST                  = module.redis[0].host
     POLAR_REDIS_PORT                  = tostring(module.redis[0].port)
     POLAR_REDIS_DB                    = "1"

--- a/terraform/test/ecs.tf
+++ b/terraform/test/ecs.tf
@@ -3,3 +3,50 @@ module "ecs_cluster" {
 
   environment = "test"
 }
+
+# =============================================================================
+# PgBouncer for the Lambda worker
+# =============================================================================
+
+resource "aws_service_discovery_private_dns_namespace" "internal" {
+  count = local.test_enabled ? 1 : 0
+  name  = "polar-test.internal"
+  vpc   = module.vpc[0].vpc_id
+}
+
+resource "aws_secretsmanager_secret" "ghcr_pull" {
+  count = local.test_enabled ? 1 : 0
+  name  = "polar-test-ghcr-pull"
+}
+
+resource "aws_secretsmanager_secret_version" "ghcr_pull" {
+  count         = local.test_enabled ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.ghcr_pull[0].id
+  secret_string = jsonencode({ username = var.ghcr_username, password = var.ghcr_auth_token })
+}
+
+module "pgbouncer_aws" {
+  count  = local.test_enabled ? 1 : 0
+  source = "../modules/services/pgbouncer"
+
+  environment = "test"
+  vpc_id      = module.vpc[0].vpc_id
+  subnet_ids  = module.vpc[0].secondary_private_subnet_ids
+  cluster_arn = module.ecs_cluster.cluster_arn
+
+  namespace = {
+    id   = aws_service_discovery_private_dns_namespace.internal[0].id
+    name = aws_service_discovery_private_dns_namespace.internal[0].name
+  }
+
+  client_security_group_ids  = [aws_security_group.lambda[0].id]
+  permissions_boundary_arn   = data.aws_iam_policy.permission_boundary.arn
+  repository_credentials_arn = aws_secretsmanager_secret_version.ghcr_pull[0].arn
+
+  database = {
+    host     = local.db_external_host
+    port     = local.db_port
+    user     = local.db_user
+    password = local.db_password
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Routes test Lambda database connections through PgBouncer on ECS to enable pooling and reduce RDS connection churn. Previously the Lambda connected directly to RDS with SSL; now it connects to a PgBouncer endpoint via Cloud Map with SSL disabled on the app-to-PgBouncer hop.

- Deploys a private DNS namespace (polar-test.internal) and a `pgbouncer` ECS service; wires its host/port into `POLAR_POSTGRES_HOST`/`POLAR_POSTGRES_PORT`.
- Sets `POLAR_POSTGRES_SSL` to false for the Lambda; confirm this meets test env encryption requirements.
- Required: Provide `ghcr_username` and `ghcr_auth_token` in the test workspace so Terraform can populate the `polar-test-ghcr-pull` secret for image pulls.

<sup>Written for commit 2799c01ee27abf8e7594b7d5147ca6f7eb78db38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

