### PR TITLE
pgbouncer: Limit what we log

### DIFF
--- a/infra/pgbouncer/entrypoint.sh
+++ b/infra/pgbouncer/entrypoint.sh
@@ -32,6 +32,8 @@ max_prepared_statements = ${MAX_PREPARED_STATEMENTS:-200}
 server_tls_sslmode = ${SERVER_TLS_SSLMODE:-prefer}
 server_tls_ca_file = ${SERVER_TLS_CA_FILE:-/etc/ssl/certs/ca-certificates.crt}
 ignore_startup_parameters = ${IGNORE_STARTUP_PARAMETERS:-extra_float_digits,statement_timeout}
+log_connections = ${LOG_CONNECTIONS:-0}
+log_disconnections = ${LOG_DISCONNECTIONS:-0}
 EOF
 
 exec pgbouncer /etc/pgbouncer/pgbouncer.ini


### PR DESCRIPTION
We don't need to log all connection and disconnections



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

