### PR TITLE
retry: Ensure that Retry exceptions don't trigger an error in logfire

### DIFF
--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -188,8 +188,15 @@ async def run_task(
     )
     token = CurrentMessage._MESSAGE.set(message)
     try:
+        # Retries are expected: re-raise outside the span so Logfire doesn't record an error
+        retry: Retry | None = None
         with _task_span(actor_name, message, correlation_id, source_correlation_id):
-            await fn(*args, **kwargs)
+            try:
+                await fn(*args, **kwargs)
+            except Retry as e:
+                retry = e
+        if retry is not None:
+            raise retry
     finally:
         CurrentMessage._MESSAGE.reset(token)
         structlog.contextvars.unbind_contextvars(

--- a/server/tests/worker/test_runner.py
+++ b/server/tests/worker/test_runner.py
@@ -1,0 +1,59 @@
+import pytest
+from dramatiq.errors import Retry
+from logfire.testing import CaptureLogfire
+from opentelemetry.sdk.trace import ReadableSpan
+from pytest_mock import MockerFixture
+
+import polar.tasks  # noqa: F401  (registers actors with the broker)
+from polar.worker._runner import run_task
+
+
+def _task_spans(capfire: CaptureLogfire) -> list[ReadableSpan]:
+    return [
+        span
+        for span in capfire.exporter.exported_spans
+        if span.name == "TASK {actor}"
+        and span.attributes is not None
+        and span.attributes.get("logfire.span_type") == "span"
+    ]
+
+
+@pytest.mark.asyncio
+class TestRunTask:
+    async def test_retry_not_recorded_as_span_error(
+        self, capfire: CaptureLogfire, mocker: MockerFixture
+    ) -> None:
+        async def raising_task() -> None:
+            raise Retry(delay=1000)
+
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"dummy": raising_task},
+        )
+
+        with pytest.raises(Retry):
+            await run_task("dummy")
+
+        spans = _task_spans(capfire)
+        assert len(spans) == 1
+        assert not spans[0].events
+        assert spans[0].attributes is not None
+        assert "logfire.level_num" not in spans[0].attributes
+
+    async def test_exception_recorded_as_span_error(
+        self, capfire: CaptureLogfire, mocker: MockerFixture
+    ) -> None:
+        async def raising_task() -> None:
+            raise ValueError("boom")
+
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"dummy": raising_task},
+        )
+
+        with pytest.raises(ValueError, match="boom"):
+            await run_task("dummy")
+
+        spans = _task_spans(capfire)
+        assert len(spans) == 1
+        assert any(event.name == "exception" for event in spans[0].events)


### PR DESCRIPTION
When raising a Retry we were flagging this as an exception and error in logfire when it happened in the lambda workers.

This already doesn't happen in the regular workers, and should not happen here either.

This aims to avoid that from happening.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

