### PR TITLE
aws/lambda: Increase max retries for webhook lambda

### DIFF
--- a/terraform/modules/aws_task_worker/variables.tf
+++ b/terraform/modules/aws_task_worker/variables.tf
@@ -61,6 +61,7 @@ variable "max_retries" {
   description = "DLQ redrive maxReceiveCount is max_retries + 1. Backoffs past 12h are rescheduled via EventBridge Scheduler, which resets the SQS receive count, so this only bounds the in-queue retry climb before the handoff."
   type        = number
   default     = 20
+  nullable    = false
 }
 
 variable "enabled" {

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -111,7 +111,7 @@ locals {
     "high-priority"         = { timeout_seconds = 120 }
     "medium-priority"       = { timeout_seconds = 120 }
     "low-priority"          = { timeout_seconds = 660 }
-    "webhooks"              = { timeout_seconds = 120 }
+    "webhooks"              = { timeout_seconds = 120, max_retries = 250 } # Must stay above webhook_event.send's max_retries.
     "tinybird"              = { timeout_seconds = 120 }
     "invoices-and-receipts" = { timeout_seconds = 240 }
   }
@@ -145,6 +145,7 @@ module "lambda_worker_queue" {
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
   enabled                  = true
   timeout_seconds          = each.value.timeout_seconds
+  max_retries              = try(each.value.max_retries, null)
   tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -130,7 +130,7 @@ locals {
     "high-priority"         = { timeout_seconds = 120 }
     "medium-priority"       = { timeout_seconds = 120 }
     "low-priority"          = { timeout_seconds = 660 }
-    "webhooks"              = { timeout_seconds = 120 }
+    "webhooks"              = { timeout_seconds = 120, max_retries = 250 } # Must stay above webhook_event.send's max_retries.
     "tinybird"              = { timeout_seconds = 120 }
     "invoices-and-receipts" = { timeout_seconds = 240 }
   }
@@ -164,6 +164,7 @@ module "lambda_worker_queue" {
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
   enabled                  = true
   timeout_seconds          = each.value.timeout_seconds
+  max_retries              = try(each.value.max_retries, null)
   tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -115,7 +115,7 @@ locals {
     "high-priority"         = { timeout_seconds = 120 }
     "medium-priority"       = { timeout_seconds = 120 }
     "low-priority"          = { timeout_seconds = 660 }
-    "webhooks"              = { timeout_seconds = 120 }
+    "webhooks"              = { timeout_seconds = 120, max_retries = 250 } # Must stay above webhook_event.send's max_retries.
     "tinybird"              = { timeout_seconds = 120 }
     "invoices-and-receipts" = { timeout_seconds = 240 }
   }
@@ -150,6 +150,7 @@ module "lambda_worker_queue" {
   image_uri                = "${module.lambda_worker_ecr[0].repository_url}:latest"
   enabled                  = true
   timeout_seconds          = each.value.timeout_seconds
+  max_retries              = try(each.value.max_retries, null)
   tags                     = local.lambda_worker_tags
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids


### PR DESCRIPTION
Since we are treating the webhook retries a bit differently from other tasks, we need to give it more retries.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

