### PR TITLE
Run dramatiq workers on Vercel Queues for Vercel

### DIFF
--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -275,6 +275,14 @@ def get_broker(*, database: bool = True) -> dramatiq.Broker:
         middleware.CurrentMessage(),
     ]
 
+    if settings.is_vercel():
+        # Vercel Queues transport, delivering into the subscriber Function
+        # declared in pyproject.toml. Local import: vercel-dramatiq is
+        # installed by the Vercel build, not declared as a dependency.
+        from vercel.integrations.dramatiq import VercelQueueBroker
+
+        return VercelQueueBroker(middleware=middleware_list)
+
     broker = RoutingRedisBroker(
         connection_pool=redis_pool,
         client=SyncFailoverRedis(connection_pool=redis_pool),

--- a/server/polar/worker/_enqueue.py
+++ b/server/polar/worker/_enqueue.py
@@ -9,6 +9,7 @@ from typing import Any, Self
 
 import dramatiq
 import structlog
+from dramatiq.brokers.redis import RedisBroker
 from dramatiq.common import dq_name
 
 from polar.config import settings
@@ -84,7 +85,7 @@ class JobQueueManager:
             job for job in self._enqueued_jobs if not should_route_to_sqs(job[0])
         ]
 
-        queue_messages = defaultdict[str, list[tuple[str, Any]]](list)
+        built_messages: list[tuple[dramatiq.Message[Any], int | None]] = []
         all_messages: list[tuple[str, Any]] = []
 
         for actor_name, args, kwargs, delay in redis_jobs:
@@ -113,28 +114,35 @@ class JobQueueManager:
                 else:
                     delay = debounce_delay
 
-            # Handle delay: convert to eta and use delayed queue
-            # See https://github.com/Bogdanp/dramatiq/blob/aa91cdfcfa6d8ad957ca0afe900266617f2661f8/dramatiq/brokers/stub.py#L107-L116
-            if delay is not None and delay > 0:
-                current_millis = int(time.time() * 1000)
-                eta = current_millis + delay
-                message = message.copy(
-                    queue_name=dq_name(message.queue_name),
-                    options={**message.options, "eta": eta},
-                )
-
-            encoded_message = message.encode()
-            queue_messages[message.queue_name].append(
-                (redis_message_id, encoded_message)
-            )
+            built_messages.append((message, delay))
             all_messages.append((fn.actor_name, message.encode()))
 
-        for queue_name, messages in queue_messages.items():
-            for batch in itertools.batched(messages, FLUSH_BATCH_SIZE):
-                await self._batch_hset_messages(redis, queue_name, batch)
-                await self._batch_rpush_queue(
-                    redis, queue_name, (message_id for message_id, _ in batch)
+        if isinstance(broker, RedisBroker):
+            queue_messages = defaultdict[str, list[tuple[str, Any]]](list)
+            for message, delay in built_messages:
+                # Handle delay: convert to eta and use delayed queue
+                # See https://github.com/Bogdanp/dramatiq/blob/aa91cdfcfa6d8ad957ca0afe900266617f2661f8/dramatiq/brokers/stub.py#L107-L116
+                if delay is not None and delay > 0:
+                    current_millis = int(time.time() * 1000)
+                    eta = current_millis + delay
+                    message = message.copy(
+                        queue_name=dq_name(message.queue_name),
+                        options={**message.options, "eta": eta},
+                    )
+                queue_messages[message.queue_name].append(
+                    (message.options["redis_message_id"], message.encode())
                 )
+            for queue_name, messages in queue_messages.items():
+                for batch in itertools.batched(messages, FLUSH_BATCH_SIZE):
+                    await self._batch_hset_messages(redis, queue_name, batch)
+                    await self._batch_rpush_queue(
+                        redis, queue_name, (message_id for message_id, _ in batch)
+                    )
+        else:
+            # Other brokers (e.g. Vercel Queues) go through the standard
+            # enqueue API.
+            for message, delay in built_messages:
+                broker.enqueue(message, delay=delay if delay and delay > 0 else None)
 
         for actor_name, encoded_message in all_messages:
             log.debug(

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -212,3 +212,6 @@ dramatiq = { git = "https://github.com/frankie567/dramatiq", rev = "memory-leak-
 
 [tool.vercel]
 entrypoint = "polar.app:app"
+
+[[tool.vercel.subscribers]]
+entrypoint = "polar.worker.run:broker"


### PR DESCRIPTION
Move the background workers from `dramatiq` processes reading Redis to Functions that listen on Vercel Queues when running on Vercel.


Summary:

Each `dramatiq` queue becomes a queue topic. The worker Function and its topics are derived from the broker config in `pyproject.toml`:

```toml
[[tool.vercel.subscribers]]
entrypoint = "polar.worker.run:broker"
```

Semantic differences on Vercel Queues:

* Delivery is push-based
* Concurrency comes from serverless function scaling, not worker processes/threads