### PR TITLE
tf: Upgrade providers

### DIFF
--- a/terraform/global/terraform.tf
+++ b/terraform/global/terraform.tf
@@ -9,17 +9,17 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.92"
+      version = "~> 6.61"
     }
 
     render = {
       source  = "render-oss/render"
-      version = "1.8.0"
+      version = "1.9.1"
     }
 
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.71.0"
+      version = "0.80.0"
     }
   }
 

--- a/terraform/identity/terraform.tf
+++ b/terraform/identity/terraform.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.92"
+      version = "~> 6.61"
     }
   }
 

--- a/terraform/organization/terraform.tf
+++ b/terraform/organization/terraform.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.92"
+      version = "~> 6.61"
     }
   }
 

--- a/terraform/production/terraform.tf
+++ b/terraform/production/terraform.tf
@@ -9,12 +9,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.92"
+      version = "~> 6.61"
     }
 
     render = {
       source  = "render-oss/render"
-      version = "1.8.0"
+      version = "1.9.1"
     }
 
     cloudflare = {

--- a/terraform/sandbox/terraform.tf
+++ b/terraform/sandbox/terraform.tf
@@ -9,12 +9,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.92"
+      version = "~> 6.61"
     }
 
     render = {
       source  = "render-oss/render"
-      version = "1.8.0"
+      version = "1.9.1"
     }
 
     cloudflare = {
@@ -24,7 +24,7 @@ terraform {
 
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.71.0"
+      version = "0.80.0"
     }
 
     vercel = {

--- a/terraform/security/terraform.tf
+++ b/terraform/security/terraform.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.92"
+      version = "~> 6.61"
     }
   }
 

--- a/terraform/test/terraform.tf
+++ b/terraform/test/terraform.tf
@@ -9,12 +9,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.92"
+      version = "~> 6.61"
     }
 
     render = {
       source  = "render-oss/render"
-      version = "1.8.0"
+      version = "1.9.1"
     }
 
     cloudflare = {
@@ -24,12 +24,12 @@ terraform {
 
     tfe = {
       source  = "hashicorp/tfe"
-      version = "0.71.0"
+      version = "0.80.0"
     }
 
     vercel = {
       source  = "vercel/vercel"
-      version = "~> 5.2"
+      version = "~> 5.3"
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade Terraform provider constraints across all stacks to keep current with upstream and reduce drift. `hashicorp/aws` moves from ~>5.92 to ~>6.61, `render-oss/render` 1.8.0→1.9.1, `hashicorp/tfe` 0.71.0→0.80.0, and `vercel/vercel` ~>5.2→~>5.3; AWS v6 may change defaults and produce plan diffs or replacements.

**Review and rollout**
- Confirm only `required_providers` blocks changed; no module or resource logic changed.
- Run terraform init -upgrade in each directory (global, identity, organization, production, sandbox, security, test) and commit updated `.terraform.lock.hcl` if present.
- Plan and apply in order (test/sandbox → production). Watch for replacements or drift from `aws` v6 and `tfe` 0.80.

<sup>Written for commit 90252646e6c144299a2dee13ea23508bc3f5bb27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

