### PR TITLE
server/subscription: allow past due subscriptions to cycle

### DIFF
--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -199,6 +199,14 @@ class OrderRepository(
             statement = statement.where(Order.status == status)
         return await self.get_all(statement)
 
+    async def count_dunning_by_subscription(self, subscription_id: UUID) -> int:
+        statement = self.get_base_statement().where(
+            Order.subscription_id == subscription_id,
+            Order.status == OrderStatus.pending,
+            Order.next_payment_attempt_at.is_not(None),
+        )
+        return await self.count(statement)
+
     async def get_by_stripe_invoice_id(
         self, stripe_invoice_id: str, *, options: Options = ()
     ) -> Order | None:

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -199,13 +199,17 @@ class OrderRepository(
             statement = statement.where(Order.status == status)
         return await self.get_all(statement)
 
-    async def count_dunning_by_subscription(self, subscription_id: UUID) -> int:
+    async def get_all_dunning_by_subscription(
+        self, subscription_id: UUID, *, for_update: bool = False
+    ) -> Sequence[Order]:
         statement = self.get_base_statement().where(
             Order.subscription_id == subscription_id,
             Order.status == OrderStatus.pending,
             Order.next_payment_attempt_at.is_not(None),
         )
-        return await self.count(statement)
+        if for_update:
+            statement = statement.with_for_update(of=self.model)
+        return await self.get_all(statement)
 
     async def get_by_stripe_invoice_id(
         self, stripe_invoice_id: str, *, options: Options = ()

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -199,17 +199,13 @@ class OrderRepository(
             statement = statement.where(Order.status == status)
         return await self.get_all(statement)
 
-    async def get_all_dunning_by_subscription(
-        self, subscription_id: UUID, *, for_update: bool = False
-    ) -> Sequence[Order]:
+    async def count_dunning_by_subscription(self, subscription_id: UUID) -> int:
         statement = self.get_base_statement().where(
             Order.subscription_id == subscription_id,
             Order.status == OrderStatus.pending,
             Order.next_payment_attempt_at.is_not(None),
         )
-        if for_update:
-            statement = statement.with_for_update(of=self.model)
-        return await self.get_all(statement)
+        return await self.count(statement)
 
     async def get_by_stripe_invoice_id(
         self, stripe_invoice_id: str, *, options: Options = ()

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -2129,11 +2129,7 @@ class OrderService:
         order = await repository.update(order, update_dict=update_dict, flush=True)
 
         # If this was a subscription retry success, reactivate the subscription
-        if (
-            previous_status == OrderStatus.pending
-            and order.subscription is not None
-            and order.subscription.status == SubscriptionStatus.past_due
-        ):
+        if previous_status == OrderStatus.pending and order.subscription is not None:
             subscription_repository = SubscriptionRepository.from_session(session)
             locked_subscription = await subscription_repository.get_by_id(
                 order.subscription.id, for_update=True
@@ -2141,7 +2137,10 @@ class OrderService:
             assert locked_subscription is not None
             # Make sure there are no other dunning orders for this subscription, otherwise we might reactivate it too early
             if (
-                await repository.count_dunning_by_subscription(locked_subscription.id)
+                locked_subscription.status == SubscriptionStatus.past_due
+                and await repository.count_dunning_by_subscription(
+                    locked_subscription.id
+                )
                 == 0
             ):
                 order.subscription = await subscription_service.mark_active(

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -2132,11 +2132,13 @@ class OrderService:
             previous_status == OrderStatus.pending
             and order.subscription is not None
             and order.subscription.status == SubscriptionStatus.past_due
-            # Make sure there are no other dunning orders for this subscription, otherwise we might reactivate it too early
-            and await repository.count_dunning_by_subscription(order.subscription.id)
-            == 0
         ):
-            await subscription_service.mark_active(session, order.subscription)
+            # Make sure there are no other dunning orders for this subscription, otherwise we might reactivate it too early
+            dunning_orders = await repository.get_all_dunning_by_subscription(
+                order.subscription.id, for_update=True
+            )
+            if len(dunning_orders) == 0:
+                await subscription_service.mark_active(session, order.subscription)
 
         if update_dict:
             await self._on_order_updated(session, order, previous_status)

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -110,6 +110,7 @@ from polar.product.price_set import (
 )
 from polar.product.repository import ProductRepository
 from polar.receipt.service import receipt as receipt_service
+from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from polar.tax.calculation import (
@@ -2133,12 +2134,19 @@ class OrderService:
             and order.subscription is not None
             and order.subscription.status == SubscriptionStatus.past_due
         ):
-            # Make sure there are no other dunning orders for this subscription, otherwise we might reactivate it too early
-            dunning_orders = await repository.get_all_dunning_by_subscription(
+            subscription_repository = SubscriptionRepository.from_session(session)
+            locked_subscription = await subscription_repository.get_by_id(
                 order.subscription.id, for_update=True
             )
-            if len(dunning_orders) == 0:
-                await subscription_service.mark_active(session, order.subscription)
+            assert locked_subscription is not None
+            # Make sure there are no other dunning orders for this subscription, otherwise we might reactivate it too early
+            if (
+                await repository.count_dunning_by_subscription(locked_subscription.id)
+                == 0
+            ):
+                order.subscription = await subscription_service.mark_active(
+                    session, locked_subscription
+                )
 
         if update_dict:
             await self._on_order_updated(session, order, previous_status)

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -2125,13 +2125,16 @@ class OrderService:
             update_dict = {**update_dict, **await self._record_tax_transaction(order)}
 
         repository = OrderRepository.from_session(session)
-        order = await repository.update(order, update_dict=update_dict)
+        order = await repository.update(order, update_dict=update_dict, flush=True)
 
         # If this was a subscription retry success, reactivate the subscription
         if (
             previous_status == OrderStatus.pending
             and order.subscription is not None
             and order.subscription.status == SubscriptionStatus.past_due
+            # Make sure there are no other dunning orders for this subscription, otherwise we might reactivate it too early
+            and await repository.count_dunning_by_subscription(order.subscription.id)
+            == 0
         ):
             await subscription_service.mark_active(session, order.subscription)
 

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -189,7 +189,7 @@ class SubscriptionJobStore(_SubscriptionScheduleJobStore):
                 ~Organization.is_deleted,
                 Organization.can_renew_subscriptions,
                 Subscription.scheduler_locked_at.is_(None),
-                Subscription.active,
+                Subscription.billable,
                 Subscription.current_period_end.is_not(None),
             )
             .order_by(_next_run_time().asc())

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -168,6 +168,13 @@ class MissingCheckoutCustomer(SubscriptionError):
         super().__init__(message)
 
 
+class NotBillableSubscription(SubscriptionError):
+    def __init__(self, subscription: Subscription) -> None:
+        self.subscription = subscription
+        message = f"Subscription {subscription.id} is not billable."
+        super().__init__(message, 403)
+
+
 class InactiveSubscription(SubscriptionError):
     def __init__(self, subscription: Subscription) -> None:
         self.subscription = subscription
@@ -951,8 +958,8 @@ class SubscriptionService:
         subscription: Subscription,
         update_cycle_dates: bool = True,
     ) -> Subscription:
-        if not subscription.active:
-            raise InactiveSubscription(subscription)
+        if not subscription.billable:
+            raise NotBillableSubscription(subscription)
 
         # Defensive: capability may have flipped off between scheduler
         # pick-up and task execution.

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -71,7 +71,7 @@ async def subscription_cycle(subscription_id: uuid.UUID, force: bool = False) ->
             and subscription.current_meter_period_end <= now
         )
 
-        if not subscription.active or not (billing_due or meter_due):
+        if not subscription.billable or not (billing_due or meter_due):
             log.info(
                 "Subscription has already been cycled",
                 subscription_id=subscription_id,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -3654,6 +3654,68 @@ class TestHandlePayment:
         )
         assert updated_order.tax_processor == TaxProcessor.numeral
 
+    async def test_past_due_subscription(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+        )
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subscription=subscription,
+            status=OrderStatus.pending,
+        )
+
+        result = await order_service.handle_payment(session, order, None)
+
+        assert result is order
+        assert result.status == OrderStatus.paid
+        assert subscription.status == SubscriptionStatus.active
+
+    async def test_past_due_subscription_other_dunning(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+        )
+        _past_order_dunning = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subscription=subscription,
+            status=OrderStatus.pending,
+            next_payment_attempt_at=utc_now() + timedelta(days=1),
+        )
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subscription=subscription,
+            status=OrderStatus.pending,
+        )
+
+        result = await order_service.handle_payment(session, order, None)
+
+        assert result is order
+        assert result.status == OrderStatus.paid
+        assert subscription.status == SubscriptionStatus.past_due
+
 
 @pytest.mark.asyncio
 class TestHandlePaymentFailure:

--- a/server/tests/subscription/test_scheduler.py
+++ b/server/tests/subscription/test_scheduler.py
@@ -1,12 +1,72 @@
+from datetime import timedelta
+
 import pytest
 from pytest_mock import MockerFixture
 
+from polar.kit.db.postgres import AsyncSession
 from polar.kit.utils import utc_now
+from polar.models import Customer, Product, Subscription
+from polar.models.subscription import SubscriptionStatus
 from polar.subscription.scheduler import (
     SubscriptionJobStore,
     SubscriptionResumeJobStore,
+    _next_run_time,
     _SubscriptionScheduleJobStore,
 )
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_subscription
+
+
+@pytest.mark.asyncio
+async def test_cycle_scheduler_only_selects_due_billable_subscriptions(
+    session: AsyncSession,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    now = utc_now()
+    past_period_end = now - timedelta(days=1)
+    future_period_end = now + timedelta(days=1)
+
+    active_due = await create_subscription(
+        save_fixture,
+        product=product,
+        customer=customer,
+        status=SubscriptionStatus.active,
+        current_period_start=past_period_end - timedelta(days=30),
+        current_period_end=past_period_end,
+    )
+    past_due = await create_subscription(
+        save_fixture,
+        product=product,
+        customer=customer,
+        status=SubscriptionStatus.past_due,
+        current_period_start=past_period_end - timedelta(days=30),
+        current_period_end=past_period_end,
+    )
+    await create_subscription(
+        save_fixture,
+        product=product,
+        customer=customer,
+        status=SubscriptionStatus.active,
+        current_period_end=future_period_end,
+    )
+    await create_subscription(
+        save_fixture,
+        product=product,
+        customer=customer,
+        status=SubscriptionStatus.canceled,
+        current_period_start=past_period_end - timedelta(days=30),
+        current_period_end=past_period_end,
+    )
+
+    statement = (
+        SubscriptionJobStore.scheduling_statement()
+        .where(_next_run_time() <= now)
+        .with_only_columns(Subscription.id)
+    )
+    result = await session.execute(statement)
+    assert set(result.scalars()) == {active_due.id, past_due.id}
 
 
 @pytest.mark.asyncio

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -88,11 +88,11 @@ from polar.subscription.service import (
     BelowMinimumSeats,
     CannotPauseSubscription,
     CannotReinstateSubscription,
-    InactiveSubscription,
     MissingCheckoutCustomer,
     NoScheduledPause,
     NotARecurringProduct,
     NotASeatBasedSubscription,
+    NotBillableSubscription,
     NotPausedSubscription,
     SeatsAlreadyAssigned,
     SubscriptionMeterCycleLag,
@@ -1288,7 +1288,7 @@ class TestCycle:
             session, updated_subscription, reset_at=cycle_at
         )
 
-    async def test_inactive(
+    async def test_not_billable(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -1299,7 +1299,7 @@ class TestCycle:
             save_fixture, product=product, customer=customer
         )
 
-        with pytest.raises(InactiveSubscription):
+        with pytest.raises(NotBillableSubscription):
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -1491,6 +1491,38 @@ class TestCycle:
         assert second_month_billing_entry.discount == discount
         assert third_month_billing_entry.discount == discount
         assert fourth_month_billing_entry.discount is None
+
+    async def test_past_due_subscription(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+            status=SubscriptionStatus.past_due,
+        )
+
+        previous_current_period_end = subscription.current_period_end
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
+
+        assert updated_subscription.status == SubscriptionStatus.past_due
+        assert updated_subscription.ended_at is None
+        assert updated_subscription.current_period_start == previous_current_period_end
+        assert updated_subscription.current_period_end is not None
+        assert previous_current_period_end is not None
+        assert updated_subscription.current_period_end > previous_current_period_end
+        assert updated_subscription.scheduler_locked_at is None
 
     @freeze_time("2024-01-15")
     async def test_nth_month_cycle(


### PR DESCRIPTION

Before, we were excluding past due subscriptions from cycling. The rationale was we wanted to avoid piling up orders that may never be recoverable. If the last order was recovered, the subscription was back to active and the cycle could resume.

However, it caused issues with shorter cycles, like weekly. Since our dunning process runs over 21 days, we could recover a subscription after a few cycles have passed. In that case, once the subscription was recovered, the scheduler would quickly catch up and create a bunch of orders for the past cycles, in a few seconds. This was confusing for the customer.

The solution we implement here is to simply allow past due subscriptions to cycle. This way, even if an order is dunning, we naturally continue the subscription cycling and each order can go into their own dunning process. This is a more natural flow and avoids the confusion of having a bunch of orders created at once.

In this commit, we take care of checking the number of dunning orders when a payment is recovered, so we only reactivate the subscription is all orders have been paid; otherwise, it stays past due.

Context: https://polar-sh.slack.com/archives/C0942KS0BD2/p1787214245009769


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

