### PR TITLE
aws/lambda: Specify concurrency limits and timeouts for workers

### DIFF
--- a/terraform/modules/aws_task_worker/main.tf
+++ b/terraform/modules/aws_task_worker/main.tf
@@ -245,4 +245,18 @@ resource "aws_lambda_event_source_mapping" "task" {
   batch_size              = 1
   enabled                 = var.enabled
   function_response_types = ["ReportBatchItemFailures"]
+
+  dynamic "scaling_config" {
+    for_each = var.max_concurrency != null ? [var.max_concurrency] : []
+    content {
+      maximum_concurrency = scaling_config.value
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.max_concurrency == null || var.reserved_concurrency == null
+      error_message = "max_concurrency and reserved_concurrency are mutually exclusive: a reservation is already a hard cap; combining them is redundant at best and reintroduces throttling at worst."
+    }
+  }
 }

--- a/terraform/modules/aws_task_worker/variables.tf
+++ b/terraform/modules/aws_task_worker/variables.tf
@@ -48,18 +48,31 @@ variable "timeout_seconds" {
   description = "Lambda function timeout. Must stay below the queue visibility timeout."
   type        = number
   default     = 120
+  nullable    = false
 }
 
 variable "memory_size" {
   description = "Lambda memory in MB."
   type        = number
   default     = 2048
+  nullable    = false
 }
 
 variable "reserved_concurrency" {
-  description = "null leaves the function unreserved (-1). Bounds warm containers, and therefore DB connections."
+  description = "Dedicated concurrency slots: a guaranteed floor that is also a hard ceiling. null leaves the function unreserved. Mutually exclusive with max_concurrency."
   type        = number
-  default     = 5
+  default     = null
+}
+
+variable "max_concurrency" {
+  description = "Caps concurrent invocations at the SQS poller without reserving from the account pool. null leaves consumption uncapped. Mutually exclusive with reserved_concurrency."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.max_concurrency == null || try(var.max_concurrency >= 2, false)
+    error_message = "AWS requires maximum_concurrency to be at least 2."
+  }
 }
 
 variable "max_retries" {
@@ -73,6 +86,7 @@ variable "enabled" {
   description = "Event source mapping toggle. false provisions the worker dormant."
   type        = bool
   default     = true
+  nullable    = false
 }
 
 variable "subnet_ids" {

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -95,12 +95,12 @@ locals {
   }
 
   lambda_worker_queues = {
-    "high-priority"         = { timeout_seconds = 120 }
-    "medium-priority"       = { timeout_seconds = 120 }
-    "low-priority"          = { timeout_seconds = 660 }
-    "webhooks"              = { timeout_seconds = 120, max_retries = 250 } # Must stay above webhook_event.send's max_retries.
-    "tinybird"              = { timeout_seconds = 120 }
-    "invoices-and-receipts" = { timeout_seconds = 240 }
+    "high-priority"         = {}
+    "medium-priority"       = { max_parallel_tasks = 8 }
+    "low-priority"          = { max_parallel_tasks = 16, task_time_limit_seconds = 660 }
+    "webhooks"              = { max_parallel_tasks = 16, max_retries = 250 } # Must stay above webhook_event.send's max_retries.
+    "tinybird"              = { max_parallel_tasks = 128 }
+    "invoices-and-receipts" = { max_parallel_tasks = 3, task_time_limit_seconds = 240 }
   }
 }
 
@@ -144,9 +144,12 @@ module "lambda_worker_queue" {
   queue_name               = "${local.worker_sqs_queue_prefix}-${each.key}"
   queue_prefix             = local.worker_sqs_queue_prefix
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
-  enabled                  = true
-  timeout_seconds          = each.value.timeout_seconds
+  enabled                  = try(each.value.processing_enabled, null)
+  timeout_seconds          = try(each.value.task_time_limit_seconds, null)
+  max_concurrency          = try(each.value.max_parallel_tasks, null)
+  reserved_concurrency     = try(each.value.guaranteed_parallel_tasks, null)
   max_retries              = try(each.value.max_retries, null)
+  memory_size              = try(each.value.memory_mb, null)
   tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -116,12 +116,12 @@ locals {
   }
 
   lambda_worker_queues = {
-    "high-priority"         = { timeout_seconds = 120 }
-    "medium-priority"       = { timeout_seconds = 120 }
-    "low-priority"          = { timeout_seconds = 660 }
-    "webhooks"              = { timeout_seconds = 120, max_retries = 250 } # Must stay above webhook_event.send's max_retries.
-    "tinybird"              = { timeout_seconds = 120 }
-    "invoices-and-receipts" = { timeout_seconds = 240 }
+    "high-priority"         = {}
+    "medium-priority"       = { max_parallel_tasks = 8 }
+    "low-priority"          = { max_parallel_tasks = 16, task_time_limit_seconds = 660 }
+    "webhooks"              = { max_parallel_tasks = 16, max_retries = 250 } # Must stay above webhook_event.send's max_retries.
+    "tinybird"              = { max_parallel_tasks = 128 }
+    "invoices-and-receipts" = { max_parallel_tasks = 3, task_time_limit_seconds = 240 }
   }
 }
 
@@ -165,9 +165,12 @@ module "lambda_worker_queue" {
   queue_name               = "${local.worker_sqs_queue_prefix}-${each.key}"
   queue_prefix             = local.worker_sqs_queue_prefix
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
-  enabled                  = true
-  timeout_seconds          = each.value.timeout_seconds
+  enabled                  = try(each.value.processing_enabled, null)
+  timeout_seconds          = try(each.value.task_time_limit_seconds, null)
+  max_concurrency          = try(each.value.max_parallel_tasks, null)
+  reserved_concurrency     = try(each.value.guaranteed_parallel_tasks, null)
   max_retries              = try(each.value.max_retries, null)
+  memory_size              = try(each.value.memory_mb, null)
   tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -101,12 +101,12 @@ locals {
   }
 
   lambda_worker_queues = {
-    "high-priority"         = { timeout_seconds = 120 }
-    "medium-priority"       = { timeout_seconds = 120 }
-    "low-priority"          = { timeout_seconds = 660 }
-    "webhooks"              = { timeout_seconds = 120, max_retries = 250 } # Must stay above webhook_event.send's max_retries.
-    "tinybird"              = { timeout_seconds = 120 }
-    "invoices-and-receipts" = { timeout_seconds = 240 }
+    "high-priority"         = {}
+    "medium-priority"       = { max_parallel_tasks = 8 }
+    "low-priority"          = { max_parallel_tasks = 16, task_time_limit_seconds = 660 }
+    "webhooks"              = { max_parallel_tasks = 16, max_retries = 250 } # Must stay above webhook_event.send's max_retries.
+    "tinybird"              = { max_parallel_tasks = 128 }
+    "invoices-and-receipts" = { max_parallel_tasks = 3, task_time_limit_seconds = 240 }
   }
 }
 
@@ -154,9 +154,12 @@ module "lambda_worker_queue" {
   queue_name               = "${local.worker_sqs_queue_prefix}-${each.key}"
   queue_prefix             = local.worker_sqs_queue_prefix
   image_uri                = "${module.lambda_worker_ecr[0].repository_url}:latest"
-  enabled                  = true
-  timeout_seconds          = each.value.timeout_seconds
+  enabled                  = try(each.value.processing_enabled, null)
+  timeout_seconds          = try(each.value.task_time_limit_seconds, null)
+  max_concurrency          = try(each.value.max_parallel_tasks, null)
+  reserved_concurrency     = try(each.value.guaranteed_parallel_tasks, null)
   max_retries              = try(each.value.max_retries, null)
+  memory_size              = try(each.value.memory_mb, null)
   tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids


### PR DESCRIPTION
Now that we have mapped our lambda workers to the same priorities as our Render workers. This specifies concurrency, timeout and other parameters for each worker queue.

From this we can go in different directions - we can increase the total concurrency, we can adjust which queue we prioritize in terms of max concurrency, etc.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

