### PR TITLE
lambda: Add more tasks to sandbox+test

### DIFF
--- a/terraform/global/sandbox.tf
+++ b/terraform/global/sandbox.tf
@@ -512,17 +512,31 @@ resource "tfe_variable" "worker_sqs_actors_sandbox" {
   description = "JSON array of Dramatiq actor names routed to the SQS execution engine for sandbox"
   sensitive   = false
   value = jsonencode([
-    "dummy",
-    "observability.invariants.enqueue",
-    "observability.invariants.check",
+    "auth.delete_expired",
+    "authentication_session.delete_expired",
     "checkout.expire_open_checkouts",
     "customer.state_changed",
+    "customer_email_update.delete_expired",
+    "customer_session.delete_expired",
+    "dummy",
     "email.send",
+    "email_otp.delete_expired",
+    "email_update.delete_expired_record",
+    "eventstream.publish",
     "external_event.prune",
+    "license_key.sync_benefit_grant",
+    "member_session.delete_expired",
     "oauth2_token.delete_expired",
+    "observability.invariants.check",
+    "observability.invariants.enqueue",
+    "order.invoice",
+    "receipt.render",
+    "tinybird.ingest",
+    "webhook_event.archive",
+    "webhook_event.failed",
     "webhook_event.publish",
     "webhook_event.send",
-    "license_key.sync_benefit_grant",
+    "webhook_event.success",
   ])
   variable_set_id = tfe_variable_set.sandbox.id
 }

--- a/terraform/global/test.tf
+++ b/terraform/global/test.tf
@@ -498,17 +498,31 @@ resource "tfe_variable" "worker_sqs_actors_test" {
   description = "JSON array of Dramatiq actor names routed to the SQS execution engine for test"
   sensitive   = false
   value = jsonencode([
-    "dummy",
-    "observability.invariants.enqueue",
-    "observability.invariants.check",
+    "auth.delete_expired",
+    "authentication_session.delete_expired",
     "checkout.expire_open_checkouts",
     "customer.state_changed",
+    "customer_email_update.delete_expired",
+    "customer_session.delete_expired",
+    "dummy",
     "email.send",
+    "email_otp.delete_expired",
+    "email_update.delete_expired_record",
+    "eventstream.publish",
     "external_event.prune",
+    "license_key.sync_benefit_grant",
+    "member_session.delete_expired",
     "oauth2_token.delete_expired",
+    "observability.invariants.check",
+    "observability.invariants.enqueue",
+    "order.invoice",
+    "receipt.render",
+    "tinybird.ingest",
+    "webhook_event.archive",
+    "webhook_event.failed",
     "webhook_event.publish",
     "webhook_event.send",
-    "license_key.sync_benefit_grant",
+    "webhook_event.success",
   ])
   variable_set_id = tfe_variable_set.test.id
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Routes more Dramatiq tasks through the SQS engine in sandbox and test to improve coverage and parity with production. Previously only a small subset was routed; now cleanup, messaging, invoicing/receipt rendering, event streaming, Tinybird ingestion, and webhook outcome events are included.

**Impact and rollout**
- Expands `tfe_variable` values for `worker_sqs_actors_sandbox` and `worker_sqs_actors_test` to include actors like `auth.delete_expired`, `authentication_session.delete_expired`, `email_otp.delete_expired`, `order.invoice`, `receipt.render`, `tinybird.ingest`, and `webhook_event.{archive,failed,success}`.
- No production change. Apply Terraform to update the `sandbox` and `test` variable sets; no application changes required.
- Expect higher SQS worker load in lower envs; verify worker scaling and queue alarms.

<sup>Written for commit 6c5c8d2c9c55e5c2100ccb2a1434e133d3887351. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

