### PR TITLE
feat(merchant-migration): selection-aware subscription switch API

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -24333,24 +24333,24 @@ export interface components {
       /** @description How urgent `reason` is: `action_required` when the merchant has to fix something, `info` when there is nothing to fix. Null without a reason. */
       reason_level: components['schemas']['PrecheckReasonLevel'] | null
       /** @description What the switch did with this subscription: `moved` (Polar bills it now), `skipped` (left on the source, see `cutover_error`) or `failed` (retryable). Null when the switch hasn't reached it, and for every entity other than subscriptions. */
-      cutover_status?:
+      cutover_status:
         | components['schemas']['MerchantMigrationCutoverStatus']
         | null
       /**
        * Cutover Error
        * @description Why the switch skipped or failed this subscription.
        */
-      cutover_error?: string | null
+      cutover_error: string | null
       /**
        * Renews At
        * @description When the subscription next renews on the source, as staged at import. Null for non-subscription rows or when the source reported none.
        */
-      renews_at?: string | null
+      renews_at: string | null
       /**
        * Has Payment Method
        * @description Whether the imported Polar subscription has a card to charge yet. Null for non-subscription rows or rows not imported.
        */
-      has_payment_method?: boolean | null
+      has_payment_method: boolean | null
     }
     /**
      * MerchantMigrationRecordStatus

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5364,6 +5364,30 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/merchant-migrations/{id}/cutover': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Merchant Migration Switch
+     * @description **Scopes**: `organizations:write`
+     */
+    get: operations['merchant-migrations:get_cutover']
+    put?: never
+    /**
+     * Switch Merchant Migration Subscriptions
+     * @description **Scopes**: `organizations:write`
+     */
+    post: operations['merchant-migrations:start_cutover']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/merchant-migrations/{id}/records/summary': {
     parameters: {
       query?: never
@@ -20041,6 +20065,17 @@ export interface components {
       | '-created_at'
       | 'balance'
       | '-balance'
+    /** CutoverNotStarted */
+    CutoverNotStarted: {
+      /**
+       * Error
+       * @example CutoverNotStarted
+       * @constant
+       */
+      error: 'CutoverNotStarted'
+      /** Detail */
+      detail: string
+    }
     /**
      * DataTableBlock
      * @description Tabular entities (orders, subscriptions, customers, ...).
@@ -24111,6 +24146,75 @@ export interface components {
        */
       api_key: string
     }
+    /**
+     * MerchantMigrationCutoverReport
+     * @description Where the switch has got to, for the imported subscriptions.
+     */
+    MerchantMigrationCutoverReport: {
+      /**
+       * Started
+       * @description Whether the merchant has confirmed the switch at least once.
+       */
+      started: boolean
+      /**
+       * Running
+       * @description Whether Polar is currently going through the subscriptions.
+       */
+      running: boolean
+      /**
+       * Completed
+       * @description Whether the last switch run has finished.
+       */
+      completed: boolean
+      /**
+       * Total
+       * @description Imported subscriptions the switch looks at.
+       */
+      total: number
+      /**
+       * Pending
+       * @description Not switched yet.
+       */
+      pending: number
+      /**
+       * Moved
+       * @description Now billed by Polar, and stopped on the source.
+       */
+      moved: number
+      /**
+       * Skipped
+       * @description Left on the source, each with a reason on its record. Retryable once the merchant has dealt with the reason.
+       */
+      skipped: number
+      /**
+       * Failed
+       * @description Hit an unexpected error. Safe to retry as-is.
+       */
+      failed: number
+    }
+    /** MerchantMigrationCutoverRequest */
+    MerchantMigrationCutoverRequest: {
+      /**
+       * Record Ids
+       * @description The imported-subscription record ids to switch (from the records listing). When omitted, every imported subscription is switched (subject to `exclude_record_ids`).
+       */
+      record_ids?: string[] | null
+      /**
+       * Exclude Record Ids
+       * @description Switch every imported subscription except these — the opt-out selection for large catalogs. Ignored when `record_ids` is set.
+       */
+      exclude_record_ids?: string[] | null
+    }
+    /**
+     * MerchantMigrationCutoverStatus
+     * @description What the cutover did with an imported subscription.
+     *
+     *     Only subscription records ever carry one, and only once the cutover has
+     *     looked at them: ``None`` means "not attempted", which is also what every
+     *     other record type keeps forever.
+     * @enum {string}
+     */
+    MerchantMigrationCutoverStatus: 'moved' | 'skipped' | 'failed'
     /** MerchantMigrationImportReport */
     MerchantMigrationImportReport: {
       /** @description The migration step after the import. */
@@ -24228,6 +24332,25 @@ export interface components {
       reason_code: string | null
       /** @description How urgent `reason` is: `action_required` when the merchant has to fix something, `info` when there is nothing to fix. Null without a reason. */
       reason_level: components['schemas']['PrecheckReasonLevel'] | null
+      /** @description What the switch did with this subscription: `moved` (Polar bills it now), `skipped` (left on the source, see `cutover_error`) or `failed` (retryable). Null when the switch hasn't reached it, and for every entity other than subscriptions. */
+      cutover_status?:
+        | components['schemas']['MerchantMigrationCutoverStatus']
+        | null
+      /**
+       * Cutover Error
+       * @description Why the switch skipped or failed this subscription.
+       */
+      cutover_error?: string | null
+      /**
+       * Renews At
+       * @description When the subscription next renews on the source, as staged at import. Null for non-subscription rows or when the source reported none.
+       */
+      renews_at?: string | null
+      /**
+       * Has Payment Method
+       * @description Whether the imported Polar subscription has a payment method to charge yet. Null for non-subscription rows or rows not imported.
+       */
+      has_payment_method?: boolean | null
     }
     /**
      * MerchantMigrationRecordStatus
@@ -53809,6 +53932,119 @@ export interface operations {
       }
     }
   }
+  'merchant-migrations:get_cutover': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationCutoverReport']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'merchant-migrations:start_cutover': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: {
+      content: {
+        'application/json':
+          | components['schemas']['MerchantMigrationCutoverRequest']
+          | null
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationCutoverReport']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description The card transfer hasn't reached the switch step yet. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CutoverNotStarted']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   'merchant-migrations:records_summary': {
     parameters: {
       query?: never
@@ -53877,6 +54113,9 @@ export interface operations {
         reason_level?: components['schemas']['PrecheckReasonLevel'] | null
         import_status?:
           | components['schemas']['MerchantMigrationRecordStatus']
+          | null
+        cutover_status?:
+          | components['schemas']['MerchantMigrationCutoverStatus']
           | null
         /** @description Page number, defaults to 1. */
         page?: number
@@ -66625,6 +66864,9 @@ export const memberRoleValues: ReadonlyArray<
 export const memberSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MemberSortProperty']
 > = ['created_at', '-created_at']
+export const merchantMigrationCutoverStatusValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['MerchantMigrationCutoverStatus']
+> = ['moved', 'skipped', 'failed']
 export const merchantMigrationRecordStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MerchantMigrationRecordStatus']
 > = ['pending', 'imported', 'skipped', 'failed']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -24153,12 +24153,12 @@ export interface components {
     MerchantMigrationCutoverReport: {
       /**
        * Started
-       * @description Whether the merchant has confirmed the switch at least once.
+       * @description Whether the merchant has confirmed the switch.
        */
       started: boolean
       /**
        * Running
-       * @description Whether Polar is currently going through the subscriptions.
+       * @description Whether a switch run is in progress.
        */
       running: boolean
       /**
@@ -24168,7 +24168,7 @@ export interface components {
       completed: boolean
       /**
        * Total
-       * @description Imported subscriptions the switch looks at.
+       * @description Imported subscriptions in scope.
        */
       total: number
       /**
@@ -24178,17 +24178,17 @@ export interface components {
       pending: number
       /**
        * Moved
-       * @description Now billed by Polar, and stopped on the source.
+       * @description Now billed by Polar.
        */
       moved: number
       /**
        * Skipped
-       * @description Left on the source, each with a reason on its record. Retryable once the merchant has dealt with the reason.
+       * @description Left on the source.
        */
       skipped: number
       /**
        * Failed
-       * @description Hit an unexpected error. Safe to retry as-is.
+       * @description Hit an unexpected error.
        */
       failed: number
     }
@@ -24348,7 +24348,7 @@ export interface components {
       renews_at?: string | null
       /**
        * Has Payment Method
-       * @description Whether the imported Polar subscription has a payment method to charge yet. Null for non-subscription rows or rows not imported.
+       * @description Whether the imported Polar subscription has a card to charge yet. Null for non-subscription rows or rows not imported.
        */
       has_payment_method?: boolean | null
     }

--- a/server/polar/merchant_migration/cards.py
+++ b/server/polar/merchant_migration/cards.py
@@ -82,7 +82,7 @@ def _preferred(
     customer: Customer,
     source_method: CanonicalPaymentMethod | None,
 ) -> PaymentMethod:
-    """Prefer the source method's copy, else the customer's default, else a card."""
+    """Prefer the source method's copy, else the customer's default, else the first stored method."""
     if source_method is not None:
         copies = [
             payment_method

--- a/server/polar/merchant_migration/cards.py
+++ b/server/polar/merchant_migration/cards.py
@@ -82,8 +82,7 @@ def _preferred(
     customer: Customer,
     source_method: CanonicalPaymentMethod | None,
 ) -> PaymentMethod:
-    """Ordered by how much each candidate says about what to charge. Any stored
-    method beats nothing: ACH and SEPA migrate too, per `requires_reentry`."""
+    """Prefer the source method's copy, else the customer's default, else a card."""
     if source_method is not None:
         copies = [
             payment_method

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -7,7 +7,10 @@ from polar.exceptions import NotPermitted, ResourceNotFound
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.models import MerchantMigration
-from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
+from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
+    MerchantMigrationRecordStatus,
+)
 from polar.openapi import APITag
 from polar.organization.schemas import OrganizationID
 from polar.postgres import AsyncReadSession, get_db_read_session, get_db_session
@@ -26,6 +29,8 @@ from .pan_transfer import (
 from .schemas import MerchantMigration as MerchantMigrationSchema
 from .schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationCutoverReport,
+    MerchantMigrationCutoverRequest,
     MerchantMigrationImportReport,
     MerchantMigrationImportRequest,
     MerchantMigrationRecordItem,
@@ -40,6 +45,7 @@ from .schemas import (
 from .service import (
     CatalogImportBlocked,
     CatalogImportNotReady,
+    CutoverNotStarted,
     InvalidSourceCredentials,
     MerchantMigrationNotEnabled,
     MerchantMigrationNotFound,
@@ -293,6 +299,67 @@ async def complete_pan_transfer_step(
 
 
 @router.get(
+    "/{id}/cutover",
+    response_model=MerchantMigrationCutoverReport,
+    summary="Get Merchant Migration Switch",
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+    },
+)
+async def get_cutover(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    # The primary: the client polls this as the switch runs, and replica lag
+    # would report subscriptions as still pending after they've moved.
+    session: AsyncSession = Depends(get_db_session),
+) -> MerchantMigrationCutoverReport:
+    return await merchant_migration_service.get_cutover_report(
+        session, auth_subject, id
+    )
+
+
+@router.post(
+    "/{id}/cutover",
+    response_model=MerchantMigrationCutoverReport,
+    summary="Switch Merchant Migration Subscriptions",
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+        409: {
+            "description": "The card transfer hasn't reached the switch step yet.",
+            "model": CutoverNotStarted.schema(),
+        },
+    },
+)
+async def start_cutover(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    body: MerchantMigrationCutoverRequest | None = None,
+    session: AsyncSession = Depends(get_db_session),
+) -> MerchantMigrationCutoverReport:
+    return await merchant_migration_service.start_cutover(
+        session,
+        auth_subject,
+        id,
+        record_ids=body.record_ids if body is not None else None,
+        exclude_record_ids=body.exclude_record_ids if body is not None else None,
+    )
+
+
+@router.get(
     "/{id}/records/summary",
     response_model=MerchantMigrationRecordSummary,
     summary="Summarize Merchant Migration Records",
@@ -349,6 +416,7 @@ async def records(
     status: Annotated[PrecheckRecordStatus | None, Query()] = None,
     reason_level: Annotated[PrecheckReasonLevel | None, Query()] = None,
     import_status: Annotated[MerchantMigrationRecordStatus | None, Query()] = None,
+    cutover_status: Annotated[MerchantMigrationCutoverStatus | None, Query()] = None,
     # The primary, like the summary above: it supplies the selection ceiling
     # and these rows supply the checkboxes, so a split would let replica lag
     # show a tickable row the count doesn't include.
@@ -362,6 +430,7 @@ async def records(
         status=status,
         reason_level=reason_level,
         import_status=import_status,
+        cutover_status=cutover_status,
         pagination=pagination,
     )
     return ListResource.from_paginated_results(items, count, pagination)

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -670,6 +670,10 @@ def _item(
         reason=reason.message if reason else None,
         reason_code=reason.code if reason else None,
         reason_level=reason.level if reason else None,
+        cutover_status=None,
+        cutover_error=None,
+        renews_at=None,
+        has_payment_method=None,
     )
 
 

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -327,13 +327,35 @@ class MerchantMigrationRecordRepository(
         )
         return await self.get_one_or_none(statement)
 
+    async def has_pending_cutover_candidates(
+        self,
+        migration_id: UUID,
+        selection: MerchantMigrationOperationSelection | None = None,
+    ) -> bool:
+        """Whether any subscription in the selection still awaits cutover.
+
+        Unlike ``get_next_cutover_candidate``, this does not skip locked rows —
+        used to tell an empty claim from work another worker is holding."""
+        statement = (
+            self._imported_subscriptions_statement(migration_id)
+            .where(
+                MerchantMigrationRecord.cutover_status.is_(None),
+                *self._selection_filter(selection),
+            )
+            .limit(1)
+        )
+        return await self.get_one_or_none(statement) is not None
+
     async def count_cutover_statuses(
-        self, migration_id: UUID
+        self,
+        migration_id: UUID,
+        selection: MerchantMigrationOperationSelection | None = None,
     ) -> dict[MerchantMigrationCutoverStatus | None, int]:
         """How the cutover has settled the imported subscriptions so far, with
         ``None`` counting the ones it hasn't reached."""
         statement = (
             self._imported_subscriptions_statement(migration_id)
+            .where(*self._selection_filter(selection))
             .with_only_columns(
                 MerchantMigrationRecord.cutover_status,
                 func.count(MerchantMigrationRecord.id),

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -12,7 +12,12 @@ from polar.kit.repository import (
     RepositorySoftDeletionIDMixin,
     RepositorySoftDeletionMixin,
 )
-from polar.models import MerchantMigration, MerchantMigrationRecord, Subscription
+from polar.models import (
+    MerchantMigration,
+    MerchantMigrationRecord,
+    PaymentMethod,
+    Subscription,
+)
 from polar.models.merchant_migration_operation import (
     MerchantMigrationOperationSelection,
 )
@@ -340,20 +345,20 @@ class MerchantMigrationRecordRepository(
         return {status: count for status, count in result.all()}
 
     async def payment_method_coverage(self, migration_id: UUID) -> set[UUID]:
-        """The imported-subscription record ids whose Polar subscription already
-        has a payment method to charge.
-
-        Any linked method counts, not only cards: ACH and SEPA move with the copy
-        and Polar can charge them. Used to hint which rows are ready to switch
-        before the merchant picks them.
-        """
+        """Imported-subscription record ids whose Polar subscription already has
+        a card linked. Used to hint which rows are ready to switch."""
         statement = (
             self._imported_subscriptions_statement(migration_id)
             .join(
                 Subscription,
                 (Subscription.id == MerchantMigrationRecord.target_id)
-                & Subscription.deleted_at.is_(None)
-                & Subscription.payment_method_id.is_not(None),
+                & Subscription.deleted_at.is_(None),
+            )
+            .join(
+                PaymentMethod,
+                (PaymentMethod.id == Subscription.payment_method_id)
+                & PaymentMethod.deleted_at.is_(None)
+                & (PaymentMethod.type == "card"),
             )
             .with_only_columns(MerchantMigrationRecord.id)
             .order_by(None)

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -339,9 +339,7 @@ class MerchantMigrationRecordRepository(
         result = await self.session.execute(statement)
         return {status: count for status, count in result.all()}
 
-    async def payment_method_coverage(
-        self, migration_id: UUID
-    ) -> set[UUID]:
+    async def payment_method_coverage(self, migration_id: UUID) -> set[UUID]:
         """The imported-subscription record ids whose Polar subscription already
         has a payment method to charge.
 

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -12,8 +12,12 @@ from polar.kit.repository import (
     RepositorySoftDeletionIDMixin,
     RepositorySoftDeletionMixin,
 )
-from polar.models import MerchantMigration, MerchantMigrationRecord
+from polar.models import MerchantMigration, MerchantMigrationRecord, Subscription
+from polar.models.merchant_migration_operation import (
+    MerchantMigrationOperationSelection,
+)
 from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
@@ -279,6 +283,110 @@ class MerchantMigrationRecordRepository(
             .limit(limit)
         )
         return await self.get_all(statement)
+
+    def _selection_filter(
+        self, selection: MerchantMigrationOperationSelection | None
+    ) -> list[ColumnElement[bool]]:
+        """Narrow the imported subscriptions to the ones the merchant picked.
+
+        Empty (or absent) selection means every imported subscription, matching
+        the opt-out shape the import already uses.
+        """
+        if selection is None:
+            return []
+        if selection.record_ids is not None:
+            return [MerchantMigrationRecord.id.in_(selection.record_ids)]
+        if selection.exclude_record_ids is not None:
+            return [MerchantMigrationRecord.id.not_in(selection.exclude_record_ids)]
+        return []
+
+    async def get_next_cutover_candidate(
+        self,
+        migration_id: UUID,
+        selection: MerchantMigrationOperationSelection | None = None,
+    ) -> MerchantMigrationRecord | None:
+        """Claim the next subscription the cutover hasn't settled yet.
+
+        Locked and skipping locked rows, so a second run started by an impatient
+        merchant works alongside the first instead of moving the same
+        subscription twice.
+        """
+        statement = (
+            self._imported_subscriptions_statement(migration_id)
+            .where(
+                MerchantMigrationRecord.cutover_status.is_(None),
+                *self._selection_filter(selection),
+            )
+            .limit(1)
+            .with_for_update(of=MerchantMigrationRecord, skip_locked=True)
+        )
+        return await self.get_one_or_none(statement)
+
+    async def count_cutover_statuses(
+        self, migration_id: UUID
+    ) -> dict[MerchantMigrationCutoverStatus | None, int]:
+        """How the cutover has settled the imported subscriptions so far, with
+        ``None`` counting the ones it hasn't reached."""
+        statement = (
+            self._imported_subscriptions_statement(migration_id)
+            .with_only_columns(
+                MerchantMigrationRecord.cutover_status,
+                func.count(MerchantMigrationRecord.id),
+            )
+            .order_by(None)
+            .group_by(MerchantMigrationRecord.cutover_status)
+        )
+        result = await self.session.execute(statement)
+        return {status: count for status, count in result.all()}
+
+    async def payment_method_coverage(
+        self, migration_id: UUID
+    ) -> set[UUID]:
+        """The imported-subscription record ids whose Polar subscription already
+        has a payment method to charge.
+
+        Any linked method counts, not only cards: ACH and SEPA move with the copy
+        and Polar can charge them. Used to hint which rows are ready to switch
+        before the merchant picks them.
+        """
+        statement = (
+            self._imported_subscriptions_statement(migration_id)
+            .join(
+                Subscription,
+                (Subscription.id == MerchantMigrationRecord.target_id)
+                & Subscription.deleted_at.is_(None)
+                & Subscription.payment_method_id.is_not(None),
+            )
+            .with_only_columns(MerchantMigrationRecord.id)
+            .order_by(None)
+        )
+        result = await self.session.execute(statement)
+        return {row[0] for row in result.all()}
+
+    async def reset_cutover(
+        self,
+        migration_id: UUID,
+        selection: MerchantMigrationOperationSelection | None = None,
+    ) -> None:
+        """Clear the settled-but-not-moved outcomes in the selection so a retry
+        looks at them again. What moved stays moved."""
+        statement = (
+            self._imported_subscriptions_statement(migration_id)
+            .where(
+                MerchantMigrationRecord.cutover_status.in_(
+                    (
+                        MerchantMigrationCutoverStatus.skipped,
+                        MerchantMigrationCutoverStatus.failed,
+                    )
+                ),
+                *self._selection_filter(selection),
+            )
+            .order_by(None)
+        )
+        for record in await self.get_all(statement):
+            await self.update(
+                record, update_dict={"cutover_status": None, "cutover_error": None}
+            )
 
     async def upsert(
         self,

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -149,8 +149,8 @@ class MerchantMigrationRecordItem(Schema):
     has_payment_method: bool | None = Field(
         default=None,
         description=(
-            "Whether the imported Polar subscription has a payment method to "
-            "charge yet. Null for non-subscription rows or rows not imported."
+            "Whether the imported Polar subscription has a card to charge yet. "
+            "Null for non-subscription rows or rows not imported."
         ),
     )
 
@@ -236,23 +236,14 @@ class MerchantMigrationCutoverRequest(Schema):
 class MerchantMigrationCutoverReport(Schema):
     """Where the switch has got to, for the imported subscriptions."""
 
-    started: bool = Field(
-        description="Whether the merchant has confirmed the switch at least once."
-    )
-    running: bool = Field(
-        description="Whether Polar is currently going through the subscriptions."
-    )
+    started: bool = Field(description="Whether the merchant has confirmed the switch.")
+    running: bool = Field(description="Whether a switch run is in progress.")
     completed: bool = Field(description="Whether the last switch run has finished.")
-    total: int = Field(description="Imported subscriptions the switch looks at.")
+    total: int = Field(description="Imported subscriptions in scope.")
     pending: int = Field(description="Not switched yet.")
-    moved: int = Field(description="Now billed by Polar, and stopped on the source.")
-    skipped: int = Field(
-        description=(
-            "Left on the source, each with a reason on its record. Retryable "
-            "once the merchant has dealt with the reason."
-        )
-    )
-    failed: int = Field(description="Hit an unexpected error. Safe to retry as-is.")
+    moved: int = Field(description="Now billed by Polar.")
+    skipped: int = Field(description="Left on the source.")
+    failed: int = Field(description="Hit an unexpected error.")
 
 
 class PanTransferStepComplete(Schema):

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -127,7 +127,6 @@ class MerchantMigrationRecordItem(Schema):
         )
     )
     cutover_status: MerchantMigrationCutoverStatus | None = Field(
-        default=None,
         description=(
             "What the switch did with this subscription: `moved` (Polar bills it "
             "now), `skipped` (left on the source, see `cutover_error`) or `failed` "
@@ -136,18 +135,15 @@ class MerchantMigrationRecordItem(Schema):
         ),
     )
     cutover_error: str | None = Field(
-        default=None,
         description="Why the switch skipped or failed this subscription.",
     )
     renews_at: datetime | None = Field(
-        default=None,
         description=(
             "When the subscription next renews on the source, as staged at import. "
             "Null for non-subscription rows or when the source reported none."
         ),
     )
     has_payment_method: bool | None = Field(
-        default=None,
         description=(
             "Whether the imported Polar subscription has a card to charge yet. "
             "Null for non-subscription rows or rows not imported."

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -242,9 +242,7 @@ class MerchantMigrationCutoverReport(Schema):
     running: bool = Field(
         description="Whether Polar is currently going through the subscriptions."
     )
-    completed: bool = Field(
-        description="Whether the last switch run has finished."
-    )
+    completed: bool = Field(description="Whether the last switch run has finished.")
     total: int = Field(description="Imported subscriptions the switch looks at.")
     pending: int = Field(description="Not switched yet.")
     moved: int = Field(description="Now billed by Polar, and stopped on the source.")

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
@@ -9,7 +10,10 @@ from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
-from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
+from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
+    MerchantMigrationRecordStatus,
+)
 
 from .pan_transfer import PanTransferMethod, PanTransferStep
 
@@ -122,6 +126,33 @@ class MerchantMigrationRecordItem(Schema):
             "reason."
         )
     )
+    cutover_status: MerchantMigrationCutoverStatus | None = Field(
+        default=None,
+        description=(
+            "What the switch did with this subscription: `moved` (Polar bills it "
+            "now), `skipped` (left on the source, see `cutover_error`) or `failed` "
+            "(retryable). Null when the switch hasn't reached it, and for every "
+            "entity other than subscriptions."
+        ),
+    )
+    cutover_error: str | None = Field(
+        default=None,
+        description="Why the switch skipped or failed this subscription.",
+    )
+    renews_at: datetime | None = Field(
+        default=None,
+        description=(
+            "When the subscription next renews on the source, as staged at import. "
+            "Null for non-subscription rows or when the source reported none."
+        ),
+    )
+    has_payment_method: bool | None = Field(
+        default=None,
+        description=(
+            "Whether the imported Polar subscription has a payment method to "
+            "charge yet. Null for non-subscription rows or rows not imported."
+        ),
+    )
 
 
 class MerchantMigrationRecordSummaryEntity(PrecheckEntitySummary):
@@ -182,6 +213,48 @@ class MerchantMigrationImportReport(Schema):
     results: list[MerchantMigrationImportResult] = Field(
         description="Per-entity counts of what was imported vs skipped."
     )
+
+
+class MerchantMigrationCutoverRequest(Schema):
+    record_ids: list[UUID4] | None = Field(
+        default=None,
+        description=(
+            "The imported-subscription record ids to switch (from the records "
+            "listing). When omitted, every imported subscription is switched "
+            "(subject to `exclude_record_ids`)."
+        ),
+    )
+    exclude_record_ids: list[UUID4] | None = Field(
+        default=None,
+        description=(
+            "Switch every imported subscription except these — the opt-out "
+            "selection for large catalogs. Ignored when `record_ids` is set."
+        ),
+    )
+
+
+class MerchantMigrationCutoverReport(Schema):
+    """Where the switch has got to, for the imported subscriptions."""
+
+    started: bool = Field(
+        description="Whether the merchant has confirmed the switch at least once."
+    )
+    running: bool = Field(
+        description="Whether Polar is currently going through the subscriptions."
+    )
+    completed: bool = Field(
+        description="Whether the last switch run has finished."
+    )
+    total: int = Field(description="Imported subscriptions the switch looks at.")
+    pending: int = Field(description="Not switched yet.")
+    moved: int = Field(description="Now billed by Polar, and stopped on the source.")
+    skipped: int = Field(
+        description=(
+            "Left on the source, each with a reason on its record. Retryable "
+            "once the merchant has dealt with the reason."
+        )
+    )
+    failed: int = Field(description="Hit an unexpected error. Safe to retry as-is.")
 
 
 class PanTransferStepComplete(Schema):

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -851,9 +851,7 @@ class MerchantMigrationService:
         selection = (
             migration.operation.selection if migration.operation is not None else None
         )
-        counts = await record_repository.count_cutover_statuses(
-            migration.id, selection
-        )
+        counts = await record_repository.count_cutover_statuses(migration.id, selection)
         completed_steps = self._complete_polar_app_step(
             migration, STEP_MOVE_SUBSCRIPTIONS
         )
@@ -987,9 +985,7 @@ class MerchantMigrationService:
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         operation = migration.operation
         selection = operation.selection if operation is not None else None
-        counts = await record_repository.count_cutover_statuses(
-            migration.id, selection
-        )
+        counts = await record_repository.count_cutover_statuses(migration.id, selection)
         return MerchantMigrationCutoverReport(
             started=self._cutover_started(migration),
             running=operation.is_active if operation is not None else False,

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -98,8 +98,8 @@ IMPORTABLE_STEPS = {
     MerchantMigrationStep.create_catalog,
 }
 
-# Entities whose records map 1:1 to a ledger row, so a listing item can carry its
-# record id for selection. Prices live inside a product record and are excluded.
+# Entities whose records map 1:1 to a ledger row. Prices live inside a product
+# record and are excluded.
 _ENTITY_RECORD_TYPE = {
     PrecheckEntity.products: MerchantMigrationRecordType.product,
     PrecheckEntity.customers: MerchantMigrationRecordType.customer,
@@ -111,17 +111,11 @@ SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT = {
     "column": "source_credentials",
 }
 
-# The checklist steps Polar itself performs, and the job that performs each. A
-# `polar_app` step is never completed by a person: becoming current is what
-# schedules the work, and the work is what completes it.
 _STEP_TASKS = {
     STEP_VERIFY_CARDS: "merchant_migration.verify_cards",
     STEP_MOVE_SUBSCRIPTIONS: "merchant_migration.cutover",
 }
 
-# Where the checklist sits maps onto the migration's coarse step. Moving the
-# subscriptions is its own phase (`activate_subscriptions`); finishing it hands
-# the merchant back the last job, switching their own billing off (`cleanup`).
 _MIGRATION_STEP_BY_PAN_STEP = {
     STEP_MOVE_SUBSCRIPTIONS: MerchantMigrationStep.activate_subscriptions,
 }
@@ -731,11 +725,12 @@ class MerchantMigrationService:
 
     async def get_cutover_report(
         self,
-        session: AsyncReadSession,
+        session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
     ) -> MerchantMigrationCutoverReport:
         migration = await self._get_manageable(session, auth_subject, migration_id)
+        await self._fail_stalled_cutover(session, migration)
         return await self._cutover_report(session, migration)
 
     async def start_cutover(
@@ -749,10 +744,9 @@ class MerchantMigrationService:
     ) -> MerchantMigrationCutoverReport:
         """Switch the picked imported subscriptions over to Polar.
 
-        Serves both the first confirmation and every retry: it records the
-        selection, re-opens the ones a previous run left on the source, and kicks
-        the one-subscription-per-run worker. Only reachable once the card
-        checklist has advanced to the switch step.
+        Serves both the first confirmation and every retry: records the
+        selection, re-opens skipped/failed rows, and kicks the worker. Only
+        reachable once the card checklist has advanced to the switch step.
         """
         migration = await self._get_manageable(
             session, auth_subject, migration_id, for_update=True
@@ -762,7 +756,6 @@ class MerchantMigrationService:
 
         selection = self._build_selection(record_ids, exclude_record_ids)
         record_repository = MerchantMigrationRecordRepository.from_session(session)
-        # Re-open the ones an earlier run left on the source; what moved stays moved.
         await record_repository.reset_cutover(migration.id, selection)
 
         repository = MerchantMigrationRepository.from_session(session)
@@ -779,8 +772,6 @@ class MerchantMigrationService:
 
         current = pan_transfer.current(migration.pan_transfer_steps)
         if current is not None and current.key == STEP_CUTOVER:
-            # Confirming the step advances the checklist to `move_subscriptions`,
-            # which schedules the switch job through `_advance_checklist`.
             await self._complete_pan_step(
                 session,
                 migration,
@@ -789,7 +780,6 @@ class MerchantMigrationService:
                 inputs={},
             )
         else:
-            # Already confirmed in an earlier batch: kick the worker again.
             enqueue_job(
                 "merchant_migration.cutover", merchant_migration_id=migration.id
             )
@@ -799,15 +789,13 @@ class MerchantMigrationService:
         """Switch one subscription over, then hand off to the next run.
 
         One subscription per run, each in its own transaction: the irreversible
-        half of a switch is a cancellation on the merchant's own provider, so a
-        batch that dies halfway would replay it for everything it had already
-        done.
+        half is a cancellation on the merchant's provider, so a batch that dies
+        halfway must not replay cancellations it already committed.
         """
         migration = await self._load(session, migration_id)
         if migration is None:
             return
         if not self._cutover_started(migration):
-            # The merchant hasn't confirmed. Nothing may touch their source.
             log.warning(
                 "merchant_migration.cutover.not_confirmed",
                 merchant_migration_id=migration.id,
@@ -815,12 +803,15 @@ class MerchantMigrationService:
             return
         organization = await self._get_organization(session, migration)
         if not organization.can_renew_subscriptions:
-            # Activating subscriptions the organization can't bill would leave
-            # them live and uncollected. Stopping keeps them on the source.
             log.warning(
                 "merchant_migration.cutover.renewals_disabled",
                 merchant_migration_id=migration.id,
                 organization_id=organization.id,
+            )
+            await self._fail_cutover(
+                session,
+                migration,
+                "Organization renewals are disabled; subscriptions stay on the source.",
             )
             return
 
@@ -861,8 +852,8 @@ class MerchantMigrationService:
             "step": MerchantMigrationStep.cleanup,
         }
         if completed_steps is not None:
-            # `annotate` refuses a completed step, so the receipt note goes on the
-            # step object directly before the completion is persisted.
+            # `annotate` refuses a completed step, so the receipt note goes on
+            # the step object directly before the completion is persisted.
             steps = list(completed_steps)
             note = self._cutover_note(counts)
             for step in steps:
@@ -871,6 +862,29 @@ class MerchantMigrationService:
             update_dict["pan_transfer_steps"] = steps
         await MerchantMigrationRepository.from_session(session).update(
             migration, update_dict=update_dict
+        )
+
+    async def _fail_cutover(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        error: str,
+    ) -> None:
+        await MerchantMigrationRepository.from_session(session).update(
+            migration,
+            update_dict={"operation": self._failed_operation(migration, error)},
+        )
+
+    async def _fail_stalled_cutover(
+        self, session: AsyncSession, migration: MerchantMigration
+    ) -> None:
+        operation = migration.operation
+        if operation is None or not operation.is_stalled():
+            return
+        await self._fail_cutover(
+            session,
+            migration,
+            "Switch stalled with no progress; start it again to resume.",
         )
 
     def _complete_polar_app_step(
@@ -896,8 +910,8 @@ class MerchantMigrationService:
     async def _bump_operation(
         self, session: AsyncSession, migration: MerchantMigration
     ) -> None:
-        """Keep the operation's progress timestamp fresh so stall detection sees
-        the chain still moving."""
+        """Refresh ``last_progress_at`` so a hang past ``STALL_THRESHOLD`` is
+        detectable on the next report poll."""
         operation = migration.operation
         if operation is None:
             return
@@ -918,6 +932,24 @@ class MerchantMigrationService:
         return operation.model_copy(
             update={
                 "status": MerchantMigrationOperationStatus.done,
+                "last_progress_at": utc_now(),
+            }
+        )
+
+    def _failed_operation(
+        self, migration: MerchantMigration, error: str
+    ) -> MerchantMigrationOperation:
+        operation = migration.operation
+        if operation is None:
+            return MerchantMigrationOperation(
+                status=MerchantMigrationOperationStatus.failed,
+                error=error,
+                last_progress_at=utc_now(),
+            )
+        return operation.model_copy(
+            update={
+                "status": MerchantMigrationOperationStatus.failed,
+                "error": error,
                 "last_progress_at": utc_now(),
             }
         )

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -14,6 +14,7 @@ from polar.config import settings
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.encryption import EncryptedString
 from polar.kit.pagination import PaginationParams
+from polar.kit.utils import utc_now
 from polar.logging import Logger
 from polar.models import (
     MerchantMigration,
@@ -25,7 +26,13 @@ from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
+from polar.models.merchant_migration_operation import (
+    MerchantMigrationOperation,
+    MerchantMigrationOperationSelection,
+    MerchantMigrationOperationStatus,
+)
 from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
@@ -44,11 +51,15 @@ from .canonical import (
     deserialize,
 )
 from .cards import AmbiguousCopiedCard, link_payment_method
+from .cutover import SubscriptionCutover
 from .errors import MerchantMigrationError
 from .importer import CatalogImporter
 from .pan_transfer import (
+    STEP_CUTOVER,
+    STEP_MOVE_SUBSCRIPTIONS,
     STEP_VERIFY_CARDS,
     PanStepActor,
+    PanStepStatus,
     PanTransferAlreadyStarted,
     PanTransferNotReady,
     PanTransferNotStarted,
@@ -67,6 +78,7 @@ from .repository import (
 )
 from .schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationCutoverReport,
     MerchantMigrationImportReport,
     MerchantMigrationRecordItem,
     MerchantMigrationRecordSummary,
@@ -99,7 +111,20 @@ SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT = {
     "column": "source_credentials",
 }
 
-_STEP_TASKS = {STEP_VERIFY_CARDS: "merchant_migration.verify_cards"}
+# The checklist steps Polar itself performs, and the job that performs each. A
+# `polar_app` step is never completed by a person: becoming current is what
+# schedules the work, and the work is what completes it.
+_STEP_TASKS = {
+    STEP_VERIFY_CARDS: "merchant_migration.verify_cards",
+    STEP_MOVE_SUBSCRIPTIONS: "merchant_migration.cutover",
+}
+
+# Where the checklist sits maps onto the migration's coarse step. Moving the
+# subscriptions is its own phase (`activate_subscriptions`); finishing it hands
+# the merchant back the last job, switching their own billing off (`cleanup`).
+_MIGRATION_STEP_BY_PAN_STEP = {
+    STEP_MOVE_SUBSCRIPTIONS: MerchantMigrationStep.activate_subscriptions,
+}
 
 # One Stripe round trip per customer, so a whole catalog can't be one job.
 CARD_VERIFICATION_BATCH_SIZE = 25
@@ -175,6 +200,15 @@ class CatalogImportNotReady(MerchantMigrationError):
         )
 
 
+class CutoverNotStarted(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Reach the switch step in the card transfer before switching "
+            "subscriptions over.",
+            409,
+        )
+
+
 class BlockedByPrecheck(MerchantMigrationError):
     """Precheck blockers as an API error: the codes stay machine-readable while
     the merchant reads the joined messages."""
@@ -219,18 +253,25 @@ class _CardLookup(NamedTuple):
 type ResolvedCards = dict[_CardLookup, PaymentMethod | None]
 
 
+def _staged_subscription(
+    record: MerchantMigrationRecord,
+) -> CanonicalSubscription | None:
+    """The canonical subscription staged for a record, or None when the record
+    isn't a subscription or its blob can't be read."""
+    try:
+        staged = deserialize(record.type, record.canonical)
+    except KeyError, TypeError, ValueError:
+        return None
+    return staged if isinstance(staged, CanonicalSubscription) else None
+
+
 def _staged_payment_method(
     record: MerchantMigrationRecord,
 ) -> CanonicalPaymentMethod | None:
     """What the source subscription was charging, so the right copy is picked
     when a customer has more than one."""
-    try:
-        staged = deserialize(record.type, record.canonical)
-    except KeyError, TypeError, ValueError:
-        return None
-    if isinstance(staged, CanonicalSubscription):
-        return staged.payment_method
-    return None
+    staged = _staged_subscription(record)
+    return staged.payment_method if staged is not None else None
 
 
 def _summarize_entities(
@@ -553,14 +594,18 @@ class MerchantMigrationService:
         migration: MerchantMigration,
         steps: Sequence[PanTransferStep],
     ) -> None:
-        """Persist the checklist and schedule the job for a step Polar
-        performs itself."""
-        repository = MerchantMigrationRepository.from_session(session)
-        await repository.update(
-            migration, update_dict={"pan_transfer_steps": list(steps)}
-        )
-
+        """Persist the checklist, advance the migration's own step when the new
+        current step implies one, and schedule the job for a step Polar performs
+        itself."""
         current = pan_transfer.current(steps)
+        update_dict: dict[str, object] = {"pan_transfer_steps": list(steps)}
+        if current is not None:
+            migration_step = _MIGRATION_STEP_BY_PAN_STEP.get(current.key)
+            if migration_step is not None:
+                update_dict["step"] = migration_step
+        repository = MerchantMigrationRepository.from_session(session)
+        await repository.update(migration, update_dict=update_dict)
+
         task = _STEP_TASKS.get(current.key) if current else None
         if task is not None:
             enqueue_job(task, merchant_migration_id=migration.id)
@@ -684,6 +729,280 @@ class MerchantMigrationService:
         )
         await self._advance_checklist(session, migration, steps)
 
+    async def get_cutover_report(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> MerchantMigrationCutoverReport:
+        migration = await self._get_manageable(session, auth_subject, migration_id)
+        return await self._cutover_report(session, migration)
+
+    async def start_cutover(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+        *,
+        record_ids: Sequence[UUID] | None = None,
+        exclude_record_ids: Sequence[UUID] | None = None,
+    ) -> MerchantMigrationCutoverReport:
+        """Switch the picked imported subscriptions over to Polar.
+
+        Serves both the first confirmation and every retry: it records the
+        selection, re-opens the ones a previous run left on the source, and kicks
+        the one-subscription-per-run worker. Only reachable once the card
+        checklist has advanced to the switch step.
+        """
+        migration = await self._get_manageable(
+            session, auth_subject, migration_id, for_update=True
+        )
+        if not self._cutover_reachable(migration):
+            raise CutoverNotStarted()
+
+        selection = self._build_selection(record_ids, exclude_record_ids)
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        # Re-open the ones an earlier run left on the source; what moved stays moved.
+        await record_repository.reset_cutover(migration.id, selection)
+
+        repository = MerchantMigrationRepository.from_session(session)
+        await repository.update(
+            migration,
+            update_dict={
+                "operation": MerchantMigrationOperation(
+                    status=MerchantMigrationOperationStatus.running,
+                    selection=selection,
+                    last_progress_at=utc_now(),
+                )
+            },
+        )
+
+        current = pan_transfer.current(migration.pan_transfer_steps)
+        if current is not None and current.key == STEP_CUTOVER:
+            # Confirming the step advances the checklist to `move_subscriptions`,
+            # which schedules the switch job through `_advance_checklist`.
+            await self._complete_pan_step(
+                session,
+                migration,
+                STEP_CUTOVER,
+                actor=PanStepActor.merchant,
+                inputs={},
+            )
+        else:
+            # Already confirmed in an earlier batch: kick the worker again.
+            enqueue_job(
+                "merchant_migration.cutover", merchant_migration_id=migration.id
+            )
+        return await self._cutover_report(session, migration)
+
+    async def run_cutover(self, session: AsyncSession, migration_id: UUID) -> None:
+        """Switch one subscription over, then hand off to the next run.
+
+        One subscription per run, each in its own transaction: the irreversible
+        half of a switch is a cancellation on the merchant's own provider, so a
+        batch that dies halfway would replay it for everything it had already
+        done.
+        """
+        migration = await self._load(session, migration_id)
+        if migration is None:
+            return
+        if not self._cutover_started(migration):
+            # The merchant hasn't confirmed. Nothing may touch their source.
+            log.warning(
+                "merchant_migration.cutover.not_confirmed",
+                merchant_migration_id=migration.id,
+            )
+            return
+        organization = await self._get_organization(session, migration)
+        if not organization.can_renew_subscriptions:
+            # Activating subscriptions the organization can't bill would leave
+            # them live and uncollected. Stopping keeps them on the source.
+            log.warning(
+                "merchant_migration.cutover.renewals_disabled",
+                merchant_migration_id=migration.id,
+                organization_id=organization.id,
+            )
+            return
+
+        selection = (
+            migration.operation.selection if migration.operation is not None else None
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        record = await record_repository.get_next_cutover_candidate(
+            migration.id, selection
+        )
+        if record is None:
+            await self._finish_cutover(session, migration)
+            return
+
+        outcome = await SubscriptionCutover(
+            session, migration, await self._build_adapter(migration)
+        ).run(record)
+        await record_repository.update(
+            record,
+            update_dict={
+                "cutover_status": outcome.status,
+                "cutover_error": outcome.message,
+            },
+        )
+        await self._bump_operation(session, migration)
+        enqueue_job("merchant_migration.cutover", merchant_migration_id=migration.id)
+
+    async def _finish_cutover(
+        self, session: AsyncSession, migration: MerchantMigration
+    ) -> None:
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        counts = await record_repository.count_cutover_statuses(migration.id)
+        completed_steps = self._complete_polar_app_step(
+            migration, STEP_MOVE_SUBSCRIPTIONS
+        )
+        update_dict: dict[str, object] = {
+            "operation": self._done_operation(migration),
+            "step": MerchantMigrationStep.cleanup,
+        }
+        if completed_steps is not None:
+            # `annotate` refuses a completed step, so the receipt note goes on the
+            # step object directly before the completion is persisted.
+            steps = list(completed_steps)
+            note = self._cutover_note(counts)
+            for step in steps:
+                if step.key == STEP_MOVE_SUBSCRIPTIONS:
+                    step.note = note
+            update_dict["pan_transfer_steps"] = steps
+        await MerchantMigrationRepository.from_session(session).update(
+            migration, update_dict=update_dict
+        )
+
+    def _complete_polar_app_step(
+        self,
+        migration: MerchantMigration,
+        key: str,
+        # `Sequence`, not `list`: this class defines a `list` method, which would
+        # shadow the builtin in an annotation evaluated in the class body.
+    ) -> Sequence[PanTransferStep] | None:
+        """Mark a step Polar performs as done, or None when it isn't ours to move
+        — the work already finished once, or the merchant restarted."""
+        current = pan_transfer.current(migration.pan_transfer_steps)
+        if current is None or current.key != key:
+            return None
+        return pan_transfer.complete(
+            migration.pan_transfer_method,
+            list(migration.pan_transfer_steps),
+            key,
+            actor=PanStepActor.system,
+            inputs={},
+        )
+
+    async def _bump_operation(
+        self, session: AsyncSession, migration: MerchantMigration
+    ) -> None:
+        """Keep the operation's progress timestamp fresh so stall detection sees
+        the chain still moving."""
+        operation = migration.operation
+        if operation is None:
+            return
+        updated = operation.model_copy(update={"last_progress_at": utc_now()})
+        await MerchantMigrationRepository.from_session(session).update(
+            migration, update_dict={"operation": updated}
+        )
+
+    def _done_operation(
+        self, migration: MerchantMigration
+    ) -> MerchantMigrationOperation:
+        operation = migration.operation
+        if operation is None:
+            return MerchantMigrationOperation(
+                status=MerchantMigrationOperationStatus.done,
+                last_progress_at=utc_now(),
+            )
+        return operation.model_copy(
+            update={
+                "status": MerchantMigrationOperationStatus.done,
+                "last_progress_at": utc_now(),
+            }
+        )
+
+    def _cutover_note(
+        self, counts: dict[MerchantMigrationCutoverStatus | None, int]
+    ) -> str:
+        moved = counts.get(MerchantMigrationCutoverStatus.moved, 0)
+        left = counts.get(MerchantMigrationCutoverStatus.skipped, 0) + counts.get(
+            MerchantMigrationCutoverStatus.failed, 0
+        )
+        note = (
+            f"Polar now bills {moved} subscription(s), and stopped them on your "
+            "source."
+        )
+        if left:
+            note += (
+                f" {left} stayed on your source; open the subscriptions list to "
+                "see why, and switch them again once they're sorted."
+            )
+        return note
+
+    async def _cutover_report(
+        self, session: AsyncReadSession, migration: MerchantMigration
+    ) -> MerchantMigrationCutoverReport:
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        counts = await record_repository.count_cutover_statuses(migration.id)
+        operation = migration.operation
+        return MerchantMigrationCutoverReport(
+            started=self._cutover_started(migration),
+            running=operation.is_active if operation is not None else False,
+            completed=operation.is_terminal if operation is not None else False,
+            total=sum(counts.values()),
+            pending=counts.get(None, 0),
+            moved=counts.get(MerchantMigrationCutoverStatus.moved, 0),
+            skipped=counts.get(MerchantMigrationCutoverStatus.skipped, 0),
+            failed=counts.get(MerchantMigrationCutoverStatus.failed, 0),
+        )
+
+    def _build_selection(
+        self,
+        record_ids: Sequence[UUID] | None,
+        exclude_record_ids: Sequence[UUID] | None,
+    ) -> MerchantMigrationOperationSelection | None:
+        if record_ids is not None:
+            return MerchantMigrationOperationSelection(record_ids=list(record_ids))
+        if exclude_record_ids is not None:
+            return MerchantMigrationOperationSelection(
+                exclude_record_ids=list(exclude_record_ids)
+            )
+        return None
+
+    def _cutover_reachable(self, migration: MerchantMigration) -> bool:
+        """The merchant may switch once the card checklist has reached the switch
+        step — either it's the one to act on now, or it was confirmed already."""
+        current = pan_transfer.current(migration.pan_transfer_steps)
+        if current is not None and current.key == STEP_CUTOVER:
+            return True
+        return self._cutover_started(migration)
+
+    def _cutover_started(self, migration: MerchantMigration) -> bool:
+        """The merchant has confirmed the switch step, so Polar is allowed to
+        stop subscriptions on their source."""
+        return self._step_completed(migration, STEP_CUTOVER)
+
+    def _step_completed(self, migration: MerchantMigration, key: str) -> bool:
+        return any(
+            step.key == key and step.status == PanStepStatus.completed
+            for step in migration.pan_transfer_steps
+        )
+
+    async def _load(
+        self, session: AsyncReadSession, migration_id: UUID
+    ) -> MerchantMigration | None:
+        """Load a migration outside a request, for the background work. A
+        migration deleted mid-run just stops the run."""
+        migration = await MerchantMigrationRepository.from_session(session).get_by_id(
+            migration_id
+        )
+        if migration is None:
+            log.warning(
+                "merchant_migration.missing", merchant_migration_id=migration_id
+            )
+        return migration
+
     def _checklist(
         self,
         migration: MerchantMigration,
@@ -752,6 +1071,7 @@ class MerchantMigrationService:
         status: PrecheckRecordStatus | None,
         reason_level: PrecheckReasonLevel | None = None,
         import_status: MerchantMigrationRecordStatus | None = None,
+        cutover_status: MerchantMigrationCutoverStatus | None = None,
         pagination: PaginationParams,
     ) -> tuple[Sequence[MerchantMigrationRecordItem], int]:
         """Return staged records classified importable/skipped and paginated in
@@ -760,10 +1080,13 @@ class MerchantMigrationService:
         ``reason_level`` filters to rows the merchant has to act on
         (`action_required`) or only needs to know about (`info`);
         ``import_status`` filters on the ledger outcome, which excludes price rows
-        since they have none. Reads what ``run_precheck`` persisted."""
+        since they have none; ``cutover_status`` narrows to what the switch did
+        with a subscription, which is how the merchant finds the ones it left on
+        the source. Reads what ``run_precheck`` persisted."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
         entities = [entity] if entity is not None else list(_ENTITY_RECORD_TYPE)
         items = await self._classify_staged(session, migration, entities)
+        await self._attach_cutover_coverage(session, migration, items)
 
         if status is not None:
             items = [item for item in items if item.status == status]
@@ -771,9 +1094,32 @@ class MerchantMigrationService:
             items = [item for item in items if item.reason_level == reason_level]
         if import_status is not None:
             items = [item for item in items if item.import_status == import_status]
+        if cutover_status is not None:
+            items = [item for item in items if item.cutover_status == cutover_status]
 
         start = (pagination.page - 1) * pagination.limit
         return items[start : start + pagination.limit], len(items)
+
+    async def _attach_cutover_coverage(
+        self,
+        session: AsyncReadSession,
+        migration: MerchantMigration,
+        items: Sequence[MerchantMigrationRecordItem],
+    ) -> None:
+        """Flag which imported subscriptions already have a payment method to
+        charge, so the switch table can hint readiness before the merchant picks.
+        """
+        if not any(item.entity == PrecheckEntity.subscriptions for item in items):
+            return
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        covered = await record_repository.payment_method_coverage(migration.id)
+        for item in items:
+            if (
+                item.entity != PrecheckEntity.subscriptions
+                or item.import_status != MerchantMigrationRecordStatus.imported
+            ):
+                continue
+            item.has_payment_method = item.record_id in covered
 
     async def _classify_staged(
         self,
@@ -851,6 +1197,18 @@ class MerchantMigrationService:
         for item, record in zip(items, staged_of_type, strict=True):
             item.record_id = record.id
             item.import_status = record.status
+            if entity == PrecheckEntity.subscriptions:
+                item.cutover_status = record.cutover_status
+                item.cutover_error = record.cutover_error
+                item.renews_at = self._staged_renews_at(record)
+
+    def _staged_renews_at(
+        self, record: MerchantMigrationRecord
+    ) -> datetime | None:
+        """When the source subscription renews, as captured at import. Best-effort:
+        an unreadable blob just leaves the column blank."""
+        staged = _staged_subscription(record)
+        return staged.current_period_end if staged is not None else None
 
     async def _stage_records(
         self,

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -930,8 +930,7 @@ class MerchantMigrationService:
             MerchantMigrationCutoverStatus.failed, 0
         )
         note = (
-            f"Polar now bills {moved} subscription(s), and stopped them on your "
-            "source."
+            f"Polar now bills {moved} subscription(s), and stopped them on your source."
         )
         if left:
             note += (
@@ -1202,9 +1201,7 @@ class MerchantMigrationService:
                 item.cutover_error = record.cutover_error
                 item.renews_at = self._staged_renews_at(record)
 
-    def _staged_renews_at(
-        self, record: MerchantMigrationRecord
-    ) -> datetime | None:
+    def _staged_renews_at(self, record: MerchantMigrationRecord) -> datetime | None:
         """When the source subscription renews, as captured at import. Best-effort:
         an unreadable blob just leaves the column blank."""
         staged = _staged_subscription(record)

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -588,9 +588,7 @@ class MerchantMigrationService:
         migration: MerchantMigration,
         steps: Sequence[PanTransferStep],
     ) -> None:
-        """Persist the checklist, advance the migration's own step when the new
-        current step implies one, and schedule the job for a step Polar performs
-        itself."""
+        """Persist progress and start work for the current Polar-managed step."""
         current = pan_transfer.current(steps)
         update_dict: dict[str, object] = {"pan_transfer_steps": list(steps)}
         if current is not None:

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -793,6 +793,9 @@ class MerchantMigrationService:
         migration = await self._load(session, migration_id)
         if migration is None:
             return
+        operation = migration.operation
+        if operation is not None and not operation.is_active:
+            return
         if not self._cutover_started(migration):
             log.warning(
                 "merchant_migration.cutover.not_confirmed",
@@ -821,6 +824,10 @@ class MerchantMigrationService:
             migration.id, selection
         )
         if record is None:
+            if await record_repository.has_pending_cutover_candidates(
+                migration.id, selection
+            ):
+                return
             await self._finish_cutover(session, migration)
             return
 
@@ -841,7 +848,12 @@ class MerchantMigrationService:
         self, session: AsyncSession, migration: MerchantMigration
     ) -> None:
         record_repository = MerchantMigrationRecordRepository.from_session(session)
-        counts = await record_repository.count_cutover_statuses(migration.id)
+        selection = (
+            migration.operation.selection if migration.operation is not None else None
+        )
+        counts = await record_repository.count_cutover_statuses(
+            migration.id, selection
+        )
         completed_steps = self._complete_polar_app_step(
             migration, STEP_MOVE_SUBSCRIPTIONS
         )
@@ -973,8 +985,11 @@ class MerchantMigrationService:
         self, session: AsyncReadSession, migration: MerchantMigration
     ) -> MerchantMigrationCutoverReport:
         record_repository = MerchantMigrationRecordRepository.from_session(session)
-        counts = await record_repository.count_cutover_statuses(migration.id)
         operation = migration.operation
+        selection = operation.selection if operation is not None else None
+        counts = await record_repository.count_cutover_statuses(
+            migration.id, selection
+        )
         return MerchantMigrationCutoverReport(
             started=self._cutover_started(migration),
             running=operation.is_active if operation is not None else False,

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -982,10 +982,12 @@ class MerchantMigrationService:
     async def _cutover_report(
         self, session: AsyncReadSession, migration: MerchantMigration
     ) -> MerchantMigrationCutoverReport:
+        # Catalog-wide counts so the switch table tabs match every imported row,
+        # even when the active run only covers a selection. The finish note still
+        # scopes to the selection via `_finish_cutover`.
         record_repository = MerchantMigrationRecordRepository.from_session(session)
+        counts = await record_repository.count_cutover_statuses(migration.id)
         operation = migration.operation
-        selection = operation.selection if operation is not None else None
-        counts = await record_repository.count_cutover_statuses(migration.id, selection)
         return MerchantMigrationCutoverReport(
             started=self._cutover_started(migration),
             running=operation.is_active if operation is not None else False,

--- a/server/polar/merchant_migration/tasks.py
+++ b/server/polar/merchant_migration/tasks.py
@@ -14,3 +14,15 @@ async def merchant_migration_verify_cards(
         await merchant_migration_service.run_card_verification(
             session, merchant_migration_id, offset=offset
         )
+
+
+@actor(actor_name="merchant_migration.cutover", priority=TaskPriority.LOW)
+async def merchant_migration_cutover(merchant_migration_id: UUID) -> None:
+    """Switch billing over to Polar, one subscription per run.
+
+    Each run is its own transaction because the run cancels a subscription on the
+    merchant's provider: work already done must never be replayed by a retry of
+    work that came after it.
+    """
+    async with AsyncSessionMaker() as session:
+        await merchant_migration_service.run_cutover(session, merchant_migration_id)

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -104,10 +104,11 @@ _STEP_ACTORS = {
 
 
 def pan_steps_until(
-    method: PanTransferMethod, target_key: str
+    method: PanTransferMethod, target_key: str | None
 ) -> list[PanTransferStep]:
     """A checklist walked forward to ``target_key``, with everything before it
     completed by whoever owns it: what the merchant would have clicked through.
+    ``None`` completes every step.
     """
     steps = pan_transfer.build(method)
     while True:

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -745,9 +745,7 @@ class TestCutover:
         self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
     ) -> None:
         migration = await _create_migration(save_fixture, organization)
-        response = await client.post(
-            f"/v1/merchant-migrations/{migration.id}/cutover"
-        )
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/cutover")
         assert response.status_code == 401
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
@@ -764,9 +762,7 @@ class TestCutover:
         )
         await save_fixture(migration)
 
-        response = await client.post(
-            f"/v1/merchant-migrations/{migration.id}/cutover"
-        )
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/cutover")
         assert response.status_code == 409
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
@@ -785,9 +781,7 @@ class TestCutover:
         )
         await save_fixture(migration)
 
-        response = await client.post(
-            f"/v1/merchant-migrations/{migration.id}/cutover"
-        )
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/cutover")
         assert response.status_code == 200
         assert response.json()["started"] is True
         assert response.json()["running"] is True

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -27,6 +27,7 @@ from tests.fixtures.database import SaveFixture
 from tests.merchant_migration._helpers import (
     assert_no_migrations,
     build_connected_migration,
+    pan_steps_until,
 )
 
 VALID_BODY = {
@@ -736,6 +737,84 @@ class TestCompletePanTransferStep:
             f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete"
         )
         assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+class TestCutover:
+    async def test_anonymous(
+        self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/cutover"
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_not_reachable_returns_409(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, "verify_cards"
+        )
+        await save_fixture(migration)
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/cutover"
+        )
+        assert response.status_code == 409
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_confirms_and_reports(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        enqueue = mocker.patch("polar.merchant_migration.service.enqueue_job")
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, "cutover"
+        )
+        await save_fixture(migration)
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/cutover"
+        )
+        assert response.status_code == 200
+        assert response.json()["started"] is True
+        assert response.json()["running"] is True
+        enqueue.assert_called_once_with(
+            "merchant_migration.cutover", merchant_migration_id=migration.id
+        )
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_get_report_before_confirmation(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, "cutover"
+        )
+        await save_fixture(migration)
+
+        response = await client.get(f"/v1/merchant-migrations/{migration.id}/cutover")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["started"] is False
+        assert body["running"] is False
+        assert body["total"] == 0
 
 
 async def _create_migration(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -2349,7 +2349,7 @@ class TestGetCutoverReport:
         assert report.started is False
 
     @pytest.mark.auth
-    async def test_counts_respect_the_selection(
+    async def test_counts_all_imports_even_with_a_selection(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -2386,8 +2386,9 @@ class TestGetCutoverReport:
 
         report = await service.get_cutover_report(session, auth_subject, migration.id)
 
-        assert report.total == 1
-        assert report.pending == 1
+        # The picker lists every imported subscription; tab counts must match.
+        assert report.total == 2
+        assert report.pending == 2
 
     @pytest.mark.auth
     async def test_marks_a_stalled_switch_failed(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -78,6 +78,7 @@ from polar.models.merchant_migration import (
     MerchantMigrationStep,
 )
 from polar.models.merchant_migration_operation import (
+    STALL_THRESHOLD,
     MerchantMigrationOperation,
     MerchantMigrationOperationSelection,
     MerchantMigrationOperationStatus,
@@ -2208,9 +2209,13 @@ class TestRunCutover:
         await service.run_cutover(session, migration.id)
 
         await session.refresh(record)
+        await session.refresh(migration)
         # Nothing on the source is touched while the org can't bill renewals.
         assert runner.run.await_count == 0
         assert record.cutover_status is None
+        assert migration.operation is not None
+        assert migration.operation.status == MerchantMigrationOperationStatus.failed
+        assert migration.operation.error is not None
 
 
 @pytest.mark.asyncio
@@ -2259,6 +2264,33 @@ class TestGetCutoverReport:
         assert report.moved == 1
         assert report.pending == 1
         assert report.started is False
+
+    @pytest.mark.auth
+    async def test_marks_a_stalled_switch_failed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_MOVE_SUBSCRIPTIONS
+        )
+        migration.operation = MerchantMigrationOperation(
+            status=MerchantMigrationOperationStatus.running,
+            last_progress_at=utc_now() - STALL_THRESHOLD - timedelta(minutes=1),
+        )
+        await save_fixture(migration)
+
+        report = await service.get_cutover_report(session, auth_subject, migration.id)
+
+        await session.refresh(migration)
+        assert report.running is False
+        assert report.completed is True
+        assert migration.operation is not None
+        assert migration.operation.status == MerchantMigrationOperationStatus.failed
 
 
 @pytest.mark.asyncio

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -2217,6 +2217,89 @@ class TestRunCutover:
         assert migration.operation.status == MerchantMigrationOperationStatus.failed
         assert migration.operation.error is not None
 
+    async def test_does_not_finish_while_another_worker_holds_the_lock(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        runner = _fake_cutover(mocker)
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_MOVE_SUBSCRIPTIONS
+        )
+        migration.operation = MerchantMigrationOperation(
+            status=MerchantMigrationOperationStatus.running
+        )
+        await save_fixture(migration)
+        await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_1",
+            email="1@example.com",
+        )
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        mocker.patch.object(
+            record_repository,
+            "get_next_cutover_candidate",
+            return_value=None,
+        )
+        mocker.patch.object(
+            record_repository,
+            "has_pending_cutover_candidates",
+            return_value=True,
+        )
+        mocker.patch.object(
+            MerchantMigrationRecordRepository,
+            "from_session",
+            return_value=record_repository,
+        )
+
+        await service.run_cutover(session, migration.id)
+
+        await session.refresh(migration)
+        assert runner.run.await_count == 0
+        assert migration.operation.status == MerchantMigrationOperationStatus.running
+        assert migration.step != MerchantMigrationStep.cleanup
+
+    async def test_skips_when_operation_is_terminal(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        runner = _fake_cutover(mocker)
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_MOVE_SUBSCRIPTIONS
+        )
+        migration.operation = MerchantMigrationOperation(
+            status=MerchantMigrationOperationStatus.failed,
+            error="Switch stalled with no progress; start it again to resume.",
+        )
+        await save_fixture(migration)
+        await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_1",
+            email="1@example.com",
+        )
+
+        await service.run_cutover(session, migration.id)
+
+        assert runner.run.await_count == 0
+
 
 @pytest.mark.asyncio
 class TestGetCutoverReport:
@@ -2264,6 +2347,47 @@ class TestGetCutoverReport:
         assert report.moved == 1
         assert report.pending == 1
         assert report.started is False
+
+    @pytest.mark.auth
+    async def test_counts_respect_the_selection(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_CUTOVER
+        )
+        picked = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_picked",
+            email="picked@example.com",
+        )
+        await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_outside",
+            email="outside@example.com",
+        )
+        migration.operation = MerchantMigrationOperation(
+            status=MerchantMigrationOperationStatus.running,
+            selection=MerchantMigrationOperationSelection(record_ids=[picked.id]),
+        )
+        await save_fixture(migration)
+
+        report = await service.get_cutover_report(session, auth_subject, migration.id)
+
+        assert report.total == 1
+        assert report.pending == 1
 
     @pytest.mark.auth
     async def test_marks_a_stalled_switch_failed(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncIterator
 from datetime import timedelta
+from unittest.mock import Mock
 from uuid import UUID
 
 import pytest
@@ -31,7 +32,10 @@ from polar.merchant_migration.canonical import (
     serialize,
 )
 from polar.merchant_migration.cards import AmbiguousCopiedCard
+from polar.merchant_migration.cutover import CutoverOutcome
 from polar.merchant_migration.pan_transfer import (
+    STEP_CUTOVER,
+    STEP_MOVE_SUBSCRIPTIONS,
     STEP_RESOLVE_UNCOVERED,
     STEP_VERIFY_CARDS,
 )
@@ -48,6 +52,7 @@ from polar.merchant_migration.schemas import (
 from polar.merchant_migration.service import (
     CatalogImportBlocked,
     CatalogImportNotReady,
+    CutoverNotStarted,
     InvalidSourceCredentials,
     MissingStripeScopes,
     SourceAccountNotMigratable,
@@ -72,11 +77,17 @@ from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
+from polar.models.merchant_migration_operation import (
+    MerchantMigrationOperation,
+    MerchantMigrationOperationSelection,
+    MerchantMigrationOperationStatus,
+)
 from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
-from polar.models.organization import OrganizationStatus
+from polar.models.organization import STATUS_CAPABILITIES, OrganizationStatus
 from polar.models.product_price import ProductPriceFixed
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
@@ -1877,3 +1888,478 @@ class TestRunCardVerification:
         assert second.payment_method_id == linked.id
         # Both subscriptions charge the same customer, so one Stripe listing.
         assert link.await_count == 1
+
+
+def _fake_cutover(
+    mocker: MockerFixture,
+    outcome: CutoverOutcome | None = None,
+) -> Mock:
+    """Stand in for the Stripe-touching engine: record every subscription it's
+    asked to switch and answer with a fixed outcome."""
+    outcome = outcome or CutoverOutcome(MerchantMigrationCutoverStatus.moved)
+    runner = mocker.Mock(run=mocker.AsyncMock(return_value=outcome))
+    mocker.patch(
+        "polar.merchant_migration.service.SubscriptionCutover",
+        return_value=runner,
+    )
+    mocker.patch.object(
+        service, "_build_adapter", new=mocker.AsyncMock(return_value=object())
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+class TestStartCutover:
+    @pytest.mark.auth
+    async def test_confirms_step_stores_selection_and_enqueues(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        enqueue = mocker.patch("polar.merchant_migration.service.enqueue_job")
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_CUTOVER
+        )
+        await save_fixture(migration)
+        record = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_1",
+            email="a@example.com",
+        )
+
+        report = await service.start_cutover(
+            session, auth_subject, migration.id, record_ids=[record.id]
+        )
+
+        await session.refresh(migration)
+        assert service._step_completed(migration, STEP_CUTOVER)
+        # Confirming the step moves the migration into the switch phase.
+        assert migration.step == MerchantMigrationStep.activate_subscriptions
+        assert migration.operation is not None
+        assert migration.operation.status == MerchantMigrationOperationStatus.running
+        assert migration.operation.selection is not None
+        assert migration.operation.selection.record_ids == [record.id]
+        enqueue.assert_called_once_with(
+            "merchant_migration.cutover", merchant_migration_id=migration.id
+        )
+        assert report.started is True
+        assert report.running is True
+
+    @pytest.mark.auth
+    async def test_not_reachable_before_the_switch_step(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_VERIFY_CARDS
+        )
+        await save_fixture(migration)
+
+        with pytest.raises(CutoverNotStarted):
+            await service.start_cutover(session, auth_subject, migration.id)
+
+    @pytest.mark.auth
+    async def test_retry_reopens_only_non_moved(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        enqueue = mocker.patch("polar.merchant_migration.service.enqueue_job")
+        migration = await build_connected_migration(save_fixture, organization)
+        # Already switched once: the step is done and the migration is at cleanup.
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, None
+        )
+        migration.step = MerchantMigrationStep.cleanup
+        await save_fixture(migration)
+        moved = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_moved",
+            email="moved@example.com",
+        )
+        skipped = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_skipped",
+            email="skipped@example.com",
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        await record_repository.update(
+            moved, update_dict={"cutover_status": MerchantMigrationCutoverStatus.moved}
+        )
+        await record_repository.update(
+            skipped,
+            update_dict={
+                "cutover_status": MerchantMigrationCutoverStatus.skipped,
+                "cutover_error": "Renews too soon.",
+            },
+        )
+
+        await service.start_cutover(session, auth_subject, migration.id)
+
+        await session.refresh(moved)
+        await session.refresh(skipped)
+        # What moved stays moved; the skipped one re-opens for another look.
+        assert moved.cutover_status == MerchantMigrationCutoverStatus.moved
+        assert skipped.cutover_status is None
+        assert skipped.cutover_error is None
+        enqueue.assert_called_once_with(
+            "merchant_migration.cutover", merchant_migration_id=migration.id
+        )
+
+
+@pytest.mark.asyncio
+class TestRunCutover:
+    async def test_moves_one_then_reenqueues(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        enqueue = mocker.patch("polar.merchant_migration.service.enqueue_job")
+        runner = _fake_cutover(mocker)
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_MOVE_SUBSCRIPTIONS
+        )
+        migration.operation = MerchantMigrationOperation(
+            status=MerchantMigrationOperationStatus.running
+        )
+        await save_fixture(migration)
+        first = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_1",
+            email="1@example.com",
+        )
+        await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_2",
+            email="2@example.com",
+        )
+
+        await service.run_cutover(session, migration.id)
+
+        await session.flush()
+        await session.refresh(first)
+        # One subscription per run, and it hands off to the next.
+        assert runner.run.await_count == 1
+        assert first.cutover_status == MerchantMigrationCutoverStatus.moved
+        enqueue.assert_called_once_with(
+            "merchant_migration.cutover", merchant_migration_id=migration.id
+        )
+
+    async def test_finishes_when_nothing_is_left(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        _fake_cutover(mocker)
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_MOVE_SUBSCRIPTIONS
+        )
+        migration.operation = MerchantMigrationOperation(
+            status=MerchantMigrationOperationStatus.running
+        )
+        await save_fixture(migration)
+        settled = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_done",
+            email="done@example.com",
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        await record_repository.update(
+            settled,
+            update_dict={"cutover_status": MerchantMigrationCutoverStatus.moved},
+        )
+
+        await service.run_cutover(session, migration.id)
+
+        await session.refresh(migration)
+        assert service._step_completed(migration, STEP_MOVE_SUBSCRIPTIONS)
+        assert migration.step == MerchantMigrationStep.cleanup
+        assert migration.operation is not None
+        assert migration.operation.status == MerchantMigrationOperationStatus.done
+
+    async def test_honours_the_selection(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        runner = _fake_cutover(mocker)
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_MOVE_SUBSCRIPTIONS
+        )
+        picked = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_picked",
+            email="picked@example.com",
+        )
+        untouched = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_untouched",
+            email="untouched@example.com",
+        )
+        migration.operation = MerchantMigrationOperation(
+            status=MerchantMigrationOperationStatus.running,
+            selection=MerchantMigrationOperationSelection(record_ids=[picked.id]),
+        )
+        await save_fixture(migration)
+
+        # Run until the selected subset is exhausted.
+        await service.run_cutover(session, migration.id)
+        await session.flush()
+        await service.run_cutover(session, migration.id)
+        await session.flush()
+
+        await session.refresh(picked)
+        await session.refresh(untouched)
+        assert runner.run.await_count == 1
+        assert picked.cutover_status == MerchantMigrationCutoverStatus.moved
+        # Outside the selection: never looked at.
+        assert untouched.cutover_status is None
+
+    async def test_skips_when_renewals_disabled(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        runner = _fake_cutover(mocker)
+        organization.capabilities = {
+            **STATUS_CAPABILITIES[OrganizationStatus.CREATED]
+        }
+        await save_fixture(organization)
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_MOVE_SUBSCRIPTIONS
+        )
+        migration.operation = MerchantMigrationOperation(
+            status=MerchantMigrationOperationStatus.running
+        )
+        await save_fixture(migration)
+        record = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_1",
+            email="1@example.com",
+        )
+
+        await service.run_cutover(session, migration.id)
+
+        await session.refresh(record)
+        # Nothing on the source is touched while the org can't bill renewals.
+        assert runner.run.await_count == 0
+        assert record.cutover_status is None
+
+
+@pytest.mark.asyncio
+class TestGetCutoverReport:
+    @pytest.mark.auth
+    async def test_counts_the_imported_subscriptions(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_CUTOVER
+        )
+        await save_fixture(migration)
+        moved = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_moved",
+            email="moved@example.com",
+        )
+        await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_pending",
+            email="pending@example.com",
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        await record_repository.update(
+            moved, update_dict={"cutover_status": MerchantMigrationCutoverStatus.moved}
+        )
+
+        report = await service.get_cutover_report(
+            session, auth_subject, migration.id
+        )
+
+        assert report.total == 2
+        assert report.moved == 1
+        assert report.pending == 1
+        assert report.started is False
+
+
+@pytest.mark.asyncio
+class TestListRecordsCutover:
+    @pytest.mark.auth
+    async def test_carries_cutover_fields_and_coverage(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        await save_fixture(migration)
+        record = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_1",
+            email="a@example.com",
+        )
+        assert record.target_id is not None
+        subscription_repository = SubscriptionRepository.from_session(session)
+        subscription = await subscription_repository.get_by_id(
+            record.target_id, options=(joinedload(Subscription.customer),)
+        )
+        assert subscription is not None
+        payment_method = await create_payment_method(
+            save_fixture, subscription.customer, processor_id="pm_1"
+        )
+        await subscription_repository.update(
+            subscription, update_dict={"payment_method_id": payment_method.id}
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        await record_repository.update(
+            record,
+            update_dict={
+                "cutover_status": MerchantMigrationCutoverStatus.skipped,
+                "cutover_error": "Renews too soon.",
+            },
+        )
+
+        items, _ = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.subscriptions,
+            status=None,
+            pagination=PaginationParams(page=1, limit=50),
+        )
+
+        assert len(items) == 1
+        item = items[0]
+        assert item.cutover_status == MerchantMigrationCutoverStatus.skipped
+        assert item.cutover_error == "Renews too soon."
+        assert item.has_payment_method is True
+        assert item.renews_at is not None
+
+    @pytest.mark.auth
+    async def test_filters_on_cutover_status(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        await save_fixture(migration)
+        skipped = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_skipped",
+            email="skipped@example.com",
+        )
+        await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_pending",
+            email="pending@example.com",
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        await record_repository.update(
+            skipped,
+            update_dict={"cutover_status": MerchantMigrationCutoverStatus.skipped},
+        )
+
+        items, count = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.subscriptions,
+            status=None,
+            cutover_status=MerchantMigrationCutoverStatus.skipped,
+            pagination=PaginationParams(page=1, limit=50),
+        )
+
+        assert count == 1
+        assert items[0].source_id == "sub_skipped"

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -2186,9 +2186,7 @@ class TestRunCutover:
     ) -> None:
         mocker.patch("polar.merchant_migration.service.enqueue_job")
         runner = _fake_cutover(mocker)
-        organization.capabilities = {
-            **STATUS_CAPABILITIES[OrganizationStatus.CREATED]
-        }
+        organization.capabilities = {**STATUS_CAPABILITIES[OrganizationStatus.CREATED]}
         await save_fixture(organization)
         migration = await build_connected_migration(save_fixture, organization)
         migration.pan_transfer_steps = pan_steps_until(
@@ -2255,9 +2253,7 @@ class TestGetCutoverReport:
             flush=True,
         )
 
-        report = await service.get_cutover_report(
-            session, auth_subject, migration.id
-        )
+        report = await service.get_cutover_report(session, auth_subject, migration.id)
 
         assert report.total == 2
         assert report.moved == 1

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -2011,7 +2011,9 @@ class TestStartCutover:
         )
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         await record_repository.update(
-            moved, update_dict={"cutover_status": MerchantMigrationCutoverStatus.moved}
+            moved,
+            update_dict={"cutover_status": MerchantMigrationCutoverStatus.moved},
+            flush=True,
         )
         await record_repository.update(
             skipped,
@@ -2019,6 +2021,7 @@ class TestStartCutover:
                 "cutover_status": MerchantMigrationCutoverStatus.skipped,
                 "cutover_error": "Renews too soon.",
             },
+            flush=True,
         )
 
         await service.start_cutover(session, auth_subject, migration.id)
@@ -2112,10 +2115,12 @@ class TestRunCutover:
         await record_repository.update(
             settled,
             update_dict={"cutover_status": MerchantMigrationCutoverStatus.moved},
+            flush=True,
         )
 
         await service.run_cutover(session, migration.id)
 
+        await session.flush()
         await session.refresh(migration)
         assert service._step_completed(migration, STEP_MOVE_SUBSCRIPTIONS)
         assert migration.step == MerchantMigrationStep.cleanup
@@ -2245,7 +2250,9 @@ class TestGetCutoverReport:
         )
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         await record_repository.update(
-            moved, update_dict={"cutover_status": MerchantMigrationCutoverStatus.moved}
+            moved,
+            update_dict={"cutover_status": MerchantMigrationCutoverStatus.moved},
+            flush=True,
         )
 
         report = await service.get_cutover_report(
@@ -2290,7 +2297,9 @@ class TestListRecordsCutover:
             save_fixture, subscription.customer, processor_id="pm_1"
         )
         await subscription_repository.update(
-            subscription, update_dict={"payment_method_id": payment_method.id}
+            subscription,
+            update_dict={"payment_method_id": payment_method.id},
+            flush=True,
         )
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         await record_repository.update(
@@ -2299,6 +2308,7 @@ class TestListRecordsCutover:
                 "cutover_status": MerchantMigrationCutoverStatus.skipped,
                 "cutover_error": "Renews too soon.",
             },
+            flush=True,
         )
 
         items, _ = await service.list_records(
@@ -2349,6 +2359,7 @@ class TestListRecordsCutover:
         await record_repository.update(
             skipped,
             update_dict={"cutover_status": MerchantMigrationCutoverStatus.skipped},
+            flush=True,
         )
 
         items, count = await service.list_records(


### PR DESCRIPTION
## Summary

Create a merchant-facing API to trigger the cutover, so the frontend has something to call. The merchant picks which imported subscriptions to switch and Polar moves them one at a time.


Looks big but most of it are tests or the v1.ts

## Checklist

- [x] This PR addresses a single concern
- [x] New functionality is covered by tests
- [x] Linting and type checking pass
- [x] No unrelated changes
