### PR TITLE
fix(server): pin VS Code to Python 3.14 venv and ruff

### DIFF
--- a/server/.vscode/settings.json
+++ b/server/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.analysis.typeCheckingMode": "basic",
   "python.analysis.autoImportCompletions": true,
   "python.analysis.showOnlyDirectDependenciesInAutoImport": true,
@@ -18,6 +19,9 @@
   "editor.rulers": [88],
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
   "python.testing.cwd": "${workspaceFolder}",
+  "ruff.path": ["${workspaceFolder}/.venv/bin/ruff"],
+  "ruff.nativeServer": "on",
+  "ruff.configurationPreference": "filesystemFirst",
   "[python]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pins the server VS Code workspace to the project Python 3.14+ venv and Ruff binary so Cloud Agents and editors stop picking up the system Python 3.12.

**Related Issue**: N/A

## What

- Set `python.defaultInterpreterPath` to `server/.venv/bin/python`
- Point the Ruff extension at `server/.venv/bin/ruff` with the native server enabled

## Why

Polar requires Python `>=3.14`. Cloud VMs still expose system `python3` as 3.12, and bare `ruff` is not on PATH. Without these pins, the IDE/linter can analyze with the wrong interpreter.

## How

VS Code settings only in this PR. Separately validated a DB-managed Cloud environment `install` update that:
- runs `uv python install 3.14` + `uv sync`
- puts `server/.venv/bin` on `PATH` via `.bashrc`
- asserts `python >= 3.14` and prints `ruff --version`

Draft build [`bld-20260820-867ece56-5dd0-42ba-b12c-293dcc28cc8d`](https://cursor.com/dashboard/cloud-agents/builds/bld-20260820-867ece56-5dd0-42ba-b12c-293dcc28cc8d) succeeded; fresh-agent smoke confirmed Python 3.14.6, ruff 0.16.2, and `uv run task lint_check` pass.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10bdc186-61f0-4d11-853c-4cd9eb83121e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10bdc186-61f0-4d11-853c-4cd9eb83121e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

