### PR TITLE
Add timeout configuration to generated SDKs

### DIFF
--- a/sdk/generator/python/template/README.md
+++ b/sdk/generator/python/template/README.md
@@ -94,6 +94,26 @@ separate.
 Keep organization access tokens on the server and never expose them in browser or client-side
 code.
 
+## Request Timeouts
+
+Set the default timeout for all requests when creating the client. Timeout values are expressed
+in seconds:
+
+```python
+polar = Polar("polar_oat_xxx", timeout=30)
+```
+
+Override the timeout for an individual request with `request_timeout`:
+
+```python
+customer_state = polar.customers.get_state_external(
+    "customer_external_id",
+    request_timeout=60,
+)
+```
+
+Pass an `httpx.Timeout` instance to configure connect, read, write, and pool timeouts separately.
+
 ## Deserializing Data
 
 Use `deserialize` to convert arbitrary data into a generated SDK model or union type:

--- a/sdk/generator/python/template/polar/__init__.py
+++ b/sdk/generator/python/template/polar/__init__.py
@@ -3,6 +3,7 @@ from polar.base import (
     PolarError,
     PolarNetworkError,
     PolarServerError,
+    RequestTimeout,
     deserialize,
 )
 
@@ -12,5 +13,6 @@ __all__ = [
     "PolarNetworkError",
     "PolarServerError",
     "PolarClientError",
+    "RequestTimeout",
     "deserialize",
 ]

--- a/sdk/generator/python/template/polar/base.py
+++ b/sdk/generator/python/template/polar/base.py
@@ -9,6 +9,7 @@ import typing_extensions
 
 _EnvironmentT = typing.TypeVar("_EnvironmentT", bound=str)
 _ModelT = typing.TypeVar("_ModelT")
+RequestTimeout: typing.TypeAlias = float | httpx.Timeout
 
 
 class PolarError(Exception):
@@ -72,6 +73,7 @@ class BuildRequestMixin:
         path_params: dict[str, typing.Any] | None = None,
         query_params: dict[str, typing.Any] | None = None,
         body: typing.Any | None = None,
+        request_timeout: RequestTimeout | None = None,
     ) -> httpx.Request:
         url = url.format(**(path_params or {}))
 
@@ -85,13 +87,23 @@ class BuildRequestMixin:
             else:
                 params[k] = v
 
-        return self._client.build_request(method, url, params=params, json=body)
+        timeout = self._client.timeout if request_timeout is None else request_timeout
+        return self._client.build_request(
+            method, url, params=params, json=body, timeout=timeout
+        )
 
 
 class SyncClientBase(BuildRequestMixin):
-    def __init__(self, base_url: str, version: str, access_token: str) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        version: str,
+        access_token: str,
+        timeout: RequestTimeout | None = 5.0,
+    ) -> None:
         self._client = httpx.Client(
             base_url=base_url,
+            timeout=timeout,
             headers={
                 "Polar-Version": version,
                 "Authorization": f"Bearer {access_token}",
@@ -118,9 +130,16 @@ class SyncClientBase(BuildRequestMixin):
 
 
 class AsyncClientBase(BuildRequestMixin):
-    def __init__(self, base_url: str, version: str, access_token: str) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        version: str,
+        access_token: str,
+        timeout: RequestTimeout | None = 5.0,
+    ) -> None:
         self._client = httpx.AsyncClient(
             base_url=base_url,
+            timeout=timeout,
             headers={
                 "Polar-Version": version,
                 "Authorization": f"Bearer {access_token}",

--- a/sdk/generator/python/template/polar/version/client.py
+++ b/sdk/generator/python/template/polar/version/client.py
@@ -1,7 +1,7 @@
 import types
 import typing
 
-from polar.base import AsyncClientBase, SyncClientBase, resolve_base_url
+from polar.base import AsyncClientBase, RequestTimeout, SyncClientBase, resolve_base_url
 
 {% for service in api.services %}
 from polar.{{ version }}.services.{{ service.name | service_name }} import {{ service.name }}Async
@@ -25,9 +25,12 @@ class Polar:
         *,
         environment: Environment = "production",
         base_url: str | None = None,
+        timeout: RequestTimeout | None = 5.0,
     ) -> None:
         resolved_base_url = resolve_base_url(SERVERS, environment, base_url)
-        self._client = SyncClientBase(resolved_base_url, self.version, access_token)
+        self._client = SyncClientBase(
+            resolved_base_url, self.version, access_token, timeout
+        )
 {% for service in api.services %}
         self.{{ service.name | service_name }} = {{ service.name }}Sync(self._client)
 {% endfor %}
@@ -54,9 +57,12 @@ class PolarAsync:
         *,
         environment: Environment = "production",
         base_url: str | None = None,
+        timeout: RequestTimeout | None = 5.0,
     ) -> None:
         resolved_base_url = resolve_base_url(SERVERS, environment, base_url)
-        self._client = AsyncClientBase(resolved_base_url, self.version, access_token)
+        self._client = AsyncClientBase(
+            resolved_base_url, self.version, access_token, timeout
+        )
 {% for service in api.services %}
         self.{{ service.name | service_name }} = {{ service.name }}Async(self._client)
 {% endfor %}

--- a/sdk/generator/python/template/polar/version/services/service.py
+++ b/sdk/generator/python/template/polar/version/services/service.py
@@ -158,7 +158,7 @@ Args:
     {{ param.parameter_name }}:{% if param.description %} {{ param.description }}{% endif %}
 
 {% endfor %}
-    request_timeout: Timeout override for this request, in seconds.
+    request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
 
 {% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}
@@ -291,7 +291,7 @@ Args:
     {{ param.parameter_name }}:{% if param.description %} {{ param.description }}{% endif %}
 
 {% endfor %}
-    request_timeout: Timeout override for each request, in seconds.
+    request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
 
 {% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}
@@ -439,7 +439,7 @@ Args:
     {{ param.parameter_name }}:{% if param.description %} {{ param.description }}{% endif %}
 
 {% endfor %}
-    request_timeout: Timeout override for this request, in seconds.
+    request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
 
 {% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}
@@ -569,7 +569,7 @@ Raises:
 {% endfor %}{% for param in method.query_params %}
     {{ param.parameter_name }}:{% if param.description %} {{ param.description }}{% endif %}
 
-{% endfor %}    request_timeout: Timeout override for each request, in seconds.
+{% endfor %}    request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
 
 {% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}

--- a/sdk/generator/python/template/polar/version/services/service.py
+++ b/sdk/generator/python/template/polar/version/services/service.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import typing
 
 from polar.base import AsyncServiceBase, SyncServiceBase
+{% if service.methods %}
+from polar.base import RequestTimeout
+{% endif %}
 {% if service.methods | selectattr("response_type", "equalto", "json") | list %}
 from polar.base import parse_response_json
 {% endif %}
@@ -68,9 +71,7 @@ class {{ service.name }}Sync(SyncServiceBase):
         {% for param in method.path_params %}
         {{ param.name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -80,6 +81,7 @@ class {{ service.name }}Sync(SyncServiceBase):
         {{ param.name }}: {{ param.type | type_annotation }} = ...,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> {{ method.response | type_annotation }}: ...
 
@@ -95,9 +97,7 @@ class {{ service.name }}Sync(SyncServiceBase):
         {% for param in method.path_params %}
         {{ param.name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -107,6 +107,7 @@ class {{ service.name }}Sync(SyncServiceBase):
         {{ param.name }}: {{ param.type | type_annotation }} = ...,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> {{ method.response | type_annotation }}: ...
 
@@ -120,9 +121,7 @@ class {{ service.name }}Sync(SyncServiceBase):
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -132,6 +131,7 @@ class {{ service.name }}Sync(SyncServiceBase):
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = None,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         {% if method.body and (method.body.kind == 'union' or method.body.kind == 'union_ref') %}
         **kwargs: typing.Any,
         {% elif method.body %}
@@ -158,6 +158,8 @@ Args:
     {{ param.parameter_name }}:{% if param.description %} {{ param.description }}{% endif %}
 
 {% endfor %}
+    request_timeout: Timeout override for this request, in seconds.
+
 {% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}
 
@@ -176,6 +178,7 @@ Raises:
             url="{{ method.path }}",
             path_params={ {% for param in method.path_params %}"{{ param.name }}": {{ param.parameter_name }}, {% endfor %} },
             query_params={ {% for param in method.query_params %}"{{ param.name }}": {{ param.parameter_name }}, {% endfor %} },
+            request_timeout=request_timeout,
             {% if method.body %}
             body=kwargs,
             {% endif %}
@@ -207,9 +210,7 @@ Raises:
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -219,6 +220,7 @@ Raises:
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = ...,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> typing.Generator[{{ method.pagination.item_schema | type_annotation }}, None, None]: ...
 
@@ -234,9 +236,7 @@ Raises:
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -246,6 +246,7 @@ Raises:
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = ...,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> typing.Generator[{{ method.pagination.item_schema | type_annotation }}, None, None]: ...
 
@@ -259,9 +260,7 @@ Raises:
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -271,6 +270,7 @@ Raises:
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = None,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         {% if method.body and (method.body.kind == 'union' or method.body.kind == 'union_ref') %}
         **kwargs: typing.Any,
         {% elif method.body %}
@@ -291,6 +291,8 @@ Args:
     {{ param.parameter_name }}:{% if param.description %} {{ param.description }}{% endif %}
 
 {% endfor %}
+    request_timeout: Timeout override for each request, in seconds.
+
 {% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}
 
@@ -315,6 +317,7 @@ Raises:
                 {% for param in method.query_params %}
                 {{ param.parameter_name }}={{ param.parameter_name }},
                 {% endfor %}
+                request_timeout=request_timeout,
                 {% if method.body %}
                 **kwargs,
                 {% endif %}
@@ -349,9 +352,7 @@ class {{ service.name }}Async(AsyncServiceBase):
         {% for param in method.path_params %}
         {{ param.name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -361,6 +362,7 @@ class {{ service.name }}Async(AsyncServiceBase):
         {{ param.name }}: {{ param.type | type_annotation }} = ...,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> {{ method.response | type_annotation }}: ...
 
@@ -376,9 +378,7 @@ class {{ service.name }}Async(AsyncServiceBase):
         {% for param in method.path_params %}
         {{ param.name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -388,6 +388,7 @@ class {{ service.name }}Async(AsyncServiceBase):
         {{ param.name }}: {{ param.type | type_annotation }} = ...,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> {{ method.response | type_annotation }}: ...
 
@@ -401,9 +402,7 @@ class {{ service.name }}Async(AsyncServiceBase):
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -413,6 +412,7 @@ class {{ service.name }}Async(AsyncServiceBase):
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = None,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         {% if method.body and (method.body.kind == 'union' or method.body.kind == 'union_ref') %}
         **kwargs: typing.Any,
         {% elif method.body %}
@@ -439,6 +439,8 @@ Args:
     {{ param.parameter_name }}:{% if param.description %} {{ param.description }}{% endif %}
 
 {% endfor %}
+    request_timeout: Timeout override for this request, in seconds.
+
 {% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}
 
@@ -457,6 +459,7 @@ Raises:
             url="{{ method.path }}",
             path_params={ {% for param in method.path_params %}"{{ param.name }}": {{ param.parameter_name }}, {% endfor %} },
             query_params={ {% for param in method.query_params %}"{{ param.name }}": {{ param.parameter_name }}, {% endfor %} },
+            request_timeout=request_timeout,
             {% if method.body %}
             body=kwargs,
             {% endif %}
@@ -488,9 +491,7 @@ Raises:
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -500,6 +501,7 @@ Raises:
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = ...,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> typing.AsyncGenerator[{{ method.pagination.item_schema | type_annotation }}, None]: ...
 
@@ -515,9 +517,7 @@ Raises:
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -527,6 +527,7 @@ Raises:
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = ...,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> typing.AsyncGenerator[{{ method.pagination.item_schema | type_annotation }}, None]: ...
 
@@ -540,9 +541,7 @@ Raises:
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
         {% endfor %}
-        {% if method.query_params %}
         *,
-        {% endif %}
         {% for param in method.query_params %}
         {% if param.default is not none %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = {{ param.default | format_default }},
@@ -552,6 +551,7 @@ Raises:
         {{ param.parameter_name }}: {{ param.type | type_annotation }} = None,
         {% endif %}
         {% endfor %}
+        request_timeout: RequestTimeout | None = None,
         {% if method.body and (method.body.kind == 'union' or method.body.kind == 'union_ref') %}
         **kwargs: typing.Any,
         {% elif method.body %}
@@ -569,7 +569,9 @@ Raises:
 {% endfor %}{% for param in method.query_params %}
     {{ param.parameter_name }}:{% if param.description %} {{ param.description }}{% endif %}
 
-{% endfor %}{% if method.body %}
+{% endfor %}    request_timeout: Timeout override for each request, in seconds.
+
+{% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}
 
 {% endif %}
@@ -593,6 +595,7 @@ Raises:
                 {% for param in method.query_params %}
                 {{ param.parameter_name }}={{ param.parameter_name }},
                 {% endfor %}
+                request_timeout=request_timeout,
                 {% if method.body %}
                 **kwargs,
                 {% endif %}

--- a/sdk/generator/python/template/tests/test_base.py
+++ b/sdk/generator/python/template/tests/test_base.py
@@ -1,6 +1,7 @@
 import dataclasses
 import typing
 
+import httpx
 import pytest
 
 from polar import deserialize
@@ -67,6 +68,51 @@ def client(request) -> SyncClientBase | AsyncClientBase:
 
 
 class TestBuildRequest:
+    def test_client_timeout(self, client: SyncClientBase | AsyncClientBase) -> None:
+        request = client.build_request(method="GET", url="/v1/items/")
+
+        assert request.extensions["timeout"] == {
+            "connect": 5.0,
+            "read": 5.0,
+            "write": 5.0,
+            "pool": 5.0,
+        }
+
+    def test_request_timeout_override(
+        self, client: SyncClientBase | AsyncClientBase
+    ) -> None:
+        request = client.build_request(
+            method="GET", url="/v1/items/", request_timeout=30.0
+        )
+
+        assert request.extensions["timeout"] == {
+            "connect": 30.0,
+            "read": 30.0,
+            "write": 30.0,
+            "pool": 30.0,
+        }
+
+    @pytest.mark.parametrize("client_class", [SyncClientBase, AsyncClientBase])
+    def test_advanced_client_timeout(
+        self,
+        client_class: type[SyncClientBase] | type[AsyncClientBase],
+    ) -> None:
+        client = client_class(
+            base_url="https://api.polar.sh",
+            version="2026-04",
+            access_token="polar_at_u_xxx",
+            timeout=httpx.Timeout(30.0, connect=10.0),
+        )
+
+        request = client.build_request(method="GET", url="/v1/items/")
+
+        assert request.extensions["timeout"] == {
+            "connect": 10.0,
+            "read": 30.0,
+            "write": 30.0,
+            "pool": 30.0,
+        }
+
     @pytest.mark.parametrize(
         ("value", "expected"),
         [

--- a/sdk/generator/typescript/template/README.md
+++ b/sdk/generator/typescript/template/README.md
@@ -38,6 +38,26 @@ The client uses the production environment by default. To use the sandbox, pass
 Keep organization access tokens on the server and never expose them in browser or client-side
 code.
 
+## Request Timeouts
+
+Set the default timeout for all requests when creating the client. Timeout values are expressed
+in seconds:
+
+```typescript
+const polar = createPolar({
+  accessToken: "polar_oat_xxx",
+  timeout: 30,
+});
+```
+
+Override the timeout for an individual request with the final request options argument:
+
+```typescript
+const customerState = await polar.customers.getStateExternal("customer_external_id", {
+  timeout: 60,
+});
+```
+
 ## Individual API Functions
 
 To import individual API functions for tree-shaking, create a core client and pass it to the

--- a/sdk/generator/typescript/template/src/base.test.ts
+++ b/sdk/generator/typescript/template/src/base.test.ts
@@ -74,6 +74,46 @@ describe("sendRequest", () => {
     expect(timeout).toHaveBeenCalledWith(30_000);
   });
 
+  test("combines a request signal with the timeout signal", async () => {
+    const requestSignal = new AbortController().signal;
+    const timeoutSignal = new AbortController().signal;
+    const combinedSignal = new AbortController().signal;
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    const any = vi.spyOn(AbortSignal, "any").mockReturnValue(combinedSignal);
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+    const client = new ClientBase({
+      baseUrl: "https://api.polar.sh",
+      version: "{{ ir.versions[0].version }}",
+      accessToken: "polar_at_u_xxx",
+      timeout: 10,
+    });
+
+    await client.sendRequest([
+      "https://api.polar.sh/v1/items/",
+      { signal: requestSignal },
+    ]);
+
+    expect(any).toHaveBeenCalledWith([requestSignal, timeoutSignal]);
+    expect(fetch).toHaveBeenCalledWith("https://api.polar.sh/v1/items/", {
+      signal: combinedSignal,
+    });
+  });
+
+  test.each([-1, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483.648])(
+    "rejects an invalid timeout of %s seconds",
+    async (timeout) => {
+      const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+
+      await expect(
+        client.sendRequest(
+          ["https://api.polar.sh/v1/items/", {}],
+          { timeout },
+        ),
+      ).rejects.toThrow(RangeError);
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+
   test("does not create a timeout signal when no timeout is configured", async () => {
     const timeout = vi.spyOn(AbortSignal, "timeout");
     const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());

--- a/sdk/generator/typescript/template/src/base.test.ts
+++ b/sdk/generator/typescript/template/src/base.test.ts
@@ -115,6 +115,13 @@ describe("sendRequest", () => {
   );
 
   test("does not create a timeout signal when no timeout is configured", async () => {
+    const client = new ClientBase({
+      baseUrl: "https://api.polar.sh",
+      version: "{{ ir.versions[0].version }}",
+      accessToken: "polar_at_u_xxx",
+      timeout: undefined,
+    });
+
     const timeout = vi.spyOn(AbortSignal, "timeout");
     const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
 

--- a/sdk/generator/typescript/template/src/base.test.ts
+++ b/sdk/generator/typescript/template/src/base.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { ClientBase, resolveBaseUrl } from "./base";
 
 const servers = {
@@ -29,6 +29,60 @@ const client = new ClientBase({
   baseUrl: "https://api.polar.sh",
   version: "2026-04",
   accessToken: "polar_at_u_xxx",
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("sendRequest", () => {
+  test("uses the client timeout in seconds", async () => {
+    const timeoutSignal = new AbortController().signal;
+    const timeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+    const client = new ClientBase({
+      baseUrl: "https://api.polar.sh",
+      version: "{{ ir.versions[0].version }}",
+      accessToken: "polar_at_u_xxx",
+      timeout: 10,
+    });
+
+    await client.sendRequest(["https://api.polar.sh/v1/items/", {}]);
+
+    expect(timeout).toHaveBeenCalledWith(10_000);
+    expect(fetch).toHaveBeenCalledWith("https://api.polar.sh/v1/items/", {
+      signal: timeoutSignal,
+    });
+  });
+
+  test("uses a per-request timeout override", async () => {
+    const timeoutSignal = new AbortController().signal;
+    const timeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+    const client = new ClientBase({
+      baseUrl: "https://api.polar.sh",
+      version: "{{ ir.versions[0].version }}",
+      accessToken: "polar_at_u_xxx",
+      timeout: 10,
+    });
+
+    await client.sendRequest(
+      ["https://api.polar.sh/v1/items/", {}],
+      { timeout: 30 },
+    );
+
+    expect(timeout).toHaveBeenCalledWith(30_000);
+  });
+
+  test("does not create a timeout signal when no timeout is configured", async () => {
+    const timeout = vi.spyOn(AbortSignal, "timeout");
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+
+    await client.sendRequest(["https://api.polar.sh/v1/items/", {}]);
+
+    expect(timeout).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledWith("https://api.polar.sh/v1/items/", {});
+  });
 });
 
 describe("buildRequest", () => {

--- a/sdk/generator/typescript/template/src/base.ts
+++ b/sdk/generator/typescript/template/src/base.ts
@@ -107,6 +107,13 @@ export interface ClientOptions {
   baseUrl: string;
   version: string;
   accessToken: string;
+  /** Default request timeout, in seconds. */
+  timeout?: number;
+}
+
+export interface RequestOptions {
+  /** Request timeout override, in seconds. */
+  timeout?: number;
 }
 
 export const resolveBaseUrl = (
@@ -160,10 +167,19 @@ export class ClientBase {
     ];
   }
 
-  public async sendRequest(request: [string, RequestInit]): Promise<Response> {
+  public async sendRequest(
+    request: [string, RequestInit],
+    requestOptions?: RequestOptions,
+  ): Promise<Response> {
     const [fullUrl, requestInit] = request;
+    const timeout = requestOptions?.timeout ?? this.options.timeout;
     try {
-      return await fetch(fullUrl, requestInit);
+      return await fetch(fullUrl, {
+        ...requestInit,
+        ...(timeout !== undefined
+          ? { signal: AbortSignal.timeout(Math.ceil(timeout * 1000)) }
+          : {}),
+      });
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);

--- a/sdk/generator/typescript/template/src/base.ts
+++ b/sdk/generator/typescript/template/src/base.ts
@@ -139,7 +139,10 @@ export class ClientBase {
   protected readonly options: ClientOptions;
 
   constructor(options: ClientOptions) {
-    this.options = options;
+    this.options = {
+      timeout: 5.0,
+      ...options,
+    }
   }
 
   public buildRequest(

--- a/sdk/generator/typescript/template/src/base.ts
+++ b/sdk/generator/typescript/template/src/base.ts
@@ -116,6 +116,8 @@ export interface RequestOptions {
   timeout?: number;
 }
 
+const MAX_ABORT_SIGNAL_TIMEOUT_MS = 2_147_483_647;
+
 export const resolveBaseUrl = (
   servers: Record<string, string>,
   environment: string,
@@ -173,12 +175,27 @@ export class ClientBase {
   ): Promise<Response> {
     const [fullUrl, requestInit] = request;
     const timeout = requestOptions?.timeout ?? this.options.timeout;
+    let signal = requestInit.signal;
+    if (timeout !== undefined) {
+      const timeoutMilliseconds = Math.ceil(timeout * 1000);
+      if (
+        !Number.isFinite(timeout) ||
+        timeout < 0 ||
+        timeoutMilliseconds > MAX_ABORT_SIGNAL_TIMEOUT_MS
+      ) {
+        throw new RangeError(
+          `Timeout must be a finite, non-negative number no greater than ${MAX_ABORT_SIGNAL_TIMEOUT_MS / 1000} seconds`,
+        );
+      }
+      const timeoutSignal = AbortSignal.timeout(timeoutMilliseconds);
+      signal = signal
+        ? AbortSignal.any([signal, timeoutSignal])
+        : timeoutSignal;
+    }
     try {
       return await fetch(fullUrl, {
         ...requestInit,
-        ...(timeout !== undefined
-          ? { signal: AbortSignal.timeout(Math.ceil(timeout * 1000)) }
-          : {}),
+        ...(signal ? { signal } : {}),
       });
     } catch (error) {
       const errorMessage =

--- a/sdk/generator/typescript/template/src/index.ts
+++ b/sdk/generator/typescript/template/src/index.ts
@@ -5,3 +5,4 @@ export {
   PolarClientError,
   PolarRateLimitError,
 } from "./base";
+export type { RequestOptions } from "./base";

--- a/sdk/generator/typescript/template/src/version/index.ts
+++ b/sdk/generator/typescript/template/src/version/index.ts
@@ -1,5 +1,6 @@
 export { createPolar, createPolarCore } from "./client";
 export type { Environment, Polar, PolarCore, PolarOptions } from "./client";
+export type { RequestOptions } from "../base";
 export * as models from "./models";
 export * as errors from "./errors";
 export * as webhooks from "./webhooks";

--- a/sdk/generator/typescript/template/src/version/services/service.ts
+++ b/sdk/generator/typescript/template/src/version/services/service.ts
@@ -1,4 +1,4 @@
-import type { ClientBase } from "{{ base_import }}";
+import type { ClientBase{% if service.methods %}, RequestOptions{% endif %} } from "{{ base_import }}";
 {% if imports.models %}
 import type { {% for name in imports.models %}{{ name }}{% if not loop.last %}, {% endif %}{% endfor %} } from "{{ models_import }}";
 {% endif %}
@@ -27,6 +27,7 @@ export const {{ method.name | exported_operation_name(service.name) }} = (
 {% if method.body %}
 * @param body - Request body{% if method.body.description %}: {{ method.body.description }}{% endif +%}
 {% endif %}
+* @param requestOptions - Request options
 {% if method.response_type == 'json' %}
 * @returns {{'{'}}{{ method.response | ts_type }}{{'}'}}
 {% elif method.response_type == 'text' %}
@@ -49,11 +50,12 @@ export const {{ method.name | exported_operation_name(service.name) }} = (
     query{{ "?" if not method.query_params | selectattr("required", "eq", true) | list else "" }}: {
       {% for param in method.query_params %}
       {{ param.name }}{% if not param.required %}?{% endif %}: {{ param.type | ts_type }};{% endfor %}
-    }{% if method.body %},{% endif %}
+    },
     {% endif %}
     {% if method.body %}
-    body: {{ method.body | ts_type }}
+    body: {{ method.body | ts_type }},
     {% endif %}
+    requestOptions?: RequestOptions,
   ): Promise<{{ method.response | ts_type if method.response_type == 'json' else 'string' if method.response_type == 'text' else 'void' }}> => {
     const pathParams = {
       {% for param in method.path_params %}"{{ param.name }}": {{ param.parameter_name }},{% endfor %}
@@ -68,7 +70,7 @@ export const {{ method.name | exported_operation_name(service.name) }} = (
       queryParams,
       {% if method.body %}body{% else %}undefined{% endif %}
     );
-    const response = await client.sendRequest(request);
+    const response = await client.sendRequest(request, requestOptions);
     return client.parseResponse<{{ method.response | ts_type if method.response_type == 'json' else 'string' if method.response_type == 'text' else 'void' }}>(
       response,
       "{{ method.response_type }}",
@@ -95,6 +97,7 @@ export const {{ method.name | exported_operation_name(service.name) }} = (
 {% if method.body %}
 * @param body - Request body{% if method.body.description %}: {{ method.body.description }}{% endif +%}
 {% endif %}
+* @param requestOptions - Request options
 * @returns {AsyncGenerator<{{ method.pagination.item_schema | ts_type }}>} A generator that yields items of type {{ method.pagination.item_schema | ts_type }}.
 * @throws {{'{'}}PolarNetworkError{{'}'}} When a network error occurs
 * @throws {{'{'}}PolarRateLimitError{{'}'}} When the rate limit is exceeded
@@ -114,11 +117,12 @@ export const {{ method.name | exported_paginator_name(service.name) }} = (
     query{{ "?" if not method.query_params | selectattr("required", "eq", true) | list else "" }}: {
       {% for param in method.query_params %}
       {{ param.name }}{% if not param.required %}?{% endif %}: {{ param.type | ts_type }};{% endfor %}
-    }{% if method.body %},{% endif %}
+    },
     {% endif %}
     {% if method.body %}
-    body: {{ method.body | ts_type }}
+    body: {{ method.body | ts_type }},
     {% endif %}
+    requestOptions?: RequestOptions,
   ): AsyncGenerator<{{ method.pagination.item_schema | ts_type }}> {
     let page: number;
     {% if method.query_params %}
@@ -150,8 +154,9 @@ export const {{ method.name | exported_paginator_name(service.name) }} = (
         { page, limit },
         {% endif %}
         {% if method.body %}
-        body
+        body,
         {% endif %}
+        requestOptions,
       );
       for (const item of response.items) {
         yield item;


### PR DESCRIPTION
## Summary

- add client-level timeout configuration, expressed in seconds, to the generated Python and TypeScript SDKs
- add per-call overrides through `request_timeout` in Python and a final `RequestOptions` argument in TypeScript
- forward timeout overrides through paginated requests
- use HTTPX timeout configuration in Python and the modern `AbortSignal.timeout()` API in TypeScript
- document the API and add generator-template tests

Generated SDK outputs are intentionally excluded; this PR changes only the generator templates.

Closes #13823

## Validation

- `just lint` in `sdk/generator`
- `just test` in `sdk/generator` (83 passed)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

