### PR TITLE
tinybird: Set group by value as a named label

### DIFF
--- a/server/polar/integrations/tinybird/service.py
+++ b/server/polar/integrations/tinybird/service.py
@@ -1221,9 +1221,10 @@ class TinybirdEventsQuery:
                     ).label(f"{label}_sum")
                 )
 
+        group_value = group_col.label("value")
         statement = (
             sqlalchemy.select(
-                group_col.label("value"),
+                group_value,
                 func.count().label("occurrences"),
                 literal_column(
                     "uniqExact(if(customer_id IS NOT NULL,"
@@ -1235,7 +1236,7 @@ class TinybirdEventsQuery:
             .select_from(events_table)
             .where(base_filter)
             .where(group_col != "")
-            .group_by(group_col)
+            .group_by(group_value)
         )
 
         for f in self._filters:

--- a/server/tests/integrations/tinybird/test_service.py
+++ b/server/tests/integrations/tinybird/test_service.py
@@ -501,6 +501,30 @@ class TestTinybirdEventsQuery:
         assert customer_stats[0].occurrences == 4
         assert len(variance) >= 1
 
+    async def test_property_group_stats_on_custom_metadata_key(
+        self, tinybird_client: TinybirdClient
+    ) -> None:
+        org_id = uuid.uuid4()
+        events = [
+            create_test_event(
+                organization_id=org_id,
+                name="checkout",
+                source=EventSource.user,
+                user_metadata={"tier": tier},
+            )
+            for tier in ("pro", "pro", "free")
+        ]
+        await tinybird_client.ingest(
+            DATASOURCE_EVENTS, [_event_to_tinybird(e) for e in events], wait=True
+        )
+
+        stats = await TinybirdEventsQuery([org_id]).get_property_group_stats(
+            "tier", ["_cost.amount"]
+        )
+
+        by_value = {s.value: s.occurrences for s in stats}
+        assert by_value == {"pro": 2, "free": 1}
+
 
 @pytest.mark.skipif(not tinybird_available(), reason="Tinybird not running")
 @pytest.mark.asyncio


### PR DESCRIPTION
We need to treat the grouped by property as the same label as the selected value, otherwise the select will mismatch with the group by causing the generated Clickhouse query to be invalid.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

