### PR TITLE
aws/ecs: Enable pgbouncer in production

### DIFF
--- a/terraform/production/ecs.tf
+++ b/terraform/production/ecs.tf
@@ -3,3 +3,46 @@ module "ecs_cluster" {
 
   environment = "production"
 }
+
+# =============================================================================
+# PgBouncer for the Lambda worker
+# =============================================================================
+
+resource "aws_service_discovery_private_dns_namespace" "internal" {
+  name = "polar-production.internal"
+  vpc  = module.vpc.vpc_id
+}
+
+resource "aws_secretsmanager_secret" "ghcr_pull" {
+  name = "polar-production-ghcr-pull"
+}
+
+resource "aws_secretsmanager_secret_version" "ghcr_pull" {
+  secret_id     = aws_secretsmanager_secret.ghcr_pull.id
+  secret_string = jsonencode({ username = var.ghcr_username, password = var.ghcr_auth_token })
+}
+
+module "pgbouncer_aws" {
+  source = "../modules/services/pgbouncer"
+
+  environment = "production"
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.private_subnet_ids
+  cluster_arn = module.ecs_cluster.cluster_arn
+
+  namespace = {
+    id   = aws_service_discovery_private_dns_namespace.internal.id
+    name = aws_service_discovery_private_dns_namespace.internal.name
+  }
+
+  client_security_group_ids  = [aws_security_group.lambda.id]
+  permissions_boundary_arn   = data.aws_iam_policy.permission_boundary.arn
+  repository_credentials_arn = aws_secretsmanager_secret_version.ghcr_pull.arn
+
+  database = {
+    host     = local.db_external_host
+    port     = local.db_port
+    user     = local.db_user
+    password = local.db_password
+  }
+}


### PR DESCRIPTION
Not used by anything yet. Mirrors setup in sandbox

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

