### PR TITLE
Instrument subscription.cycle to be able to distinguish normal cycling from meter cycling

### DIFF
--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import timedelta
 
 import structlog
+from opentelemetry import trace
 from sqlalchemy.orm import selectinload
 
 from polar.exceptions import PolarTaskError
@@ -79,6 +80,9 @@ async def subscription_cycle(subscription_id: uuid.UUID, force: bool = False) ->
                 subscription, update_dict={"scheduler_locked_at": None}
             )
             return
+
+        span = trace.get_current_span()
+        span.set_attribute("cycle_type", "default" if billing_due else "meter")
 
         if billing_due:
             # Honor the multi-period meter lag guard even when billing is due.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds OpenTelemetry instrumentation to subscription_cycle to label each run as normal or meter-triggered. Improves observability only; no runtime behavior change.

- Sets current span attribute cycle_type to "default" when billing_due is true, otherwise "meter" (via `opentelemetry.trace`).
- No migrations or config changes required; deploy safely.

<sup>Written for commit 1102b553e39a5c03712a891cc08dcbb938784ccf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

