### PR TITLE
tf/redis: Enable slow logs

### DIFF
--- a/terraform/modules/aws_redis/main.tf
+++ b/terraform/modules/aws_redis/main.tf
@@ -22,6 +22,12 @@ resource "aws_elasticache_parameter_group" "this" {
   }
 }
 
+resource "aws_cloudwatch_log_group" "slow_log" {
+  name              = "/aws/elasticache/${var.name}/slow-log"
+  retention_in_days = var.log_retention_days
+  tags              = var.tags
+}
+
 resource "aws_elasticache_replication_group" "this" {
   replication_group_id       = var.name
   description                = "${var.name} cache"
@@ -37,4 +43,11 @@ resource "aws_elasticache_replication_group" "this" {
   subnet_group_name          = aws_elasticache_subnet_group.this.name
   security_group_ids         = [aws_security_group.this.id]
   tags                       = var.tags
+
+  log_delivery_configuration {
+    destination      = aws_cloudwatch_log_group.slow_log.name
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "slow-log"
+  }
 }

--- a/terraform/modules/aws_redis/variables.tf
+++ b/terraform/modules/aws_redis/variables.tf
@@ -49,6 +49,12 @@ variable "port" {
   default     = 6379
 }
 
+variable "log_retention_days" {
+  description = "CloudWatch retention for the slow log group."
+  type        = number
+  default     = 30
+}
+
 variable "tags" {
   description = "Tags applied to all created resources."
   type        = map(string)


### PR DESCRIPTION
Could be good to have in the future

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Redis ElastiCache slow logs and delivers them to CloudWatch Logs to improve observability. Previously no slow logs were emitted; now a dedicated log group receives JSON slow logs with a 30-day default retention.

- Creates CloudWatch log group "/aws/elasticache/${var.name}/slow-log" with tags; adjust retention via new variable "log_retention_days" (default 30).
- Adds log delivery to the replication group for "slow-log" in JSON; applies without resource replacement.

<sup>Written for commit c87ab795bcc3e32e7370c8adf2669b20b56289da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

