### PR TITLE
aws/lambda: Move basically all env vars to secrets manager

### DIFF
--- a/terraform/modules/aws_task_worker/variables.tf
+++ b/terraform/modules/aws_task_worker/variables.tf
@@ -94,7 +94,7 @@ variable "environment_variables" {
 }
 
 variable "secrets_arn" {
-  description = "Secrets Manager secret holding a JSON map of secret env vars, exported by the image bootstrap at cold start."
+  description = "Secrets Manager secret holding a JSON map of env vars, exported by the image bootstrap at cold start."
   type        = string
   default     = null
 }

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -62,8 +62,9 @@ locals {
 
   worker_sqs_queue_prefix = "polar-production-tasks"
 
-  lambda_worker_environment = merge(
+  lambda_worker_secrets = merge(
     module.backend_environment.environment_variables,
+    module.backend_environment.secret_environment_variables,
     {
       POLAR_JWKS              = "/tmp/jwks.json"
       POLAR_POSTGRES_DATABASE = "polar_cpit_p9lf"
@@ -74,15 +75,9 @@ locals {
       POLAR_REDIS_HOST        = module.redis.host
       POLAR_REDIS_PORT        = tostring(module.redis.port)
       POLAR_REDIS_DB          = "1"
-    },
-  )
-
-  lambda_worker_secrets = merge(
-    module.backend_environment.secret_environment_variables,
-    {
-      POLAR_JWKS_CONTENT = var.backend_jwks_production
-      POLAR_POSTGRES_PWD = local.db_password
-      TAILSCALE_AUTHKEY  = var.lambda_worker_tailscale_token
+      POLAR_JWKS_CONTENT      = var.backend_jwks_production
+      POLAR_POSTGRES_PWD      = local.db_password
+      TAILSCALE_AUTHKEY       = var.lambda_worker_tailscale_token
     },
   )
 
@@ -129,10 +124,9 @@ module "lambda_worker" {
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 
-  environment_variables = local.lambda_worker_environment
-  secrets_arn           = aws_secretsmanager_secret.lambda_worker.arn
-  secrets_version_id    = aws_secretsmanager_secret_version.lambda_worker.version_id
-  kms_key_arn           = module.secrets_kms.key_arn
+  secrets_arn        = aws_secretsmanager_secret.lambda_worker.arn
+  secrets_version_id = aws_secretsmanager_secret_version.lambda_worker.version_id
+  kms_key_arn        = module.secrets_kms.key_arn
 }
 
 module "lambda_worker_queue" {
@@ -152,10 +146,9 @@ module "lambda_worker_queue" {
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 
-  environment_variables = local.lambda_worker_environment
-  secrets_arn           = aws_secretsmanager_secret.lambda_worker.arn
-  secrets_version_id    = aws_secretsmanager_secret_version.lambda_worker.version_id
-  kms_key_arn           = module.secrets_kms.key_arn
+  secrets_arn        = aws_secretsmanager_secret.lambda_worker.arn
+  secrets_version_id = aws_secretsmanager_secret_version.lambda_worker.version_id
+  kms_key_arn        = module.secrets_kms.key_arn
 }
 
 # =============================================================================

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -83,8 +83,9 @@ locals {
 
   worker_sqs_queue_prefix = "polar-sandbox-tasks"
 
-  lambda_worker_environment = merge(
+  lambda_worker_secrets = merge(
     module.backend_environment.environment_variables,
+    module.backend_environment.secret_environment_variables,
     {
       POLAR_JWKS              = "/tmp/jwks.json"
       POLAR_POSTGRES_DATABASE = "polar_sandbox"
@@ -95,15 +96,9 @@ locals {
       POLAR_REDIS_HOST        = module.redis.host
       POLAR_REDIS_PORT        = tostring(module.redis.port)
       POLAR_REDIS_DB          = "1"
-    },
-  )
-
-  lambda_worker_secrets = merge(
-    module.backend_environment.secret_environment_variables,
-    {
-      POLAR_JWKS_CONTENT = var.backend_jwks_sandbox
-      POLAR_POSTGRES_PWD = local.db_password
-      TAILSCALE_AUTHKEY  = var.lambda_worker_tailscale_token
+      POLAR_JWKS_CONTENT      = var.backend_jwks_sandbox
+      POLAR_POSTGRES_PWD      = local.db_password
+      TAILSCALE_AUTHKEY       = var.lambda_worker_tailscale_token
     },
   )
 
@@ -150,10 +145,9 @@ module "lambda_worker" {
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 
-  environment_variables = local.lambda_worker_environment
-  secrets_arn           = aws_secretsmanager_secret.lambda_worker.arn
-  secrets_version_id    = aws_secretsmanager_secret_version.lambda_worker.version_id
-  kms_key_arn           = module.secrets_kms.key_arn
+  secrets_arn        = aws_secretsmanager_secret.lambda_worker.arn
+  secrets_version_id = aws_secretsmanager_secret_version.lambda_worker.version_id
+  kms_key_arn        = module.secrets_kms.key_arn
 }
 
 module "lambda_worker_queue" {
@@ -173,10 +167,9 @@ module "lambda_worker_queue" {
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 
-  environment_variables = local.lambda_worker_environment
-  secrets_arn           = aws_secretsmanager_secret.lambda_worker.arn
-  secrets_version_id    = aws_secretsmanager_secret_version.lambda_worker.version_id
-  kms_key_arn           = module.secrets_kms.key_arn
+  secrets_arn        = aws_secretsmanager_secret.lambda_worker.arn
+  secrets_version_id = aws_secretsmanager_secret_version.lambda_worker.version_id
+  kms_key_arn        = module.secrets_kms.key_arn
 }
 
 moved {

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -68,8 +68,9 @@ locals {
 
   worker_sqs_queue_prefix = "polar-test-tasks"
 
-  lambda_worker_environment = local.test_enabled ? merge(
+  lambda_worker_secrets = local.test_enabled ? merge(
     module.backend_environment[0].environment_variables,
+    module.backend_environment[0].secret_environment_variables,
     {
       POLAR_JWKS              = "/tmp/jwks.json"
       POLAR_POSTGRES_DATABASE = local.db_name
@@ -80,15 +81,9 @@ locals {
       POLAR_REDIS_HOST        = module.redis[0].host
       POLAR_REDIS_PORT        = tostring(module.redis[0].port)
       POLAR_REDIS_DB          = "1"
-    },
-  ) : {}
-
-  lambda_worker_secrets = local.test_enabled ? merge(
-    module.backend_environment[0].secret_environment_variables,
-    {
-      POLAR_JWKS_CONTENT = var.backend_jwks
-      POLAR_POSTGRES_PWD = local.db_password
-      TAILSCALE_AUTHKEY  = var.lambda_worker_tailscale_token
+      POLAR_JWKS_CONTENT      = var.backend_jwks
+      POLAR_POSTGRES_PWD      = local.db_password
+      TAILSCALE_AUTHKEY       = var.lambda_worker_tailscale_token
     },
   ) : {}
 
@@ -139,10 +134,9 @@ module "lambda_worker" {
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 
-  environment_variables = local.lambda_worker_environment
-  secrets_arn           = aws_secretsmanager_secret.lambda_worker[0].arn
-  secrets_version_id    = aws_secretsmanager_secret_version.lambda_worker[0].version_id
-  kms_key_arn           = module.secrets_kms[0].key_arn
+  secrets_arn        = aws_secretsmanager_secret.lambda_worker[0].arn
+  secrets_version_id = aws_secretsmanager_secret_version.lambda_worker[0].version_id
+  kms_key_arn        = module.secrets_kms[0].key_arn
 }
 
 module "lambda_worker_queue" {
@@ -162,10 +156,9 @@ module "lambda_worker_queue" {
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 
-  environment_variables = local.lambda_worker_environment
-  secrets_arn           = aws_secretsmanager_secret.lambda_worker[0].arn
-  secrets_version_id    = aws_secretsmanager_secret_version.lambda_worker[0].version_id
-  kms_key_arn           = module.secrets_kms[0].key_arn
+  secrets_arn        = aws_secretsmanager_secret.lambda_worker[0].arn
+  secrets_version_id = aws_secretsmanager_secret_version.lambda_worker[0].version_id
+  kms_key_arn        = module.secrets_kms[0].key_arn
 }
 
 # =============================================================================


### PR DESCRIPTION
Since lambdas have a max limit on environment variables (4KB) we can't put all of them there.

By putting them into secrets manager and utilising the system to pull out the secrets into env in startup we can bypass the limit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

