### PR TITLE
aws: Use pgbouncer in production and test

### DIFF
--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -69,10 +69,10 @@ locals {
     POLAR_LOG_LEVEL                   = "INFO"
     POLAR_TESTING                     = "0"
     POLAR_POSTGRES_DATABASE           = "polar_cpit_p9lf"
-    POLAR_POSTGRES_HOST               = local.db_external_host
-    POLAR_POSTGRES_PORT               = local.db_port
+    POLAR_POSTGRES_HOST               = module.pgbouncer_aws.host
+    POLAR_POSTGRES_PORT               = module.pgbouncer_aws.port
     POLAR_POSTGRES_USER               = local.db_user
-    POLAR_POSTGRES_SSL                = "true"
+    POLAR_POSTGRES_SSL                = "false"
     POLAR_REDIS_HOST                  = module.redis.host
     POLAR_REDIS_PORT                  = tostring(module.redis.port)
     POLAR_REDIS_DB                    = "1"

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -75,10 +75,10 @@ locals {
     POLAR_LOG_LEVEL                   = "INFO"
     POLAR_TESTING                     = "0"
     POLAR_POSTGRES_DATABASE           = local.db_name
-    POLAR_POSTGRES_HOST               = local.db_external_host
-    POLAR_POSTGRES_PORT               = local.db_port
+    POLAR_POSTGRES_HOST               = module.pgbouncer_aws[0].host
+    POLAR_POSTGRES_PORT               = module.pgbouncer_aws[0].port
     POLAR_POSTGRES_USER               = local.db_user
-    POLAR_POSTGRES_SSL                = "true"
+    POLAR_POSTGRES_SSL                = "false"
     POLAR_REDIS_HOST                  = module.redis[0].host
     POLAR_REDIS_PORT                  = tostring(module.redis[0].port)
     POLAR_REDIS_DB                    = "1"

--- a/terraform/test/ecs.tf
+++ b/terraform/test/ecs.tf
@@ -3,3 +3,50 @@ module "ecs_cluster" {
 
   environment = "test"
 }
+
+# =============================================================================
+# PgBouncer for the Lambda worker
+# =============================================================================
+
+resource "aws_service_discovery_private_dns_namespace" "internal" {
+  count = local.test_enabled ? 1 : 0
+  name  = "polar-test.internal"
+  vpc   = module.vpc[0].vpc_id
+}
+
+resource "aws_secretsmanager_secret" "ghcr_pull" {
+  count = local.test_enabled ? 1 : 0
+  name  = "polar-test-ghcr-pull"
+}
+
+resource "aws_secretsmanager_secret_version" "ghcr_pull" {
+  count         = local.test_enabled ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.ghcr_pull[0].id
+  secret_string = jsonencode({ username = var.ghcr_username, password = var.ghcr_auth_token })
+}
+
+module "pgbouncer_aws" {
+  count  = local.test_enabled ? 1 : 0
+  source = "../modules/services/pgbouncer"
+
+  environment = "test"
+  vpc_id      = module.vpc[0].vpc_id
+  subnet_ids  = module.vpc[0].secondary_private_subnet_ids
+  cluster_arn = module.ecs_cluster.cluster_arn
+
+  namespace = {
+    id   = aws_service_discovery_private_dns_namespace.internal[0].id
+    name = aws_service_discovery_private_dns_namespace.internal[0].name
+  }
+
+  client_security_group_ids  = [aws_security_group.lambda[0].id]
+  permissions_boundary_arn   = data.aws_iam_policy.permission_boundary.arn
+  repository_credentials_arn = aws_secretsmanager_secret_version.ghcr_pull[0].arn
+
+  database = {
+    host     = local.db_external_host
+    port     = local.db_port
+    user     = local.db_user
+    password = local.db_password
+  }
+}


### PR DESCRIPTION
This enables the lambda workers in production and test to use the pgbouncer running in AWS.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

