### PR TITLE
sdk/python: introduce a deserialization error

### DIFF
--- a/sdk/generator/python/template/polar/__init__.py
+++ b/sdk/generator/python/template/polar/__init__.py
@@ -1,5 +1,6 @@
 from polar.base import (
     PolarClientError,
+    PolarDeserializationError,
     PolarError,
     PolarNetworkError,
     PolarServerError,
@@ -9,6 +10,7 @@ from polar.base import (
 __version__ = "{{ version }}"
 __all__ = [
     "PolarError",
+    "PolarDeserializationError",
     "PolarNetworkError",
     "PolarServerError",
     "PolarClientError",

--- a/sdk/generator/python/template/polar/base.py
+++ b/sdk/generator/python/template/polar/base.py
@@ -4,6 +4,7 @@ import types
 import typing
 
 import adaptix
+import adaptix.load_error
 import httpx
 import typing_extensions
 
@@ -28,6 +29,12 @@ class PolarServerError(PolarError):
         super().__init__(
             f"Polar API returned a server error: {status_code} - {message}"
         )
+
+
+class PolarDeserializationError(PolarError):
+    def __init__(self, error: adaptix.load_error.LoadError):
+        self.error = error
+        super().__init__(f"Failed to deserialize Polar API response: {error}")
 
 
 class PolarClientError(PolarError):
@@ -170,7 +177,10 @@ _retort = adaptix.Retort()
 def deserialize(
     data: object, model: typing_extensions.TypeForm[_ModelT]
 ) -> _ModelT:
-    return typing.cast(_ModelT, _retort.load(data, model))
+    try:
+        return typing.cast(_ModelT, _retort.load(data, model))
+    except adaptix.load_error.LoadError as e:
+        raise PolarDeserializationError(e) from e
 
 E = typing.TypeVar("E", bound=PolarClientError)
 

--- a/sdk/generator/python/template/polar/base.py
+++ b/sdk/generator/python/template/polar/base.py
@@ -34,7 +34,7 @@ class PolarServerError(PolarError):
 class PolarDeserializationError(PolarError):
     def __init__(self, error: adaptix.load_error.LoadError):
         self.error = error
-        super().__init__(f"Failed to deserialize Polar API response: {error}")
+        super().__init__(f"Failed to deserialize data: {error}")
 
 
 class PolarClientError(PolarError):

--- a/sdk/generator/python/template/tests/test_base.py
+++ b/sdk/generator/python/template/tests/test_base.py
@@ -3,7 +3,7 @@ import typing
 
 import pytest
 
-from polar import deserialize
+from polar import deserialize, PolarDeserializationError
 from polar.base import AsyncClientBase, SyncClientBase, resolve_base_url
 
 SERVERS = {
@@ -32,6 +32,11 @@ def test_deserialize_model() -> None:
 
     typing.assert_type(cat, Cat)
     assert cat == Cat(type="cat", lives=9)
+
+
+def test_deserialize_model_invalid() -> None:
+    with pytest.raises(PolarDeserializationError):
+        deserialize({"type": "cat", "lives": "nine"}, Cat)
 
 
 def test_deserialize_union() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Raises a new `PolarDeserializationError` from `deserialize()` when `adaptix` parsing fails. Previously it surfaced `adaptix.load_error.LoadError`; callers now get a stable SDK error that extends `PolarError`, preserves the original error on `.error`, and is exported from `polar`.

- Migration
  - Replace catches of `adaptix.load_error.LoadError` around `deserialize()` with `PolarDeserializationError` (or `PolarError`).
  - Import from `polar`: `from polar import PolarDeserializationError`.

<sup>Written for commit 5e1f31855d645ca190b6b0f2427fc419e8a44d1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

