### PR TITLE
lambda: adhere to task time limit

### DIFF
--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -37,6 +37,8 @@ from ._sqlalchemy import SQLAlchemyMiddleware
 
 log: Logger = structlog.get_logger()
 
+TASK_TIME_LIMIT_DEFAULT_MS = 60_000
+
 
 class OperationalErrorMiddleware(dramatiq.Middleware):
     """Middleware to detect and handle operational errors during message processing."""
@@ -271,7 +273,7 @@ def get_broker(*, database: bool = True) -> dramatiq.Broker:
             min_backoff=settings.WORKER_MIN_BACKOFF_MILLISECONDS,
         ),
         middleware.AgeLimit(),
-        middleware.TimeLimit(time_limit=60_000),
+        middleware.TimeLimit(time_limit=TASK_TIME_LIMIT_DEFAULT_MS),
         middleware.CurrentMessage(),
     ]
 
@@ -286,6 +288,7 @@ def get_broker(*, database: bool = True) -> dramatiq.Broker:
 
 
 __all__ = [
+    "TASK_TIME_LIMIT_DEFAULT_MS",
     "get_broker",
     "scheduler_middleware",
 ]

--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -182,7 +182,7 @@ async def run_task(
     time_limit_ms = actor_obj.options.get("time_limit", TASK_TIME_LIMIT_DEFAULT_MS)
     timeout_seconds = time_limit_ms / 1000
     if remaining_time_seconds is not None:
-        timeout_seconds = min(timeout_seconds, remaining_time_seconds)
+        timeout_seconds = max(0.0, min(timeout_seconds, remaining_time_seconds))
     message: dramatiq.Message[Any] = dramatiq.Message(
         queue_name=actor_obj.queue_name,
         actor_name=actor_name,

--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import enum
 import functools
@@ -19,6 +20,7 @@ from polar.config import settings
 from polar.logging import CorrelationID, Logger
 
 from . import _sqs
+from ._broker import TASK_TIME_LIMIT_DEFAULT_MS
 from ._httpx import _close_client, setup_httpx
 from ._redis import _close_redis, setup_redis
 from ._sqlalchemy import dispose_sqlalchemy_engine, setup_sqlalchemy
@@ -38,6 +40,15 @@ class UnknownActor(Exception):
     def __init__(self, actor_name: str) -> None:
         self.actor_name = actor_name
         super().__init__(f"No registered actor named {actor_name!r}")
+
+
+class TaskTimeoutError(Exception):
+    def __init__(self, actor_name: str, timeout_seconds: float) -> None:
+        self.actor_name = actor_name
+        self.timeout_seconds = timeout_seconds
+        super().__init__(
+            f"Task {actor_name!r} timed out after {timeout_seconds:g} seconds"
+        )
 
 
 def _unwrap_to_coroutine(fn: Any, actor_name: str) -> Any:
@@ -159,6 +170,7 @@ async def run_task(
     *,
     receive_count: int = 1,
     source_correlation_id: str | None = None,
+    remaining_time_seconds: float | None = None,
 ) -> None:
     registry = build_registry()
     fn = registry.get(actor_name)
@@ -167,6 +179,10 @@ async def run_task(
 
     kwargs = kwargs or {}
     actor_obj = dramatiq.get_broker().get_actor(actor_name)
+    time_limit_ms = actor_obj.options.get("time_limit", TASK_TIME_LIMIT_DEFAULT_MS)
+    timeout_seconds = time_limit_ms / 1000
+    if remaining_time_seconds is not None:
+        timeout_seconds = min(timeout_seconds, remaining_time_seconds)
     message: dramatiq.Message[Any] = dramatiq.Message(
         queue_name=actor_obj.queue_name,
         actor_name=actor_name,
@@ -192,7 +208,13 @@ async def run_task(
         retry: Retry | None = None
         with _task_span(actor_name, message, correlation_id, source_correlation_id):
             try:
-                await fn(*args, **kwargs)
+                timeout_cm = asyncio.timeout(timeout_seconds)
+                async with timeout_cm:
+                    await fn(*args, **kwargs)
+            except TimeoutError:
+                if timeout_cm.expired():
+                    raise TaskTimeoutError(actor_name, timeout_seconds) from None
+                raise
             except Retry as e:
                 retry = e
         if retry is not None:
@@ -220,6 +242,7 @@ async def shutdown() -> None:
 
 __all__ = [
     "RetryAction",
+    "TaskTimeoutError",
     "UnknownActor",
     "bootstrap",
     "build_registry",

--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -40,6 +40,8 @@ bootstrap(pool_pre_ping=True)
 consumer_sqs_client = get_consumer_sqs_client()
 consumer_scheduler_client = get_consumer_scheduler_client()
 
+_REMAINING_TIME_MARGIN_SECONDS = 5
+
 
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     batch_item_failures: list[dict[str, str]] = []
@@ -57,6 +59,10 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                         kwargs,
                         receive_count=_effective_receive_count(record, attempt),
                         source_correlation_id=correlation_id,
+                        remaining_time_seconds=(
+                            context.get_remaining_time_in_millis() / 1000
+                            - _REMAINING_TIME_MARGIN_SECONDS
+                        ),
                     )
                 )
             except Retry as exc:

--- a/server/tests/worker/test_runner.py
+++ b/server/tests/worker/test_runner.py
@@ -1,3 +1,6 @@
+import asyncio
+
+import dramatiq
 import pytest
 from dramatiq.errors import Retry
 from logfire.testing import CaptureLogfire
@@ -5,7 +8,7 @@ from opentelemetry.sdk.trace import ReadableSpan
 from pytest_mock import MockerFixture
 
 import polar.tasks  # noqa: F401  (registers actors with the broker)
-from polar.worker._runner import run_task
+from polar.worker._runner import TaskTimeoutError, run_task
 
 
 def _task_spans(capfire: CaptureLogfire) -> list[ReadableSpan]:
@@ -57,3 +60,57 @@ class TestRunTask:
         spans = _task_spans(capfire)
         assert len(spans) == 1
         assert any(event.name == "exception" for event in spans[0].events)
+
+    async def test_time_limit_exceeded(self, mocker: MockerFixture) -> None:
+        async def slow_task() -> None:
+            await asyncio.sleep(10)
+
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"dummy": slow_task},
+        )
+        mocker.patch.dict(
+            dramatiq.get_broker().get_actor("dummy").options, {"time_limit": 100}
+        )
+
+        with pytest.raises(TaskTimeoutError, match="dummy"):
+            await run_task("dummy")
+
+    async def test_remaining_time_bounds_time_limit(
+        self, mocker: MockerFixture
+    ) -> None:
+        async def slow_task() -> None:
+            await asyncio.sleep(10)
+
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"dummy": slow_task},
+        )
+
+        with pytest.raises(TaskTimeoutError):
+            await run_task("dummy", remaining_time_seconds=0.1)
+
+    async def test_completes_within_time_limit(self, mocker: MockerFixture) -> None:
+        async def fast_task() -> None:
+            await asyncio.sleep(0)
+
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"dummy": fast_task},
+        )
+
+        await run_task("dummy", remaining_time_seconds=30)
+
+    async def test_task_raised_timeout_error_not_converted(
+        self, mocker: MockerFixture
+    ) -> None:
+        async def raising_task() -> None:
+            raise TimeoutError("upstream timed out")
+
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"dummy": raising_task},
+        )
+
+        with pytest.raises(TimeoutError, match="upstream timed out"):
+            await run_task("dummy")


### PR DESCRIPTION
We want to adhere to the task time limit set per actor for lambda workers as well.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

