### PR TITLE
Add support for KRW (South Korean Won)

### DIFF
--- a/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodEmbed.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodEmbed.tsx
@@ -28,6 +28,7 @@ interface Props {
   locale?: AcceptedLocale
   serverURL: string
   customerBillingDetails: CustomerBillingDetails
+  setupCurrency: string
   redirectStatus?: string
   setupIntentId?: string
 }
@@ -42,6 +43,7 @@ export const PaymentMethodEmbed = ({
   locale = DEFAULT_LOCALE,
   serverURL,
   customerBillingDetails,
+  setupCurrency,
   redirectStatus,
   setupIntentId,
 }: Props) => {
@@ -128,6 +130,7 @@ export const PaymentMethodEmbed = ({
       setAsDefault={setAsDefault}
       locale={locale}
       customerBillingDetails={customerBillingDetails}
+      setupCurrency={setupCurrency}
       onProcessingStart={handleProcessingStart}
       onPaymentMethodAdded={handleSuccess}
       onProcessingError={handleProcessingError}

--- a/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodForm.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/PaymentMethodForm.tsx
@@ -49,6 +49,7 @@ interface Props {
   setAsDefault: boolean
   locale?: AcceptedLocale
   customerBillingDetails: CustomerBillingDetails
+  setupCurrency: string
   onProcessingStart?: () => void
   onProcessingError?: () => void
   onPaymentMethodAdded?: (
@@ -78,6 +79,7 @@ export const PaymentMethodForm = ({
   setAsDefault,
   locale = DEFAULT_LOCALE,
   customerBillingDetails,
+  setupCurrency,
   onProcessingStart,
   onProcessingError,
   onPaymentMethodAdded,
@@ -260,7 +262,7 @@ export const PaymentMethodForm = ({
         mode: 'setup',
         paymentMethodCreation: 'manual',
         setupFutureUsage: 'off_session',
-        currency: 'usd',
+        currency: setupCurrency,
         appearance: themePreset.stripe,
       }}
     >

--- a/clients/apps/web/src/app/(embed)/embed/payment-method/page.tsx
+++ b/clients/apps/web/src/app/(embed)/embed/payment-method/page.tsx
@@ -110,6 +110,19 @@ export default async function Page(props: {
     )
   }
 
+  let setupCurrency = 'usd'
+  try {
+    const subscriptions = await unwrap(
+      api.GET('/v1/customer-portal/subscriptions/', {
+        params: { query: { active: true, limit: 1 } },
+        cache: 'no-store',
+      }),
+    )
+    setupCurrency = subscriptions.items[0]?.currency ?? 'usd'
+  } catch {
+    // A failed request only narrows the offered payment methods to the USD set
+  }
+
   return (
     <PaymentMethodEmbed
       sessionToken={sessionToken}
@@ -125,6 +138,7 @@ export default async function Page(props: {
         email: customer.email ?? null,
         address: customer.billing_address ?? null,
       }}
+      setupCurrency={setupCurrency}
       redirectStatus={redirect_status}
       setupIntentId={polar_setup_intent}
     />

--- a/clients/apps/web/src/components/CustomerPortal/OrderPaymentRetryModal.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/OrderPaymentRetryModal.tsx
@@ -38,7 +38,8 @@ export const OrderPaymentRetryModal = ({
 
   const { data: paymentMethodsData } = useCustomerPaymentMethods(api)
   const cardPaymentMethods = (paymentMethodsData?.items || []).filter(
-    (pm): pm is schemas['PaymentMethodCard'] => pm.type === 'card',
+    (pm): pm is schemas['PaymentMethodCard'] | schemas['PaymentMethodKrCard'] =>
+      pm.type === 'card' || (pm.type === 'kr_card' && order.currency === 'krw'),
   )
 
   const stripePromise = useMemo(() => loadPolarStripe(), [])

--- a/clients/apps/web/src/components/CustomerPortal/PaymentMethod.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/PaymentMethod.tsx
@@ -7,15 +7,13 @@ import type { Client, operations, schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import { Status } from '@polar-sh/orbit'
 import { X } from 'lucide-react'
-import { PaymentMethodDisplay } from '../PaymentMethodDisplay'
+import {
+  PaymentMethodDisplay,
+  getPaymentMethodCardInfo,
+} from '../PaymentMethodDisplay'
 
 type PaymentMethodType =
   operations['customer_portal:customers:list_payment_methods']['responses']['200']['content']['application/json']['items'][number]
-
-const isCardPaymentMethod = (
-  paymentMethod: PaymentMethodType,
-): paymentMethod is schemas['PaymentMethodCard'] =>
-  paymentMethod.type === 'card'
 
 const PaymentMethod = ({
   api,
@@ -76,11 +74,7 @@ const PaymentMethod = ({
     <div className="flex items-center justify-between gap-2">
       <PaymentMethodDisplay
         type={paymentMethod.type}
-        card={
-          isCardPaymentMethod(paymentMethod)
-            ? paymentMethod.method_metadata
-            : null
-        }
+        card={getPaymentMethodCardInfo(paymentMethod)}
       />
       <div className="flex flex-row items-center gap-x-4">
         {isDefault ? (

--- a/clients/apps/web/src/components/CustomerPortal/SavedCardsSelector.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/SavedCardsSelector.tsx
@@ -1,11 +1,17 @@
 'use client'
 
 import type { schemas } from '@polar-sh/client'
-import { Button } from '@polar-sh/orbit'
+import { Button, Text } from '@polar-sh/orbit'
 import { useState } from 'react'
 import CreditCardBrandIcon from '../CreditCardBrandIcon'
+import {
+  getPaymentMethodCardInfo,
+  getPaymentMethodTypeLabel,
+} from '../PaymentMethodDisplay'
 
-type PaymentMethodType = schemas['PaymentMethodCard']
+type PaymentMethodType =
+  | schemas['PaymentMethodCard']
+  | schemas['PaymentMethodKrCard']
 
 interface SavedCardsSelectorProps {
   paymentMethods: PaymentMethodType[]
@@ -53,8 +59,7 @@ export const SavedCardsSelector = ({
         <h4 className="font-medium">Saved Payment Methods</h4>
         <div className="space-y-2">
           {paymentMethods.map((paymentMethod) => {
-            const { brand, last4, exp_year, exp_month } =
-              paymentMethod.method_metadata
+            const card = getPaymentMethodCardInfo(paymentMethod)
             const isSelected = selectedMethodId === paymentMethod.id
 
             return (
@@ -71,16 +76,22 @@ export const SavedCardsSelector = ({
                 <div className="flex items-center gap-3">
                   <CreditCardBrandIcon
                     width="2.5em"
-                    brand={brand}
+                    brand={card?.brand ?? 'unknown'}
                     className="dark:border-polar-700 shrink-0 rounded-sm border border-gray-200 p-1"
                   />
                   <div className="grow">
                     <div className="font-medium capitalize">
-                      {brand} •••• {last4}
+                      {card?.brand ??
+                        getPaymentMethodTypeLabel(paymentMethod.type)}
+                      {card?.last4 ? ` •••• ${card.last4}` : ''}
                     </div>
-                    <div className="dark:text-polar-500 text-sm text-gray-500">
-                      Expires {exp_month.toString().padStart(2, '0')}/{exp_year}
-                    </div>
+                    {card?.exp_month !== undefined &&
+                      card?.exp_year !== undefined && (
+                        <Text color="muted" variant="caption">
+                          Expires {card.exp_month.toString().padStart(2, '0')}/
+                          {card.exp_year}
+                        </Text>
+                      )}
                   </div>
                   {isSelected && (
                     <div className="shrink-0">

--- a/clients/apps/web/src/components/PaymentMethod/PaymentMethod.tsx
+++ b/clients/apps/web/src/components/PaymentMethod/PaymentMethod.tsx
@@ -1,30 +1,28 @@
-import { isCardPayment } from '@/utils/payment'
+import { isCardPayment, isKrCardPayment } from '@/utils/payment'
 import { schemas } from '@polar-sh/client'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import CreditCardBrandIcon from '../CreditCardBrandIcon'
-
-const CardPaymentMethod = ({
-  payment,
-}: {
-  payment: schemas['CardPayment']
-}) => {
-  return (
-    <div className="flex flex-row items-center gap-1">
-      <CreditCardBrandIcon
-        height="1.5em"
-        brand={payment.method_metadata.brand}
-      />
-      <span className="capitalize">
-        {`•••• ${payment.method_metadata.last4}`}
-      </span>
-    </div>
-  )
-}
+import { getPaymentMethodTypeLabel } from '../PaymentMethodDisplay'
 
 const PaymentMethod = ({ payment }: { payment: schemas['Payment'] }) => {
-  if (isCardPayment(payment)) {
-    return <CardPaymentMethod payment={payment} />
+  const metadata =
+    isCardPayment(payment) || isKrCardPayment(payment)
+      ? payment.method_metadata
+      : null
+
+  if (metadata?.last4) {
+    return (
+      <Box alignItems="center" columnGap="xs">
+        <CreditCardBrandIcon
+          height="1.5em"
+          brand={metadata.brand ?? 'unknown'}
+        />
+        <Text>{`•••• ${metadata.last4}`}</Text>
+      </Box>
+    )
   }
-  return <span className="capitalize">{payment.method}</span>
+  return <Text>{getPaymentMethodTypeLabel(payment.method)}</Text>
 }
 
 export default PaymentMethod

--- a/clients/apps/web/src/components/PaymentMethodDisplay.tsx
+++ b/clients/apps/web/src/components/PaymentMethodDisplay.tsx
@@ -1,13 +1,39 @@
+import type { schemas } from '@polar-sh/client'
 import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { Wallet } from 'lucide-react'
 import CreditCardBrandIcon from './CreditCardBrandIcon'
 
-interface PaymentMethodCardInfo {
-  brand: string
-  last4: string
-  exp_month: number
-  exp_year: number
+export interface PaymentMethodCardInfo {
+  brand: string | null
+  last4: string | null
+  exp_month?: number
+  exp_year?: number
+}
+
+type CardLikeMetadata = Partial<
+  schemas['PaymentMethodCardMetadata'] & schemas['PaymentMethodKrCardMetadata']
+>
+
+export const getPaymentMethodCardInfo = (paymentMethod: {
+  type: string
+  method_metadata?: unknown
+}): PaymentMethodCardInfo | null => {
+  if (paymentMethod.type !== 'card' && paymentMethod.type !== 'kr_card') {
+    return null
+  }
+  const metadata = (paymentMethod.method_metadata ?? {}) as CardLikeMetadata
+  const brand = metadata.brand ?? null
+  const last4 = metadata.last4 ?? null
+  if (!brand && !last4) {
+    return null
+  }
+  return {
+    brand,
+    last4,
+    exp_month: metadata.exp_month,
+    exp_year: metadata.exp_year,
+  }
 }
 
 interface PaymentMethodDisplayProps {
@@ -18,6 +44,11 @@ interface PaymentMethodDisplayProps {
 const PAYMENT_METHOD_TYPE_LABELS: Record<string, string> = {
   link: 'Link',
   amazon_pay: 'Amazon Pay',
+  kr_card: 'Korean card',
+  kakao_pay: 'Kakao Pay',
+  naver_pay: 'Naver Pay',
+  samsung_pay: 'Samsung Pay',
+  payco: 'PAYCO',
 }
 
 const capitalize = (value: string): string =>
@@ -31,18 +62,23 @@ export const PaymentMethodDisplay = ({
   card,
 }: PaymentMethodDisplayProps) => {
   if (card) {
+    const label = card.brand
+      ? capitalize(card.brand)
+      : getPaymentMethodTypeLabel(type)
     return (
       <Box alignItems="center" columnGap="m" flexGrow={1}>
         <CreditCardBrandIcon
           width="3.5em"
-          brand={card.brand}
+          brand={card.brand ?? 'unknown'}
           className="dark:border-polar-700 rounded-lg border border-gray-200"
         />
         <Box flexDirection="column">
-          <Text>{`${capitalize(card.brand)} •••• ${card.last4}`}</Text>
-          <Text color="muted" variant="caption">
-            Expires {card.exp_month}/{card.exp_year}
-          </Text>
+          <Text>{`${label}${card.last4 ? ` •••• ${card.last4}` : ''}`}</Text>
+          {card.exp_month !== undefined && card.exp_year !== undefined && (
+            <Text color="muted" variant="caption">
+              Expires {card.exp_month}/{card.exp_year}
+            </Text>
+          )}
         </Box>
       </Box>
     )

--- a/clients/apps/web/src/components/Settings/Billing/BillingPaymentMethods.tsx
+++ b/clients/apps/web/src/components/Settings/Billing/BillingPaymentMethods.tsx
@@ -6,7 +6,6 @@ import {
   useOrganizationPaymentMethods,
   useSetDefaultOrganizationPaymentMethod,
   type OrganizationPaymentMethod,
-  type OrganizationPaymentMethodCard,
 } from '@/hooks/queries/billing'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import { Text } from '@polar-sh/orbit'
@@ -14,14 +13,12 @@ import { Box } from '@polar-sh/orbit/Box'
 import { Button } from '@polar-sh/orbit'
 import { Status } from '@polar-sh/orbit'
 import { X } from 'lucide-react'
-import { PaymentMethodDisplay } from '../../PaymentMethodDisplay'
+import {
+  PaymentMethodDisplay,
+  getPaymentMethodCardInfo,
+} from '../../PaymentMethodDisplay'
 import { LoadingBox } from '../../Shared/LoadingBox'
 import { SectionDescription } from '../Section'
-
-const isCardPaymentMethod = (
-  paymentMethod: OrganizationPaymentMethod,
-): paymentMethod is OrganizationPaymentMethodCard =>
-  paymentMethod.type === 'card'
 
 const PaymentMethodRow = ({
   organizationId,
@@ -80,11 +77,7 @@ const PaymentMethodRow = ({
     <Box alignItems="center" justifyContent="between" columnGap="m">
       <PaymentMethodDisplay
         type={paymentMethod.type}
-        card={
-          isCardPaymentMethod(paymentMethod)
-            ? paymentMethod.method_metadata
-            : null
-        }
+        card={getPaymentMethodCardInfo(paymentMethod)}
       />
       <Box alignItems="center" columnGap="m">
         {paymentMethod.default ? (

--- a/clients/apps/web/src/utils/payment.ts
+++ b/clients/apps/web/src/utils/payment.ts
@@ -22,3 +22,7 @@ export const PaymentStatusDisplayColor: Record<
 export const isCardPayment = (
   payment: schemas['Payment'],
 ): payment is schemas['CardPayment'] => payment.method === 'card'
+
+export const isKrCardPayment = (
+  payment: schemas['Payment'],
+): payment is schemas['KrCardPayment'] => payment.method === 'kr_card'

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -45,6 +45,15 @@ import PolarLogo from './PolarLogo'
 import { CheckoutBanner } from './CheckoutBanner'
 
 const WALLET_PAYMENT_METHODS = ['apple_pay', 'google_pay', 'link']
+const DEFAULT_PAYMENT_METHOD_ORDER = ['apple_pay', 'google_pay', 'card']
+const KRW_PAYMENT_METHOD_ORDER = [
+  'kr_card',
+  'kakao_pay',
+  'naver_pay',
+  'samsung_pay',
+  'payco',
+  ...DEFAULT_PAYMENT_METHOD_ORDER,
+]
 
 type ContactField = 'customer_email' | 'customer_name'
 
@@ -893,7 +902,10 @@ const StripeCheckoutForm = (props: CheckoutFormProps) => {
             {checkout.is_payment_form_required && (
               <PaymentElement
                 options={{
-                  paymentMethodOrder: ['apple_pay', 'google_pay', 'card'],
+                  paymentMethodOrder:
+                    checkout.currency === 'krw'
+                      ? KRW_PAYMENT_METHOD_ORDER
+                      : DEFAULT_PAYMENT_METHOD_ORDER,
                   layout: 'tabs',
                   fields: {
                     billingDetails: {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -12147,7 +12147,7 @@ export interface components {
       amount: number
       /**
        * Currency
-       * @description The payment currency. Currently, only `usd` is supported.
+       * @description The payment currency
        * @example usd
        */
       currency: string
@@ -17787,6 +17787,7 @@ export interface components {
     }
     CustomerPaymentMethod:
       | components['schemas']['PaymentMethodCard']
+      | components['schemas']['PaymentMethodKrCard']
       | components['schemas']['PaymentMethodGeneric']
     /** CustomerPaymentMethodCard */
     CustomerPaymentMethodCard: {
@@ -17892,6 +17893,44 @@ export interface components {
       customer_id: string
       /** Type */
       type: string
+      /**
+       * Is Default
+       * @description Whether this payment method is the customer's default payment method.
+       * @example false
+       */
+      is_default: boolean
+    }
+    /** CustomerPaymentMethodKrCard */
+    CustomerPaymentMethodKrCard: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      processor: components['schemas']['PaymentProcessor']
+      /**
+       * Customer Id
+       * Format: uuid4
+       */
+      customer_id: string
+      /**
+       * Type
+       * @constant
+       */
+      type: 'kr_card'
+      method_metadata: components['schemas']['PaymentMethodKrCardMetadata']
       /**
        * Is Default
        * @description Whether this payment method is the customer's default payment method.
@@ -22074,7 +22113,7 @@ export interface components {
       amount: number
       /**
        * Currency
-       * @description The payment currency. Currently, only `usd` is supported.
+       * @description The payment currency
        * @example usd
        */
       currency: string
@@ -22357,6 +22396,122 @@ export interface components {
       error: 'InvalidSourceCredentials'
       /** Detail */
       detail: string
+    }
+    /**
+     * KrCardPayment
+     * @description Schema of a payment with a South Korean card payment method.
+     */
+    KrCardPayment: {
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * @description The payment processor.
+       * @example stripe
+       */
+      processor: components['schemas']['PaymentProcessor']
+      /**
+       * @description The payment status.
+       * @example succeeded
+       */
+      status: components['schemas']['PaymentStatus']
+      /**
+       * Amount
+       * @description The payment amount in cents.
+       * @example 1000
+       */
+      amount: number
+      /**
+       * Currency
+       * @description The payment currency
+       * @example usd
+       */
+      currency: string
+      /**
+       * Method
+       * @description The payment method used.
+       * @example kr_card
+       * @constant
+       */
+      method: 'kr_card'
+      /**
+       * @description What initiated this payment attempt, e.g. initial purchase, subscription renewal, or an automated dunning retry.
+       * @example subscription_cycle
+       */
+      trigger: components['schemas']['PaymentTrigger'] | null
+      /**
+       * Decline Reason
+       * @description Error code, if the payment was declined.
+       * @example insufficient_funds
+       */
+      decline_reason: string | null
+      /**
+       * Decline Message
+       * @description Human-readable error message, if the payment was declined.
+       * @example Your card has insufficient funds.
+       */
+      decline_message: string | null
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization that owns the payment.
+       * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
+       */
+      organization_id: string
+      /**
+       * Checkout Id
+       * @description The ID of the checkout session associated with this payment.
+       * @example e4b478fa-cd25-4253-9f1f-8a41e6370ede
+       */
+      checkout_id: string | null
+      /**
+       * Order Id
+       * @description The ID of the order associated with this payment.
+       * @example e4b478fa-cd25-4253-9f1f-8a41e6370ede
+       */
+      order_id: string | null
+      /**
+       * Processor Metadata
+       * @description Additional metadata from the payment processor for internal use.
+       */
+      processor_metadata?: {
+        [key: string]: unknown
+      }
+      /** @description Additional metadata for the South Korean card payment method. */
+      method_metadata: components['schemas']['KrCardPaymentMetadata']
+    }
+    /**
+     * KrCardPaymentMetadata
+     * @description Additional metadata for a South Korean card payment method.
+     */
+    KrCardPaymentMetadata: {
+      /**
+       * Brand
+       * @description The local South Korean card brand used for the payment.
+       * @example kookmin
+       * @example shinhan
+       */
+      brand: string | null
+      /**
+       * Last4
+       * @description The last 4 digits of the card number.
+       * @example 4242
+       */
+      last4: string | null
     }
     /** LLMMetadata */
     LLMMetadata: {
@@ -29821,6 +29976,7 @@ export interface components {
     }
     Payment:
       | components['schemas']['CardPayment']
+      | components['schemas']['KrCardPayment']
       | components['schemas']['GenericPayment']
     /** PaymentActionRequired */
     PaymentActionRequired: {
@@ -29879,6 +30035,7 @@ export interface components {
     }
     PaymentMethod:
       | components['schemas']['CustomerPaymentMethodCard']
+      | components['schemas']['CustomerPaymentMethodKrCard']
       | components['schemas']['CustomerPaymentMethodGeneric']
     /** PaymentMethodCard */
     PaymentMethodCard: {
@@ -29963,6 +30120,45 @@ export interface components {
       error: 'PaymentMethodInUseByActiveSubscription'
       /** Detail */
       detail: string
+    }
+    /** PaymentMethodKrCard */
+    PaymentMethodKrCard: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      processor: components['schemas']['PaymentProcessor']
+      /**
+       * Customer Id
+       * Format: uuid4
+       */
+      customer_id: string
+      /**
+       * Type
+       * @constant
+       */
+      type: 'kr_card'
+      method_metadata: components['schemas']['PaymentMethodKrCardMetadata']
+    }
+    /** PaymentMethodKrCardMetadata */
+    PaymentMethodKrCardMetadata: {
+      /** Brand */
+      brand: string | null
+      /** Last4 */
+      last4: string | null
     }
     /** PaymentMethodRequired */
     PaymentMethodRequired: {

--- a/server/polar/customer/schemas/customer.py
+++ b/server/polar/customer/schemas/customer.py
@@ -34,7 +34,11 @@ from polar.kit.schemas import (
 from polar.member import MemberOwnerCreate
 from polar.models.customer import CustomerType
 from polar.organization.schemas import OrganizationID
-from polar.payment_method.schemas import PaymentMethodCard, PaymentMethodGeneric
+from polar.payment_method.schemas import (
+    PaymentMethodCard,
+    PaymentMethodGeneric,
+    PaymentMethodKrCard,
+)
 from polar.tax.tax_id import TaxID
 
 CustomerID = Annotated[UUID4, Path(description="The customer ID.")]
@@ -305,12 +309,18 @@ class CustomerPaymentMethodCard(PaymentMethodCard):
     is_default: bool = Field(description=_is_default_description, examples=[True])
 
 
+class CustomerPaymentMethodKrCard(PaymentMethodKrCard):
+    is_default: bool = Field(description=_is_default_description, examples=[False])
+
+
 class CustomerPaymentMethodGeneric(PaymentMethodGeneric):
     is_default: bool = Field(description=_is_default_description, examples=[False])
 
 
 CustomerPaymentMethod = Annotated[
-    CustomerPaymentMethodCard | CustomerPaymentMethodGeneric,
+    CustomerPaymentMethodCard
+    | CustomerPaymentMethodKrCard
+    | CustomerPaymentMethodGeneric,
     SetSchemaReference("PaymentMethod"),
     MergeJSONSchema({"title": "PaymentMethod"}),
     ClassName("PaymentMethod"),

--- a/server/polar/customer_portal/schemas/customer.py
+++ b/server/polar/customer_portal/schemas/customer.py
@@ -14,7 +14,11 @@ from polar.kit.schemas import (
     TimestampedSchema,
 )
 from polar.models.customer import CustomerType
-from polar.payment_method.schemas import PaymentMethodCard, PaymentMethodGeneric
+from polar.payment_method.schemas import (
+    PaymentMethodCard,
+    PaymentMethodGeneric,
+    PaymentMethodKrCard,
+)
 from polar.tax.tax_id import TaxID
 
 
@@ -44,7 +48,7 @@ class CustomerPortalCustomerUpdate(Schema):
 
 
 CustomerPaymentMethod = Annotated[
-    PaymentMethodCard | PaymentMethodGeneric,
+    PaymentMethodCard | PaymentMethodKrCard | PaymentMethodGeneric,
     SetSchemaReference("CustomerPaymentMethod"),
     MergeJSONSchema({"title": "CustomerPaymentMethod"}),
     ClassName("CustomerPaymentMethod"),

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -34,6 +34,7 @@ class CanonicalCollectionMethod(StrEnum):
 
 class CanonicalPaymentMethodType(StrEnum):
     card = "card"
+    kr_card = "kr_card"
     us_bank_account = "us_bank_account"
     sepa_debit = "sepa_debit"
     bacs_debit = "bacs_debit"
@@ -43,6 +44,7 @@ class CanonicalPaymentMethodType(StrEnum):
     @property
     def requires_reentry(self) -> bool:
         return self in {
+            CanonicalPaymentMethodType.kr_card,
             CanonicalPaymentMethodType.bacs_debit,
             CanonicalPaymentMethodType.link,
             CanonicalPaymentMethodType.other,

--- a/server/polar/payment/schemas.py
+++ b/server/polar/payment/schemas.py
@@ -27,7 +27,7 @@ class PaymentBase(IDSchema, TimestampedSchema):
     )
     amount: int = Field(description="The payment amount in cents.", examples=[1000])
     currency: str = Field(
-        description="The payment currency. Currently, only `usd` is supported.",
+        description="The payment currency",
         examples=["usd"],
     )
     method: str = Field(description="The payment method used.", examples=["card"])
@@ -91,8 +91,31 @@ class CardPayment(PaymentBase):
     )
 
 
+class KrCardPaymentMetadata(Schema):
+    """Additional metadata for a South Korean card payment method."""
+
+    brand: str | None = Field(
+        description="The local South Korean card brand used for the payment.",
+        examples=["kookmin", "shinhan"],
+    )
+    last4: str | None = Field(
+        description="The last 4 digits of the card number.", examples=["4242"]
+    )
+
+
+class KrCardPayment(PaymentBase):
+    """Schema of a payment with a South Korean card payment method."""
+
+    method: Literal["kr_card"] = Field(
+        description="The payment method used.", examples=["kr_card"]
+    )
+    method_metadata: KrCardPaymentMetadata = Field(
+        description="Additional metadata for the South Korean card payment method."
+    )
+
+
 Payment = Annotated[
-    CardPayment | GenericPayment,
+    CardPayment | KrCardPayment | GenericPayment,
     SetSchemaReference("Payment"),
     ClassName("Payment"),
 ]

--- a/server/polar/payment_method/schemas.py
+++ b/server/polar/payment_method/schemas.py
@@ -30,5 +30,15 @@ class PaymentMethodCard(PaymentMethodBase):
     method_metadata: PaymentMethodCardMetadata
 
 
-PaymentMethod = PaymentMethodCard | PaymentMethodGeneric
+class PaymentMethodKrCardMetadata(Schema):
+    brand: str | None
+    last4: str | None
+
+
+class PaymentMethodKrCard(PaymentMethodBase):
+    type: Literal["kr_card"]
+    method_metadata: PaymentMethodKrCardMetadata
+
+
+PaymentMethod = PaymentMethodCard | PaymentMethodKrCard | PaymentMethodGeneric
 PaymentMethodTypeAdapter: TypeAdapter[PaymentMethod] = TypeAdapter(PaymentMethod)

--- a/server/polar/receipt/generator.py
+++ b/server/polar/receipt/generator.py
@@ -42,10 +42,10 @@ class ReceiptPayment(BaseModel):
         """Format the payment method as 'Visa — 4242' style."""
         brand = self.method_metadata.get("brand")
         last4 = self.method_metadata.get("last4")
-        if self.method == "card" and brand and last4:
+        if self.method in ("card", "kr_card") and brand and last4:
             return f"{brand.title()} — {last4}"
         if last4:
-            return f"{self.method.title()} — {last4}"
+            return f"{self.method.replace('_', ' ').title()} — {last4}"
         return self.method.replace("_", " ").title()
 
 

--- a/server/polar/transaction/service/platform_fee.py
+++ b/server/polar/transaction/service/platform_fee.py
@@ -23,6 +23,9 @@ from .base import BaseTransactionService, BaseTransactionServiceError
 log: Logger = structlog.get_logger()
 
 
+INTERNATIONAL_CARD_PAYMENT_METHOD_TYPES: frozenset[str] = frozenset({"kr_card"})
+
+
 class PlatformFeeTransactionError(BaseTransactionServiceError): ...
 
 
@@ -288,10 +291,13 @@ class PlatformFeeTransactionService(BaseTransactionService):
         self, payment_transaction: Transaction
     ) -> bool:
         """
-        Check if the payment transaction is an international payment.
+        Check if the payment transaction is an international payment, i.e.
+        paid with a card issued outside the US.
 
-        Currently, we only check if the payment was made using Stripe
-        and the card is not from the US.
+        For Stripe card and Link payments, we check the card's country. Card
+        methods that only exist outside the US, like South Korean cards, are
+        always international. Non-card methods are never international: the
+        fee only applies to cards.
         """
         if payment_transaction.processor != Processor.stripe:
             return False
@@ -316,7 +322,7 @@ class PlatformFeeTransactionService(BaseTransactionService):
         ):
             return payment_method_details.link.country != "US"
 
-        return False
+        return payment_method_details.type in INTERNATIONAL_CARD_PAYMENT_METHOD_TYPES
 
     async def _get_last_payout(
         self, session: AsyncSession, account: Account

--- a/server/tests/payment_method/test_schemas.py
+++ b/server/tests/payment_method/test_schemas.py
@@ -1,0 +1,61 @@
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from polar.payment_method.schemas import (
+    PaymentMethodCard,
+    PaymentMethodGeneric,
+    PaymentMethodKrCard,
+    PaymentMethodTypeAdapter,
+)
+
+
+def build_payment_method_dict(
+    type: str, method_metadata: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "id": uuid4(),
+        "created_at": datetime(2026, 1, 1, tzinfo=UTC),
+        "modified_at": None,
+        "processor": "stripe",
+        "customer_id": uuid4(),
+        "type": type,
+        "method_metadata": method_metadata,
+    }
+
+
+class TestPaymentMethodTypeAdapter:
+    def test_card(self) -> None:
+        payment_method = PaymentMethodTypeAdapter.validate_python(
+            build_payment_method_dict(
+                "card",
+                {
+                    "brand": "visa",
+                    "last4": "4242",
+                    "exp_month": 12,
+                    "exp_year": 2030,
+                },
+            )
+        )
+        assert isinstance(payment_method, PaymentMethodCard)
+
+    @pytest.mark.parametrize(
+        "method_metadata",
+        [
+            {"brand": "kookmin", "last4": "1234"},
+            {"brand": None, "last4": None},
+        ],
+    )
+    def test_kr_card(self, method_metadata: dict[str, Any]) -> None:
+        payment_method = PaymentMethodTypeAdapter.validate_python(
+            build_payment_method_dict("kr_card", method_metadata)
+        )
+        assert isinstance(payment_method, PaymentMethodKrCard)
+
+    def test_unknown_type_falls_back_to_generic(self) -> None:
+        payment_method = PaymentMethodTypeAdapter.validate_python(
+            build_payment_method_dict("paypal", {})
+        )
+        assert isinstance(payment_method, PaymentMethodGeneric)

--- a/server/tests/payment_method/test_service.py
+++ b/server/tests/payment_method/test_service.py
@@ -53,6 +53,26 @@ class TestUpsertFromStripe:
         assert payment_method.method_metadata == {"brand": "visa", "last4": "4242"}
         assert payment_method.customer == customer
 
+    async def test_create_new_kr_card_payment_method(
+        self,
+        session: AsyncSession,
+        customer: Customer,
+    ) -> None:
+        stripe_payment_method = build_stripe_payment_method(
+            type="kr_card",
+            details={"brand": "kookmin", "last4": "1234"},
+        )
+
+        payment_method = await payment_method_service.upsert_from_stripe(
+            session, customer, stripe_payment_method
+        )
+
+        assert payment_method.processor == PaymentProcessor.stripe
+        assert payment_method.processor_id == stripe_payment_method.id
+        assert payment_method.type == "kr_card"
+        assert payment_method.method_metadata == {"brand": "kookmin", "last4": "1234"}
+        assert payment_method.customer == customer
+
     async def test_update_existing_payment_method(
         self,
         session: AsyncSession,

--- a/server/tests/receipt/test_generator.py
+++ b/server/tests/receipt/test_generator.py
@@ -188,6 +188,26 @@ class TestReceiptPayment:
         )
         assert payment.display_method == "Card"
 
+    def test_kr_card_with_brand_and_last4(self) -> None:
+        payment = ReceiptPayment(
+            date=utc_now(),
+            method="kr_card",
+            method_metadata={"brand": "kookmin", "last4": "1234"},
+            amount=10000,
+            currency="krw",
+        )
+        assert payment.display_method == "Kookmin — 1234"
+
+    def test_kr_card_without_brand(self) -> None:
+        payment = ReceiptPayment(
+            date=utc_now(),
+            method="kr_card",
+            method_metadata={"brand": None, "last4": "1234"},
+            amount=10000,
+            currency="krw",
+        )
+        assert payment.display_method == "Kr Card — 1234"
+
     def test_non_card_method(self) -> None:
         payment = ReceiptPayment(
             date=utc_now(),

--- a/server/tests/transaction/service/test_platform_fee.py
+++ b/server/tests/transaction/service/test_platform_fee.py
@@ -314,6 +314,59 @@ class TestCreateFeesReversalBalances:
         )
         assert reversal_incoming.incurred_by_transaction == outgoing
 
+    @pytest.mark.parametrize("payment_method_type", ["kr_card"])
+    async def test_international_card_payment_method(
+        self,
+        payment_method_type: str,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account_processor_fees: Account,
+        transaction_order_subscription: Order,
+    ) -> None:
+        stripe_service_mock = MagicMock(spec=StripeService)
+        mocker.patch(
+            "polar.transaction.service.platform_fee.stripe_service",
+            new=stripe_service_mock,
+        )
+        stripe_service_mock.get_charge.return_value = stripe_lib.Charge.construct_from(
+            {
+                "id": "STRIPE_CHARGE_ID",
+                "payment_method_details": {
+                    "type": payment_method_type,
+                    payment_method_type: {},
+                },
+            },
+            None,
+        )
+
+        balance_transactions = await create_balance_transactions(
+            save_fixture,
+            account=account_processor_fees,
+            order=transaction_order_subscription,
+            payment_charge_id="STRIPE_CHARGE_ID",
+        )
+
+        balance_transactions = await load_balance_transactions(
+            session, balance_transactions
+        )
+
+        fees_reversal_balances = (
+            await platform_fee_transaction_service.create_fees_reversal_balances(
+                session, balance_transactions=balance_transactions
+            )
+        )
+
+        assert len(fees_reversal_balances) == 2
+
+        reversal_outgoing, reversal_incoming = fees_reversal_balances[1]
+        assert (
+            reversal_outgoing.platform_fee_type == PlatformFeeType.international_payment
+        )
+        assert (
+            reversal_incoming.platform_fee_type == PlatformFeeType.international_payment
+        )
+
     async def test_link_payment(
         self,
         mocker: MockerFixture,


### PR DESCRIPTION
This PR will enable Stripe's `Korean cards` payment method.

<img width="1351" height="552" alt="Monosnap Payment methods – New business sandbox – Stripe  Test  2026-08-19 17-35-45" src="https://github.com/user-attachments/assets/043f5f11-bb76-49a8-9e6a-caa8ac3cca22" />

Fixes: https://github.com/polarsource/feedback/issues/292

## Demo

https://github.com/user-attachments/assets/bfd6ccdc-ec0d-45be-837f-a07b957c0b4e



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

