### PR TITLE
ecs: Add log shipping to logfire

### DIFF
--- a/terraform/modules/ecs_service/main.tf
+++ b/terraform/modules/ecs_service/main.tf
@@ -20,6 +20,11 @@ locals {
   cpu    = var.profile != null ? local.profiles[var.profile].cpu : var.cpu
   memory = var.profile != null ? local.profiles[var.profile].memory : var.memory
 
+  secret_arns = concat(
+    values(var.secrets),
+    var.logfire == null ? [] : [aws_secretsmanager_secret.logfire_header[0].arn],
+  )
+
   fargate_memory_by_cpu = {
     "256"   = [512, 1024, 2048]
     "512"   = range(1024, 4097, 1024)
@@ -76,17 +81,29 @@ resource "aws_iam_role_policy" "repository_credentials" {
   policy = data.aws_iam_policy_document.repository_credentials[0].json
 }
 
+resource "aws_secretsmanager_secret" "logfire_header" {
+  count = var.logfire == null ? 0 : 1
+  name  = "${local.full_name}-logfire-header"
+  tags  = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "logfire_header" {
+  count         = var.logfire == null ? 0 : 1
+  secret_id     = aws_secretsmanager_secret.logfire_header[0].id
+  secret_string = "Authorization ${var.logfire.token}"
+}
+
 data "aws_iam_policy_document" "secrets" {
-  count = length(var.secrets) == 0 ? 0 : 1
+  count = length(local.secret_arns) == 0 ? 0 : 1
 
   statement {
     actions   = ["secretsmanager:GetSecretValue"]
-    resources = values(var.secrets)
+    resources = local.secret_arns
   }
 }
 
 resource "aws_iam_role_policy" "secrets" {
-  count  = length(var.secrets) == 0 ? 0 : 1
+  count  = length(local.secret_arns) == 0 ? 0 : 1
   name   = "secrets"
   role   = aws_iam_role.execution.id
   policy = data.aws_iam_policy_document.secrets[0].json
@@ -102,38 +119,79 @@ resource "aws_ecs_task_definition" "this" {
   task_role_arn            = var.task_role_arn
   tags                     = var.tags
 
-  container_definitions = jsonencode([
-    merge(
+  container_definitions = jsonencode(concat(
+    [
+      merge(
+        {
+          name      = local.full_name
+          image     = var.image
+          essential = true
+          command   = var.command
+          environment = [
+            for key, value in var.environment_variables : { name = key, value = value }
+          ]
+          portMappings = var.container_port == null ? [] : [
+            { containerPort = var.container_port, protocol = "tcp" }
+          ]
+          logConfiguration = merge(
+            {
+              logDriver = var.logfire == null ? "awslogs" : "awsfirelens"
+              options = var.logfire == null ? {
+                "awslogs-group"         = aws_cloudwatch_log_group.this.name
+                "awslogs-region"        = data.aws_region.current.name
+                "awslogs-stream-prefix" = local.full_name
+                } : {
+                Name                     = "opentelemetry"
+                host                     = var.logfire.host
+                port                     = "443"
+                tls                      = "on"
+                "tls.verify"             = "on"
+                logs_uri                 = "/v1/logs"
+                compress                 = "gzip"
+                logs_body_key            = "log"
+                logs_body_key_attributes = "true"
+              }
+            },
+            var.logfire == null ? {} : {
+              secretOptions = [
+                { name = "header", valueFrom = aws_secretsmanager_secret_version.logfire_header[0].arn }
+              ]
+            },
+          )
+        },
+        var.repository_credentials == null ? {} : {
+          repositoryCredentials = { credentialsParameter = var.repository_credentials.arn }
+        },
+        length(var.secrets) == 0 ? {} : {
+          secrets = [for name, arn in var.secrets : { name = name, valueFrom = arn }]
+        },
+      )
+    ],
+    var.logfire == null ? [] : [
       {
-        name      = local.full_name
-        image     = var.image
-        essential = true
-        command   = var.command
-        environment = [
-          for key, value in var.environment_variables : { name = key, value = value }
-        ]
-        portMappings = var.container_port == null ? [] : [
-          { containerPort = var.container_port, protocol = "tcp" }
-        ]
+        name              = "log-router"
+        image             = var.logfire.router_image
+        essential         = true
+        memoryReservation = 51
+        firelensConfiguration = {
+          type    = "fluentbit"
+          options = { "enable-ecs-log-metadata" = "true" }
+        }
         logConfiguration = {
           logDriver = "awslogs"
           options = {
             "awslogs-group"         = aws_cloudwatch_log_group.this.name
             "awslogs-region"        = data.aws_region.current.name
-            "awslogs-stream-prefix" = local.full_name
+            "awslogs-stream-prefix" = "firelens"
           }
         }
-      },
-      var.repository_credentials == null ? {} : {
-        repositoryCredentials = { credentialsParameter = var.repository_credentials.arn }
-      },
-      length(var.secrets) == 0 ? {} : {
-        secrets = [for name, arn in var.secrets : { name = name, valueFrom = arn }]
-      },
-    )
-  ])
+      }
+    ],
+  ))
 
   lifecycle {
+    replace_triggered_by = [aws_secretsmanager_secret_version.logfire_header]
+
     precondition {
       condition     = alltrue([for n in local.aws_names : length(n.value) <= n.max])
       error_message = "Name over its AWS length limit: ${join(", ", [for key, n in local.aws_names : "${key} \"${n.value}\" (${length(n.value)} > ${n.max})" if length(n.value) > n.max])}."

--- a/terraform/modules/ecs_service/variables.tf
+++ b/terraform/modules/ecs_service/variables.tf
@@ -118,6 +118,17 @@ variable "permissions_boundary_arn" {
   type        = string
 }
 
+variable "logfire" {
+  description = "Ship container logs to Logfire via a FireLens fluent-bit sidecar instead of CloudWatch, if set."
+  type = object({
+    token        = string
+    host         = optional(string, "logfire-us.pydantic.dev")
+    router_image = optional(string, "public.ecr.aws/aws-observability/aws-for-fluent-bit:3.4.13")
+  })
+  default   = null
+  sensitive = true
+}
+
 variable "log_retention_days" {
   description = "CloudWatch log retention in days."
   type        = number

--- a/terraform/modules/services/pgbouncer/main.tf
+++ b/terraform/modules/services/pgbouncer/main.tf
@@ -61,6 +61,7 @@ module "service" {
   subnet_ids               = var.subnet_ids
   security_group_ids       = [aws_security_group.this.id]
   permissions_boundary_arn = var.permissions_boundary_arn
+  logfire                  = var.logfire
 
   service_registry = {
     arn = aws_service_discovery_service.this.arn

--- a/terraform/modules/services/pgbouncer/variables.tf
+++ b/terraform/modules/services/pgbouncer/variables.tf
@@ -52,6 +52,17 @@ variable "image" {
   default     = "ghcr.io/polarsource/polar-pgbouncer:latest"
 }
 
+variable "logfire" {
+  description = "Logfire log shipping configuration, forwarded to the ECS service module."
+  type = object({
+    token        = string
+    host         = optional(string)
+    router_image = optional(string)
+  })
+  default   = null
+  sensitive = true
+}
+
 variable "database" {
   description = "Postgres endpoint PgBouncer proxies to."
   type = object({

--- a/terraform/production/ecs.tf
+++ b/terraform/production/ecs.tf
@@ -39,6 +39,10 @@ module "pgbouncer_aws" {
   permissions_boundary_arn   = data.aws_iam_policy.permission_boundary.arn
   repository_credentials_arn = aws_secretsmanager_secret_version.ghcr_pull.arn
 
+  logfire = {
+    token = var.logfire_token
+  }
+
   database = {
     host     = local.db_external_host
     port     = local.db_port

--- a/terraform/sandbox/ecs.tf
+++ b/terraform/sandbox/ecs.tf
@@ -39,6 +39,10 @@ module "pgbouncer_aws" {
   permissions_boundary_arn   = data.aws_iam_policy.permission_boundary.arn
   repository_credentials_arn = aws_secretsmanager_secret_version.ghcr_pull.arn
 
+  logfire = {
+    token = var.logfire_token
+  }
+
   database = {
     host     = local.db_external_host
     port     = local.db_port

--- a/terraform/test/ecs.tf
+++ b/terraform/test/ecs.tf
@@ -43,6 +43,10 @@ module "pgbouncer_aws" {
   permissions_boundary_arn   = data.aws_iam_policy.permission_boundary.arn
   repository_credentials_arn = aws_secretsmanager_secret_version.ghcr_pull[0].arn
 
+  logfire = {
+    token = var.logfire_token
+  }
+
   database = {
     host     = local.db_external_host
     port     = local.db_port


### PR DESCRIPTION
This makes it possible to ship logs to logfire with fluentbit from ECS. Instead of sending the logs to CloudWatch


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

