### PR TITLE
Tweak api ref webhook event page urls

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -6192,7 +6192,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * checkout.created
+     * checkout_created
      * @description Sent when a new checkout is created.
      *
      *     **Discord & Slack support:** Basic
@@ -6214,7 +6214,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * checkout.updated
+     * checkout_updated
      * @description Sent when a checkout is updated.
      *
      *     **Discord & Slack support:** Basic
@@ -6236,7 +6236,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * checkout.expired
+     * checkout_expired
      * @description Sent when a checkout expires.
      *
      *     This event fires when a checkout reaches its expiration time without being completed.
@@ -6261,7 +6261,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * customer.created
+     * customer_created
      * @description Sent when a new customer is created.
      *
      *     A customer can be created:
@@ -6288,7 +6288,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * customer.updated
+     * customer_updated
      * @description Sent when a customer is updated.
      *
      *     This event is fired when the customer details are updated.
@@ -6314,7 +6314,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * customer.deleted
+     * customer_deleted
      * @description Sent when a customer is deleted.
      *
      *     **Discord & Slack support:** Basic
@@ -6336,7 +6336,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * customer.state_changed
+     * customer_state_changed
      * @description Sent when a customer state has changed.
      *
      *     It's triggered when:
@@ -6364,7 +6364,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * customer_seat.assigned
+     * customer_seat_assigned
      * @description Sent when a new customer seat is assigned.
      *
      *     This event is triggered when a seat is assigned to a customer by the organization.
@@ -6387,7 +6387,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * customer_seat.claimed
+     * customer_seat_claimed
      * @description Sent when a customer seat is claimed.
      *
      *     This event is triggered when a customer accepts the seat invitation and claims their access.
@@ -6409,7 +6409,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * customer_seat.revoked
+     * customer_seat_revoked
      * @description Sent when a customer seat is revoked.
      *
      *     This event is triggered when access to a seat is revoked, either manually by the organization or automatically when a subscription is canceled.
@@ -6431,7 +6431,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * member.created
+     * member_created
      * @description Sent when a new member is created.
      *
      *     A member represents an individual within a customer (team).
@@ -6458,7 +6458,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * member.updated
+     * member_updated
      * @description Sent when a member is updated.
      *
      *     This event is triggered when member details are updated,
@@ -6483,7 +6483,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * member.deleted
+     * member_deleted
      * @description Sent when a member is deleted.
      *
      *     This event is triggered when a member is removed from a customer.
@@ -6508,7 +6508,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * order.created
+     * order_created
      * @description Sent when a new order is created.
      *
      *     A new order is created when:
@@ -6540,7 +6540,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * order.updated
+     * order_updated
      * @description Sent when an order is updated.
      *
      *     An order is updated when:
@@ -6567,7 +6567,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * order.paid
+     * order_paid
      * @description Sent when an order is paid.
      *
      *     When you receive this event, the order is fully processed and payment has been received.
@@ -6591,7 +6591,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * order.refunded
+     * order_refunded
      * @description Sent when an order is fully or partially refunded.
      *
      *     **Discord & Slack support:** Full
@@ -6613,7 +6613,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * subscription.created
+     * subscription_created
      * @description Sent when a new subscription is created.
      *
      *     When this event occurs, the subscription `status` might not be `active` yet, as we can still have to wait for the first payment to be processed.
@@ -6637,7 +6637,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * subscription.updated
+     * subscription_updated
      * @description Sent when a subscription is updated. This event fires for all changes to the subscription, including renewals.
      *
      *     If you want more specific events, you can listen to `subscription.active`, `subscription.canceled`, `subscription.past_due`, and `subscription.revoked`.
@@ -6663,7 +6663,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * subscription.active
+     * subscription_active
      * @description Sent when a subscription becomes active,
      *     whether because it's a new paid subscription or because payment was recovered.
      *
@@ -6686,7 +6686,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * subscription.canceled
+     * subscription_canceled
      * @description Sent when a subscription is canceled.
      *     Customers might still have access until the end of the current period.
      *
@@ -6709,7 +6709,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * subscription.uncanceled
+     * subscription_uncanceled
      * @description Sent when a customer revokes a pending cancellation.
      *
      *     When a customer cancels with "at period end", they retain access until the
@@ -6735,7 +6735,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * subscription.cycled
+     * subscription_cycled
      * @description Sent when a subscription enters a new billing period.
      *
      *     The payload carries the new `current_period_start` and `current_period_end`.
@@ -6765,7 +6765,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * subscription.revoked
+     * subscription_revoked
      * @description Sent when a subscription is revoked and the user loses access immediately.
      *     Happens when the subscription is canceled or payment retries are exhausted (status becomes `unpaid`).
      *
@@ -6790,7 +6790,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * subscription.past_due
+     * subscription_past_due
      * @description Sent when a subscription payment fails and the subscription enters `past_due` status.
      *
      *     This is a recoverable state - the customer can update their payment method to restore the subscription.
@@ -6817,7 +6817,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * subscription.paused
+     * subscription_paused
      * @description Sent when a subscription is paused and the customer temporarily loses access.
      *
      *     No order is created while paused. The subscription resumes either on its
@@ -6842,7 +6842,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * subscription.resumed
+     * subscription_resumed
      * @description Sent when a paused subscription resumes, restoring the customer's access.
      *
      *     Resuming starts a new billing period and charges the customer immediately.
@@ -6866,7 +6866,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * refund.created
+     * refund_created
      * @description Sent when a refund is created regardless of status.
      *
      *     **Discord & Slack support:** Full
@@ -6888,7 +6888,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * refund.updated
+     * refund_updated
      * @description Sent when a refund is updated.
      *
      *     **Discord & Slack support:** Full
@@ -6910,7 +6910,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * product.created
+     * product_created
      * @description Sent when a new product is created.
      *
      *     **Discord & Slack support:** Basic
@@ -6932,7 +6932,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * product.updated
+     * product_updated
      * @description Sent when a product is updated.
      *
      *     **Discord & Slack support:** Basic
@@ -6954,7 +6954,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * discount.created
+     * discount_created
      * @description Sent when a new discount is created.
      *
      *     **Discord & Slack support:** Basic
@@ -6976,7 +6976,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * discount.updated
+     * discount_updated
      * @description Sent when a discount is updated.
      *
      *     **Discord & Slack support:** Basic
@@ -6998,7 +6998,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * discount.deleted
+     * discount_deleted
      * @description Sent when a discount is deleted.
      *
      *     **Discord & Slack support:** Basic
@@ -7020,7 +7020,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * organization.updated
+     * organization_updated
      * @description Sent when a organization is updated.
      *
      *     **Discord & Slack support:** Basic
@@ -7042,7 +7042,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * benefit.created
+     * benefit_created
      * @description Sent when a new benefit is created.
      *
      *     **Discord & Slack support:** Basic
@@ -7064,7 +7064,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * benefit.updated
+     * benefit_updated
      * @description Sent when a benefit is updated.
      *
      *     **Discord & Slack support:** Basic
@@ -7086,7 +7086,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * benefit_grant.created
+     * benefit_grant_created
      * @description Sent when a new benefit grant is created.
      *
      *     **Discord & Slack support:** Basic
@@ -7108,7 +7108,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * benefit_grant.updated
+     * benefit_grant_updated
      * @description Sent when a benefit grant is updated.
      *
      *     **Discord & Slack support:** Basic
@@ -7130,7 +7130,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * benefit_grant.cycled
+     * benefit_grant_cycled
      * @description Sent when a benefit grant is cycled,
      *     meaning the related subscription has been renewed for another period.
      *
@@ -7153,7 +7153,7 @@ export interface webhooks {
     get?: never
     put?: never
     /**
-     * benefit_grant.revoked
+     * benefit_grant_revoked
      * @description Sent when a benefit grant is revoked.
      *
      *     **Discord & Slack support:** Basic

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1513,6 +1513,334 @@
     {
       "source": "/features/integrations/refgrow",
       "destination": "https://refgrow.com/polar-affiliate-software"
+    },
+    {
+      "source": "/api-reference/2026-04/checkoutcreated",
+      "destination": "/api-reference/2026-04/checkout_created"
+    },
+    {
+      "source": "/api-reference/2026-04/checkoutupdated",
+      "destination": "/api-reference/2026-04/checkout_updated"
+    },
+    {
+      "source": "/api-reference/2026-04/checkoutexpired",
+      "destination": "/api-reference/2026-04/checkout_expired"
+    },
+    {
+      "source": "/api-reference/2026-04/customercreated",
+      "destination": "/api-reference/2026-04/customer_created"
+    },
+    {
+      "source": "/api-reference/2026-04/customerupdated",
+      "destination": "/api-reference/2026-04/customer_updated"
+    },
+    {
+      "source": "/api-reference/2026-04/customerdeleted",
+      "destination": "/api-reference/2026-04/customer_deleted"
+    },
+    {
+      "source": "/api-reference/2026-04/customerstate_changed",
+      "destination": "/api-reference/2026-04/customer_state_changed"
+    },
+    {
+      "source": "/api-reference/2026-04/customer_seatassigned",
+      "destination": "/api-reference/2026-04/customer_seat_assigned"
+    },
+    {
+      "source": "/api-reference/2026-04/customer_seatclaimed",
+      "destination": "/api-reference/2026-04/customer_seat_claimed"
+    },
+    {
+      "source": "/api-reference/2026-04/customer_seatrevoked",
+      "destination": "/api-reference/2026-04/customer_seat_revoked"
+    },
+    {
+      "source": "/api-reference/2026-04/membercreated",
+      "destination": "/api-reference/2026-04/member_created"
+    },
+    {
+      "source": "/api-reference/2026-04/memberupdated",
+      "destination": "/api-reference/2026-04/member_updated"
+    },
+    {
+      "source": "/api-reference/2026-04/memberdeleted",
+      "destination": "/api-reference/2026-04/member_deleted"
+    },
+    {
+      "source": "/api-reference/2026-04/ordercreated",
+      "destination": "/api-reference/2026-04/order_created"
+    },
+    {
+      "source": "/api-reference/2026-04/orderupdated",
+      "destination": "/api-reference/2026-04/order_updated"
+    },
+    {
+      "source": "/api-reference/2026-04/orderpaid",
+      "destination": "/api-reference/2026-04/order_paid"
+    },
+    {
+      "source": "/api-reference/2026-04/orderrefunded",
+      "destination": "/api-reference/2026-04/order_refunded"
+    },
+    {
+      "source": "/api-reference/2026-04/subscriptioncreated",
+      "destination": "/api-reference/2026-04/subscription_created"
+    },
+    {
+      "source": "/api-reference/2026-04/subscriptionupdated",
+      "destination": "/api-reference/2026-04/subscription_updated"
+    },
+    {
+      "source": "/api-reference/2026-04/subscriptionactive",
+      "destination": "/api-reference/2026-04/subscription_active"
+    },
+    {
+      "source": "/api-reference/2026-04/subscriptioncanceled",
+      "destination": "/api-reference/2026-04/subscription_canceled"
+    },
+    {
+      "source": "/api-reference/2026-04/subscriptionuncanceled",
+      "destination": "/api-reference/2026-04/subscription_uncanceled"
+    },
+    {
+      "source": "/api-reference/2026-04/subscriptioncycled",
+      "destination": "/api-reference/2026-04/subscription_cycled"
+    },
+    {
+      "source": "/api-reference/2026-04/subscriptionrevoked",
+      "destination": "/api-reference/2026-04/subscription_revoked"
+    },
+    {
+      "source": "/api-reference/2026-04/subscriptionpast_due",
+      "destination": "/api-reference/2026-04/subscription_past_due"
+    },
+    {
+      "source": "/api-reference/2026-04/subscriptionpaused",
+      "destination": "/api-reference/2026-04/subscription_paused"
+    },
+    {
+      "source": "/api-reference/2026-04/subscriptionresumed",
+      "destination": "/api-reference/2026-04/subscription_resumed"
+    },
+    {
+      "source": "/api-reference/2026-04/refundcreated",
+      "destination": "/api-reference/2026-04/refund_created"
+    },
+    {
+      "source": "/api-reference/2026-04/refundupdated",
+      "destination": "/api-reference/2026-04/refund_updated"
+    },
+    {
+      "source": "/api-reference/2026-04/productcreated",
+      "destination": "/api-reference/2026-04/product_created"
+    },
+    {
+      "source": "/api-reference/2026-04/productupdated",
+      "destination": "/api-reference/2026-04/product_updated"
+    },
+    {
+      "source": "/api-reference/2026-04/discountcreated",
+      "destination": "/api-reference/2026-04/discount_created"
+    },
+    {
+      "source": "/api-reference/2026-04/discountupdated",
+      "destination": "/api-reference/2026-04/discount_updated"
+    },
+    {
+      "source": "/api-reference/2026-04/discountdeleted",
+      "destination": "/api-reference/2026-04/discount_deleted"
+    },
+    {
+      "source": "/api-reference/2026-04/benefitcreated",
+      "destination": "/api-reference/2026-04/benefit_created"
+    },
+    {
+      "source": "/api-reference/2026-04/benefitupdated",
+      "destination": "/api-reference/2026-04/benefit_updated"
+    },
+    {
+      "source": "/api-reference/2026-04/benefit_grantcreated",
+      "destination": "/api-reference/2026-04/benefit_grant_created"
+    },
+    {
+      "source": "/api-reference/2026-04/benefit_grantcycled",
+      "destination": "/api-reference/2026-04/benefit_grant_cycled"
+    },
+    {
+      "source": "/api-reference/2026-04/benefit_grantupdated",
+      "destination": "/api-reference/2026-04/benefit_grant_updated"
+    },
+    {
+      "source": "/api-reference/2026-04/benefit_grantrevoked",
+      "destination": "/api-reference/2026-04/benefit_grant_revoked"
+    },
+    {
+      "source": "/api-reference/2026-04/organizationupdated",
+      "destination": "/api-reference/2026-04/organization_updated"
+    },
+    {
+      "source": "/api-reference/2026-10/checkoutcreated",
+      "destination": "/api-reference/2026-10/checkout_created"
+    },
+    {
+      "source": "/api-reference/2026-10/checkoutupdated",
+      "destination": "/api-reference/2026-10/checkout_updated"
+    },
+    {
+      "source": "/api-reference/2026-10/checkoutexpired",
+      "destination": "/api-reference/2026-10/checkout_expired"
+    },
+    {
+      "source": "/api-reference/2026-10/customercreated",
+      "destination": "/api-reference/2026-10/customer_created"
+    },
+    {
+      "source": "/api-reference/2026-10/customerupdated",
+      "destination": "/api-reference/2026-10/customer_updated"
+    },
+    {
+      "source": "/api-reference/2026-10/customerdeleted",
+      "destination": "/api-reference/2026-10/customer_deleted"
+    },
+    {
+      "source": "/api-reference/2026-10/customerstate_changed",
+      "destination": "/api-reference/2026-10/customer_state_changed"
+    },
+    {
+      "source": "/api-reference/2026-10/customer_seatassigned",
+      "destination": "/api-reference/2026-10/customer_seat_assigned"
+    },
+    {
+      "source": "/api-reference/2026-10/customer_seatclaimed",
+      "destination": "/api-reference/2026-10/customer_seat_claimed"
+    },
+    {
+      "source": "/api-reference/2026-10/customer_seatrevoked",
+      "destination": "/api-reference/2026-10/customer_seat_revoked"
+    },
+    {
+      "source": "/api-reference/2026-10/membercreated",
+      "destination": "/api-reference/2026-10/member_created"
+    },
+    {
+      "source": "/api-reference/2026-10/memberupdated",
+      "destination": "/api-reference/2026-10/member_updated"
+    },
+    {
+      "source": "/api-reference/2026-10/memberdeleted",
+      "destination": "/api-reference/2026-10/member_deleted"
+    },
+    {
+      "source": "/api-reference/2026-10/ordercreated",
+      "destination": "/api-reference/2026-10/order_created"
+    },
+    {
+      "source": "/api-reference/2026-10/orderupdated",
+      "destination": "/api-reference/2026-10/order_updated"
+    },
+    {
+      "source": "/api-reference/2026-10/orderpaid",
+      "destination": "/api-reference/2026-10/order_paid"
+    },
+    {
+      "source": "/api-reference/2026-10/orderrefunded",
+      "destination": "/api-reference/2026-10/order_refunded"
+    },
+    {
+      "source": "/api-reference/2026-10/subscriptioncreated",
+      "destination": "/api-reference/2026-10/subscription_created"
+    },
+    {
+      "source": "/api-reference/2026-10/subscriptionupdated",
+      "destination": "/api-reference/2026-10/subscription_updated"
+    },
+    {
+      "source": "/api-reference/2026-10/subscriptionactive",
+      "destination": "/api-reference/2026-10/subscription_active"
+    },
+    {
+      "source": "/api-reference/2026-10/subscriptioncanceled",
+      "destination": "/api-reference/2026-10/subscription_canceled"
+    },
+    {
+      "source": "/api-reference/2026-10/subscriptionuncanceled",
+      "destination": "/api-reference/2026-10/subscription_uncanceled"
+    },
+    {
+      "source": "/api-reference/2026-10/subscriptioncycled",
+      "destination": "/api-reference/2026-10/subscription_cycled"
+    },
+    {
+      "source": "/api-reference/2026-10/subscriptionrevoked",
+      "destination": "/api-reference/2026-10/subscription_revoked"
+    },
+    {
+      "source": "/api-reference/2026-10/subscriptionpast_due",
+      "destination": "/api-reference/2026-10/subscription_past_due"
+    },
+    {
+      "source": "/api-reference/2026-10/subscriptionpaused",
+      "destination": "/api-reference/2026-10/subscription_paused"
+    },
+    {
+      "source": "/api-reference/2026-10/subscriptionresumed",
+      "destination": "/api-reference/2026-10/subscription_resumed"
+    },
+    {
+      "source": "/api-reference/2026-10/refundcreated",
+      "destination": "/api-reference/2026-10/refund_created"
+    },
+    {
+      "source": "/api-reference/2026-10/refundupdated",
+      "destination": "/api-reference/2026-10/refund_updated"
+    },
+    {
+      "source": "/api-reference/2026-10/productcreated",
+      "destination": "/api-reference/2026-10/product_created"
+    },
+    {
+      "source": "/api-reference/2026-10/productupdated",
+      "destination": "/api-reference/2026-10/product_updated"
+    },
+    {
+      "source": "/api-reference/2026-10/discountcreated",
+      "destination": "/api-reference/2026-10/discount_created"
+    },
+    {
+      "source": "/api-reference/2026-10/discountupdated",
+      "destination": "/api-reference/2026-10/discount_updated"
+    },
+    {
+      "source": "/api-reference/2026-10/discountdeleted",
+      "destination": "/api-reference/2026-10/discount_deleted"
+    },
+    {
+      "source": "/api-reference/2026-10/benefitcreated",
+      "destination": "/api-reference/2026-10/benefit_created"
+    },
+    {
+      "source": "/api-reference/2026-10/benefitupdated",
+      "destination": "/api-reference/2026-10/benefit_updated"
+    },
+    {
+      "source": "/api-reference/2026-10/benefit_grantcreated",
+      "destination": "/api-reference/2026-10/benefit_grant_created"
+    },
+    {
+      "source": "/api-reference/2026-10/benefit_grantcycled",
+      "destination": "/api-reference/2026-10/benefit_grant_cycled"
+    },
+    {
+      "source": "/api-reference/2026-10/benefit_grantupdated",
+      "destination": "/api-reference/2026-10/benefit_grant_updated"
+    },
+    {
+      "source": "/api-reference/2026-10/benefit_grantrevoked",
+      "destination": "/api-reference/2026-10/benefit_grant_revoked"
+    },
+    {
+      "source": "/api-reference/2026-10/organizationupdated",
+      "destination": "/api-reference/2026-10/organization_updated"
     }
   ]
 }

--- a/docs/openapi/2026-04.openapi.json
+++ b/docs/openapi/2026-04.openapi.json
@@ -24417,7 +24417,7 @@
   "webhooks": {
     "checkout.created": {
       "post": {
-        "summary": "checkout.created",
+        "summary": "checkout_created",
         "description": "Sent when a new checkout is created.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcheckout_created_post",
         "requestBody": {
@@ -24459,7 +24459,7 @@
     },
     "checkout.updated": {
       "post": {
-        "summary": "checkout.updated",
+        "summary": "checkout_updated",
         "description": "Sent when a checkout is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcheckout_updated_post",
         "requestBody": {
@@ -24501,7 +24501,7 @@
     },
     "checkout.expired": {
       "post": {
-        "summary": "checkout.expired",
+        "summary": "checkout_expired",
         "description": "Sent when a checkout expires.\n\nThis event fires when a checkout reaches its expiration time without being completed.\nDevelopers can use this to send reminder emails or track checkout abandonment.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcheckout_expired_post",
         "requestBody": {
@@ -24543,7 +24543,7 @@
     },
     "customer.created": {
       "post": {
-        "summary": "customer.created",
+        "summary": "customer_created",
         "description": "Sent when a new customer is created.\n\nA customer can be created:\n\n* After a successful checkout.\n* Programmatically via the API.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcustomer_created_post",
         "requestBody": {
@@ -24585,7 +24585,7 @@
     },
     "customer.updated": {
       "post": {
-        "summary": "customer.updated",
+        "summary": "customer_updated",
         "description": "Sent when a customer is updated.\n\nThis event is fired when the customer details are updated.\n\nIf you want to be notified when a customer subscription or benefit state changes, you should listen to the `customer_state_changed` event.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcustomer_updated_post",
         "requestBody": {
@@ -24627,7 +24627,7 @@
     },
     "customer.deleted": {
       "post": {
-        "summary": "customer.deleted",
+        "summary": "customer_deleted",
         "description": "Sent when a customer is deleted.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcustomer_deleted_post",
         "requestBody": {
@@ -24669,7 +24669,7 @@
     },
     "customer.state_changed": {
       "post": {
-        "summary": "customer.state_changed",
+        "summary": "customer_state_changed",
         "description": "Sent when a customer state has changed.\n\nIt's triggered when:\n\n* Customer is created, updated or deleted.\n* A subscription is created or updated.\n* A benefit is granted or revoked.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcustomer_state_changed_post",
         "requestBody": {
@@ -24711,7 +24711,7 @@
     },
     "customer_seat.assigned": {
       "post": {
-        "summary": "customer_seat.assigned",
+        "summary": "customer_seat_assigned",
         "description": "Sent when a new customer seat is assigned.\n\nThis event is triggered when a seat is assigned to a customer by the organization.\nThe customer will receive an invitation email to claim the seat.",
         "operationId": "_endpointcustomer_seat_assigned_post",
         "requestBody": {
@@ -24753,7 +24753,7 @@
     },
     "customer_seat.claimed": {
       "post": {
-        "summary": "customer_seat.claimed",
+        "summary": "customer_seat_claimed",
         "description": "Sent when a customer seat is claimed.\n\nThis event is triggered when a customer accepts the seat invitation and claims their access.",
         "operationId": "_endpointcustomer_seat_claimed_post",
         "requestBody": {
@@ -24795,7 +24795,7 @@
     },
     "customer_seat.revoked": {
       "post": {
-        "summary": "customer_seat.revoked",
+        "summary": "customer_seat_revoked",
         "description": "Sent when a customer seat is revoked.\n\nThis event is triggered when access to a seat is revoked, either manually by the organization or automatically when a subscription is canceled.",
         "operationId": "_endpointcustomer_seat_revoked_post",
         "requestBody": {
@@ -24837,7 +24837,7 @@
     },
     "member.created": {
       "post": {
-        "summary": "member.created",
+        "summary": "member_created",
         "description": "Sent when a new member is created.\n\nA member represents an individual within a customer (team).\nThis event is triggered when a member is added to a customer,\neither programmatically via the API or when an owner is automatically\ncreated for a new customer.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointmember_created_post",
         "requestBody": {
@@ -24879,7 +24879,7 @@
     },
     "member.updated": {
       "post": {
-        "summary": "member.updated",
+        "summary": "member_updated",
         "description": "Sent when a member is updated.\n\nThis event is triggered when member details are updated,\nsuch as their name or role within the customer.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointmember_updated_post",
         "requestBody": {
@@ -24921,7 +24921,7 @@
     },
     "member.deleted": {
       "post": {
-        "summary": "member.deleted",
+        "summary": "member_deleted",
         "description": "Sent when a member is deleted.\n\nThis event is triggered when a member is removed from a customer.\nAny active seats assigned to the member will be automatically revoked.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointmember_deleted_post",
         "requestBody": {
@@ -24963,7 +24963,7 @@
     },
     "order.created": {
       "post": {
-        "summary": "order.created",
+        "summary": "order_created",
         "description": "Sent when a new order is created.\n\nA new order is created when:\n\n* A customer purchases a one-time product. In this case, `billing_reason` is set to `purchase`.\n* A customer starts a subscription. In this case, `billing_reason` is set to `subscription_create`.\n* A subscription is renewed. In this case, `billing_reason` is set to `subscription_cycle`.\n* A subscription is upgraded or downgraded with an immediate proration invoice. In this case, `billing_reason` is set to `subscription_update`.\n\n> [!WARNING]\n> The order might not be paid yet, so the `status` field might be `pending`.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointorder_created_post",
         "requestBody": {
@@ -25005,7 +25005,7 @@
     },
     "order.updated": {
       "post": {
-        "summary": "order.updated",
+        "summary": "order_updated",
         "description": "Sent when an order is updated.\n\nAn order is updated when:\n\n* Its status changes, e.g. from `pending` to `paid`.\n* It's refunded, partially or fully.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointorder_updated_post",
         "requestBody": {
@@ -25047,7 +25047,7 @@
     },
     "order.paid": {
       "post": {
-        "summary": "order.paid",
+        "summary": "order_paid",
         "description": "Sent when an order is paid.\n\nWhen you receive this event, the order is fully processed and payment has been received.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointorder_paid_post",
         "requestBody": {
@@ -25089,7 +25089,7 @@
     },
     "order.refunded": {
       "post": {
-        "summary": "order.refunded",
+        "summary": "order_refunded",
         "description": "Sent when an order is fully or partially refunded.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointorder_refunded_post",
         "requestBody": {
@@ -25131,7 +25131,7 @@
     },
     "subscription.created": {
       "post": {
-        "summary": "subscription.created",
+        "summary": "subscription_created",
         "description": "Sent when a new subscription is created.\n\nWhen this event occurs, the subscription `status` might not be `active` yet, as we can still have to wait for the first payment to be processed.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_created_post",
         "requestBody": {
@@ -25173,7 +25173,7 @@
     },
     "subscription.updated": {
       "post": {
-        "summary": "subscription.updated",
+        "summary": "subscription_updated",
         "description": "Sent when a subscription is updated. This event fires for all changes to the subscription, including renewals.\n\nIf you want more specific events, you can listen to `subscription.active`, `subscription.canceled`, `subscription.past_due`, and `subscription.revoked`.\n\nTo listen specifically for renewals, listen to `subscription.cycled`.\n\n**Discord & Slack support:** On cancellation, past due, and revocation. Renewals are skipped.",
         "operationId": "_endpointsubscription_updated_post",
         "requestBody": {
@@ -25215,7 +25215,7 @@
     },
     "subscription.active": {
       "post": {
-        "summary": "subscription.active",
+        "summary": "subscription_active",
         "description": "Sent when a subscription becomes active,\nwhether because it's a new paid subscription or because payment was recovered.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_active_post",
         "requestBody": {
@@ -25257,7 +25257,7 @@
     },
     "subscription.canceled": {
       "post": {
-        "summary": "subscription.canceled",
+        "summary": "subscription_canceled",
         "description": "Sent when a subscription is canceled.\nCustomers might still have access until the end of the current period.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_canceled_post",
         "requestBody": {
@@ -25299,7 +25299,7 @@
     },
     "subscription.uncanceled": {
       "post": {
-        "summary": "subscription.uncanceled",
+        "summary": "subscription_uncanceled",
         "description": "Sent when a customer revokes a pending cancellation.\n\nWhen a customer cancels with \"at period end\", they retain access until the\nsubscription would renew. During this time, they can change their mind and\nundo the cancellation. This event is triggered when they do so.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_uncanceled_post",
         "requestBody": {
@@ -25341,7 +25341,7 @@
     },
     "subscription.cycled": {
       "post": {
-        "summary": "subscription.cycled",
+        "summary": "subscription_cycled",
         "description": "Sent when a subscription enters a new billing period.\n\nThe payload carries the new `current_period_start` and `current_period_end`.\nIt fires when the period rolls over, before the renewal order exists and\nregardless of whether the renewal payment succeeds \u2014 listen to `order.paid`\nif you need the payment.\n\nA trial converting to a paid subscription starts a new period, so it fires\nthere too. Read `status` to tell the two apart.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointsubscription_cycled_post",
         "requestBody": {
@@ -25383,7 +25383,7 @@
     },
     "subscription.revoked": {
       "post": {
-        "summary": "subscription.revoked",
+        "summary": "subscription_revoked",
         "description": "Sent when a subscription is revoked and the user loses access immediately.\nHappens when the subscription is canceled or payment retries are exhausted (status becomes `unpaid`).\n\nFor payment failures that can still be recovered, see `subscription.past_due`.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_revoked_post",
         "requestBody": {
@@ -25425,7 +25425,7 @@
     },
     "subscription.past_due": {
       "post": {
-        "summary": "subscription.past_due",
+        "summary": "subscription_past_due",
         "description": "Sent when a subscription payment fails and the subscription enters `past_due` status.\n\nThis is a recoverable state - the customer can update their payment method to restore the subscription.\nBenefits may be revoked depending on the organization's grace period settings.\n\nIf payment retries are exhausted, a `subscription.revoked` event will be sent.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_past_due_post",
         "requestBody": {
@@ -25467,7 +25467,7 @@
     },
     "subscription.paused": {
       "post": {
-        "summary": "subscription.paused",
+        "summary": "subscription_paused",
         "description": "Sent when a subscription is paused and the customer temporarily loses access.\n\nNo order is created while paused. The subscription resumes either on its\nscheduled resume date or when resumed manually, starting a new billing period.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_paused_post",
         "requestBody": {
@@ -25509,7 +25509,7 @@
     },
     "subscription.resumed": {
       "post": {
-        "summary": "subscription.resumed",
+        "summary": "subscription_resumed",
         "description": "Sent when a paused subscription resumes, restoring the customer's access.\n\nResuming starts a new billing period and charges the customer immediately.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_resumed_post",
         "requestBody": {
@@ -25551,7 +25551,7 @@
     },
     "refund.created": {
       "post": {
-        "summary": "refund.created",
+        "summary": "refund_created",
         "description": "Sent when a refund is created regardless of status.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointrefund_created_post",
         "requestBody": {
@@ -25593,7 +25593,7 @@
     },
     "refund.updated": {
       "post": {
-        "summary": "refund.updated",
+        "summary": "refund_updated",
         "description": "Sent when a refund is updated.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointrefund_updated_post",
         "requestBody": {
@@ -25635,7 +25635,7 @@
     },
     "product.created": {
       "post": {
-        "summary": "product.created",
+        "summary": "product_created",
         "description": "Sent when a new product is created.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointproduct_created_post",
         "requestBody": {
@@ -25677,7 +25677,7 @@
     },
     "product.updated": {
       "post": {
-        "summary": "product.updated",
+        "summary": "product_updated",
         "description": "Sent when a product is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointproduct_updated_post",
         "requestBody": {
@@ -25719,7 +25719,7 @@
     },
     "discount.created": {
       "post": {
-        "summary": "discount.created",
+        "summary": "discount_created",
         "description": "Sent when a new discount is created.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointdiscount_created_post",
         "requestBody": {
@@ -25761,7 +25761,7 @@
     },
     "discount.updated": {
       "post": {
-        "summary": "discount.updated",
+        "summary": "discount_updated",
         "description": "Sent when a discount is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointdiscount_updated_post",
         "requestBody": {
@@ -25803,7 +25803,7 @@
     },
     "discount.deleted": {
       "post": {
-        "summary": "discount.deleted",
+        "summary": "discount_deleted",
         "description": "Sent when a discount is deleted.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointdiscount_deleted_post",
         "requestBody": {
@@ -25845,7 +25845,7 @@
     },
     "organization.updated": {
       "post": {
-        "summary": "organization.updated",
+        "summary": "organization_updated",
         "description": "Sent when a organization is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointorganization_updated_post",
         "requestBody": {
@@ -25887,7 +25887,7 @@
     },
     "benefit.created": {
       "post": {
-        "summary": "benefit.created",
+        "summary": "benefit_created",
         "description": "Sent when a new benefit is created.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_created_post",
         "requestBody": {
@@ -25929,7 +25929,7 @@
     },
     "benefit.updated": {
       "post": {
-        "summary": "benefit.updated",
+        "summary": "benefit_updated",
         "description": "Sent when a benefit is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_updated_post",
         "requestBody": {
@@ -25971,7 +25971,7 @@
     },
     "benefit_grant.created": {
       "post": {
-        "summary": "benefit_grant.created",
+        "summary": "benefit_grant_created",
         "description": "Sent when a new benefit grant is created.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_grant_created_post",
         "requestBody": {
@@ -26013,7 +26013,7 @@
     },
     "benefit_grant.updated": {
       "post": {
-        "summary": "benefit_grant.updated",
+        "summary": "benefit_grant_updated",
         "description": "Sent when a benefit grant is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_grant_updated_post",
         "requestBody": {
@@ -26055,7 +26055,7 @@
     },
     "benefit_grant.cycled": {
       "post": {
-        "summary": "benefit_grant.cycled",
+        "summary": "benefit_grant_cycled",
         "description": "Sent when a benefit grant is cycled,\nmeaning the related subscription has been renewed for another period.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_grant_cycled_post",
         "requestBody": {
@@ -26097,7 +26097,7 @@
     },
     "benefit_grant.revoked": {
       "post": {
-        "summary": "benefit_grant.revoked",
+        "summary": "benefit_grant_revoked",
         "description": "Sent when a benefit grant is revoked.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_grant_revoked_post",
         "requestBody": {

--- a/docs/openapi/2026-10.openapi.json
+++ b/docs/openapi/2026-10.openapi.json
@@ -24417,7 +24417,7 @@
   "webhooks": {
     "checkout.created": {
       "post": {
-        "summary": "checkout.created",
+        "summary": "checkout_created",
         "description": "Sent when a new checkout is created.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcheckout_created_post",
         "requestBody": {
@@ -24459,7 +24459,7 @@
     },
     "checkout.updated": {
       "post": {
-        "summary": "checkout.updated",
+        "summary": "checkout_updated",
         "description": "Sent when a checkout is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcheckout_updated_post",
         "requestBody": {
@@ -24501,7 +24501,7 @@
     },
     "checkout.expired": {
       "post": {
-        "summary": "checkout.expired",
+        "summary": "checkout_expired",
         "description": "Sent when a checkout expires.\n\nThis event fires when a checkout reaches its expiration time without being completed.\nDevelopers can use this to send reminder emails or track checkout abandonment.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcheckout_expired_post",
         "requestBody": {
@@ -24543,7 +24543,7 @@
     },
     "customer.created": {
       "post": {
-        "summary": "customer.created",
+        "summary": "customer_created",
         "description": "Sent when a new customer is created.\n\nA customer can be created:\n\n* After a successful checkout.\n* Programmatically via the API.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcustomer_created_post",
         "requestBody": {
@@ -24585,7 +24585,7 @@
     },
     "customer.updated": {
       "post": {
-        "summary": "customer.updated",
+        "summary": "customer_updated",
         "description": "Sent when a customer is updated.\n\nThis event is fired when the customer details are updated.\n\nIf you want to be notified when a customer subscription or benefit state changes, you should listen to the `customer_state_changed` event.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcustomer_updated_post",
         "requestBody": {
@@ -24627,7 +24627,7 @@
     },
     "customer.deleted": {
       "post": {
-        "summary": "customer.deleted",
+        "summary": "customer_deleted",
         "description": "Sent when a customer is deleted.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcustomer_deleted_post",
         "requestBody": {
@@ -24669,7 +24669,7 @@
     },
     "customer.state_changed": {
       "post": {
-        "summary": "customer.state_changed",
+        "summary": "customer_state_changed",
         "description": "Sent when a customer state has changed.\n\nIt's triggered when:\n\n* Customer is created, updated or deleted.\n* A subscription is created or updated.\n* A benefit is granted or revoked.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointcustomer_state_changed_post",
         "requestBody": {
@@ -24711,7 +24711,7 @@
     },
     "customer_seat.assigned": {
       "post": {
-        "summary": "customer_seat.assigned",
+        "summary": "customer_seat_assigned",
         "description": "Sent when a new customer seat is assigned.\n\nThis event is triggered when a seat is assigned to a customer by the organization.\nThe customer will receive an invitation email to claim the seat.",
         "operationId": "_endpointcustomer_seat_assigned_post",
         "requestBody": {
@@ -24753,7 +24753,7 @@
     },
     "customer_seat.claimed": {
       "post": {
-        "summary": "customer_seat.claimed",
+        "summary": "customer_seat_claimed",
         "description": "Sent when a customer seat is claimed.\n\nThis event is triggered when a customer accepts the seat invitation and claims their access.",
         "operationId": "_endpointcustomer_seat_claimed_post",
         "requestBody": {
@@ -24795,7 +24795,7 @@
     },
     "customer_seat.revoked": {
       "post": {
-        "summary": "customer_seat.revoked",
+        "summary": "customer_seat_revoked",
         "description": "Sent when a customer seat is revoked.\n\nThis event is triggered when access to a seat is revoked, either manually by the organization or automatically when a subscription is canceled.",
         "operationId": "_endpointcustomer_seat_revoked_post",
         "requestBody": {
@@ -24837,7 +24837,7 @@
     },
     "member.created": {
       "post": {
-        "summary": "member.created",
+        "summary": "member_created",
         "description": "Sent when a new member is created.\n\nA member represents an individual within a customer (team).\nThis event is triggered when a member is added to a customer,\neither programmatically via the API or when an owner is automatically\ncreated for a new customer.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointmember_created_post",
         "requestBody": {
@@ -24879,7 +24879,7 @@
     },
     "member.updated": {
       "post": {
-        "summary": "member.updated",
+        "summary": "member_updated",
         "description": "Sent when a member is updated.\n\nThis event is triggered when member details are updated,\nsuch as their name or role within the customer.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointmember_updated_post",
         "requestBody": {
@@ -24921,7 +24921,7 @@
     },
     "member.deleted": {
       "post": {
-        "summary": "member.deleted",
+        "summary": "member_deleted",
         "description": "Sent when a member is deleted.\n\nThis event is triggered when a member is removed from a customer.\nAny active seats assigned to the member will be automatically revoked.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointmember_deleted_post",
         "requestBody": {
@@ -24963,7 +24963,7 @@
     },
     "order.created": {
       "post": {
-        "summary": "order.created",
+        "summary": "order_created",
         "description": "Sent when a new order is created.\n\nA new order is created when:\n\n* A customer purchases a one-time product. In this case, `billing_reason` is set to `purchase`.\n* A customer starts a subscription. In this case, `billing_reason` is set to `subscription_create`.\n* A subscription is renewed. In this case, `billing_reason` is set to `subscription_cycle`.\n* A subscription is upgraded or downgraded with an immediate proration invoice. In this case, `billing_reason` is set to `subscription_update`.\n\n> [!WARNING]\n> The order might not be paid yet, so the `status` field might be `pending`.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointorder_created_post",
         "requestBody": {
@@ -25005,7 +25005,7 @@
     },
     "order.updated": {
       "post": {
-        "summary": "order.updated",
+        "summary": "order_updated",
         "description": "Sent when an order is updated.\n\nAn order is updated when:\n\n* Its status changes, e.g. from `pending` to `paid`.\n* It's refunded, partially or fully.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointorder_updated_post",
         "requestBody": {
@@ -25047,7 +25047,7 @@
     },
     "order.paid": {
       "post": {
-        "summary": "order.paid",
+        "summary": "order_paid",
         "description": "Sent when an order is paid.\n\nWhen you receive this event, the order is fully processed and payment has been received.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointorder_paid_post",
         "requestBody": {
@@ -25089,7 +25089,7 @@
     },
     "order.refunded": {
       "post": {
-        "summary": "order.refunded",
+        "summary": "order_refunded",
         "description": "Sent when an order is fully or partially refunded.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointorder_refunded_post",
         "requestBody": {
@@ -25131,7 +25131,7 @@
     },
     "subscription.created": {
       "post": {
-        "summary": "subscription.created",
+        "summary": "subscription_created",
         "description": "Sent when a new subscription is created.\n\nWhen this event occurs, the subscription `status` might not be `active` yet, as we can still have to wait for the first payment to be processed.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_created_post",
         "requestBody": {
@@ -25173,7 +25173,7 @@
     },
     "subscription.updated": {
       "post": {
-        "summary": "subscription.updated",
+        "summary": "subscription_updated",
         "description": "Sent when a subscription is updated. This event fires for all changes to the subscription, including renewals.\n\nIf you want more specific events, you can listen to `subscription.active`, `subscription.canceled`, `subscription.past_due`, and `subscription.revoked`.\n\nTo listen specifically for renewals, listen to `subscription.cycled`.\n\n**Discord & Slack support:** On cancellation, past due, and revocation. Renewals are skipped.",
         "operationId": "_endpointsubscription_updated_post",
         "requestBody": {
@@ -25215,7 +25215,7 @@
     },
     "subscription.active": {
       "post": {
-        "summary": "subscription.active",
+        "summary": "subscription_active",
         "description": "Sent when a subscription becomes active,\nwhether because it's a new paid subscription or because payment was recovered.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_active_post",
         "requestBody": {
@@ -25257,7 +25257,7 @@
     },
     "subscription.canceled": {
       "post": {
-        "summary": "subscription.canceled",
+        "summary": "subscription_canceled",
         "description": "Sent when a subscription is canceled.\nCustomers might still have access until the end of the current period.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_canceled_post",
         "requestBody": {
@@ -25299,7 +25299,7 @@
     },
     "subscription.uncanceled": {
       "post": {
-        "summary": "subscription.uncanceled",
+        "summary": "subscription_uncanceled",
         "description": "Sent when a customer revokes a pending cancellation.\n\nWhen a customer cancels with \"at period end\", they retain access until the\nsubscription would renew. During this time, they can change their mind and\nundo the cancellation. This event is triggered when they do so.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_uncanceled_post",
         "requestBody": {
@@ -25341,7 +25341,7 @@
     },
     "subscription.cycled": {
       "post": {
-        "summary": "subscription.cycled",
+        "summary": "subscription_cycled",
         "description": "Sent when a subscription enters a new billing period.\n\nThe payload carries the new `current_period_start` and `current_period_end`.\nIt fires when the period rolls over, before the renewal order exists and\nregardless of whether the renewal payment succeeds \u2014 listen to `order.paid`\nif you need the payment.\n\nA trial converting to a paid subscription starts a new period, so it fires\nthere too. Read `status` to tell the two apart.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointsubscription_cycled_post",
         "requestBody": {
@@ -25383,7 +25383,7 @@
     },
     "subscription.revoked": {
       "post": {
-        "summary": "subscription.revoked",
+        "summary": "subscription_revoked",
         "description": "Sent when a subscription is revoked and the user loses access immediately.\nHappens when the subscription is canceled or payment retries are exhausted (status becomes `unpaid`).\n\nFor payment failures that can still be recovered, see `subscription.past_due`.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_revoked_post",
         "requestBody": {
@@ -25425,7 +25425,7 @@
     },
     "subscription.past_due": {
       "post": {
-        "summary": "subscription.past_due",
+        "summary": "subscription_past_due",
         "description": "Sent when a subscription payment fails and the subscription enters `past_due` status.\n\nThis is a recoverable state - the customer can update their payment method to restore the subscription.\nBenefits may be revoked depending on the organization's grace period settings.\n\nIf payment retries are exhausted, a `subscription.revoked` event will be sent.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_past_due_post",
         "requestBody": {
@@ -25467,7 +25467,7 @@
     },
     "subscription.paused": {
       "post": {
-        "summary": "subscription.paused",
+        "summary": "subscription_paused",
         "description": "Sent when a subscription is paused and the customer temporarily loses access.\n\nNo order is created while paused. The subscription resumes either on its\nscheduled resume date or when resumed manually, starting a new billing period.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_paused_post",
         "requestBody": {
@@ -25509,7 +25509,7 @@
     },
     "subscription.resumed": {
       "post": {
-        "summary": "subscription.resumed",
+        "summary": "subscription_resumed",
         "description": "Sent when a paused subscription resumes, restoring the customer's access.\n\nResuming starts a new billing period and charges the customer immediately.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointsubscription_resumed_post",
         "requestBody": {
@@ -25551,7 +25551,7 @@
     },
     "refund.created": {
       "post": {
-        "summary": "refund.created",
+        "summary": "refund_created",
         "description": "Sent when a refund is created regardless of status.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointrefund_created_post",
         "requestBody": {
@@ -25593,7 +25593,7 @@
     },
     "refund.updated": {
       "post": {
-        "summary": "refund.updated",
+        "summary": "refund_updated",
         "description": "Sent when a refund is updated.\n\n**Discord & Slack support:** Full",
         "operationId": "_endpointrefund_updated_post",
         "requestBody": {
@@ -25635,7 +25635,7 @@
     },
     "product.created": {
       "post": {
-        "summary": "product.created",
+        "summary": "product_created",
         "description": "Sent when a new product is created.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointproduct_created_post",
         "requestBody": {
@@ -25677,7 +25677,7 @@
     },
     "product.updated": {
       "post": {
-        "summary": "product.updated",
+        "summary": "product_updated",
         "description": "Sent when a product is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointproduct_updated_post",
         "requestBody": {
@@ -25719,7 +25719,7 @@
     },
     "discount.created": {
       "post": {
-        "summary": "discount.created",
+        "summary": "discount_created",
         "description": "Sent when a new discount is created.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointdiscount_created_post",
         "requestBody": {
@@ -25761,7 +25761,7 @@
     },
     "discount.updated": {
       "post": {
-        "summary": "discount.updated",
+        "summary": "discount_updated",
         "description": "Sent when a discount is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointdiscount_updated_post",
         "requestBody": {
@@ -25803,7 +25803,7 @@
     },
     "discount.deleted": {
       "post": {
-        "summary": "discount.deleted",
+        "summary": "discount_deleted",
         "description": "Sent when a discount is deleted.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointdiscount_deleted_post",
         "requestBody": {
@@ -25845,7 +25845,7 @@
     },
     "organization.updated": {
       "post": {
-        "summary": "organization.updated",
+        "summary": "organization_updated",
         "description": "Sent when a organization is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointorganization_updated_post",
         "requestBody": {
@@ -25887,7 +25887,7 @@
     },
     "benefit.created": {
       "post": {
-        "summary": "benefit.created",
+        "summary": "benefit_created",
         "description": "Sent when a new benefit is created.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_created_post",
         "requestBody": {
@@ -25929,7 +25929,7 @@
     },
     "benefit.updated": {
       "post": {
-        "summary": "benefit.updated",
+        "summary": "benefit_updated",
         "description": "Sent when a benefit is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_updated_post",
         "requestBody": {
@@ -25971,7 +25971,7 @@
     },
     "benefit_grant.created": {
       "post": {
-        "summary": "benefit_grant.created",
+        "summary": "benefit_grant_created",
         "description": "Sent when a new benefit grant is created.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_grant_created_post",
         "requestBody": {
@@ -26013,7 +26013,7 @@
     },
     "benefit_grant.updated": {
       "post": {
-        "summary": "benefit_grant.updated",
+        "summary": "benefit_grant_updated",
         "description": "Sent when a benefit grant is updated.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_grant_updated_post",
         "requestBody": {
@@ -26055,7 +26055,7 @@
     },
     "benefit_grant.cycled": {
       "post": {
-        "summary": "benefit_grant.cycled",
+        "summary": "benefit_grant_cycled",
         "description": "Sent when a benefit grant is cycled,\nmeaning the related subscription has been renewed for another period.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_grant_cycled_post",
         "requestBody": {
@@ -26097,7 +26097,7 @@
     },
     "benefit_grant.revoked": {
       "post": {
-        "summary": "benefit_grant.revoked",
+        "summary": "benefit_grant_revoked",
         "description": "Sent when a benefit grant is revoked.\n\n**Discord & Slack support:** Basic",
         "operationId": "_endpointbenefit_grant_revoked_post",
         "requestBody": {

--- a/server/polar/webhook/webhooks.py
+++ b/server/polar/webhook/webhooks.py
@@ -1612,7 +1612,7 @@ def get_webhook_routes() -> Sequence[WebhookAPIRoute]:
                 event_type,
                 endpoint,
                 methods=["POST"],
-                summary=event_type,
+                summary=event_type.name,
                 description=inspect.getdoc(webhook_schema),
                 openapi_extra={
                     "x-mint": {"metadata": {"sidebarTitle": event_type.value}}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use snake_case slugs for webhook API reference pages to fix Mintlify URL generation and keep links stable. Previously Mintlify slugified dotted summaries (e.g., benefit_grant.created) into benefit_grantcreated; now summaries use snake_case (benefit_grant_created) and redirects cover old paths.

- OpenAPI/server: set webhook operation summaries to snake_case via the enum name to produce correct Mintlify slugs.
- Docs: add redirects from old slugs to new ones for `2026-04` and `2026-10`.
- Client: regenerate the TypeScript client to reflect the summary rename; no API surface changes.
- Behavior: webhook keys and payload `type` remain dotted; sidebar titles unchanged. No consumer action required; existing links continue via redirects.

<sup>Written for commit 056d106bd383f35113bac5c35f352c812da7c512. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

