### PR TITLE
fix: create token after forced session refresh

### DIFF
--- a/clients/apps/web/src/components/Finance/Account/ChecklistRow.tsx
+++ b/clients/apps/web/src/components/Finance/Account/ChecklistRow.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { LoadingBox } from '@/components/Shared/LoadingBox'
+import { ORGANIZATION_ACCESS_TOKEN_RESUME_PARAM } from '@/components/Settings/organizationAccessTokenContinuation'
 import { useAccountSetup } from '@/providers/accountSetup'
 import { OrganizationContext } from '@/providers/maintainerOrganization'
 import { schemas } from '@polar-sh/client'
@@ -8,6 +9,7 @@ import { Pill, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { Button } from '@polar-sh/orbit'
 import { AnimatePresence, motion } from 'motion/react'
+import { useSearchParams } from 'next/navigation'
 import { useContext, useEffect, useState } from 'react'
 import { StatusIcon } from './StatusIcon'
 import { COMMON_REASON_LABELS, STEP_CONFIG } from './sections'
@@ -42,7 +44,11 @@ const collapsedActionLabel = (
 export const ChecklistRow = ({ step, isLoading }: Props) => {
   const { organization } = useContext(OrganizationContext)
   const { targetStepKey, setTargetStepKey } = useAccountSetup()
-  const [isExpanded, setIsExpanded] = useState(false)
+  const searchParams = useSearchParams()
+  const isTokenCreationResume =
+    step?.key === 'setup_readiness' &&
+    searchParams.has(ORGANIZATION_ACCESS_TOKEN_RESUME_PARAM)
+  const [isExpanded, setIsExpanded] = useState(isTokenCreationResume)
   const [isDeepLinkTarget] = useState(
     () => targetStepKey != null && step?.key === targetStepKey,
   )

--- a/clients/apps/web/src/components/Finance/Account/sections/SetupReadinessSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/SetupReadinessSection.tsx
@@ -3,6 +3,7 @@
 import { CheckoutLinkManagementModal } from '@/components/CheckoutLinks/CheckoutLinkManagementModal'
 import { useModal } from '@/components/Modal/useModal'
 import { CreateAccessTokenModal } from '@/components/Settings/CreateAccessTokenModal'
+import { useResumeOrganizationAccessTokenCreation } from '@/components/Settings/useResumeOrganizationAccessTokenCreation'
 import NewWebhookModal from '@/components/Settings/Webhook/NewWebhookModal'
 import { toast } from '@/components/Toast/use-toast'
 import { useCheckoutLinks } from '@/hooks/queries/checkout_links'
@@ -105,6 +106,19 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
       queryKey: ['organizationReviewState', organization.id],
     })
   }
+
+  const onTokenCreated = (
+    token: schemas['OrganizationAccessTokenCreateResponse'],
+  ) => {
+    setCreatedToken(token)
+    tokenModal.hide()
+    invalidateReviewState()
+  }
+
+  useResumeOrganizationAccessTokenCreation({
+    organizationId: organization.id,
+    onSuccess: onTokenCreated,
+  })
 
   return (
     <Box flexDirection="column" rowGap="l">
@@ -211,11 +225,7 @@ export const SetupReadinessSection = ({ organization, step }: Props) => {
           <CreateAccessTokenModal
             organization={organization}
             title="Create API key"
-            onSuccess={(token) => {
-              setCreatedToken(token)
-              tokenModal.hide()
-              invalidateReviewState()
-            }}
+            onSuccess={onTokenCreated}
             onHide={tokenModal.hide}
           />
         }

--- a/clients/apps/web/src/components/SessionRefresh/SessionRefreshModal.tsx
+++ b/clients/apps/web/src/components/SessionRefresh/SessionRefreshModal.tsx
@@ -12,7 +12,9 @@ export const SessionRefreshModal = () => {
 
   useEffect(() => {
     setSessionRefreshListener((nextOptions = {}) => {
-      setOptions(nextOptions)
+      setOptions((currentOptions) =>
+        nextOptions.returnTo === undefined ? currentOptions : nextOptions,
+      )
       setShown(true)
     })
     return () => setSessionRefreshListener(null)
@@ -32,7 +34,7 @@ export const SessionRefreshModal = () => {
       onConfirm={() => {
         const returnTo =
           options.returnTo ??
-          `${window.location.pathname}${window.location.search}${window.location.hash}`
+          `${window.location.pathname}${window.location.search}`
         router.push(`/auth?return_to=${encodeURIComponent(returnTo)}`)
       }}
     />

--- a/clients/apps/web/src/components/SessionRefresh/SessionRefreshModal.tsx
+++ b/clients/apps/web/src/components/SessionRefresh/SessionRefreshModal.tsx
@@ -3,25 +3,36 @@
 import { ConfirmModal } from '@/components/Modal/ConfirmModal'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
-import { setSessionRefreshListener } from './store'
+import { type SessionRefreshOptions, setSessionRefreshListener } from './store'
 
 export const SessionRefreshModal = () => {
   const router = useRouter()
   const [isShown, setShown] = useState(false)
+  const [options, setOptions] = useState<SessionRefreshOptions>({})
 
   useEffect(() => {
-    setSessionRefreshListener(() => setShown(true))
+    setSessionRefreshListener((nextOptions = {}) => {
+      setOptions(nextOptions)
+      setShown(true)
+    })
     return () => setSessionRefreshListener(null)
   }, [])
+
+  const hide = () => {
+    setShown(false)
+    setOptions({})
+  }
 
   return (
     <ConfirmModal
       isShown={isShown}
-      hide={() => setShown(false)}
+      hide={hide}
       title="Please sign in again"
       description="For your security, this action requires that you signed in recently. Sign in again to continue."
       onConfirm={() => {
-        const returnTo = `${window.location.pathname}${window.location.search}`
+        const returnTo =
+          options.returnTo ??
+          `${window.location.pathname}${window.location.search}${window.location.hash}`
         router.push(`/auth?return_to=${encodeURIComponent(returnTo)}`)
       }}
     />

--- a/clients/apps/web/src/components/SessionRefresh/store.ts
+++ b/clients/apps/web/src/components/SessionRefresh/store.ts
@@ -1,4 +1,8 @@
-type Listener = () => void
+export interface SessionRefreshOptions {
+  returnTo?: string
+}
+
+type Listener = (options?: SessionRefreshOptions) => void
 
 let listener: Listener | null = null
 
@@ -6,6 +10,6 @@ export const setSessionRefreshListener = (l: Listener | null) => {
   listener = l
 }
 
-export const promptSessionRefresh = () => {
-  listener?.()
+export const promptSessionRefresh = (options?: SessionRefreshOptions) => {
+  listener?.(options)
 }

--- a/clients/apps/web/src/components/Settings/CreateAccessTokenModal.tsx
+++ b/clients/apps/web/src/components/Settings/CreateAccessTokenModal.tsx
@@ -1,14 +1,23 @@
 'use client'
 
-import { InlineModalHeader } from '@polar-sh/orbit'
+import { promptSessionRefresh } from '@/components/SessionRefresh/store'
+import { useAuth } from '@/hooks/auth'
 import { useCreateOrganizationAccessToken } from '@/hooks/queries'
+import {
+  extractApiErrorMessage,
+  isSessionNotFreshError,
+} from '@/utils/api/errors'
+import { InlineModalHeader } from '@polar-sh/orbit'
 import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
-import { extractApiErrorMessage } from '@/utils/api/errors'
 import { toast } from '../Toast/use-toast'
+import {
+  getOrganizationAccessTokenResumePath,
+  savePendingOrganizationAccessTokenCreation,
+} from './organizationAccessTokenContinuation'
 import {
   AccessTokenForm,
   type AccessTokenCreate,
@@ -27,6 +36,7 @@ export const CreateAccessTokenModal = ({
   onHide,
   title = 'Create Organization Token',
 }: CreateAccessTokenModalProps) => {
+  const { currentUser } = useAuth()
   const createToken = useCreateOrganizationAccessToken(organization.id)
   const form = useForm<AccessTokenCreate>({
     defaultValues: {
@@ -39,24 +49,38 @@ export const CreateAccessTokenModal = ({
 
   const onCreate = useCallback(
     async (data: AccessTokenCreate) => {
-      const { data: created, error } = await createToken.mutateAsync({
+      const body = {
         comment: data.comment ? data.comment : '',
         expires_in:
           data.expires_in === 'no-expiration' ? null : data.expires_in,
         scopes: data.scopes,
-      })
+      }
+      const { data: created, error } = await createToken.mutateAsync(body)
       if (created) {
         onSuccess(created)
         reset({ scopes: [] })
         createToken.reset()
       } else if (error) {
+        if (isSessionNotFreshError(error) && currentUser) {
+          const actionId = savePendingOrganizationAccessTokenCreation(
+            organization.id,
+            currentUser.id,
+            body,
+          )
+          if (actionId) {
+            promptSessionRefresh({
+              returnTo: getOrganizationAccessTokenResumePath(actionId),
+            })
+            return
+          }
+        }
         toast({
           title: 'Could not create access token',
           description: extractApiErrorMessage(error),
         })
       }
     },
-    [createToken, onSuccess, reset],
+    [createToken, currentUser, onSuccess, organization.id, reset],
   )
 
   return (
@@ -73,7 +97,9 @@ export const CreateAccessTokenModal = ({
             className="max-w-[700px] space-y-8"
           >
             <AccessTokenForm />
-            <Button type="submit">Create Token</Button>
+            <Button type="submit" loading={createToken.isPending}>
+              Create Token
+            </Button>
           </form>
         </Form>
       </div>

--- a/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
@@ -29,12 +29,13 @@ import {
   FormLabel,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import { useCallback, useState } from 'react'
+import { type Ref, useCallback, useEffect, useRef, useState } from 'react'
 import { useForm, useFormContext } from 'react-hook-form'
 import { ConfirmModal } from '../Modal/ConfirmModal'
 import { toast, useToast } from '../Toast/use-toast'
 import { CreateAccessTokenModal } from './CreateAccessTokenModal'
 import { TreeMultiSelect } from './TreeMultiSelect'
+import { useResumeOrganizationAccessTokenCreation } from './useResumeOrganizationAccessTokenCreation'
 
 export interface AccessTokenCreate {
   comment: string
@@ -194,10 +195,12 @@ const AccessTokenItem = ({
   token,
   rawToken,
   minimal,
+  rootRef,
 }: {
   token: schemas['OrganizationAccessToken']
   rawToken?: string
   minimal?: boolean
+  rootRef?: Ref<HTMLDivElement>
 }) => {
   const {
     isShown: updateModalShown,
@@ -236,7 +239,7 @@ const AccessTokenItem = ({
   }, [token, deleteToken])
 
   return (
-    <div className="flex flex-col gap-y-4">
+    <div ref={rootRef} className="flex flex-col gap-y-4">
       <div className="flex flex-col gap-y-2 md:flex-row md:items-center md:justify-between md:gap-x-4">
         <div className="flex min-w-0 flex-row">
           <div className="flex min-w-0 flex-col">
@@ -351,6 +354,7 @@ const OrganizationAccessTokensSettings = ({
   const tokens = useOrganizationAccessTokens(organization.id)
   const [createdToken, setCreatedToken] =
     useState<schemas['OrganizationAccessTokenCreateResponse']>()
+  const createdTokenRef = useRef<HTMLDivElement>(null)
 
   const {
     isShown: createModalShown,
@@ -358,26 +362,43 @@ const OrganizationAccessTokensSettings = ({
     hide: hideCreateModal,
   } = useModal()
 
-  const onCreate = (
-    token: schemas['OrganizationAccessTokenCreateResponse'],
-  ) => {
-    hideCreateModal()
-    setCreatedToken(token)
-    onTokenCreated?.(token.token)
-  }
+  const onCreate = useCallback(
+    (token: schemas['OrganizationAccessTokenCreateResponse']) => {
+      hideCreateModal()
+      setCreatedToken(token)
+      onTokenCreated?.(token.token)
+    },
+    [hideCreateModal, onTokenCreated],
+  )
 
-  const hasTokens =
-    (tokens.data?.items && tokens.data.items.length > 0) || createdToken
-  const showNewTokenButton = !singleTokenMode || !hasTokens
+  useResumeOrganizationAccessTokenCreation({
+    organizationId: organization.id,
+    onSuccess: onCreate,
+  })
 
-  const hasExistingTokens = tokens.data?.items && tokens.data.items.length > 0
+  const createdAccessToken = createdToken?.organization_access_token
+  const listedTokens = tokens.data?.items ?? []
+  const displayedTokens =
+    createdAccessToken &&
+    !listedTokens.some((token) => token.id === createdAccessToken.id)
+      ? [createdAccessToken, ...listedTokens]
+      : listedTokens
+  const createdTokenId = createdAccessToken?.id
+
+  useEffect(() => {
+    if (!createdTokenId) return
+    createdTokenRef.current?.scrollIntoView({ block: 'center' })
+  }, [createdTokenId])
+
+  const hasExistingTokens = displayedTokens.length > 0
+  const showNewTokenButton = !singleTokenMode || !hasExistingTokens
 
   // Minimal mode: just show a button or the created token
   if (minimal) {
     return (
       <div className="flex w-full flex-col items-start gap-y-4">
         {hasExistingTokens
-          ? tokens.data?.items.map((token) => {
+          ? displayedTokens.map((token) => {
               const isNewToken =
                 token.id === createdToken?.organization_access_token.id
               return (
@@ -389,6 +410,7 @@ const OrganizationAccessTokensSettings = ({
                     token={token}
                     minimal={minimal}
                     rawToken={isNewToken ? createdToken?.token : undefined}
+                    rootRef={isNewToken ? createdTokenRef : undefined}
                   />
                 </div>
               )
@@ -417,7 +439,7 @@ const OrganizationAccessTokensSettings = ({
     <div className="flex w-full flex-col">
       <ListGroup>
         {hasExistingTokens ? (
-          tokens.data?.items.map((token) => {
+          displayedTokens.map((token) => {
             const isNewToken =
               token.id === createdToken?.organization_access_token.id
 
@@ -426,6 +448,7 @@ const OrganizationAccessTokensSettings = ({
                 <AccessTokenItem
                   token={token}
                   rawToken={isNewToken ? createdToken?.token : undefined}
+                  rootRef={isNewToken ? createdTokenRef : undefined}
                 />
               </ListGroup.Item>
             )

--- a/clients/apps/web/src/components/Settings/organizationAccessTokenContinuation.ts
+++ b/clients/apps/web/src/components/Settings/organizationAccessTokenContinuation.ts
@@ -1,0 +1,88 @@
+import { enums, type schemas } from '@polar-sh/client'
+import { z } from 'zod'
+
+export const ORGANIZATION_ACCESS_TOKEN_RESUME_PARAM =
+  'resume_organization_access_token_creation'
+
+const STORAGE_KEY_PREFIX = 'polar:organization-access-token:create:v1:'
+const MAX_AGE_MS = 15 * 60 * 1000
+
+export type OrganizationAccessTokenCreateBody = Omit<
+  schemas['OrganizationAccessTokenCreate'],
+  'organization_id'
+>
+
+const organizationAccessTokenCreateBodySchema = z.object({
+  comment: z.string(),
+  expires_in: z.string().nullable().optional(),
+  scopes: z.array(z.enum(enums.availableScopeValues)),
+})
+
+const pendingOrganizationAccessTokenCreationSchema = z.object({
+  organizationId: z.string(),
+  userId: z.string(),
+  createdAt: z.number(),
+  body: organizationAccessTokenCreateBodySchema,
+})
+
+type PendingOrganizationAccessTokenCreation = z.infer<
+  typeof pendingOrganizationAccessTokenCreationSchema
+>
+
+const getStorageKey = (actionId: string) => `${STORAGE_KEY_PREFIX}${actionId}`
+
+export const savePendingOrganizationAccessTokenCreation = (
+  organizationId: string,
+  userId: string,
+  body: OrganizationAccessTokenCreateBody,
+): string | null => {
+  const actionId = crypto.randomUUID()
+  const pending: PendingOrganizationAccessTokenCreation = {
+    organizationId,
+    userId,
+    createdAt: Date.now(),
+    body,
+  }
+
+  try {
+    sessionStorage.setItem(getStorageKey(actionId), JSON.stringify(pending))
+    return actionId
+  } catch {
+    return null
+  }
+}
+
+export const takePendingOrganizationAccessTokenCreation = (
+  actionId: string,
+  organizationId: string,
+  userId: string,
+): OrganizationAccessTokenCreateBody | null => {
+  const storageKey = getStorageKey(actionId)
+  const serialized = sessionStorage.getItem(storageKey)
+  sessionStorage.removeItem(storageKey)
+
+  if (!serialized) return null
+
+  const result = pendingOrganizationAccessTokenCreationSchema.safeParse(
+    JSON.parse(serialized),
+  )
+  if (!result.success) return null
+
+  const pending = result.data
+  const age = Date.now() - pending.createdAt
+  if (
+    pending.organizationId !== organizationId ||
+    pending.userId !== userId ||
+    age > MAX_AGE_MS ||
+    age < -60_000
+  ) {
+    return null
+  }
+  return pending.body
+}
+
+export const getOrganizationAccessTokenResumePath = (actionId: string) => {
+  const url = new URL(window.location.href)
+  url.searchParams.set(ORGANIZATION_ACCESS_TOKEN_RESUME_PARAM, actionId)
+  return `${url.pathname}${url.search}${url.hash}`
+}

--- a/clients/apps/web/src/components/Settings/organizationAccessTokenContinuation.ts
+++ b/clients/apps/web/src/components/Settings/organizationAccessTokenContinuation.ts
@@ -84,5 +84,5 @@ export const takePendingOrganizationAccessTokenCreation = (
 export const getOrganizationAccessTokenResumePath = (actionId: string) => {
   const url = new URL(window.location.href)
   url.searchParams.set(ORGANIZATION_ACCESS_TOKEN_RESUME_PARAM, actionId)
-  return `${url.pathname}${url.search}${url.hash}`
+  return `${url.pathname}${url.search}`
 }

--- a/clients/apps/web/src/components/Settings/useResumeOrganizationAccessTokenCreation.ts
+++ b/clients/apps/web/src/components/Settings/useResumeOrganizationAccessTokenCreation.ts
@@ -1,0 +1,77 @@
+'use client'
+
+import { useAuth } from '@/hooks/auth'
+import { useCreateOrganizationAccessToken } from '@/hooks/queries'
+import { extractApiErrorMessage } from '@/utils/api/errors'
+import { type schemas } from '@polar-sh/client'
+import { useSearchParams } from 'next/navigation'
+import { useEffect, useEffectEvent, useRef } from 'react'
+import { toast } from '../Toast/use-toast'
+import {
+  ORGANIZATION_ACCESS_TOKEN_RESUME_PARAM,
+  takePendingOrganizationAccessTokenCreation,
+} from './organizationAccessTokenContinuation'
+
+interface UseResumeOrganizationAccessTokenCreationProps {
+  organizationId: string
+  onSuccess: (created: schemas['OrganizationAccessTokenCreateResponse']) => void
+}
+
+export const useResumeOrganizationAccessTokenCreation = ({
+  organizationId,
+  onSuccess,
+}: UseResumeOrganizationAccessTokenCreationProps) => {
+  const { currentUser } = useAuth()
+  const searchParams = useSearchParams()
+  const actionId = searchParams.get(ORGANIZATION_ACCESS_TOKEN_RESUME_PARAM)
+  const resumedActionId = useRef<string | null>(null)
+  const onResumedSuccess = useEffectEvent(onSuccess)
+  const { mutate } = useCreateOrganizationAccessToken(organizationId)
+
+  useEffect(() => {
+    const userId = currentUser?.id
+    if (!actionId || !userId || resumedActionId.current === actionId) return
+
+    resumedActionId.current = actionId
+
+    const url = new URL(window.location.href)
+    url.searchParams.delete(ORGANIZATION_ACCESS_TOKEN_RESUME_PARAM)
+    window.history.replaceState(window.history.state, '', url)
+
+    const body = takePendingOrganizationAccessTokenCreation(
+      actionId,
+      organizationId,
+      userId,
+    )
+    if (!body) {
+      toast({
+        title: 'Could not resume access token creation',
+        description:
+          'The saved request is missing, expired, or no longer valid.',
+      })
+      return
+    }
+
+    mutate(body, {
+      onSuccess: ({ data, error }) => {
+        if (data) {
+          onResumedSuccess(data)
+          return
+        }
+
+        if (error) {
+          toast({
+            title: 'Could not create access token',
+            description: extractApiErrorMessage(error),
+          })
+        }
+      },
+      onError: () => {
+        toast({
+          title: 'Could not create access token',
+          description: 'Please try again.',
+        })
+      },
+    })
+  }, [actionId, currentUser?.id, mutate, organizationId])
+}


### PR DESCRIPTION
## Summary

**Related Issue**: #NA

When you try to create an access token, if your session is older than an hour the app prompts you to re-authenticate after you hit `Create token`, but the there is an annoying UX here where the token you configured is not actually created so you have to re-create it.

This PR introduces a mechanism where it saves the token config into a short-lived session storage value and when the user is redirected from the authentication, the dashboard reads the saved token config, creates it then displays it.

## Demo


https://github.com/user-attachments/assets/931c6af8-9164-4974-99cf-607964268257


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
