### PR TITLE
feat(web): subscription switch picker for merchant migrations

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
@@ -13,6 +13,7 @@ import { MigrationStepper } from '../MigrationStepper'
 import { PrecheckPanel } from '../PrecheckPanel'
 import { ReviewTable } from '../review/ReviewTable'
 import { currentStepDef, MigrationStepDef, OWNER_LABELS } from '../steps'
+import { SwitchPanel } from '../switch/SwitchPanel'
 import { StripeMark } from '../StripeMark'
 
 interface Props {
@@ -135,6 +136,16 @@ function StepContent({
         <Box flexDirection="column" rowGap="l">
           <StepHeading def={def} />
           <PanTransferPanel migrationId={migration.id} />
+        </Box>
+      )
+    // The switch runs here, and stays reachable at cleanup so the merchant can
+    // switch the ones an earlier run left on Stripe.
+    case 'activate_subscriptions':
+    case 'cleanup':
+      return (
+        <Box flexDirection="column" rowGap="l">
+          {def && <StepHeading def={def} />}
+          <SwitchPanel migrationId={migration.id} />
         </Box>
       )
   }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
@@ -9,8 +9,6 @@ import { SwitchPanel } from '../switch/SwitchPanel'
 import { StepCopy } from './panTransferCopy'
 import { PanTransferStepForm } from './PanTransferStepForm'
 
-// The confirm step for the switch is where the merchant picks which
-// subscriptions move; the picker submits the selection and confirms the step.
 const SWITCH_STEP_KEY = 'cutover'
 
 interface Props {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
@@ -5,8 +5,13 @@ import { Alert, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import { SwitchPanel } from '../switch/SwitchPanel'
 import { StepCopy } from './panTransferCopy'
 import { PanTransferStepForm } from './PanTransferStepForm'
+
+// The confirm step for the switch is where the merchant picks which
+// subscriptions move; the picker submits the selection and confirms the step.
+const SWITCH_STEP_KEY = 'cutover'
 
 interface Props {
   step: schemas['PanTransferStep']
@@ -69,7 +74,10 @@ export function PanTransferStepBody({
 
       <OpsUpdate step={step} />
 
-      {submittable &&
+      {step.key === SWITCH_STEP_KEY ? (
+        <SwitchPanel migrationId={migrationId} />
+      ) : (
+        submittable &&
         (fieldsUnknown || !copy.action ? (
           <Text variant="caption" color="muted">
             This step needs a newer version of this page. Please refresh.
@@ -80,7 +88,8 @@ export function PanTransferStepBody({
             migrationId={migrationId}
             stepKey={step.key}
           />
-        ))}
+        ))
+      )}
     </Box>
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
@@ -135,16 +135,16 @@ export const STEP_COPY: Record<string, StepCopy> = {
     action: 'I handled these customers',
   },
   cutover: {
-    title: 'Cut over billing',
+    title: 'Switch billing to Polar',
     description:
-      'Polar takes over billing. Stop billing these subscriptions on your old provider first.',
+      'Pick the subscriptions to switch. Polar starts billing them and stops them on Stripe.',
     warning: 'You cannot undo this. Charges start on Polar from now on.',
-    action: 'Cut over billing',
+    action: 'Switch subscriptions',
   },
   move_subscriptions: {
-    title: 'Polar moves your subscriptions',
+    title: 'Polar switches your subscriptions',
     description:
-      'We activate the imported subscriptions. They are charged on their next renewal date.',
+      'We start billing the subscriptions you picked. They are charged on their next renewal date.',
   },
 }
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.ts
@@ -52,11 +52,11 @@ export const MIGRATION_STEPS: MigrationStepDef[] = [
   },
   {
     key: 'cutover',
-    short: 'Cutover',
+    short: 'Switch',
     owner: 'polar',
-    title: 'Cut over billing',
+    title: 'Switch billing to Polar',
     description:
-      'Polar takes over billing for active subscriptions and stops them on Stripe.',
+      'Polar starts billing the subscriptions you pick and stops them on Stripe.',
     steps: ['activate_subscriptions'],
   },
 ]

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
@@ -5,9 +5,10 @@ import {
   useMigrationSwitch,
   useStartMigrationSwitch,
 } from '@/hooks/queries/merchantMigrations'
+import { getQueryClient } from '@/utils/api/query'
 import { Alert, Spinner } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   SelectionState,
   selectedCount,
@@ -50,9 +51,20 @@ export function SwitchPanel({ migrationId }: { migrationId: string }) {
   )
   const startSwitch = useStartMigrationSwitch(migrationId)
 
+  const wasRunning = useRef(false)
+  useEffect(() => {
+    if (wasRunning.current && !running) {
+      getQueryClient().invalidateQueries({
+        queryKey: ['merchantMigrationRecords', { id: migrationId }],
+      })
+    }
+    wasRunning.current = running
+  }, [running, migrationId])
+
   const onFilterChange = (next: SwitchFilter) => {
     setFilter(next)
     setPage(1)
+    setSelection(initialSwitchSelection)
   }
   const onPageSizeChange = (size: number) => {
     setPageSize(size)
@@ -90,6 +102,9 @@ export function SwitchPanel({ migrationId }: { migrationId: string }) {
 
   const report = switchReport.data
   const switchableTotal = Math.max(0, report.total - report.moved)
+  // Select-all sends `{}` (every imported subscription). Only safe on the All
+  // tab — on a status tab it would bill rows the merchant isn't looking at.
+  const canSelectAll = filter === 'all' && switchableTotal > 0
   const switchCount = selectedCount(selection, switchableTotal)
 
   return (
@@ -107,6 +122,7 @@ export function SwitchPanel({ migrationId }: { migrationId: string }) {
       selection={selection}
       switchCount={switchCount}
       switchableTotal={switchableTotal}
+      canSelectAll={canSelectAll}
       onToggle={onToggle}
       onToggleAll={onToggleAll}
       onSwitch={() => {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import {
+  useMigrationRecords,
+  useMigrationSwitch,
+  useStartMigrationSwitch,
+} from '@/hooks/queries/merchantMigrations'
+import { Alert, Spinner } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { useCallback, useState } from 'react'
+import {
+  SelectionState,
+  selectedCount,
+  selectionAfterSubmit,
+  selectionPayload,
+  toggleAll,
+  toggleRow,
+} from '../selection'
+import { SwitchPanelView } from './SwitchPanelView'
+import { SwitchFilter } from './switchCopy'
+
+// Opt in, not out: switching bills customers and can't be undone, so nothing is
+// picked until the merchant picks it.
+const initialSwitchSelection: SelectionState = {
+  mode: 'none',
+  toggled: new Set(),
+}
+
+export function SwitchPanel({ migrationId }: { migrationId: string }) {
+  const [filter, setFilter] = useState<SwitchFilter>('all')
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(20)
+  const [selection, setSelection] = useState<SelectionState>(
+    initialSwitchSelection,
+  )
+
+  const switchReport = useMigrationSwitch(migrationId)
+  const running = switchReport.data?.running ?? false
+  const records = useMigrationRecords(
+    migrationId,
+    {
+      entity: 'subscriptions',
+      importStatus: 'imported',
+      ...(filter !== 'all' ? { cutoverStatus: filter } : {}),
+      page,
+      limit: pageSize,
+    },
+    // Follow the run: rows flip to their outcome as the worker chain lands.
+    running ? 3000 : false,
+  )
+  const startSwitch = useStartMigrationSwitch(migrationId)
+
+  const onFilterChange = (next: SwitchFilter) => {
+    setFilter(next)
+    setPage(1)
+  }
+  const onPageSizeChange = (size: number) => {
+    setPageSize(size)
+    setPage(1)
+  }
+  const onToggle = useCallback(
+    (id: string) => setSelection((prev) => toggleRow(prev, id)),
+    [],
+  )
+  const onToggleAll = useCallback(
+    () => setSelection((prev) => toggleAll(prev)),
+    [],
+  )
+
+  if (switchReport.isLoading || records.isLoading) {
+    return (
+      <Box padding="2xl" alignItems="center" justifyContent="center">
+        <Spinner />
+      </Box>
+    )
+  }
+
+  if (switchReport.isError || records.isError || !switchReport.data) {
+    return (
+      <Alert
+        variant="danger"
+        title="We couldn't load your subscriptions"
+        description="Something went wrong. Please refresh and try again."
+      />
+    )
+  }
+
+  const report = switchReport.data
+  // Everything imported that Polar doesn't bill yet: what a switch could move.
+  const switchableTotal = Math.max(0, report.total - report.moved)
+  const switchCount = selectedCount(selection, switchableTotal)
+
+  return (
+    <SwitchPanelView
+      report={report}
+      filter={filter}
+      onFilterChange={onFilterChange}
+      rows={records.data?.items ?? []}
+      page={page}
+      pageSize={pageSize}
+      pageCount={records.data?.pagination.max_page ?? 1}
+      rowCount={records.data?.pagination.total_count ?? 0}
+      onPageChange={setPage}
+      onPageSizeChange={onPageSizeChange}
+      selection={selection}
+      switchCount={switchCount}
+      switchableTotal={switchableTotal}
+      onToggle={onToggle}
+      onToggleAll={onToggleAll}
+      onSwitch={() => {
+        const submitted = selection
+        startSwitch.mutate(selectionPayload(submitted), {
+          onSuccess: () =>
+            setSelection((current) =>
+              selectionAfterSubmit(submitted, current),
+            ),
+        })
+      }}
+      switching={startSwitch.isPending}
+      switchError={
+        startSwitch.isError
+          ? startSwitch.error?.message ||
+            'Something went wrong. Please try again.'
+          : undefined
+      }
+    />
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
@@ -121,7 +121,6 @@ export function SwitchPanel({ migrationId }: { migrationId: string }) {
       onPageSizeChange={onPageSizeChange}
       selection={selection}
       switchCount={switchCount}
-      switchableTotal={switchableTotal}
       canSelectAll={canSelectAll}
       onToggle={onToggle}
       onToggleAll={onToggleAll}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
@@ -19,12 +19,13 @@ import {
 import { SwitchPanelView } from './SwitchPanelView'
 import { SwitchFilter } from './switchCopy'
 
-// Opt in, not out: switching bills customers and can't be undone, so nothing is
-// picked until the merchant picks it.
 const initialSwitchSelection: SelectionState = {
   mode: 'none',
   toggled: new Set(),
 }
+
+const errorMessage = (error: unknown, fallback: string) =>
+  error instanceof Error && error.message ? error.message : fallback
 
 export function SwitchPanel({ migrationId }: { migrationId: string }) {
   const [filter, setFilter] = useState<SwitchFilter>('all')
@@ -45,7 +46,6 @@ export function SwitchPanel({ migrationId }: { migrationId: string }) {
       page,
       limit: pageSize,
     },
-    // Follow the run: rows flip to their outcome as the worker chain lands.
     running ? 3000 : false,
   )
   const startSwitch = useStartMigrationSwitch(migrationId)
@@ -80,13 +80,15 @@ export function SwitchPanel({ migrationId }: { migrationId: string }) {
       <Alert
         variant="danger"
         title="We couldn't load your subscriptions"
-        description="Something went wrong. Please refresh and try again."
+        description={errorMessage(
+          switchReport.error ?? records.error,
+          'Something went wrong. Please refresh and try again.',
+        )}
       />
     )
   }
 
   const report = switchReport.data
-  // Everything imported that Polar doesn't bill yet: what a switch could move.
   const switchableTotal = Math.max(0, report.total - report.moved)
   const switchCount = selectedCount(selection, switchableTotal)
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
@@ -111,9 +111,7 @@ export function SwitchPanel({ migrationId }: { migrationId: string }) {
         const submitted = selection
         startSwitch.mutate(selectionPayload(submitted), {
           onSuccess: () =>
-            setSelection((current) =>
-              selectionAfterSubmit(submitted, current),
-            ),
+            setSelection((current) => selectionAfterSubmit(submitted, current)),
         })
       }}
       switching={startSwitch.isPending}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanelView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanelView.tsx
@@ -94,9 +94,6 @@ export function SwitchPanelView({
     onPageChange(next.pageIndex + 1)
   }
 
-  const left = report.skipped + report.failed
-  const showResult = report.completed && !running
-
   return (
     <Box as="section" flexDirection="column" rowGap="xl">
       {switchError && (
@@ -104,18 +101,6 @@ export function SwitchPanelView({
           variant="danger"
           title="We couldn't switch these subscriptions"
           description={switchError}
-        />
-      )}
-
-      {showResult && report.moved > 0 && (
-        <Alert
-          variant="success"
-          title={`Polar now bills ${numberFormat.format(report.moved)} subscription(s)`}
-          description={
-            left > 0
-              ? `${numberFormat.format(left)} stayed on Stripe. Open them below to see why, then switch again once they're sorted.`
-              : 'They are stopped on Stripe and charged on Polar from their next renewal.'
-          }
         />
       )}
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanelView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanelView.tsx
@@ -33,7 +33,6 @@ interface Props {
   onPageSizeChange: (size: number) => void
   selection: SelectionState
   switchCount: number
-  switchableTotal: number
   canSelectAll: boolean
   onToggle: (id: string) => void
   onToggleAll: () => void
@@ -55,7 +54,6 @@ export function SwitchPanelView({
   onPageSizeChange,
   selection,
   switchCount,
-  switchableTotal,
   canSelectAll,
   onToggle,
   onToggleAll,

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanelView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanelView.tsx
@@ -1,0 +1,204 @@
+'use client'
+
+import { ConfirmModal } from '@/components/Modal/ConfirmModal'
+import { schemas } from '@polar-sh/client'
+import { Alert, Button, DataTable, InlineModal, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { OnChangeFn, PaginationState } from '@tanstack/react-table'
+import { useMemo, useState } from 'react'
+import { headerCheckState, isRowSelected, SelectionState } from '../selection'
+import { SwitchRecordModal } from './SwitchRecordModal'
+import { SwitchStatusTabs } from './SwitchStatusTabs'
+import { SwitchSummary } from './SwitchSummary'
+import { buildSwitchColumns } from './switchColumns'
+import {
+  SWITCH_EMPTY_MESSAGES,
+  SWITCH_UNDONE_WARNING,
+  SwitchFilter,
+} from './switchCopy'
+import { SwitchRow } from './switchRows'
+
+const numberFormat = new Intl.NumberFormat('en-US')
+
+interface Props {
+  report: schemas['MerchantMigrationCutoverReport']
+  filter: SwitchFilter
+  onFilterChange: (filter: SwitchFilter) => void
+  rows: SwitchRow[]
+  page: number
+  pageSize: number
+  pageCount: number
+  rowCount: number
+  onPageChange: (page: number) => void
+  onPageSizeChange: (size: number) => void
+  selection: SelectionState
+  switchCount: number
+  switchableTotal: number
+  onToggle: (id: string) => void
+  onToggleAll: () => void
+  onSwitch: () => void
+  switching: boolean
+  switchError?: string
+}
+
+export function SwitchPanelView({
+  report,
+  filter,
+  onFilterChange,
+  rows,
+  page,
+  pageSize,
+  pageCount,
+  rowCount,
+  onPageChange,
+  onPageSizeChange,
+  selection,
+  switchCount,
+  switchableTotal,
+  onToggle,
+  onToggleAll,
+  onSwitch,
+  switching,
+  switchError,
+}: Props) {
+  const [openRow, setOpenRow] = useState<SwitchRow | null>(null)
+  const [confirming, setConfirming] = useState(false)
+
+  const running = report.running || switching
+  const buttonLabel = running
+    ? 'Switching…'
+    : switchCount > 0
+      ? `Switch ${numberFormat.format(switchCount)} subscriptions`
+      : 'Switch subscriptions'
+
+  const columns = useMemo(
+    () =>
+      buildSwitchColumns({
+        isSelected: (id) => isRowSelected(selection, id),
+        headerState:
+          switchableTotal > 0 ? headerCheckState(selection) : 'unchecked',
+        canSelectAll: switchableTotal > 0,
+        onToggle,
+        onToggleAll,
+      }),
+    [switchableTotal, selection, onToggle, onToggleAll],
+  )
+
+  const pagination: PaginationState = { pageIndex: page - 1, pageSize }
+  const onPaginationChange: OnChangeFn<PaginationState> = (updater) => {
+    const next = typeof updater === 'function' ? updater(pagination) : updater
+    if (next.pageSize !== pageSize) {
+      onPageSizeChange(next.pageSize)
+      return
+    }
+    onPageChange(next.pageIndex + 1)
+  }
+
+  const left = report.skipped + report.failed
+  const showResult = report.completed && !running
+
+  return (
+    <Box as="section" flexDirection="column" rowGap="xl">
+      {switchError && (
+        <Alert
+          variant="danger"
+          title="We couldn't switch these subscriptions"
+          description={switchError}
+        />
+      )}
+
+      {showResult && report.moved > 0 && (
+        <Alert
+          variant="success"
+          title={`Polar now bills ${numberFormat.format(report.moved)} subscription(s)`}
+          description={
+            left > 0
+              ? `${numberFormat.format(left)} stayed on Stripe. Open them below to see why, then switch again once they're sorted.`
+              : 'They are stopped on Stripe and charged on Polar from their next renewal.'
+          }
+        />
+      )}
+
+      <SwitchSummary report={report} />
+
+      <Box flexDirection="column" rowGap="m">
+        <Box
+          alignItems="center"
+          justifyContent="between"
+          columnGap="m"
+          rowGap="s"
+          flexWrap="wrap"
+        >
+          <Box maxWidth="100%" overflowX="auto">
+            <SwitchStatusTabs
+              value={filter}
+              counts={{
+                all: report.total,
+                skipped: report.skipped,
+                failed: report.failed,
+                moved: report.moved,
+              }}
+              onChange={onFilterChange}
+            />
+          </Box>
+          <Button
+            size="sm"
+            onClick={() => setConfirming(true)}
+            disabled={running || switchCount <= 0}
+          >
+            {buttonLabel}
+          </Button>
+        </Box>
+
+        {rows.length === 0 ? (
+          <Box
+            borderWidth={1}
+            borderStyle="solid"
+            borderColor="border-primary"
+            borderRadius="l"
+            paddingVertical="2xl"
+            justifyContent="center"
+          >
+            <Text variant="caption" color="muted">
+              {SWITCH_EMPTY_MESSAGES[filter]}
+            </Text>
+          </Box>
+        ) : (
+          <DataTable
+            columns={columns}
+            data={rows}
+            rowCount={rowCount}
+            pageCount={pageCount}
+            pagination={pagination}
+            onPaginationChange={onPaginationChange}
+            isLoading={false}
+            getRowId={(row) => row.record_id ?? row.source_id}
+            onRowClick={(row) => setOpenRow(row.original)}
+          />
+        )}
+      </Box>
+
+      <ConfirmModal
+        isShown={confirming}
+        hide={() => setConfirming(false)}
+        title={`Switch ${numberFormat.format(switchCount)} subscriptions?`}
+        description={SWITCH_UNDONE_WARNING}
+        destructive
+        destructiveText={`Switch ${numberFormat.format(switchCount)} subscriptions`}
+        onConfirm={onSwitch}
+      />
+
+      <InlineModal
+        isShown={openRow !== null}
+        hide={() => setOpenRow(null)}
+        modalContent={
+          openRow ? (
+            <SwitchRecordModal row={openRow} onClose={() => setOpenRow(null)} />
+          ) : (
+            <Box />
+          )
+        }
+      />
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanelView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanelView.tsx
@@ -75,9 +75,7 @@ export function SwitchPanelView({
     () =>
       buildSwitchColumns({
         isSelected: (id) => isRowSelected(selection, id),
-        headerState: canSelectAll
-          ? headerCheckState(selection)
-          : 'unchecked',
+        headerState: canSelectAll ? headerCheckState(selection) : 'unchecked',
         canSelectAll,
         onToggle,
         onToggleAll,

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanelView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanelView.tsx
@@ -34,6 +34,7 @@ interface Props {
   selection: SelectionState
   switchCount: number
   switchableTotal: number
+  canSelectAll: boolean
   onToggle: (id: string) => void
   onToggleAll: () => void
   onSwitch: () => void
@@ -55,6 +56,7 @@ export function SwitchPanelView({
   selection,
   switchCount,
   switchableTotal,
+  canSelectAll,
   onToggle,
   onToggleAll,
   onSwitch,
@@ -75,13 +77,14 @@ export function SwitchPanelView({
     () =>
       buildSwitchColumns({
         isSelected: (id) => isRowSelected(selection, id),
-        headerState:
-          switchableTotal > 0 ? headerCheckState(selection) : 'unchecked',
-        canSelectAll: switchableTotal > 0,
+        headerState: canSelectAll
+          ? headerCheckState(selection)
+          : 'unchecked',
+        canSelectAll,
         onToggle,
         onToggleAll,
       }),
-    [switchableTotal, selection, onToggle, onToggleAll],
+    [canSelectAll, selection, onToggle, onToggleAll],
   )
 
   const pagination: PaginationState = { pageIndex: page - 1, pageSize }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchRecordModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchRecordModal.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { Alert, InlineModalHeader, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import { ReactNode } from 'react'
+import { SwitchStatusIndicator } from './SwitchStatusIndicator'
+import { needsAttention, SwitchRow } from './switchRows'
+
+export function SwitchRecordModal({
+  row,
+  onClose,
+}: {
+  row: SwitchRow
+  onClose: () => void
+}) {
+  return (
+    <Box flexDirection="column" height="100%">
+      <InlineModalHeader hide={onClose}>
+        <Text variant="heading-xs" as="h2">
+          {row.title}
+        </Text>
+      </InlineModalHeader>
+
+      <Box
+        flexDirection="column"
+        rowGap="xl"
+        padding="xl"
+        flex={1}
+        overflowY="auto"
+      >
+        {row.cutover_error && (
+          <Box>
+            <Alert
+              variant={needsAttention(row) ? 'warning' : 'info'}
+              title={
+                row.cutover_status === 'failed'
+                  ? 'This one failed'
+                  : 'Left on Stripe'
+              }
+              description={row.cutover_error}
+            />
+          </Box>
+        )}
+
+        <Box as="section" flexDirection="column" rowGap="m">
+          <Field label="Status">
+            <SwitchStatusIndicator row={row} />
+          </Field>
+          {row.subtitle && (
+            <Field label="Stripe status">
+              <Text>{row.subtitle}</Text>
+            </Field>
+          )}
+          <Field label="Payment method">
+            <Text color={row.has_payment_method ? 'default' : 'danger'}>
+              {row.has_payment_method ? 'Ready to charge' : 'None yet'}
+            </Text>
+          </Field>
+          {row.renews_at && (
+            <Field label="Renews on Stripe">
+              <FormattedDateTime datetime={row.renews_at} />
+            </Field>
+          )}
+          <Field label="Stripe ID">
+            <Text monospace variant="caption" color="muted">
+              {row.source_id}
+            </Text>
+          </Field>
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Box alignItems="baseline" columnGap="l" justifyContent="between">
+      <Text variant="caption" color="muted">
+        {label}
+      </Text>
+      <Box minWidth={0} justifyContent="end">
+        {children}
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchStatusIndicator.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchStatusIndicator.tsx
@@ -1,0 +1,10 @@
+import { Status } from '@polar-sh/orbit'
+import { SwitchRow } from './switchRows'
+import { switchStatus } from './switchStatus'
+
+// The switch outcome as both the table cell and the detail modal show it, so
+// the two can't drift apart.
+export function SwitchStatusIndicator({ row }: { row: SwitchRow }) {
+  const { label, color } = switchStatus(row)
+  return <Status status={label} color={color} size="small" />
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchStatusIndicator.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchStatusIndicator.tsx
@@ -2,8 +2,6 @@ import { Status } from '@polar-sh/orbit'
 import { SwitchRow } from './switchRows'
 import { switchStatus } from './switchStatus'
 
-// The switch outcome as both the table cell and the detail modal show it, so
-// the two can't drift apart.
 export function SwitchStatusIndicator({ row }: { row: SwitchRow }) {
   const { label, color } = switchStatus(row)
   return <Status status={label} color={color} size="small" />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchStatusTabs.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchStatusTabs.tsx
@@ -1,0 +1,23 @@
+import { SegmentedControl } from '@polar-sh/orbit'
+import { SWITCH_FILTERS, SwitchFilter } from './switchCopy'
+
+const numberFormat = new Intl.NumberFormat('en-US')
+
+interface Props {
+  value: SwitchFilter
+  counts: Record<SwitchFilter, number>
+  onChange: (filter: SwitchFilter) => void
+}
+
+export function SwitchStatusTabs({ value, counts, onChange }: Props) {
+  return (
+    <SegmentedControl
+      value={value}
+      onChange={(next) => onChange(next as SwitchFilter)}
+      options={SWITCH_FILTERS.map((option) => ({
+        ...option,
+        label: `${option.label} ${numberFormat.format(counts[option.value])}`,
+      }))}
+    />
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchSummary.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchSummary.tsx
@@ -10,10 +10,11 @@ export function SwitchSummary({
 }: {
   report: schemas['MerchantMigrationCutoverReport']
 }) {
+  const toSwitch = Math.max(0, report.total - report.moved)
   const parts = [
     `${numberFormat.format(report.total)} imported`,
     `${numberFormat.format(report.moved)} switched`,
-    `${numberFormat.format(report.pending)} to switch`,
+    `${numberFormat.format(toSwitch)} to switch`,
   ]
   const left = report.skipped + report.failed
   if (left > 0) {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchSummary.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchSummary.tsx
@@ -1,0 +1,35 @@
+import { schemas } from '@polar-sh/client'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { SWITCH_INTRO } from './switchCopy'
+
+const numberFormat = new Intl.NumberFormat('en-US')
+
+// The one-line tally above the table: how many subscriptions were imported, how
+// many Polar bills now, and how many are still waiting to be switched.
+export function SwitchSummary({
+  report,
+}: {
+  report: schemas['MerchantMigrationCutoverReport']
+}) {
+  const parts = [
+    `${numberFormat.format(report.total)} imported`,
+    `${numberFormat.format(report.moved)} switched`,
+    `${numberFormat.format(report.pending)} to switch`,
+  ]
+  const left = report.skipped + report.failed
+  if (left > 0) {
+    parts.push(`${numberFormat.format(left)} left on Stripe`)
+  }
+
+  return (
+    <Box flexDirection="column" rowGap="xs">
+      <Text variant="caption" color="muted">
+        {SWITCH_INTRO}
+      </Text>
+      <Text variant="caption" tabularNums>
+        {parts.join('  ·  ')}
+      </Text>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchSummary.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchSummary.tsx
@@ -5,8 +5,6 @@ import { SWITCH_INTRO } from './switchCopy'
 
 const numberFormat = new Intl.NumberFormat('en-US')
 
-// The one-line tally above the table: how many subscriptions were imported, how
-// many Polar bills now, and how many are still waiting to be switched.
 export function SwitchSummary({
   report,
 }: {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchColumns.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchColumns.tsx
@@ -122,8 +122,6 @@ function SelectCell({
   onToggle: (id: string) => void
 }) {
   const id = row.record_id
-  // Already billed by Polar: shown ticked and locked, so the column stays a
-  // column instead of a run of gaps.
   if (isSwitched(row)) {
     return (
       <SelectCheckbox

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchColumns.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchColumns.tsx
@@ -126,7 +126,11 @@ function SelectCell({
   // column instead of a run of gaps.
   if (isSwitched(row)) {
     return (
-      <SelectCheckbox checked disabled ariaLabel={`${row.title} has switched`} />
+      <SelectCheckbox
+        checked
+        disabled
+        ariaLabel={`${row.title} has switched`}
+      />
     )
   }
   if (!isSwitchable(row) || !id) {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchColumns.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchColumns.tsx
@@ -1,0 +1,169 @@
+import { DataTableColumnDef, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { formatCurrency } from '@polar-sh/currency'
+import { HeaderCheckState } from '../selection'
+import { SelectCheckbox } from '../SelectCheckbox'
+import { SwitchStatusIndicator } from './SwitchStatusIndicator'
+import {
+  intervalAbbreviation,
+  isSwitchable,
+  isSwitched,
+  renewsLabel,
+  SwitchRow,
+} from './switchRows'
+
+interface ColumnContext {
+  isSelected: (id: string) => boolean
+  headerState: HeaderCheckState
+  canSelectAll: boolean
+  onToggle: (id: string) => void
+  onToggleAll: () => void
+}
+
+const formatAmount = formatCurrency('accounting', 'en-US')
+
+export function buildSwitchColumns({
+  isSelected,
+  headerState,
+  canSelectAll,
+  onToggle,
+  onToggleAll,
+}: ColumnContext): DataTableColumnDef<SwitchRow>[] {
+  return [
+    {
+      id: 'select',
+      size: 44,
+      header: () => (
+        <HeaderCheckbox
+          state={headerState}
+          disabled={!canSelectAll}
+          onToggle={onToggleAll}
+        />
+      ),
+      cell: ({ row }) => (
+        <SelectCell
+          row={row.original}
+          isSelected={isSelected}
+          onToggle={onToggle}
+        />
+      ),
+    },
+    {
+      id: 'customer',
+      size: 320,
+      header: 'Customer',
+      cell: ({ row }) => (
+        <Box minWidth={0}>
+          <Text truncate>{row.original.title}</Text>
+        </Box>
+      ),
+    },
+    {
+      id: 'plan',
+      size: 150,
+      header: () => (
+        <Box width="100%" justifyContent="end">
+          <Text variant="caption" color="muted">
+            Plan
+          </Text>
+        </Box>
+      ),
+      cell: ({ row }) => <PlanCell row={row.original} />,
+    },
+    {
+      id: 'renews',
+      size: 140,
+      header: 'Renews',
+      cell: ({ row }) => <RenewsCell row={row.original} />,
+    },
+    {
+      id: 'status',
+      size: 170,
+      header: 'Status',
+      cell: ({ row }) => <SwitchStatusIndicator row={row.original} />,
+    },
+  ]
+}
+
+function PlanCell({ row }: { row: SwitchRow }) {
+  if (row.amount == null || !row.currency) {
+    return <Box />
+  }
+  const interval = intervalAbbreviation(row.recurring_interval)
+  return (
+    <Box width="100%" justifyContent="end" alignItems="baseline" columnGap="xs">
+      <Text monospace tabularNums align="right">
+        {formatAmount(row.amount, row.currency)}
+      </Text>
+      {interval && (
+        <Text variant="caption" monospace color="muted">
+          {interval}
+        </Text>
+      )}
+    </Box>
+  )
+}
+
+function RenewsCell({ row }: { row: SwitchRow }) {
+  const label = renewsLabel(row)
+  if (!label) {
+    return <Text color="muted">—</Text>
+  }
+  return <Text color="muted">{label}</Text>
+}
+
+function SelectCell({
+  row,
+  isSelected,
+  onToggle,
+}: {
+  row: SwitchRow
+  isSelected: (id: string) => boolean
+  onToggle: (id: string) => void
+}) {
+  const id = row.record_id
+  // Already billed by Polar: shown ticked and locked, so the column stays a
+  // column instead of a run of gaps.
+  if (isSwitched(row)) {
+    return (
+      <SelectCheckbox checked disabled ariaLabel={`${row.title} has switched`} />
+    )
+  }
+  if (!isSwitchable(row) || !id) {
+    return (
+      <SelectCheckbox
+        checked={false}
+        disabled
+        ariaLabel={`${row.title} can't be switched`}
+      />
+    )
+  }
+  return (
+    <SelectCheckbox
+      checked={isSelected(id)}
+      ariaLabel={`Switch ${row.title}`}
+      onToggle={() => onToggle(id)}
+    />
+  )
+}
+
+function HeaderCheckbox({
+  state,
+  disabled,
+  onToggle,
+}: {
+  state: HeaderCheckState
+  disabled: boolean
+  onToggle: () => void
+}) {
+  return (
+    <SelectCheckbox
+      checked={
+        state === 'indeterminate' ? 'indeterminate' : state === 'checked'
+      }
+      disabled={disabled}
+      ariaLabel="Select all"
+      onToggle={onToggle}
+    />
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchCopy.ts
@@ -1,0 +1,25 @@
+import { SwitchCutoverStatus } from './switchRows'
+
+// The status tabs map one-to-one onto what the records endpoint can filter, so
+// every tab is a real server-side query rather than a client-side slice.
+export type SwitchFilter = 'all' | SwitchCutoverStatus
+
+export const SWITCH_FILTERS: { value: SwitchFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'skipped', label: 'Left on Stripe' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'moved', label: 'Switched' },
+]
+
+export const SWITCH_EMPTY_MESSAGES: Record<SwitchFilter, string> = {
+  all: 'No imported subscriptions to switch.',
+  skipped: 'None were left on Stripe.',
+  failed: 'None failed to switch.',
+  moved: 'Nothing has switched to Polar yet.',
+}
+
+export const SWITCH_INTRO =
+  'Polar starts billing the subscriptions you pick, and stops them on Stripe first. It reads Stripe again for each one, so anything that renews too soon or has no card stays put with a reason.'
+
+export const SWITCH_UNDONE_WARNING =
+  'Polar stops these subscriptions on Stripe and starts billing them. This cannot be undone.'

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchCopy.ts
@@ -1,7 +1,5 @@
 import { SwitchCutoverStatus } from './switchRows'
 
-// The status tabs map one-to-one onto what the records endpoint can filter, so
-// every tab is a real server-side query rather than a client-side slice.
 export type SwitchFilter = 'all' | SwitchCutoverStatus
 
 export const SWITCH_FILTERS: { value: SwitchFilter; label: string }[] = [

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchRows.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchRows.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isSwitchable,
+  isSwitched,
+  needsAttention,
+  renewsLabel,
+  type SwitchRow,
+} from './switchRows'
+
+const baseRow = {
+  record_id: 'rec_1',
+  entity: 'subscriptions' as const,
+  source_id: 'sub_1',
+  title: 'ada@example.com',
+  subtitle: null,
+  amount: 2900,
+  currency: 'usd',
+  recurring_interval: 'month',
+  reason: null,
+  reason_code: null,
+  reason_level: null,
+  import_status: 'imported' as const,
+  cutover_status: null,
+  cutover_error: null,
+  renews_at: null,
+  has_payment_method: true,
+}
+
+function row(overrides: Partial<SwitchRow>): SwitchRow {
+  return { ...baseRow, ...overrides } as SwitchRow
+}
+
+describe('isSwitched', () => {
+  it('is true only for moved rows', () => {
+    expect(isSwitched(row({ cutover_status: 'moved' }))).toBe(true)
+    expect(isSwitched(row({ cutover_status: 'skipped' }))).toBe(false)
+    expect(isSwitched(row({ cutover_status: null }))).toBe(false)
+  })
+})
+
+describe('isSwitchable', () => {
+  it('is true for an imported, not-yet-moved row with a record id', () => {
+    expect(isSwitchable(row({ cutover_status: null }))).toBe(true)
+  })
+
+  // Retrying re-opens skipped and failed rows, so they stay selectable.
+  it('stays true for skipped and failed rows', () => {
+    expect(isSwitchable(row({ cutover_status: 'skipped' }))).toBe(true)
+    expect(isSwitchable(row({ cutover_status: 'failed' }))).toBe(true)
+  })
+
+  it('is false once moved', () => {
+    expect(isSwitchable(row({ cutover_status: 'moved' }))).toBe(false)
+  })
+
+  it('is false when not imported or without a record id', () => {
+    expect(isSwitchable(row({ import_status: 'pending' }))).toBe(false)
+    expect(isSwitchable(row({ record_id: null }))).toBe(false)
+  })
+})
+
+describe('needsAttention', () => {
+  it('is true for skipped and failed only', () => {
+    expect(needsAttention(row({ cutover_status: 'skipped' }))).toBe(true)
+    expect(needsAttention(row({ cutover_status: 'failed' }))).toBe(true)
+    expect(needsAttention(row({ cutover_status: 'moved' }))).toBe(false)
+    expect(needsAttention(row({ cutover_status: null }))).toBe(false)
+  })
+})
+
+describe('renewsLabel', () => {
+  const now = Date.parse('2026-01-01T00:00:00Z')
+
+  it('is null without a renewal date', () => {
+    expect(renewsLabel(row({ renews_at: null }), now)).toBeNull()
+  })
+
+  it('reads in days when the renewal is more than a day out', () => {
+    expect(
+      renewsLabel(row({ renews_at: '2026-01-13T00:00:00Z' }), now),
+    ).toBe('in 12 days')
+  })
+
+  it('reads in hours near the safety window', () => {
+    expect(
+      renewsLabel(row({ renews_at: '2026-01-01T03:00:00Z' }), now),
+    ).toBe('in 3 hours')
+  })
+})

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchRows.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchRows.test.ts
@@ -76,14 +76,14 @@ describe('renewsLabel', () => {
   })
 
   it('reads in days when the renewal is more than a day out', () => {
-    expect(
-      renewsLabel(row({ renews_at: '2026-01-13T00:00:00Z' }), now),
-    ).toBe('in 12 days')
+    expect(renewsLabel(row({ renews_at: '2026-01-13T00:00:00Z' }), now)).toBe(
+      'in 12 days',
+    )
   })
 
   it('reads in hours near the safety window', () => {
-    expect(
-      renewsLabel(row({ renews_at: '2026-01-01T03:00:00Z' }), now),
-    ).toBe('in 3 hours')
+    expect(renewsLabel(row({ renews_at: '2026-01-01T03:00:00Z' }), now)).toBe(
+      'in 3 hours',
+    )
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchRows.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchRows.ts
@@ -29,7 +29,10 @@ const DAY = 24 * HOUR
 
 // When the source next renews, phrased relative to now. The switch keeps a 24h
 // safety window, so hours matter near the edge; days are enough further out.
-export function renewsLabel(row: SwitchRow, now: number = Date.now()): string | null {
+export function renewsLabel(
+  row: SwitchRow,
+  now: number = Date.now(),
+): string | null {
   if (!row.renews_at) return null
   const delta = new Date(row.renews_at).getTime() - now
   if (Number.isNaN(delta)) return null

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchRows.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchRows.ts
@@ -1,0 +1,53 @@
+import { schemas } from '@polar-sh/client'
+
+export type SwitchRow = schemas['MerchantMigrationRecordItem']
+export type SwitchCutoverStatus = schemas['MerchantMigrationCutoverStatus']
+
+export function isSwitched(row: SwitchRow): boolean {
+  return row.cutover_status === 'moved'
+}
+
+// Imported and not yet billed by Polar, so it can be picked. Skipped and failed
+// rows re-open on a retry, so they stay selectable too; only the moved ones and
+// anything not imported are out.
+export function isSwitchable(row: SwitchRow): boolean {
+  return (
+    row.record_id != null &&
+    row.import_status === 'imported' &&
+    row.cutover_status !== 'moved'
+  )
+}
+
+// Left on the source with a reason the merchant can act on.
+export function needsAttention(row: SwitchRow): boolean {
+  return row.cutover_status === 'skipped' || row.cutover_status === 'failed'
+}
+
+const RELATIVE = new Intl.RelativeTimeFormat('en-US', { numeric: 'auto' })
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
+
+// When the source next renews, phrased relative to now. The switch keeps a 24h
+// safety window, so hours matter near the edge; days are enough further out.
+export function renewsLabel(row: SwitchRow, now: number = Date.now()): string | null {
+  if (!row.renews_at) return null
+  const delta = new Date(row.renews_at).getTime() - now
+  if (Number.isNaN(delta)) return null
+  const absolute = Math.abs(delta)
+  if (absolute >= DAY) {
+    return RELATIVE.format(Math.round(delta / DAY), 'day')
+  }
+  return RELATIVE.format(Math.round(delta / HOUR), 'hour')
+}
+
+const INTERVAL_ABBREVIATION: Record<string, string> = {
+  day: '/day',
+  week: '/wk',
+  month: '/mo',
+  year: '/yr',
+}
+
+export function intervalAbbreviation(interval: string | null): string | null {
+  if (!interval) return null
+  return INTERVAL_ABBREVIATION[interval] ?? null
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchRows.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchRows.ts
@@ -7,9 +7,6 @@ export function isSwitched(row: SwitchRow): boolean {
   return row.cutover_status === 'moved'
 }
 
-// Imported and not yet billed by Polar, so it can be picked. Skipped and failed
-// rows re-open on a retry, so they stay selectable too; only the moved ones and
-// anything not imported are out.
 export function isSwitchable(row: SwitchRow): boolean {
   return (
     row.record_id != null &&
@@ -18,7 +15,6 @@ export function isSwitchable(row: SwitchRow): boolean {
   )
 }
 
-// Left on the source with a reason the merchant can act on.
 export function needsAttention(row: SwitchRow): boolean {
   return row.cutover_status === 'skipped' || row.cutover_status === 'failed'
 }
@@ -27,8 +23,6 @@ const RELATIVE = new Intl.RelativeTimeFormat('en-US', { numeric: 'auto' })
 const HOUR = 60 * 60 * 1000
 const DAY = 24 * HOUR
 
-// When the source next renews, phrased relative to now. The switch keeps a 24h
-// safety window, so hours matter near the edge; days are enough further out.
 export function renewsLabel(
   row: SwitchRow,
   now: number = Date.now(),

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchStatus.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchStatus.test.ts
@@ -26,10 +26,9 @@ function row(overrides: Partial<SwitchRow>): SwitchRow {
 }
 
 describe('switchStatus', () => {
-  it('shows "Switched" (green) when moved', () => {
+  it('shows "Switched" without an attention color when moved', () => {
     expect(switchStatus(row({ cutover_status: 'moved' }))).toEqual({
       label: 'Switched',
-      color: 'green',
     })
   })
 
@@ -65,6 +64,6 @@ describe('switchStatus', () => {
   it('prefers the settled outcome over the card hint', () => {
     expect(
       switchStatus(row({ cutover_status: 'moved', has_payment_method: false })),
-    ).toEqual({ label: 'Switched', color: 'green' })
+    ).toEqual({ label: 'Switched' })
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchStatus.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchStatus.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import type { SwitchRow } from './switchRows'
+import { switchStatus } from './switchStatus'
+
+const baseRow = {
+  record_id: 'rec_1',
+  entity: 'subscriptions' as const,
+  source_id: 'sub_1',
+  title: 'ada@example.com',
+  subtitle: null,
+  amount: 2900,
+  currency: 'usd',
+  recurring_interval: 'month',
+  reason: null,
+  reason_code: null,
+  reason_level: null,
+  import_status: 'imported' as const,
+  cutover_status: null,
+  cutover_error: null,
+  renews_at: null,
+  has_payment_method: true,
+}
+
+function row(overrides: Partial<SwitchRow>): SwitchRow {
+  return { ...baseRow, ...overrides } as SwitchRow
+}
+
+describe('switchStatus', () => {
+  it('shows "Switched" (green) when moved', () => {
+    expect(switchStatus(row({ cutover_status: 'moved' }))).toEqual({
+      label: 'Switched',
+      color: 'green',
+    })
+  })
+
+  it('shows "Failed" (red) when failed', () => {
+    expect(switchStatus(row({ cutover_status: 'failed' }))).toEqual({
+      label: 'Failed',
+      color: 'red',
+    })
+  })
+
+  it('shows "Left on Stripe" (yellow) when skipped', () => {
+    expect(switchStatus(row({ cutover_status: 'skipped' }))).toEqual({
+      label: 'Left on Stripe',
+      color: 'yellow',
+    })
+  })
+
+  it('hints "No payment method" (yellow) for a pending row without a card', () => {
+    expect(switchStatus(row({ has_payment_method: false }))).toEqual({
+      label: 'No payment method',
+      color: 'yellow',
+    })
+  })
+
+  it('shows "Ready" for a pending row with a card', () => {
+    expect(switchStatus(row({ has_payment_method: true }))).toEqual({
+      label: 'Ready',
+    })
+  })
+
+  // The engine re-reads Stripe, so a settled outcome always wins over the
+  // pre-switch card hint.
+  it('prefers the settled outcome over the card hint', () => {
+    expect(
+      switchStatus(row({ cutover_status: 'moved', has_payment_method: false })),
+    ).toEqual({ label: 'Switched', color: 'green' })
+  })
+})

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchStatus.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchStatus.ts
@@ -3,9 +3,8 @@ import { SwitchRow } from './switchRows'
 
 export interface SwitchStatus {
   label: string
-  // Undefined renders a neutral chip. Colour marks the outcomes that need the
-  // merchant's eye — switched, or left behind — so a table mid-run reads at a
-  // glance.
+  // Undefined renders a neutral chip. Colour is reserved for outcomes that need
+  // the merchant's attention, so the normal path stays visually quiet.
   color?: StatusColor
 }
 
@@ -15,7 +14,7 @@ export interface SwitchStatus {
 export function switchStatus(row: SwitchRow): SwitchStatus {
   switch (row.cutover_status) {
     case 'moved':
-      return { label: 'Switched', color: 'green' }
+      return { label: 'Switched' }
     case 'failed':
       return { label: 'Failed', color: 'red' }
     case 'skipped':

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchStatus.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchStatus.ts
@@ -1,0 +1,28 @@
+import { StatusColor } from '@polar-sh/orbit'
+import { SwitchRow } from './switchRows'
+
+export interface SwitchStatus {
+  label: string
+  // Undefined renders a neutral chip. Colour marks the outcomes that need the
+  // merchant's eye — switched, or left behind — so a table mid-run reads at a
+  // glance.
+  color?: StatusColor
+}
+
+// One question per row: what has the switch done with this subscription, and if
+// nothing yet, is it ready to go. The engine re-reads Stripe and is the real
+// authority, so the pre-switch hints ("No payment method") are just that.
+export function switchStatus(row: SwitchRow): SwitchStatus {
+  switch (row.cutover_status) {
+    case 'moved':
+      return { label: 'Switched', color: 'green' }
+    case 'failed':
+      return { label: 'Failed', color: 'red' }
+    case 'skipped':
+      return { label: 'Left on Stripe', color: 'yellow' }
+  }
+  if (row.has_payment_method === false) {
+    return { label: 'No payment method', color: 'yellow' }
+  }
+  return { label: 'Ready' }
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchStatus.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchStatus.ts
@@ -3,14 +3,9 @@ import { SwitchRow } from './switchRows'
 
 export interface SwitchStatus {
   label: string
-  // Undefined renders a neutral chip. Colour is reserved for outcomes that need
-  // the merchant's attention, so the normal path stays visually quiet.
   color?: StatusColor
 }
 
-// One question per row: what has the switch done with this subscription, and if
-// nothing yet, is it ready to go. The engine re-reads Stripe and is the real
-// authority, so the pre-switch hints ("No payment method") are just that.
 export function switchStatus(row: SwitchRow): SwitchStatus {
   switch (row.cutover_status) {
     case 'moved':

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -192,9 +192,13 @@ export const useMigrationRecords = (
     status?: schemas['PrecheckRecordStatus']
     reasonLevel?: schemas['PrecheckReasonLevel']
     importStatus?: schemas['MerchantMigrationRecordStatus']
+    cutoverStatus?: schemas['MerchantMigrationCutoverStatus']
     page: number
     limit: number
   },
+  // The switch table polls while Polar works through the subscriptions, so the
+  // rows flip to their outcome without a manual refresh.
+  refetchInterval?: number | false,
 ) =>
   useQuery({
     queryKey: ['merchantMigrationRecords', { id, ...params }],
@@ -212,6 +216,9 @@ export const useMigrationRecords = (
               ...(params.importStatus
                 ? { import_status: params.importStatus }
                 : {}),
+              ...(params.cutoverStatus
+                ? { cutover_status: params.cutoverStatus }
+                : {}),
               page: params.page,
               limit: params.limit,
             },
@@ -220,6 +227,45 @@ export const useMigrationRecords = (
       ),
     retry: defaultRetry,
     enabled: !!id,
+    refetchInterval: refetchInterval ?? false,
+  })
+
+const switchKey = (id: string) => ['merchantMigrationSwitch', { id }]
+
+// Polls only while a switch run is in flight; a settled report just sits.
+export const useMigrationSwitch = (id: string) =>
+  useQuery({
+    queryKey: switchKey(id),
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/merchant-migrations/{id}/cutover', {
+          params: { path: { id } },
+        }),
+      ),
+    retry: defaultRetry,
+    enabled: !!id,
+    refetchInterval: (query) => (query.state.data?.running ? 3000 : false),
+  })
+
+export const useStartMigrationSwitch = (id: string) =>
+  useMutation({
+    mutationFn: (options: ImportOptions = {}) =>
+      dataOrThrow(
+        api.POST('/v1/merchant-migrations/{id}/cutover', {
+          params: { path: { id } },
+          body: {
+            ...(options.recordIds ? { record_ids: options.recordIds } : {}),
+            ...(options.excludeRecordIds
+              ? { exclude_record_ids: options.excludeRecordIds }
+              : {}),
+          },
+        }),
+        "We couldn't switch these subscriptions.",
+      ),
+    onSuccess: (report) => {
+      getQueryClient().setQueryData(switchKey(id), report)
+      invalidateMigrationRecords(id)
+    },
   })
 
 // One read for every count the UI shows: asking per number made the server

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -196,8 +196,6 @@ export const useMigrationRecords = (
     page: number
     limit: number
   },
-  // The switch table polls while Polar works through the subscriptions, so the
-  // rows flip to their outcome without a manual refresh.
   refetchInterval?: number | false,
 ) =>
   useQuery({
@@ -232,7 +230,6 @@ export const useMigrationRecords = (
 
 const switchKey = (id: string) => ['merchantMigrationSwitch', { id }]
 
-// Polls only while a switch run is in flight; a settled report just sits.
 export const useMigrationSwitch = (id: string) =>
   useQuery({
     queryKey: switchKey(id),
@@ -268,8 +265,6 @@ export const useStartMigrationSwitch = (id: string) =>
     },
   })
 
-// One read for every count the UI shows: asking per number made the server
-// re-read and re-classify the whole staged catalog once per count.
 export const useMerchantMigrationRecordSummary = (id: string) =>
   useQuery({
     queryKey: ['merchantMigrationRecordSummary', { id }],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The merchant-facing UI for the subscription switch (built on the API in #13873). The merchant picks which imported subscriptions to switch (cut over) to Polar, confirms the irreversible action, and watches Polar work through them.

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/5af55bf2-585a-4955-9982-d72de832d303" />



## Checklist

- [x] Single concern
- [x] New logic covered by tests
- [x] Lint and typecheck pass
- [x] No unrelated changes

Stacked on #13873.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-861354d0-02c3-468c-b195-953fa41d41fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-861354d0-02c3-468c-b195-953fa41d41fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

