### PR TITLE
pgbouncer: Send SNI on server connections so Render accepts them

### DIFF
--- a/infra/pgbouncer/entrypoint.sh
+++ b/infra/pgbouncer/entrypoint.sh
@@ -30,6 +30,7 @@ reserve_pool_size = ${RESERVE_POOL_SIZE:-0}
 reserve_pool_timeout = ${RESERVE_POOL_TIMEOUT:-5}
 max_prepared_statements = ${MAX_PREPARED_STATEMENTS:-200}
 server_tls_sslmode = ${SERVER_TLS_SSLMODE:-prefer}
+server_tls_ca_file = ${SERVER_TLS_CA_FILE:-/etc/ssl/certs/ca-certificates.crt}
 ignore_startup_parameters = ${IGNORE_STARTUP_PARAMETERS:-extra_float_digits,statement_timeout}
 EOF
 

--- a/terraform/modules/services/pgbouncer/main.tf
+++ b/terraform/modules/services/pgbouncer/main.tf
@@ -74,7 +74,7 @@ module "service" {
     DB_HOST            = var.database.host
     DB_PORT            = var.database.port
     DB_USER            = var.database.user
-    SERVER_TLS_SSLMODE = "require"
+    SERVER_TLS_SSLMODE = "verify-full"
   }
 
   secrets = {


### PR DESCRIPTION
We need to set verify-full TLS SSLMODE in pgbouncer, otherwise Render rejects us because we're not sending SNI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

