### PR TITLE
redis: Move to new subnets for sandbox

### DIFF
--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -22,7 +22,7 @@ module "redis" {
 
   name       = "polar-sandbox-worker"
   vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.private_subnet_ids
+  subnet_ids = module.vpc.secondary_private_subnet_ids
   node_type  = "cache.t4g.small"
   node_count = 2
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moves the sandbox Redis cluster from the primary private subnets to the secondary private subnets to align with the new sandbox VPC layout. Previously used `module.vpc.private_subnet_ids`; now uses `module.vpc.secondary_private_subnet_ids`. This may trigger a subnet group update and brief failover during apply.

- Review: Run a plan and confirm only the ElastiCache subnet group/replication group is modified, not replaced; if replacement is shown, schedule a maintenance window.
- Rollout: Ensure the secondary private subnets have NAT egress and routing, and that existing security groups allow worker-to-Redis traffic. No application changes required.

<sup>Written for commit 753ef2b353a0879629df619ac01cab5c74afb2cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

