### PR TITLE
worker: Initialize httpx in lambda worker as well

### DIFF
--- a/server/polar/worker/_httpx.py
+++ b/server/polar/worker/_httpx.py
@@ -19,6 +19,12 @@ async def _close_client() -> None:
         _httpx = None
 
 
+def setup_httpx() -> None:
+    global _httpx
+    _httpx = httpx.AsyncClient()
+    log.info("Created HTTPX client")
+
+
 class HTTPXMiddleware(dramatiq.Middleware):
     """
     Middleware managing the lifecycle of an HTTPX AsyncClient.
@@ -34,9 +40,7 @@ class HTTPXMiddleware(dramatiq.Middleware):
     def before_worker_boot(
         self, broker: dramatiq.Broker, worker: dramatiq.Worker
     ) -> None:
-        global _httpx
-        _httpx = httpx.AsyncClient()
-        log.info("Created HTTPX client")
+        setup_httpx()
 
     def after_worker_shutdown(
         self, broker: dramatiq.Broker, worker: dramatiq.Worker

--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -19,6 +19,7 @@ from polar.config import settings
 from polar.logging import CorrelationID, Logger
 
 from . import _sqs
+from ._httpx import _close_client, setup_httpx
 from ._redis import _close_redis, setup_redis
 from ._sqlalchemy import dispose_sqlalchemy_engine, setup_sqlalchemy
 
@@ -197,15 +198,17 @@ async def run_task(
 
 
 def bootstrap() -> None:
-    """Initialize worker resources (DB engine + Redis) for the SQS runner."""
+    """Initialize worker resources (DB engine + Redis + HTTPX) for the SQS runner."""
     setup_sqlalchemy(pool_name="worker-sqs")
     setup_redis()
+    setup_httpx()
     validate_allowlist()
 
 
 async def shutdown() -> None:
     await dispose_sqlalchemy_engine()
     await _close_redis()
+    await _close_client()
 
 
 __all__ = [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Initialize a shared `httpx.AsyncClient` in the Lambda/SQS worker and close it on shutdown. This matches the dramatiq worker behavior and prevents missing-client errors and connection leaks during HTTP calls.

- Extract `setup_httpx()` and reuse it in `HTTPXMiddleware.before_worker_boot`.
- Call `setup_httpx()` in SQS `bootstrap()` and `_close_client()` in `shutdown()`.
- No task or config changes required.

<sup>Written for commit b935b1aab2a1e591258acd26d17c230e9f3b171b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

