### PR TITLE
server: Drop TrailingSlashRestoreMiddleware

### DIFF
--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -45,7 +45,6 @@ from polar.middlewares import (
     PathRewriteMiddleware,
     RootPathMiddleware,
     SandboxResponseHeaderMiddleware,
-    TrailingSlashRestoreMiddleware,
 )
 from polar.oauth2.endpoints.well_known import router as well_known_router
 from polar.oauth2.exception_handlers import OAuth2Error, oauth2_error_exception_handler
@@ -211,11 +210,6 @@ def create_app() -> FastAPI:
         app.add_middleware(FlushEnqueuedWorkerJobsMiddleware)
         app.add_middleware(AsyncSessionMiddleware)
         app.add_middleware(rate_limit.get_middleware, redis=rate_limit_redis)
-    if settings.is_vercel():
-        # The service-binding proxy strips trailing slashes, which would turn
-        # the router's redirect_slashes 307 into an infinite loop; restore the
-        # slash instead. Added before PathRewriteMiddleware to see its output.
-        app.add_middleware(TrailingSlashRestoreMiddleware, routes=app.router.routes)
     app.add_middleware(PathRewriteMiddleware, pattern=r"^/api/v1", replacement="/v1")
     if settings.is_vercel():
         # The app origin mounts the API at /api (api.* hosts serve it

--- a/server/polar/middlewares.py
+++ b/server/polar/middlewares.py
@@ -2,14 +2,12 @@ import contextlib
 import functools
 import json
 import re
-from collections.abc import Sequence
 
 import dramatiq
 import logfire
 import sentry_sdk
 import structlog
 from starlette.datastructures import Headers, MutableHeaders
-from starlette.routing import BaseRoute, Match
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from polar.logging import ClientContext, CorrelationID, Logger
@@ -104,35 +102,6 @@ class RootPathMiddleware:
             if path == self.prefix or path.startswith(f"{self.prefix}/"):
                 scope["root_path"] = self.prefix
         await self.app(scope, receive, send)
-
-
-class TrailingSlashRestoreMiddleware:
-    """Restore trailing slashes stripped by a fronting proxy.
-
-    The Vercel service-binding proxy strips trailing slashes from request
-    paths, so a request for a collection endpoint (routed with a trailing
-    slash) arrives slashless, gets the router's redirect_slashes 307 back to
-    the slashed path — which the proxy strips again, looping until the client
-    gives up. When a path matches no route but its slashed variant does,
-    rewrite the path in place instead of redirecting.
-    """
-
-    def __init__(self, app: ASGIApp, routes: Sequence[BaseRoute]) -> None:
-        self.app = app
-        self.routes = routes
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] in ("http", "websocket") and not scope["path"].endswith("/"):
-            slashed_scope = {**scope, "path": f"{scope['path']}/"}
-            if not self._matches_any(scope) and self._matches_any(slashed_scope):
-                scope["path"] = slashed_scope["path"]
-                raw_path: bytes | None = scope.get("raw_path")
-                if raw_path is not None:
-                    scope["raw_path"] = raw_path + b"/"
-        await self.app(scope, receive, send)
-
-    def _matches_any(self, scope: Scope) -> bool:
-        return any(route.matches(scope)[0] is not Match.NONE for route in self.routes)
 
 
 class PathRewriteMiddleware:


### PR DESCRIPTION
Addresses the https://github.com/polarsource/polar/pull/13765#discussion_r3788999364, the platform has fixed this behavior and the middleware is no longer required.