### PR TITLE
lambda: Prevent Retry exception from being reported as an error

### DIFF
--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -4,6 +4,7 @@ from typing import Any
 import logfire
 import sentry_sdk
 import structlog
+from dramatiq.errors import Retry
 
 from polar.config import settings
 from polar.logfire import configure_logfire
@@ -58,6 +59,9 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                         source_correlation_id=correlation_id,
                     )
                 )
+            except Retry as exc:
+                if _apply_retry_backoff(record, exc):
+                    batch_item_failures.append({"itemIdentifier": message_id})
             except Exception as exc:
                 sentry_sdk.capture_exception(exc)
                 log.error(


### PR DESCRIPTION
Retries are expected and should not be reported as errors in Sentry or otherwise


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

