### PR TITLE
Add Hong Kong Business Registration Number validation

### DIFF
--- a/server/polar/tax/tax_id.py
+++ b/server/polar/tax/tax_id.py
@@ -525,7 +525,7 @@ def validate_tax_id(number: str, country: str) -> TaxID:
             try:
                 validator = _get_validator(tax_id_type)
                 return validator.validate(number, country), tax_id_type
-            except (UnsupportedTaxIDFormat, InvalidTaxID):
+            except UnsupportedTaxIDFormat, InvalidTaxID:
                 continue
     raise InvalidTaxID(number, country)
 

--- a/server/polar/tax/tax_id.py
+++ b/server/polar/tax/tax_id.py
@@ -436,6 +436,21 @@ class GEVATValidator(ValidatorProtocol):
         return number
 
 
+class HKBRValidator(ValidatorProtocol):
+    # Business Registration Number: 8 digits whose last digit is a mod-11 check
+    # digit (weights 9..2, weighted sum divisible by 11).
+    _WEIGHTS = (9, 8, 7, 6, 5, 4, 3, 2)
+
+    def validate(self, number: str, country: str) -> str:
+        number = re.sub(r"[\s.()-]", "", number)
+        if len(number) != 8 or not number.isdigit():
+            raise InvalidTaxID(number, country)
+        checksum = sum(int(d) * w for d, w in zip(number, self._WEIGHTS))
+        if checksum % 11 != 0:
+            raise InvalidTaxID(number, country)
+        return number
+
+
 class MUTANValidator(ValidatorProtocol):
     def validate(self, number: str, country: str) -> str:
         # Remove spaces, dashes, and other common separators
@@ -465,6 +480,8 @@ def _get_validator(tax_id_type: TaxIDFormat) -> ValidatorProtocol:
             return ECRUCValidator()
         case TaxIDFormat.ge_vat:
             return GEVATValidator()
+        case TaxIDFormat.hk_br:
+            return HKBRValidator()
         case TaxIDFormat.il_vat:
             return ILVATValidator()
         case TaxIDFormat.mk_vat:
@@ -508,7 +525,7 @@ def validate_tax_id(number: str, country: str) -> TaxID:
             try:
                 validator = _get_validator(tax_id_type)
                 return validator.validate(number, country), tax_id_type
-            except UnsupportedTaxIDFormat, InvalidTaxID:
+            except (UnsupportedTaxIDFormat, InvalidTaxID):
                 continue
     raise InvalidTaxID(number, country)
 

--- a/server/polar/tax/tax_id.py
+++ b/server/polar/tax/tax_id.py
@@ -437,16 +437,11 @@ class GEVATValidator(ValidatorProtocol):
 
 
 class HKBRValidator(ValidatorProtocol):
-    # Business Registration Number: 8 digits whose last digit is a mod-11 check
-    # digit (weights 9..2, weighted sum divisible by 11).
-    _WEIGHTS = (9, 8, 7, 6, 5, 4, 3, 2)
-
     def validate(self, number: str, country: str) -> str:
+        # Business Registration Number: 8 digits (the trailing check digit is
+        # sometimes written in parentheses, e.g. 1234567(8)).
         number = re.sub(r"[\s.()-]", "", number)
         if len(number) != 8 or not number.isdigit():
-            raise InvalidTaxID(number, country)
-        checksum = sum(int(d) * w for d, w in zip(number, self._WEIGHTS))
-        if checksum % 11 != 0:
             raise InvalidTaxID(number, country)
         return number
 

--- a/server/tests/tax/test_tax_id.py
+++ b/server/tests/tax/test_tax_id.py
@@ -83,6 +83,11 @@ from polar.tax.tax_id import InvalidTaxID, TaxID, TaxIDFormat, validate_tax_id
         ("211003420017", "UY", ("211003420017", TaxIDFormat.uy_ruc)),
         ("21-100342-001-7", "UY", ("211003420017", TaxIDFormat.uy_ruc)),
         ("UY 21 140634 001 1", "UY", ("211406340011", TaxIDFormat.uy_ruc)),
+        # HK BR: 8-digit Business Registration Number with mod-11 check digit
+        ("12345677", "HK", ("12345677", TaxIDFormat.hk_br)),
+        ("98765433", "HK", ("98765433", TaxIDFormat.hk_br)),
+        ("1234567-7", "HK", ("12345677", TaxIDFormat.hk_br)),
+        ("1234567(7)", "HK", ("12345677", TaxIDFormat.hk_br)),
     ],
 )
 def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> None:
@@ -120,6 +125,7 @@ def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> No
         ("9999999999", "CR"),  # Invalid CR TIN
         ("1-1000-0001", "CR"),  # cédula física (individual), not accepted
         ("210303670014", "UY"),  # Wrong check digit
+        ("12345678", "HK"),  # Wrong check digit
     ],
 )
 def test_validate_tax_id_invalid(number: str, country: str) -> None:

--- a/server/tests/tax/test_tax_id.py
+++ b/server/tests/tax/test_tax_id.py
@@ -83,11 +83,11 @@ from polar.tax.tax_id import InvalidTaxID, TaxID, TaxIDFormat, validate_tax_id
         ("211003420017", "UY", ("211003420017", TaxIDFormat.uy_ruc)),
         ("21-100342-001-7", "UY", ("211003420017", TaxIDFormat.uy_ruc)),
         ("UY 21 140634 001 1", "UY", ("211406340011", TaxIDFormat.uy_ruc)),
-        # HK BR: 8-digit Business Registration Number with mod-11 check digit
-        ("12345677", "HK", ("12345677", TaxIDFormat.hk_br)),
-        ("98765433", "HK", ("98765433", TaxIDFormat.hk_br)),
-        ("1234567-7", "HK", ("12345677", TaxIDFormat.hk_br)),
-        ("1234567(7)", "HK", ("12345677", TaxIDFormat.hk_br)),
+        # HK BR: 8-digit Business Registration Number
+        ("12345678", "HK", ("12345678", TaxIDFormat.hk_br)),
+        ("98765432", "HK", ("98765432", TaxIDFormat.hk_br)),
+        ("1234567-8", "HK", ("12345678", TaxIDFormat.hk_br)),
+        ("1234567(8)", "HK", ("12345678", TaxIDFormat.hk_br)),
     ],
 )
 def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> None:
@@ -125,7 +125,7 @@ def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> No
         ("9999999999", "CR"),  # Invalid CR TIN
         ("1-1000-0001", "CR"),  # cédula física (individual), not accepted
         ("210303670014", "UY"),  # Wrong check digit
-        ("12345678", "HK"),  # Wrong check digit
+        ("1234567", "HK"),  # Too short (7 digits)
     ],
 )
 def test_validate_tax_id_invalid(number: str, country: str) -> None:


### PR DESCRIPTION
## Summary

Adds validation for Hong Kong Business Registration Numbers (`hk_br`), which previously had no dedicated validator and were always rejected.

## What

- Added `HKBRValidator` and wired it into `_get_validator()` for `TaxIDFormat.hk_br`.
- Validates the **format only**: 8 digits, after stripping common separators (spaces, dots, dashes, and the parentheses sometimes placed around the trailing check digit, e.g. `1234567(8)`).
- Added test cases for valid 8-digit numbers (plain and separator/parenthesis forms) plus one invalid (too short).

## Why

`hk_br` was declared in the enum and country map but had no validator, so it fell through to the `stdnum` fallback — and since `stdnum` has no `hk.br` module, every Hong Kong BR number was rejected.

We deliberately do **not** verify a check digit: Hong Kong has no publicly documented BR check-digit algorithm (available sources conflict and none is authoritative), so a checksum can't be verified and would risk rejecting genuine numbers. Hong Kong also has no VAT, so the numeric validity of the tax ID is not load-bearing. This matches how Stripe validates `hk_br` and the other non-`stdnum` validators (`AE`/`GE`/`MU`), which are format-only.

## Notes

- No API/schema change — `hk_br` was already part of `TaxIDFormat`; OpenAPI diff is empty.

https://claude.ai/code/session_01Foc6R3DM5SV4v3813XwTgt