### PR TITLE
sqs: Add byte batching

### DIFF
--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -24,6 +24,7 @@ from polar.event_type.repository import EventTypeRepository
 from polar.exceptions import PolarError, PolarRequestValidationError, ValidationError
 from polar.integrations.tinybird.service import (
     TinybirdTimeseriesStats,
+    chunk_tinybird_events,
     events_to_tinybird,
 )
 from polar.kit.metadata import MetadataQuery
@@ -1061,7 +1062,8 @@ class EventService:
             enqueue_job("customer_meter.update_customer", customer.id)
 
         tinybird_events = events_to_tinybird(events, ancestors_by_event)
-        enqueue_job("tinybird.ingest", tinybird_events)
+        for chunk in chunk_tinybird_events(tinybird_events):
+            enqueue_job("tinybird.ingest", chunk)
 
         for customer_id in customers_with_user_events:
             enqueue_job("customer.resolve_first_user_event_at", customer_id)

--- a/server/polar/integrations/tinybird/service.py
+++ b/server/polar/integrations/tinybird/service.py
@@ -1,6 +1,6 @@
 import json
 import math
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from functools import partial
@@ -39,6 +39,7 @@ from polar.meter.aggregation import Aggregation, PropertyAggregation
 from polar.meter.filter import Filter, FilterClause, FilterConjunction, FilterOperator
 from polar.models import Event
 from polar.models.event import EventSource
+from polar.worker import MAX_JOB_PAYLOAD_BYTES
 
 from .client import client
 from .schemas import TinybirdEvent
@@ -326,6 +327,24 @@ def events_to_tinybird(
     ancestors_by_event: Mapping[UUID, Sequence[str]] | None = None,
 ) -> list[TinybirdEvent]:
     return [_event_to_tinybird(e, (ancestors_by_event or {}).get(e.id)) for e in events]
+
+
+def chunk_tinybird_events(
+    events: Sequence[TinybirdEvent],
+) -> Iterator[list[TinybirdEvent]]:
+    """Split events into groups that each fit in a single job payload."""
+    chunk: list[TinybirdEvent] = []
+    chunk_bytes = 0
+    for event in events:
+        event_bytes = len(json.dumps(event).encode("utf-8"))
+        if chunk and chunk_bytes + event_bytes > MAX_JOB_PAYLOAD_BYTES:
+            yield chunk
+            chunk = []
+            chunk_bytes = 0
+        chunk.append(event)
+        chunk_bytes += event_bytes
+    if chunk:
+        yield chunk
 
 
 async def ingest_events(

--- a/server/polar/worker/__init__.py
+++ b/server/polar/worker/__init__.py
@@ -26,6 +26,7 @@ from ._httpx import HTTPXMiddleware
 from ._queues import TaskPriority, TaskQueue
 from ._redis import RedisMiddleware
 from ._sqlalchemy import AsyncReadSessionMaker, AsyncSessionMaker
+from ._sqs import MAX_JOB_PAYLOAD_BYTES
 
 _ = _prometheus_metrics  # for mypy and ruff: ensure import is used
 
@@ -113,6 +114,7 @@ def actor[**P, R](
 
 
 __all__ = [
+    "MAX_JOB_PAYLOAD_BYTES",
     "AsyncReadSessionMaker",
     "AsyncSessionMaker",
     "BulkJobDelayCalculator",

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -1,8 +1,8 @@
 import asyncio
 import hashlib
-import itertools
 import json
 from collections import defaultdict
+from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -25,8 +25,12 @@ log: Logger = structlog.get_logger()
 
 # SQS hard limits.
 SQS_BATCH_SIZE = 10
+SQS_MAX_BATCH_BYTES = 262_144
 MAX_DELAY_SECONDS = 900
 MAX_VISIBILITY_TIMEOUT_SECONDS = 43_200
+
+# Argument budget for a single job, leaving room for the envelope around it.
+MAX_JOB_PAYLOAD_BYTES = 200_000
 
 type Job = tuple[str, tuple[Any, ...], dict[str, Any], int | None, str | None]
 
@@ -216,6 +220,27 @@ def send_to_dlq(client: "SQSClient", queue_arn: str, body: str) -> None:
     client.send_message(QueueUrl=dlq_url, MessageBody=body)
 
 
+def pack_batches(
+    entries: list["SendMessageBatchRequestEntryTypeDef"],
+) -> Iterator[list["SendMessageBatchRequestEntryTypeDef"]]:
+    """Group entries into SQS batches within both the count and the size limit."""
+    batch: list[SendMessageBatchRequestEntryTypeDef] = []
+    batch_bytes = 0
+    for entry in entries:
+        entry_bytes = len(entry["MessageBody"].encode("utf-8"))
+        if batch and (
+            len(batch) >= SQS_BATCH_SIZE
+            or batch_bytes + entry_bytes > SQS_MAX_BATCH_BYTES
+        ):
+            yield batch
+            batch = []
+            batch_bytes = 0
+        batch.append(entry)
+        batch_bytes += entry_bytes
+    if batch:
+        yield batch
+
+
 async def send_jobs(jobs: list[Job]) -> None:
     if not jobs:
         return
@@ -240,10 +265,8 @@ def send_jobs_sync(jobs: list[Job]) -> None:
 
     for queue_name, entries in by_queue.items():
         queue_url = resolve_queue_url(client, queue_name)
-        for batch in itertools.batched(entries, SQS_BATCH_SIZE):
-            response = client.send_message_batch(
-                QueueUrl=queue_url, Entries=list(batch)
-            )
+        for batch in pack_batches(entries):
+            response = client.send_message_batch(QueueUrl=queue_url, Entries=batch)
             failed = response.get("Failed", [])
             if failed:
                 log.error(
@@ -254,6 +277,7 @@ def send_jobs_sync(jobs: list[Job]) -> None:
 
 
 __all__ = [
+    "MAX_JOB_PAYLOAD_BYTES",
     "MAX_VISIBILITY_TIMEOUT_SECONDS",
     "Job",
     "SQSSendError",
@@ -264,6 +288,7 @@ __all__ = [
     "get_consumer_sqs_client",
     "get_queue_url",
     "get_sqs_client",
+    "pack_batches",
     "parse_envelope",
     "resolve_queue_url",
     "schedule_delayed_message",

--- a/server/tests/integrations/tinybird/test_service.py
+++ b/server/tests/integrations/tinybird/test_service.py
@@ -15,12 +15,14 @@ from polar.integrations.tinybird.client import (
     TinybirdOperationalError,
     TinybirdRequestError,
 )
+from polar.integrations.tinybird.schemas import TinybirdEvent
 from polar.integrations.tinybird.service import (
     DATASOURCE_EVENTS,
     TinybirdEventsQuery,
     TinybirdEventTypesQuery,
     _compile,
     _event_to_tinybird,
+    chunk_tinybird_events,
     clickhouse_dialect,
     count_user_events_by_organization,
     events_table,
@@ -33,6 +35,7 @@ from polar.meter.filter import (
 )
 from polar.models import Event
 from polar.models.event import EventSource
+from polar.worker import MAX_JOB_PAYLOAD_BYTES
 from tests.fixtures.tinybird import tinybird_available
 
 pytestmark = pytest.mark.xdist_group(name="tinybird")
@@ -148,6 +151,53 @@ def compile_clause(clause: Any) -> tuple[str, dict[str, Any]]:
         dialect=clickhouse_dialect, compile_kwargs={"render_postcompile": True}
     )
     return str(compiled), dict(compiled.params)
+
+
+class TestChunkTinybirdEvents:
+    def make_events(self, count: int, metadata_bytes: int) -> list[TinybirdEvent]:
+        return [
+            _event_to_tinybird(
+                create_test_event(
+                    name="usage",
+                    source=EventSource.user,
+                    user_metadata={"blob": "x" * metadata_bytes},
+                )
+            )
+            for _ in range(count)
+        ]
+
+    def test_empty(self) -> None:
+        assert list(chunk_tinybird_events([])) == []
+
+    def test_small_batch_stays_in_one_chunk(self) -> None:
+        events = self.make_events(50, 100)
+
+        chunks = list(chunk_tinybird_events(events))
+
+        assert chunks == [events]
+
+    def test_large_batch_is_split_below_the_payload_budget(self) -> None:
+        events = self.make_events(20, 50_000)
+
+        chunks = list(chunk_tinybird_events(events))
+
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert len(json.dumps(chunk).encode("utf-8")) <= MAX_JOB_PAYLOAD_BYTES
+
+    def test_every_event_is_kept_exactly_once_and_in_order(self) -> None:
+        events = self.make_events(20, 50_000)
+
+        chunks = list(chunk_tinybird_events(events))
+
+        assert [event for chunk in chunks for event in chunk] == events
+
+    def test_event_larger_than_the_budget_is_not_dropped(self) -> None:
+        events = self.make_events(1, MAX_JOB_PAYLOAD_BYTES * 2)
+
+        chunks = list(chunk_tinybird_events(events))
+
+        assert chunks == [events]
 
 
 class TestQueryWildcardsAreLiteral:

--- a/server/tests/worker/test_enqueue_gate.py
+++ b/server/tests/worker/test_enqueue_gate.py
@@ -1,3 +1,4 @@
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import dramatiq
@@ -8,8 +9,17 @@ import polar.tasks  # noqa: F401  (registers actors with the broker)
 from polar.config import settings
 from polar.logging import CorrelationID
 from polar.redis import Redis
-from polar.worker import JobQueueManager
-from polar.worker._sqs import actor_to_queue_name, get_sqs_client, resolve_queue_url
+from polar.worker import MAX_JOB_PAYLOAD_BYTES, JobQueueManager
+from polar.worker._sqs import (
+    SQS_MAX_BATCH_BYTES,
+    actor_to_queue_name,
+    get_sqs_client,
+    pack_batches,
+    resolve_queue_url,
+)
+
+if TYPE_CHECKING:
+    from mypy_boto3_sqs.type_defs import SendMessageBatchRequestEntryTypeDef
 
 
 def test_actor_to_queue_name_maps_dramatiq_queue(mocker: MockerFixture) -> None:
@@ -86,3 +96,47 @@ class TestFlushGate:
         # Non-allowlisted actor still went to Redis; the SQS one did not.
         assert await redis.llen("dramatiq:low_priority") == 1
         assert await redis.llen("dramatiq:high_priority") == 0
+
+
+class TestPackBatches:
+    def make_entries(
+        self, sizes: list[int]
+    ) -> list["SendMessageBatchRequestEntryTypeDef"]:
+        return [
+            {"Id": str(index), "MessageBody": "x" * size}
+            for index, size in enumerate(sizes)
+        ]
+
+    def test_empty(self) -> None:
+        assert list(pack_batches([])) == []
+
+    def test_caps_on_entry_count(self) -> None:
+        batches = list(pack_batches(self.make_entries([10] * 25)))
+
+        assert [len(batch) for batch in batches] == [10, 10, 5]
+
+    def test_caps_on_total_bytes(self) -> None:
+        batches = list(pack_batches(self.make_entries([MAX_JOB_PAYLOAD_BYTES] * 4)))
+
+        assert [len(batch) for batch in batches] == [1, 1, 1, 1]
+        for batch in batches:
+            total = sum(len(entry["MessageBody"]) for entry in batch)
+            assert total <= SQS_MAX_BATCH_BYTES
+
+    def test_entry_larger_than_the_batch_limit_stays_alone(self) -> None:
+        entries = self.make_entries([10, SQS_MAX_BATCH_BYTES + 1, 10])
+
+        batches = list(pack_batches(entries))
+
+        assert [[entry["Id"] for entry in batch] for batch in batches] == [
+            ["0"],
+            ["1"],
+            ["2"],
+        ]
+
+    def test_every_entry_is_sent_exactly_once(self) -> None:
+        entries = self.make_entries([100_000, 10, 100_000, 10, 100_000])
+
+        batches = list(pack_batches(entries))
+
+        assert [entry for batch in batches for entry in batch] == entries


### PR DESCRIPTION
Since SQS messages have a max size limit, we need to batch them if the message is too big


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

