### PR TITLE
fix: stop the event loop watchdog from freezing the worker

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -67,8 +67,8 @@ class Settings(BaseSettings):
     WORKER_HEALTH_CHECK_INTERVAL: timedelta = timedelta(seconds=30)
     WORKER_MAX_RETRIES: int = 20
     WORKER_MIN_BACKOFF_MILLISECONDS: int = 2_000
-    # Consecutive watchdog misses (~20s each) before the worker exits to be
-    # restarted. 0 disables the exit and only logs.
+    # Misses in a row before the worker exits and gets restarted. Each miss
+    # takes about 20s. Set to 0 to only log.
     WORKER_EVENT_LOOP_WATCHDOG_MAX_MISSES: int = 3
     WORKER_PROMETHEUS_DIR: Path = Path(tempfile.gettempdir()) / "prometheus_multiproc"
 
@@ -365,9 +365,8 @@ class Settings(BaseSettings):
     AWS_SECRET_ACCESS_KEY: str = "polar123456789"
     AWS_REGION: str = "us-east-2"
     AWS_SIGNATURE_VERSION: str = "v4"
-    # botocore defaults to 60s/60s with 5 attempts, so one call can take five
-    # minutes. Keep the worst case under the worker time limit instead: a call
-    # that outlives the job it belongs to holds an executor thread for nothing.
+    # botocore defaults allow about 5 minutes per call. That is longer than the
+    # job that started it, so a slow upload keeps a thread busy for nothing.
     AWS_S3_CONNECT_TIMEOUT_SECONDS: float = 5.0
     AWS_S3_READ_TIMEOUT_SECONDS: float = 20.0
     AWS_S3_MAX_ATTEMPTS: int = 3

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -67,6 +67,9 @@ class Settings(BaseSettings):
     WORKER_HEALTH_CHECK_INTERVAL: timedelta = timedelta(seconds=30)
     WORKER_MAX_RETRIES: int = 20
     WORKER_MIN_BACKOFF_MILLISECONDS: int = 2_000
+    # Consecutive watchdog misses (~20s each) before the worker exits to be
+    # restarted. 0 disables the exit and only logs.
+    WORKER_EVENT_LOOP_WATCHDOG_MAX_MISSES: int = 3
     WORKER_PROMETHEUS_DIR: Path = Path(tempfile.gettempdir()) / "prometheus_multiproc"
 
     # Grafana Cloud Prometheus
@@ -362,6 +365,12 @@ class Settings(BaseSettings):
     AWS_SECRET_ACCESS_KEY: str = "polar123456789"
     AWS_REGION: str = "us-east-2"
     AWS_SIGNATURE_VERSION: str = "v4"
+    # botocore defaults to 60s/60s with 5 attempts, so one call can take five
+    # minutes. Keep the worst case under the worker time limit instead: a call
+    # that outlives the job it belongs to holds an executor thread for nothing.
+    AWS_S3_CONNECT_TIMEOUT_SECONDS: float = 5.0
+    AWS_S3_READ_TIMEOUT_SECONDS: float = 20.0
+    AWS_S3_MAX_ATTEMPTS: int = 3
 
     # Secrets encryption. Production and sandbox wrap data keys with a KMS key
     # (AWS_KMS_KEY_ID); local and CI use a static key instead, so tests make no

--- a/server/polar/dummy/tasks.py
+++ b/server/polar/dummy/tasks.py
@@ -1,17 +1,6 @@
-import time
-
-import structlog
 from sqlalchemy import text
 
-from polar.config import settings
-from polar.exceptions import PolarTaskError
-from polar.logging import Logger
 from polar.worker import AsyncSessionMaker, RedisMiddleware, TaskPriority, actor
-
-log: Logger = structlog.get_logger()
-
-
-class DummyTaskError(PolarTaskError): ...
 
 
 @actor(actor_name="dummy", priority=TaskPriority.LOW)
@@ -23,29 +12,3 @@ async def dummy_task(*, redis_key: str = "dummy", failure: bool = False) -> None
         await session.execute(text("SELECT 1"))
 
     await RedisMiddleware.get().incr(redis_key)
-
-
-@actor(actor_name="dummy.blocking_io", priority=TaskPriority.LOW)
-async def dummy_blocking_io(*, seconds: float = 30.0) -> None:
-    """Reproduce the event loop stall caused by synchronous I/O in an async actor.
-
-    Mirrors `order.confirmation_email`: hold a database session, make a blocking
-    call on the event loop thread the way a sync boto3 call does, then persist
-    the result. Every other job in the same worker process stops until the
-    blocking call returns.
-
-    The two log markers show what a time limit does to this shape. `work_done`
-    is emitted synchronously, so it survives. `persisted` sits behind an await,
-    which is where cancellation lands, so it does not. The retry then redoes the
-    expensive work from scratch.
-    """
-    if not settings.is_development() and not settings.is_testing():
-        raise DummyTaskError("dummy.blocking_io only runs in development.")
-
-    async with AsyncSessionMaker() as session:
-        await session.execute(text("SELECT 1"))
-        log.info("dummy.blocking_io.start", seconds=seconds)
-        time.sleep(seconds)
-        log.info("dummy.blocking_io.work_done", seconds=seconds)
-        await session.execute(text("SELECT 1"))
-        log.info("dummy.blocking_io.persisted", seconds=seconds)

--- a/server/polar/dummy/tasks.py
+++ b/server/polar/dummy/tasks.py
@@ -1,6 +1,17 @@
+import time
+
+import structlog
 from sqlalchemy import text
 
+from polar.config import settings
+from polar.exceptions import PolarTaskError
+from polar.logging import Logger
 from polar.worker import AsyncSessionMaker, RedisMiddleware, TaskPriority, actor
+
+log: Logger = structlog.get_logger()
+
+
+class DummyTaskError(PolarTaskError): ...
 
 
 @actor(actor_name="dummy", priority=TaskPriority.LOW)
@@ -12,3 +23,29 @@ async def dummy_task(*, redis_key: str = "dummy", failure: bool = False) -> None
         await session.execute(text("SELECT 1"))
 
     await RedisMiddleware.get().incr(redis_key)
+
+
+@actor(actor_name="dummy.blocking_io", priority=TaskPriority.LOW)
+async def dummy_blocking_io(*, seconds: float = 30.0) -> None:
+    """Reproduce the event loop stall caused by synchronous I/O in an async actor.
+
+    Mirrors `order.confirmation_email`: hold a database session, make a blocking
+    call on the event loop thread the way a sync boto3 call does, then persist
+    the result. Every other job in the same worker process stops until the
+    blocking call returns.
+
+    The two log markers show what a time limit does to this shape. `work_done`
+    is emitted synchronously, so it survives. `persisted` sits behind an await,
+    which is where cancellation lands, so it does not. The retry then redoes the
+    expensive work from scratch.
+    """
+    if not settings.is_development() and not settings.is_testing():
+        raise DummyTaskError("dummy.blocking_io only runs in development.")
+
+    async with AsyncSessionMaker() as session:
+        await session.execute(text("SELECT 1"))
+        log.info("dummy.blocking_io.start", seconds=seconds)
+        time.sleep(seconds)
+        log.info("dummy.blocking_io.work_done", seconds=seconds)
+        await session.execute(text("SELECT 1"))
+        log.info("dummy.blocking_io.persisted", seconds=seconds)

--- a/server/polar/integrations/aws/s3/client.py
+++ b/server/polar/integrations/aws/s3/client.py
@@ -20,7 +20,11 @@ def get_client(
         aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
         aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
         config=Config(
-            region_name=settings.AWS_REGION, signature_version=signature_version
+            region_name=settings.AWS_REGION,
+            signature_version=signature_version,
+            connect_timeout=settings.AWS_S3_CONNECT_TIMEOUT_SECONDS,
+            read_timeout=settings.AWS_S3_READ_TIMEOUT_SECONDS,
+            retries={"mode": "standard", "max_attempts": settings.AWS_S3_MAX_ATTEMPTS},
         ),
     )
 

--- a/server/polar/invoice/service.py
+++ b/server/polar/invoice/service.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import json
 from datetime import datetime
@@ -65,8 +66,8 @@ class InvoiceService:
         invoice_bytes = await render_invoice_pdf(invoice)
 
         s3 = S3Service(settings.S3_CUSTOMER_INVOICES_BUCKET_NAME)
-        return s3.upload(
-            bytes(invoice_bytes), order.invoice_filename, "application/pdf"
+        return await asyncio.to_thread(
+            s3.upload, bytes(invoice_bytes), order.invoice_filename, "application/pdf"
         )
 
     async def get_order_invoice_url(self, order: Order) -> tuple[str, datetime]:
@@ -188,7 +189,8 @@ class InvoiceService:
             invoice, heading_title="Reverse Invoice"
         )
         s3 = S3Service(settings.S3_PAYOUT_INVOICES_BUCKET_NAME)
-        return s3.upload(
+        return await asyncio.to_thread(
+            s3.upload,
             bytes(invoice_bytes),
             f"{account.id}/Payout-{payout.invoice_number}.pdf",
             "application/pdf",

--- a/server/polar/support_case/tasks.py
+++ b/server/polar/support_case/tasks.py
@@ -1,3 +1,4 @@
+import asyncio
 from uuid import UUID, uuid4
 
 from sqlalchemy.orm import joinedload
@@ -176,7 +177,7 @@ async def merge_case_attachments(case_id: UUID, attachment_ids: list[UUID]) -> N
             f"{case.organization_id}/{uuid4()}/{filename}"
         )
         s3_service = S3_SERVICES[FileServiceTypes.support_case_attachment]
-        s3_service.upload(merged, path, "application/pdf")
+        await asyncio.to_thread(s3_service.upload, merged, path, "application/pdf")
 
         file = File(
             organization=case.organization,

--- a/server/polar/support_case/tasks.py
+++ b/server/polar/support_case/tasks.py
@@ -123,6 +123,10 @@ async def notify_organization_of_new_message(message_id: UUID) -> None:
             )
 
 
+def _read_attachment(service: FileServiceTypes, path: str) -> bytes:
+    return S3_SERVICES[service].get_object_or_raise(path)["Body"].read()
+
+
 @actor(actor_name="support_case.merge_attachments", priority=TaskPriority.LOW)
 async def merge_case_attachments(case_id: UUID, attachment_ids: list[UUID]) -> None:
     """Merge the selected case attachments into one PDF stored back on the
@@ -146,10 +150,9 @@ async def merge_case_attachments(case_id: UUID, attachment_ids: list[UUID]) -> N
         # than dropped, so the merge still runs as long as anything was selected.
         payloads = []
         for attachment in mergeable:
-            s3_service = S3_SERVICES[attachment.file.service]
-            content = s3_service.get_object_or_raise(attachment.file.path)[
-                "Body"
-            ].read()
+            content = await asyncio.to_thread(
+                _read_attachment, attachment.file.service, attachment.file.path
+            )
             payloads.append((attachment.file.name, attachment.file.mime_type, content))
         skipped = [a for a in selected if not is_mergeable(a.file.mime_type)]
         if skipped:

--- a/server/polar/worker/_asyncio.py
+++ b/server/polar/worker/_asyncio.py
@@ -1,6 +1,5 @@
 import asyncio
 import concurrent.futures
-import logging
 import os
 import sys
 import threading
@@ -18,6 +17,7 @@ log: Logger = structlog.get_logger()
 
 HEARTBEAT_INTERVAL = 5.0
 HEARTBEAT_TIMEOUT = 15.0
+EXIT_GRACE_SECONDS = 5.0
 
 
 class _EventLoopWatchdog(threading.Thread):
@@ -66,7 +66,12 @@ class _EventLoopWatchdog(threading.Thread):
 
             if not self._heartbeat_event.wait(timeout=self.heartbeat_timeout):
                 self._consecutive_misses += 1
-                self._dump_stacks()
+                try:
+                    self._dump_stacks()
+                except Exception:
+                    # Diagnostics are best effort. A failure here must never
+                    # skip the exit below, or a stuck worker stays stuck.
+                    pass
                 if self.max_misses > 0 and self._consecutive_misses >= self.max_misses:
                     self._exit_process()
             else:
@@ -90,17 +95,23 @@ class _EventLoopWatchdog(threading.Thread):
         if self._exiting:
             return
         self._exiting = True
+        # A stuck thread can hold the logging lock, which would hang the log
+        # call below. Arm the exit first so nothing can keep the worker alive.
+        timer = threading.Timer(EXIT_GRACE_SECONDS, os._exit, args=(1,))
+        timer.daemon = True
+        timer.start()
         log.error(
             "event_loop_unrecoverable",
             consecutive_misses=self._consecutive_misses,
             max_misses=self.max_misses,
             message="Event loop never recovered, exiting so the worker restarts.",
         )
-        # os._exit skips cleanup. Flush by hand or this last message stays
-        # in the buffer and is lost.
-        logging.shutdown()
-        sys.stdout.flush()
-        sys.stderr.flush()
+        # os._exit skips cleanup, so flush by hand or this last message is lost.
+        for stream in (sys.stdout, sys.stderr):
+            try:
+                stream.flush()
+            except (OSError, ValueError):
+                pass
         os._exit(1)
 
     def _get_event_loop_stack(self) -> str:
@@ -177,8 +188,11 @@ class _EventLoopWatchdog(threading.Thread):
         )
         # Also write it raw. The log field above gets scrubbed and cut
         # short, and this dump is the whole point.
-        sys.stderr.write(f"{thread_stacks}\n")
-        sys.stderr.flush()
+        try:
+            sys.stderr.write(f"{thread_stacks}\n")
+            sys.stderr.flush()
+        except (OSError, ValueError):
+            pass
 
 
 class MonitoredAsyncIO(AsyncIO):

--- a/server/polar/worker/_asyncio.py
+++ b/server/polar/worker/_asyncio.py
@@ -27,9 +27,9 @@ class _EventLoopWatchdog(threading.Thread):
     If the callback hasn't executed within HEARTBEAT_TIMEOUT seconds,
     dumps all thread stacks to help diagnose what's blocking the event loop.
 
-    After WORKER_EVENT_LOOP_WATCHDOG_MAX_MISSES consecutive misses the process
-    exits. A wedged loop cannot shut down gracefully, and dramatiq brings the
-    whole worker down when a process dies, so the platform restarts it.
+    After WORKER_EVENT_LOOP_WATCHDOG_MAX_MISSES misses in a row the process
+    exits. A stuck loop cannot shut down cleanly, and dramatiq stops the whole
+    worker when a process dies, so the platform starts a new one.
     """
 
     def __init__(
@@ -96,8 +96,8 @@ class _EventLoopWatchdog(threading.Thread):
             max_misses=self.max_misses,
             message="Event loop never recovered, exiting so the worker restarts.",
         )
-        # os._exit skips interpreter cleanup, so flush by hand or this last
-        # message never leaves the buffer dramatiq hands the worker process.
+        # os._exit skips cleanup. Flush by hand or this last message stays
+        # in the buffer and is lost.
         logging.shutdown()
         sys.stdout.flush()
         sys.stderr.flush()
@@ -117,9 +117,9 @@ class _EventLoopWatchdog(threading.Thread):
     def _get_thread_stacks(self) -> str:
         """Format every thread's stack.
 
-        Deliberately pure Python. `faulthandler.dump_traceback(all_threads=True)`
-        can wedge the whole process when a thread is parked in a blocking C call,
-        which is exactly the situation this watchdog runs in.
+        Kept in pure Python on purpose. `faulthandler.dump_traceback(all_threads=True)`
+        can freeze the process when a thread sits in a blocking C call, which is
+        exactly when this watchdog runs.
         """
         names = {thread.ident: thread.name for thread in threading.enumerate()}
         sections = []
@@ -175,8 +175,8 @@ class _EventLoopWatchdog(threading.Thread):
             asyncio_tasks=asyncio_tasks,
             thread_stacks=thread_stacks,
         )
-        # Second copy straight to stderr: the structured field above gets
-        # scrubbed and truncated, and this dump is the whole point.
+        # Also write it raw. The log field above gets scrubbed and cut
+        # short, and this dump is the whole point.
         sys.stderr.write(f"{thread_stacks}\n")
         sys.stderr.flush()
 

--- a/server/polar/worker/_asyncio.py
+++ b/server/polar/worker/_asyncio.py
@@ -1,8 +1,8 @@
 import asyncio
 import concurrent.futures
-import faulthandler
+import logging
+import os
 import sys
-import tempfile
 import threading
 import traceback
 
@@ -11,6 +11,7 @@ import structlog
 from dramatiq.asyncio import get_event_loop_thread
 from dramatiq.middleware.asyncio import AsyncIO
 
+from polar.config import settings
 from polar.logging import Logger
 
 log: Logger = structlog.get_logger()
@@ -25,22 +26,35 @@ class _EventLoopWatchdog(threading.Thread):
     Schedules a callback on the event loop every HEARTBEAT_INTERVAL seconds.
     If the callback hasn't executed within HEARTBEAT_TIMEOUT seconds,
     dumps all thread stacks to help diagnose what's blocking the event loop.
+
+    After WORKER_EVENT_LOOP_WATCHDOG_MAX_MISSES consecutive misses the process
+    exits. A wedged loop cannot shut down gracefully, and dramatiq brings the
+    whole worker down when a process dies, so the platform restarts it.
     """
 
     def __init__(
         self,
         loop: asyncio.AbstractEventLoop,
+        loop_thread_ident: int | None,
         *,
         heartbeat_interval: float = HEARTBEAT_INTERVAL,
         heartbeat_timeout: float = HEARTBEAT_TIMEOUT,
+        max_misses: int | None = None,
     ) -> None:
         super().__init__(daemon=True, name="event-loop-watchdog")
         self.loop = loop
+        self.loop_thread_ident = loop_thread_ident
         self.heartbeat_interval = heartbeat_interval
         self.heartbeat_timeout = heartbeat_timeout
+        self.max_misses = (
+            max_misses
+            if max_misses is not None
+            else settings.WORKER_EVENT_LOOP_WATCHDOG_MAX_MISSES
+        )
         self._stop_event = threading.Event()
         self._heartbeat_event = threading.Event()
         self._consecutive_misses = 0
+        self._exiting = False
 
     def run(self) -> None:
         while not self._stop_event.is_set():
@@ -53,6 +67,8 @@ class _EventLoopWatchdog(threading.Thread):
             if not self._heartbeat_event.wait(timeout=self.heartbeat_timeout):
                 self._consecutive_misses += 1
                 self._dump_stacks()
+                if self.max_misses > 0 and self._consecutive_misses >= self.max_misses:
+                    self._exit_process()
             else:
                 if self._consecutive_misses > 0:
                     total_blocked = self._consecutive_misses * (
@@ -70,22 +86,48 @@ class _EventLoopWatchdog(threading.Thread):
     def stop(self) -> None:
         self._stop_event.set()
 
+    def _exit_process(self) -> None:
+        if self._exiting:
+            return
+        self._exiting = True
+        log.error(
+            "event_loop_unrecoverable",
+            consecutive_misses=self._consecutive_misses,
+            max_misses=self.max_misses,
+            message="Event loop never recovered, exiting so the worker restarts.",
+        )
+        # os._exit skips interpreter cleanup, so flush by hand or this last
+        # message never leaves the buffer dramatiq hands the worker process.
+        logging.shutdown()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(1)
+
     def _get_event_loop_stack(self) -> str:
         """Extract the stack trace of the event loop thread specifically."""
-        loop_thread_id: int | None = None
-        for thread in threading.enumerate():
-            if thread.name == "dramatiq-asyncio":
-                loop_thread_id = thread.ident
-                break
+        if self.loop_thread_ident is None:
+            return "<event loop thread ident unknown>"
 
-        if loop_thread_id is None:
-            return "<event loop thread not found>"
-
-        frame = sys._current_frames().get(loop_thread_id)
+        frame = sys._current_frames().get(self.loop_thread_ident)
         if frame is None:
             return "<no frame for event loop thread>"
 
         return "".join(traceback.format_stack(frame))
+
+    def _get_thread_stacks(self) -> str:
+        """Format every thread's stack.
+
+        Deliberately pure Python. `faulthandler.dump_traceback(all_threads=True)`
+        can wedge the whole process when a thread is parked in a blocking C call,
+        which is exactly the situation this watchdog runs in.
+        """
+        names = {thread.ident: thread.name for thread in threading.enumerate()}
+        sections = []
+        for ident, frame in sys._current_frames().items():
+            name = names.get(ident, "unknown")
+            stack = "".join(traceback.format_stack(frame))
+            sections.append(f"Thread {ident} ({name}):\n{stack}")
+        return "\n".join(sections)
 
     def _get_asyncio_tasks(self) -> str:
         """Get info about asyncio tasks running on the event loop.
@@ -115,11 +157,7 @@ class _EventLoopWatchdog(threading.Thread):
     def _dump_stacks(self) -> None:
         # Collect fast diagnostics first — these don't touch the event loop
         event_loop_stack = self._get_event_loop_stack()
-
-        with tempfile.TemporaryFile(mode="w+") as f:
-            faulthandler.dump_traceback(file=f, all_threads=True)
-            f.seek(0)
-            traceback_text = f.read()
+        thread_stacks = self._get_thread_stacks()
 
         # Collect async tasks last — this may wait up to 2s if the loop is blocked
         asyncio_tasks = self._get_asyncio_tasks()
@@ -135,9 +173,12 @@ class _EventLoopWatchdog(threading.Thread):
             estimated_blocked_seconds=round(total_blocked, 1),
             event_loop_stack=event_loop_stack,
             asyncio_tasks=asyncio_tasks,
-            thread_stacks=traceback_text,
+            thread_stacks=thread_stacks,
         )
-        faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
+        # Second copy straight to stderr: the structured field above gets
+        # scrubbed and truncated, and this dump is the whole point.
+        sys.stderr.write(f"{thread_stacks}\n")
+        sys.stderr.flush()
 
 
 class MonitoredAsyncIO(AsyncIO):
@@ -158,7 +199,9 @@ class MonitoredAsyncIO(AsyncIO):
         super().before_worker_boot(broker, worker)
         event_loop_thread = get_event_loop_thread()
         assert event_loop_thread is not None
-        self._watchdog = _EventLoopWatchdog(event_loop_thread.loop)
+        self._watchdog = _EventLoopWatchdog(
+            event_loop_thread.loop, event_loop_thread.ident
+        )
         self._watchdog.start()
 
     def after_worker_shutdown(

--- a/server/tests/worker/test_asyncio_watchdog.py
+++ b/server/tests/worker/test_asyncio_watchdog.py
@@ -24,7 +24,7 @@ def event_loop_thread() -> Iterator[tuple[asyncio.AbstractEventLoop, threading.T
 def _block(
     loop: asyncio.AbstractEventLoop, seconds: float, name: str = "block"
 ) -> None:
-    """Wedge the loop from another thread and wait until it is really wedged."""
+    """Block the loop from another thread, and wait until it is really blocked."""
     started = threading.Event()
 
     def obviously_blocking_function() -> None:
@@ -131,7 +131,7 @@ class TestEventLoopWatchdog:
     def test_event_loop_stack_resolves_without_thread_name(
         self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
     ) -> None:
-        """dramatiq never names its loop thread, so the ident is the only handle."""
+        """dramatiq never names its loop thread, so the id is the only way in."""
         loop, thread = event_loop_thread
         assert thread.name != "dramatiq-asyncio"
         _block(loop, 2)
@@ -157,10 +157,10 @@ class TestEventLoopWatchdog:
     def test_dump_does_not_call_faulthandler(
         self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
     ) -> None:
-        """faulthandler.dump_traceback(all_threads=True) can wedge the process.
+        """faulthandler.dump_traceback(all_threads=True) can freeze the process.
 
-        The watchdog runs precisely when a thread is parked in a blocking C call,
-        which is the case that hangs, so it must stay pure Python.
+        It hangs when a thread sits in a blocking C call, which is exactly when
+        the watchdog runs, so this must stay pure Python.
         """
         loop, thread = event_loop_thread
         _block(loop, 2)

--- a/server/tests/worker/test_asyncio_watchdog.py
+++ b/server/tests/worker/test_asyncio_watchdog.py
@@ -232,6 +232,38 @@ class TestEventLoopWatchdog:
 
             mock_exit.assert_called_with(1)
 
+    def test_exits_even_when_the_dump_fails(
+        self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
+    ) -> None:
+        """A broken stderr must not stop the restart.
+
+        _dump_stacks used to run unguarded, so a write error killed the
+        watchdog thread and left the stuck worker alive.
+        """
+        loop, thread = event_loop_thread
+        _block(loop, 3)
+
+        watchdog = _EventLoopWatchdog(
+            loop,
+            thread.ident,
+            heartbeat_interval=0.05,
+            heartbeat_timeout=0.3,
+            max_misses=2,
+        )
+
+        with (
+            patch.object(
+                _EventLoopWatchdog, "_dump_stacks", side_effect=OSError("broken pipe")
+            ),
+            patch("polar.worker._asyncio.os._exit") as mock_exit,
+        ):
+            watchdog.start()
+            time.sleep(1.0)
+            watchdog.stop()
+            watchdog.join(timeout=5)
+
+            mock_exit.assert_called_with(1)
+
     def test_does_not_exit_when_disabled(
         self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
     ) -> None:

--- a/server/tests/worker/test_asyncio_watchdog.py
+++ b/server/tests/worker/test_asyncio_watchdog.py
@@ -10,26 +10,44 @@ from polar.worker._asyncio import _EventLoopWatchdog
 
 
 @pytest.fixture
-def event_loop_thread() -> Iterator[asyncio.AbstractEventLoop]:
+def event_loop_thread() -> Iterator[tuple[asyncio.AbstractEventLoop, threading.Thread]]:
     """An event loop running in a background thread."""
     loop = asyncio.new_event_loop()
     thread = threading.Thread(target=loop.run_forever, daemon=True)
     thread.start()
-    yield loop
+    yield loop, thread
     loop.call_soon_threadsafe(loop.stop)
     thread.join(timeout=2)
     loop.close()
 
 
+def _block(
+    loop: asyncio.AbstractEventLoop, seconds: float, name: str = "block"
+) -> None:
+    """Wedge the loop from another thread and wait until it is really wedged."""
+    started = threading.Event()
+
+    def obviously_blocking_function() -> None:
+        started.set()
+        time.sleep(seconds)
+
+    obviously_blocking_function.__name__ = name
+    loop.call_soon_threadsafe(obviously_blocking_function)
+    started.wait(timeout=1)
+
+
 class TestEventLoopWatchdog:
     def test_healthy_loop_no_dump(
-        self, event_loop_thread: asyncio.AbstractEventLoop
+        self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
     ) -> None:
+        loop, thread = event_loop_thread
         with patch.object(_EventLoopWatchdog, "_dump_stacks") as mock_dump:
             watchdog = _EventLoopWatchdog(
-                event_loop_thread,
+                loop,
+                thread.ident,
                 heartbeat_interval=0.05,
                 heartbeat_timeout=0.5,
+                max_misses=0,
             )
             watchdog.start()
             time.sleep(0.3)
@@ -39,22 +57,18 @@ class TestEventLoopWatchdog:
             mock_dump.assert_not_called()
 
     def test_frozen_loop_triggers_dump(
-        self, event_loop_thread: asyncio.AbstractEventLoop
+        self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
     ) -> None:
-        blocker_started = threading.Event()
-
-        def block_loop() -> None:
-            blocker_started.set()
-            time.sleep(2)
-
-        event_loop_thread.call_soon_threadsafe(block_loop)
-        blocker_started.wait(timeout=1)
+        loop, thread = event_loop_thread
+        _block(loop, 2)
 
         with patch.object(_EventLoopWatchdog, "_dump_stacks") as mock_dump:
             watchdog = _EventLoopWatchdog(
-                event_loop_thread,
+                loop,
+                thread.ident,
                 heartbeat_interval=0.05,
                 heartbeat_timeout=0.3,
+                max_misses=0,
             )
             watchdog.start()
             time.sleep(0.6)
@@ -69,7 +83,11 @@ class TestEventLoopWatchdog:
         thread.start()
 
         watchdog = _EventLoopWatchdog(
-            loop, heartbeat_interval=0.05, heartbeat_timeout=0.5
+            loop,
+            thread.ident,
+            heartbeat_interval=0.05,
+            heartbeat_timeout=0.5,
+            max_misses=0,
         )
         watchdog.start()
         time.sleep(0.1)
@@ -82,21 +100,17 @@ class TestEventLoopWatchdog:
         assert not watchdog.is_alive()
 
     def test_dump_contains_blocking_function_name(
-        self, event_loop_thread: asyncio.AbstractEventLoop
+        self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
     ) -> None:
-        blocker_started = threading.Event()
-
-        def obviously_blocking_function() -> None:
-            blocker_started.set()
-            time.sleep(2)
-
-        event_loop_thread.call_soon_threadsafe(obviously_blocking_function)
-        blocker_started.wait(timeout=1)
+        loop, thread = event_loop_thread
+        _block(loop, 2)
 
         watchdog = _EventLoopWatchdog(
-            event_loop_thread,
+            loop,
+            thread.ident,
             heartbeat_interval=0.05,
             heartbeat_timeout=0.3,
+            max_misses=0,
         )
 
         with patch("polar.worker._asyncio.log") as mock_log:
@@ -114,22 +128,71 @@ class TestEventLoopWatchdog:
             assert "consecutive_misses" in call_kwargs
             assert call_kwargs["consecutive_misses"] >= 1
 
-    def test_consecutive_misses_tracked(
-        self, event_loop_thread: asyncio.AbstractEventLoop
+    def test_event_loop_stack_resolves_without_thread_name(
+        self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
     ) -> None:
-        blocker_started = threading.Event()
-
-        def block_loop() -> None:
-            blocker_started.set()
-            time.sleep(3)
-
-        event_loop_thread.call_soon_threadsafe(block_loop)
-        blocker_started.wait(timeout=1)
+        """dramatiq never names its loop thread, so the ident is the only handle."""
+        loop, thread = event_loop_thread
+        assert thread.name != "dramatiq-asyncio"
+        _block(loop, 2)
 
         watchdog = _EventLoopWatchdog(
-            event_loop_thread,
+            loop,
+            thread.ident,
             heartbeat_interval=0.05,
             heartbeat_timeout=0.3,
+            max_misses=0,
+        )
+
+        with patch("polar.worker._asyncio.log") as mock_log:
+            watchdog.start()
+            time.sleep(0.6)
+            watchdog.stop()
+            watchdog.join(timeout=2)
+
+            event_loop_stack = mock_log.error.call_args_list[0][1]["event_loop_stack"]
+            assert "not found" not in event_loop_stack
+            assert "obviously_blocking_function" in event_loop_stack
+
+    def test_dump_does_not_call_faulthandler(
+        self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
+    ) -> None:
+        """faulthandler.dump_traceback(all_threads=True) can wedge the process.
+
+        The watchdog runs precisely when a thread is parked in a blocking C call,
+        which is the case that hangs, so it must stay pure Python.
+        """
+        loop, thread = event_loop_thread
+        _block(loop, 2)
+
+        watchdog = _EventLoopWatchdog(
+            loop,
+            thread.ident,
+            heartbeat_interval=0.05,
+            heartbeat_timeout=0.3,
+            max_misses=0,
+        )
+
+        with patch("faulthandler.dump_traceback") as mock_faulthandler:
+            watchdog.start()
+            time.sleep(0.6)
+            watchdog.stop()
+            watchdog.join(timeout=2)
+
+            mock_faulthandler.assert_not_called()
+
+    def test_consecutive_misses_tracked(
+        self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
+    ) -> None:
+        loop, thread = event_loop_thread
+        _block(loop, 3)
+
+        watchdog = _EventLoopWatchdog(
+            loop,
+            thread.ident,
+            heartbeat_interval=0.05,
+            heartbeat_timeout=0.3,
+            max_misses=0,
         )
 
         with patch("polar.worker._asyncio.log") as mock_log:
@@ -146,3 +209,47 @@ class TestEventLoopWatchdog:
             assert len(error_calls) >= 2
             assert error_calls[0][1]["consecutive_misses"] == 1
             assert error_calls[1][1]["consecutive_misses"] == 2
+
+    def test_exits_process_after_max_misses(
+        self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
+    ) -> None:
+        loop, thread = event_loop_thread
+        _block(loop, 3)
+
+        watchdog = _EventLoopWatchdog(
+            loop,
+            thread.ident,
+            heartbeat_interval=0.05,
+            heartbeat_timeout=0.3,
+            max_misses=2,
+        )
+
+        with patch("polar.worker._asyncio.os._exit") as mock_exit:
+            watchdog.start()
+            time.sleep(1.0)
+            watchdog.stop()
+            watchdog.join(timeout=5)
+
+            mock_exit.assert_called_with(1)
+
+    def test_does_not_exit_when_disabled(
+        self, event_loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread]
+    ) -> None:
+        loop, thread = event_loop_thread
+        _block(loop, 3)
+
+        watchdog = _EventLoopWatchdog(
+            loop,
+            thread.ident,
+            heartbeat_interval=0.05,
+            heartbeat_timeout=0.3,
+            max_misses=0,
+        )
+
+        with patch("polar.worker._asyncio.os._exit") as mock_exit:
+            watchdog.start()
+            time.sleep(1.0)
+            watchdog.stop()
+            watchdog.join(timeout=5)
+
+            mock_exit.assert_not_called()


### PR DESCRIPTION
## Summary

A worker stopped processing its queue and never came back. This PR fixes the cause, and makes the worker restart itself if it happens again.

## Why

We found two problems.

**1. The watchdog froze the worker.**

We have a watchdog that logs thread stacks when the event loop stops responding. It used `faulthandler.dump_traceback(all_threads=True)`.

That call can freeze the whole process when a thread is stuck inside a blocking C call. That is exactly when the watchdog runs. So the watchdog made things worse. 

We reproduced it locally. One blocking job, and the worker never returned. The log showed one warning and then silence. That matches what we saw in production.

**2. A blocking S3 upload ran on the event loop.**

`create_order_invoice` is `async`, but `s3.upload` is normal blocking boto3 code. Dramatiq runs all async jobs of a process on one event loop. So one slow upload stops every other job in that process.

`receipt/service.py` already handled this correctly. The invoice path did not.

## What

- The watchdog no longer uses `faulthandler`. It builds the stack text in plain Python.
- The watchdog finds the event loop thread by id. It used to look for a thread name that dramatiq never sets, so that log field was always empty.
- The watchdog exits the process after 3 misses in a row (about 60 seconds).
- The three blocking `s3.upload` calls now run in a thread with `asyncio.to_thread`.
- The S3 client now has timeouts. Before this, one call could take about 5 minutes.

## How

A stuck event loop cannot shut down cleanly, so the watchdog calls `os._exit`. Dramatiq sees the process die, stops the rest, and the platform starts a new one.

`WORKER_EVENT_LOOP_WATCHDOG_MAX_MISSES` controls this. Set it to `0` to only log and never exit.

## How we tested it

We reproduced the freeze locally with a temporary job that blocks on purpose, using the same setup as production (2 processes, 8 threads each). That job was only a local test and is not part of this PR (check the job code here https://github.com/polarsource/polar/pull/13827/changes/4369e3235b0cd03b261e20c9a44fc5a8ed26659c#diff-ccd625cb8c09c1f129a73ae8e068ea94cccfdb66339b7419bdbcabb5249b2e0e) 

| Case | Before | After |
| --- | --- | --- |
| One process stuck | Queue slow, the other process kept working | Same |
| Both processes stuck | Queue dead, nothing moved | Both exit in about 75s, service restarts |

One note: this was tested on macOS. The freeze itself may behave differently on Linux. The fix is safe either way.

## Follow up (not in this PR)

`send_confirmation_email` still builds the invoice PDF inline. That puts heavy PDF and S3 work on the low priority queue, even though a separate queue already exists for it.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
