### PR TITLE
scripts: Add SQS DLQ redrive script

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -104,6 +104,7 @@ dev = [
   # * https://futuresearch.ai/blog/litellm-pypi-supply-chain-attack/
   # * https://pypi.org/project/litellm/
   # "litellm==1.82.3",
+  "botocore[crt]>=1.43.38",
 ]
 
 [tool.taskipy.tasks]

--- a/server/scripts/dlq.py
+++ b/server/scripts/dlq.py
@@ -1,0 +1,136 @@
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+import boto3
+import typer
+from botocore.config import Config
+
+if TYPE_CHECKING:
+    from mypy_boto3_sqs.client import SQSClient
+    from mypy_boto3_sqs.type_defs import ListMessageMoveTasksResultEntryTypeDef
+
+cli = typer.Typer()
+
+
+class Env(StrEnum):
+    production = "production"
+    sandbox = "sandbox"
+    test = "test"
+
+
+def get_client(region: str) -> "SQSClient":
+    return boto3.client("sqs", config=Config(region_name=region))
+
+
+def get_dlq_urls(client: "SQSClient", env: Env) -> dict[str, str]:
+    prefix = f"polar-{env.value}-tasks"
+    urls: list[str] = []
+    next_token: str | None = None
+    while True:
+        response = client.list_queues(
+            QueueNamePrefix=prefix,
+            MaxResults=1000,
+            **({"NextToken": next_token} if next_token else {}),
+        )
+        urls.extend(response.get("QueueUrls", []))
+        next_token = response.get("NextToken")
+        if next_token is None:
+            break
+    return {url.rsplit("/", 1)[1]: url for url in urls if url.endswith("-dlq")}
+
+
+def get_queue_arn_and_depth(client: "SQSClient", queue_url: str) -> tuple[str, int]:
+    attributes = client.get_queue_attributes(
+        QueueUrl=queue_url,
+        AttributeNames=["QueueArn", "ApproximateNumberOfMessages"],
+    )["Attributes"]
+    return attributes["QueueArn"], int(attributes["ApproximateNumberOfMessages"])
+
+
+def get_latest_move_task(
+    client: "SQSClient", source_arn: str
+) -> "ListMessageMoveTasksResultEntryTypeDef | None":
+    results = client.list_message_move_tasks(SourceArn=source_arn, MaxResults=1).get(
+        "Results", []
+    )
+    return results[0] if results else None
+
+
+def resolve_dlq(client: "SQSClient", env: Env, queue: str) -> tuple[str, str]:
+    name = f"polar-{env.value}-tasks-{queue}-dlq"
+    dlq_urls = get_dlq_urls(client, env)
+    if name not in dlq_urls:
+        typer.echo(f"No DLQ named {name}. Available: {', '.join(sorted(dlq_urls))}")
+        raise typer.Exit(1)
+    return name, dlq_urls[name]
+
+
+@cli.command("list")
+def list_dlqs(env: Env, region: str = typer.Option("us-east-2", "--region")) -> None:
+    client = get_client(region)
+    dlq_urls = get_dlq_urls(client, env)
+    if not dlq_urls:
+        typer.echo(f"No DLQs found for {env.value}")
+        raise typer.Exit(1)
+    for name, url in sorted(dlq_urls.items()):
+        arn, depth = get_queue_arn_and_depth(client, url)
+        line = f"{name}: {depth} message(s)"
+        task = get_latest_move_task(client, arn)
+        if task is not None:
+            moved = task.get("ApproximateNumberOfMessagesMoved", 0)
+            total = task.get("ApproximateNumberOfMessagesToMove", 0)
+            line += f" — last redrive {task['Status']} ({moved}/{total} moved)"
+            if task.get("FailureReason"):
+                line += f" [{task['FailureReason']}]"
+        typer.echo(line)
+
+
+@cli.command()
+def redrive(
+    env: Env,
+    queue: str = typer.Argument(help="Short queue name (e.g. webhooks), or 'all'"),
+    rate: int | None = typer.Option(None, "--rate", min=1, max=500),
+    region: str = typer.Option("us-east-2", "--region"),
+) -> None:
+    client = get_client(region)
+    if queue == "all":
+        targets = get_dlq_urls(client, env)
+    else:
+        targets = dict([resolve_dlq(client, env, queue)])
+    for name, url in sorted(targets.items()):
+        arn, depth = get_queue_arn_and_depth(client, url)
+        if depth == 0:
+            typer.echo(f"{name}: empty, skipping")
+            continue
+        task = get_latest_move_task(client, arn)
+        if task is not None and task["Status"] == "RUNNING":
+            typer.echo(f"{name}: redrive already running, skipping")
+            continue
+        if rate is not None:
+            client.start_message_move_task(
+                SourceArn=arn, MaxNumberOfMessagesPerSecond=rate
+            )
+        else:
+            client.start_message_move_task(SourceArn=arn)
+        typer.echo(f"{name}: redrive started for {depth} message(s)")
+
+
+@cli.command()
+def cancel(
+    env: Env,
+    queue: str,
+    region: str = typer.Option("us-east-2", "--region"),
+) -> None:
+    client = get_client(region)
+    name, url = resolve_dlq(client, env, queue)
+    arn, _ = get_queue_arn_and_depth(client, url)
+    task = get_latest_move_task(client, arn)
+    if task is None or task["Status"] != "RUNNING":
+        typer.echo(f"{name}: no running redrive")
+        raise typer.Exit(1)
+    client.cancel_message_move_task(TaskHandle=task["TaskHandle"])
+    typer.echo(f"{name}: redrive cancelled")
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -370,6 +370,33 @@ wheels = [
 ]
 
 [[package]]
+name = "awscrt"
+version = "0.32.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/cb/980fe60c4209af71d036276217f8b9f372f958e290c15d2849a3de4dcd23/awscrt-0.32.2.tar.gz", hash = "sha256:a4f48805e8a66237923f03b7b692d213994cff42d1ff08125d1d60c74fcaf872", size = 36862073, upload-time = "2026-04-24T22:59:55.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/99/a6c712a2f638c766b0879da0eacd9fe5695c64deb89c0357bcc4f1f4df9b/awscrt-0.32.2-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:32785f54d0786e07b6491b51f9c2f75ea9e17decd39bb6b66fdc60cd871a49ef", size = 3406247, upload-time = "2026-04-24T22:58:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/03/665c81f3b9d3c56fcdfb8f353c22501bc538d192c431cfaaf307f867d404/awscrt-0.32.2-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f8a586c52f41ff14c2f1b8afeb764e231ad3d66acfd42a6b9fb6c8afd8da8fe2", size = 3906890, upload-time = "2026-04-24T22:58:47.96Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ad/5db0691a0c72d55a17c03c47149cf15d4602b83b470355c322c9a7f115e8/awscrt-0.32.2-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3ef1664588d35dcad2115377120667e689cd7a517da52a481373c9536811ed96", size = 4196631, upload-time = "2026-04-24T22:58:49.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/66/63a4654b2996158f33e88d74d79178a5812d94a7e0d6c94ec475115dff18/awscrt-0.32.2-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7ed7c209136650fe25659436bb4150e5af6eb43d71a0bf294f0bf414428736ee", size = 3818090, upload-time = "2026-04-24T22:58:50.657Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/26/b8fee227918465830a0bbba48f54ebf0a5029c3a7d11d4fa973838a79262/awscrt-0.32.2-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:cfd437122d5a2ec7eb9fffaf2cd8b96543d4a0d7e906b9515b79672005a1607a", size = 4056453, upload-time = "2026-04-24T22:58:52.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/f5b9e9677bf90d1840d4db1513ba92e73601ef82e61a16e747a83493d35c/awscrt-0.32.2-cp311-abi3-win32.whl", hash = "sha256:5197d1e4e780d755632f79f8d32a09a30a9101cccb51ca1694fe25c711b2e801", size = 4066027, upload-time = "2026-04-24T22:58:53.752Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0b/fd1798551ecdc8a28d61ecdeda248f99faa3457f83aefa10ab797f466889/awscrt-0.32.2-cp311-abi3-win_amd64.whl", hash = "sha256:80420aa19c074a4c0335f2bd0e4aee3381fa452328d937795a1e0c779f0c052d", size = 4221984, upload-time = "2026-04-24T22:58:55.115Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a3/075e29b39945f398adfb5d5ee4d533e00d37c0f5c68d79b250a1bdb087ba/awscrt-0.32.2-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:d2f7aee3bce261ab1ceba1fac404de4d496aa866237161d4257cef92bff9d828", size = 3404901, upload-time = "2026-04-24T22:58:56.492Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/41/1c4783b32bf4ec7383156787570ea1221c95c037c2c0f11cbc9e9529ba48/awscrt-0.32.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff0fff9c2b613d7fabc298b0fd81f0d7056353f3d20271a852a719c5b2f7ccf4", size = 3897627, upload-time = "2026-04-24T22:58:58.144Z" },
+    { url = "https://files.pythonhosted.org/packages/af/2d/5736128847ff4a877d50720ea7a48d7e50a56b78741919e4b6ffabffb1ad/awscrt-0.32.2-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:79bb11d5d1dfdcfd867aac4a026bee11afbd2154279e12b66588442d8c14bdf7", size = 4189579, upload-time = "2026-04-24T22:58:59.56Z" },
+    { url = "https://files.pythonhosted.org/packages/90/f5/064b23d4c927e9b63725ee60c88edb75a1e8f5fd1e97d56d4d6a63fe954b/awscrt-0.32.2-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:47330f421948207a122092042f235cf82d48fa145c446ff4db12cc8cd3a418b6", size = 3809647, upload-time = "2026-04-24T22:59:00.884Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/36/f14ea531cccb6ff85c4d50c9e79e61030675520a393b4af23685d24ea018/awscrt-0.32.2-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5ec4d8200eb0158b60e35fbb65faa96ef1eb7763f6ce1192827886ee24c6df99", size = 4051532, upload-time = "2026-04-24T22:59:02.593Z" },
+    { url = "https://files.pythonhosted.org/packages/64/aa/b12e721c8148a1bbc58a22cbd204d88d0a6263331049d40c057f9dcd3e11/awscrt-0.32.2-cp313-abi3-win32.whl", hash = "sha256:a81f30a501d2eb6ba52c769cd6ecb3f7005512fba4a533211dc717e1115b0d94", size = 4062484, upload-time = "2026-04-24T22:59:04.251Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/26/9f5f23647465a4fe1b28afce334e54a4264e23b69365024c28955f0c4119/awscrt-0.32.2-cp313-abi3-win_amd64.whl", hash = "sha256:8d731edda20dce5afc15a04731d91136a31779a244672d1f0a292a8b04aa0fd3", size = 4220425, upload-time = "2026-04-24T22:59:05.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/09/51fca333d42b53ddb04881f53e3cc0f4462872ac81426fbb34f5d0b1d1fb/awscrt-0.32.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7404cb551046bbe7cd454ea75f88b4a1b26f018d1b9bea83dbe46c174789d835", size = 3414716, upload-time = "2026-04-24T22:59:18.918Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3a/0ae52a8dfb0e3c37f0129232d79307c65e6ee1ea13a3cbdcf301aaad0a6a/awscrt-0.32.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:51d6132e9d70de40da07dfad5f17780a652dd4b351c35ca97c79d0fa0186d645", size = 4028980, upload-time = "2026-04-24T22:59:20.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/7f/7f52020bfcf29122cad77e936d82abaa1f6857a5a70453e8cc734119f0e2/awscrt-0.32.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:193cc3ecf03a1dd6f989853b6c21549a0a9750c855520fedc8c3c8fbcd32e1bc", size = 4312564, upload-time = "2026-04-24T22:59:21.851Z" },
+    { url = "https://files.pythonhosted.org/packages/25/86/2c9b5479e08b8198459d2a781df5524e45d4d0f9c6329bad26979a4d1e85/awscrt-0.32.2-cp314-cp314t-win32.whl", hash = "sha256:25c7e7e6535cb2d2a4d22fd6264f621672d3903491318364dbc59066b63c7186", size = 4195784, upload-time = "2026-04-24T22:59:23.769Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/85/a12515514de8969b9e7fa40bb782501a336a8a985cc3093309120a80b627/awscrt-0.32.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a6782c19a00f354c7b232b675f09cde94d1ca37bcf29009b8779b3f6395b27b4", size = 4366435, upload-time = "2026-04-24T22:59:25.53Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -471,6 +498,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/73/6c/815f49f0c582396b1a4c37df554ffab6bb420abd5a96d5329183a97022de/botocore-1.43.38.tar.gz", hash = "sha256:70fbd5c74f5742f5975ddcc61e6afb5174cb80577c2ccc17c6898ad3a49b51f3", size = 15628316, upload-time = "2026-06-30T19:55:19.2Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/b4/fdff7920b3776b37f8b42d4e6eabb141974fa88f9fb1aae5c2224bdaf635/botocore-1.43.38-py3-none-any.whl", hash = "sha256:54c1c41aff82422d2b88a8a7d782fde8ae1299a45f088d00011d85c4bc44b0cc", size = 15312254, upload-time = "2026-06-30T19:55:14.837Z" },
+]
+
+[package.optional-dependencies]
+crt = [
+    { name = "awscrt" },
 ]
 
 [[package]]
@@ -2530,6 +2562,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "boto3-stubs", extra = ["lambda", "s3", "scheduler", "sqs"] },
+    { name = "botocore", extra = ["crt"] },
     { name = "coverage" },
     { name = "debugpy" },
     { name = "fakeredis", extra = ["lua"] },
@@ -2629,6 +2662,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "boto3-stubs", extras = ["s3", "sqs", "lambda", "scheduler"], specifier = ">=1.43.26" },
+    { name = "botocore", extras = ["crt"], specifier = ">=1.43.38" },
     { name = "coverage", specifier = ">=7.14.1" },
     { name = "debugpy", specifier = ">=1.8.21" },
     { name = "fakeredis", extras = ["lua"], specifier = ">=2.36.1" },


### PR DESCRIPTION
When tasks end up in the DLQ for whatever reason, we need a way to put them back in the original queue if we can fix the issue that placed them there in the first place.

This script allows us to inspect and redrive messages from any queue.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

