### PR TITLE
Fix: show subtotal amount without discount for inclusive tax in checkout

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
@@ -130,8 +130,36 @@ describe('CheckoutPricingBreakdown', () => {
 
       render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
 
+      expect(getRowValue('Subtotal')).toBe('$9.99')
       expect(getRowValue('Taxes (included)')).toBe('$2')
       expect(getRowValue('Total')).toBe('$9.99')
+    })
+
+    it('shows the pre-discount subtotal when a discount is applied', () => {
+      const checkout = createBaseCheckout({
+        amount: 1000,
+        discount_amount: 500,
+        net_amount: 400,
+        tax_amount: 100,
+        tax_behavior: 'inclusive',
+        total_amount: 500,
+        discount: {
+          id: 'disc_1',
+          name: '50% off',
+          type: 'percentage',
+          duration: 'once',
+          code: null,
+          basis_points: 5000,
+        } satisfies schemas['CheckoutPublic']['discount'],
+      })
+
+      render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
+
+      expect(getRowValue('Subtotal')).toBe('$10')
+      expect(getRowValue('50% off')).toBe('-$5')
+      expect(getRowValue('Taxable amount')).toBe('$4')
+      expect(getRowValue('Taxes (included)')).toBe('$1')
+      expect(getRowValue('Total')).toBe('$5')
     })
   })
 

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -208,12 +208,7 @@ const CheckoutPricingBreakdown = ({
             className="text-gray-600"
           >
             <AmountLabel
-              amount={
-                checkout.tax_behavior === 'inclusive' &&
-                checkout.tax_amount !== null
-                  ? checkout.total_amount - checkout.tax_amount
-                  : checkout.amount
-              }
+              amount={checkout.amount}
               currency={checkout.currency}
               interval={interval}
               intervalCount={intervalCount}


### PR DESCRIPTION
A slight digress from #10713

Attempts to fix the fact that the pre-discount amount is never shown in checkout for inclusive tax.

Before:
<img width="840" height="626" alt="before" src="https://github.com/user-attachments/assets/72670db0-0489-45c2-a8a2-4df69a72ccf6" />


After:
<img width="840" height="626" alt="after" src="https://github.com/user-attachments/assets/48113bec-e6aa-43a4-8e5a-66779be24e0e" />

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Subtotal in Checkout for inclusive tax to show the pre-discount amount. Previously, Subtotal used total minus tax for inclusive tax; now it always uses `checkout.amount`, so discounts and included tax rows display correctly.

- Subtotal now reflects the pre-discount amount even when `tax_behavior: 'inclusive'`.
- No API or migration changes; exclusive-tax behavior is unchanged.
- Reviewer focus: inclusive-tax with discounts—confirm Subtotal, Discount, Taxable amount (`net_amount`), and Taxes (included) (`tax_amount`) align with the displayed total.

<sup>Written for commit b7186db2f241e9e905582e7d3403dc783eb18f0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

