### PR TITLE
lambda: Ensure that we can read the enqueue time

### DIFF
--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -4,6 +4,7 @@ import enum
 import functools
 import inspect
 import math
+import time
 from collections.abc import Iterator, Sequence
 from typing import Any
 
@@ -171,6 +172,7 @@ async def run_task(
     receive_count: int = 1,
     source_correlation_id: str | None = None,
     remaining_time_seconds: float | None = None,
+    message_timestamp: int | None = None,
 ) -> None:
     registry = build_registry()
     fn = registry.get(actor_name)
@@ -194,6 +196,9 @@ async def run_task(
                 "max_retries", settings.WORKER_MAX_RETRIES
             ),
         },
+        message_timestamp=message_timestamp
+        if message_timestamp is not None
+        else int(time.time() * 1000),
     )
 
     correlation_id = CorrelationID.set()

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import json
+import time
 from collections import defaultdict
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
@@ -139,7 +140,10 @@ def build_envelope(
     kwargs: dict[str, Any],
     correlation_id: str | None,
     attempt: int = 1,
+    message_timestamp: int | None = None,
 ) -> str:
+    if message_timestamp is None:
+        message_timestamp = int(time.time() * 1000)
     return json.dumps(
         {
             "actor": actor,
@@ -147,6 +151,7 @@ def build_envelope(
             "kwargs": kwargs,
             "correlation_id": correlation_id,
             "attempt": attempt,
+            "message_timestamp": message_timestamp,
         },
         separators=(",", ":"),
         default=json_obj_serializer,
@@ -155,7 +160,7 @@ def build_envelope(
 
 def parse_envelope(
     body: str,
-) -> tuple[str, list[Any], dict[str, Any], str | None, int]:
+) -> tuple[str, list[Any], dict[str, Any], str | None, int, int | None]:
     data = json.loads(body)
     return (
         data["actor"],
@@ -163,6 +168,7 @@ def parse_envelope(
         data.get("kwargs", {}),
         data.get("correlation_id"),
         data.get("attempt", 1),
+        data.get("message_timestamp"),
     )
 
 

--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -49,8 +49,8 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         for record in event.get("Records", []):
             message_id = record["messageId"]
             try:
-                actor, args, kwargs, correlation_id, attempt = parse_envelope(
-                    record["body"]
+                actor, args, kwargs, correlation_id, attempt, message_timestamp = (
+                    parse_envelope(record["body"])
                 )
                 _loop.run_until_complete(
                     run_task(
@@ -63,6 +63,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                             context.get_remaining_time_in_millis() / 1000
                             - _REMAINING_TIME_MARGIN_SECONDS
                         ),
+                        message_timestamp=message_timestamp,
                     )
                 )
             except Retry as exc:
@@ -92,7 +93,9 @@ def _effective_receive_count(record: dict[str, Any], attempt: int) -> int:
 def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> bool:
     """Schedule the failed message's next retry. Returns True if SQS should redeliver it."""
     try:
-        actor, args, kwargs, correlation_id, attempt = parse_envelope(record["body"])
+        actor, args, kwargs, correlation_id, attempt, message_timestamp = (
+            parse_envelope(record["body"])
+        )
         queue_arn = record["eventSourceARN"]
         receive_count = _effective_receive_count(record, attempt)
         scheduler_role_arn = settings.WORKER_SQS_SCHEDULER_ROLE_ARN
@@ -120,7 +123,12 @@ def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> bo
                 queue_arn,
                 scheduler_role_arn,
                 build_envelope(
-                    actor, tuple(args), kwargs, correlation_id, receive_count + 1
+                    actor,
+                    tuple(args),
+                    kwargs,
+                    correlation_id,
+                    receive_count + 1,
+                    message_timestamp,
                 ),
                 delay_seconds,
                 build_retry_schedule_name(queue_arn, record["messageId"], attempt),

--- a/server/polar/worker/sqs.py
+++ b/server/polar/worker/sqs.py
@@ -47,9 +47,14 @@ async def _poll_loop(actors: list[str], max_iterations: int) -> None:
                     MessageSystemAttributeNames=["ApproximateReceiveCount"],
                 )
                 for message in response.get("Messages", []):
-                    actor, args, kwargs, correlation_id, attempt = parse_envelope(
-                        message["Body"]
-                    )
+                    (
+                        actor,
+                        args,
+                        kwargs,
+                        correlation_id,
+                        attempt,
+                        message_timestamp,
+                    ) = parse_envelope(message["Body"])
                     sqs_receive_count = int(
                         message.get("Attributes", {}).get(
                             "ApproximateReceiveCount", "1"
@@ -63,6 +68,7 @@ async def _poll_loop(actors: list[str], max_iterations: int) -> None:
                             kwargs,
                             receive_count=receive_count,
                             source_correlation_id=correlation_id,
+                            message_timestamp=message_timestamp,
                         )
                     except Exception:
                         log.exception("polar.worker.sqs_poll_failed", actor=actor)

--- a/server/tests/worker/test_backoff.py
+++ b/server/tests/worker/test_backoff.py
@@ -1,5 +1,6 @@
 import json
 import math
+import time
 
 import pytest
 from botocore.exceptions import ClientError
@@ -91,25 +92,39 @@ class TestSetMessageVisibility:
 
 class TestEnvelopeAttempt:
     def test_round_trips(self) -> None:
-        body = _sqs.build_envelope("dummy", (1, "x"), {"k": 2}, "corr", 7)
-        actor, args, kwargs, correlation_id, attempt = _sqs.parse_envelope(body)
+        body = _sqs.build_envelope(
+            "dummy", (1, "x"), {"k": 2}, "corr", 7, 1234567890000
+        )
+        actor, args, kwargs, correlation_id, attempt, message_timestamp = (
+            _sqs.parse_envelope(body)
+        )
         assert actor == "dummy"
         assert args == [1, "x"]
         assert kwargs == {"k": 2}
         assert correlation_id == "corr"
         assert attempt == 7
+        assert message_timestamp == 1234567890000
 
     def test_defaults_to_one(self) -> None:
         body = _sqs.build_envelope("dummy", (), {}, None)
-        *_, attempt = _sqs.parse_envelope(body)
+        *_, attempt, _ = _sqs.parse_envelope(body)
         assert attempt == 1
+
+    def test_stamps_current_timestamp_by_default(self) -> None:
+        before = int(time.time() * 1000)
+        body = _sqs.build_envelope("dummy", (), {}, None)
+        after = int(time.time() * 1000)
+        *_, message_timestamp = _sqs.parse_envelope(body)
+        assert message_timestamp is not None
+        assert before <= message_timestamp <= after
 
     def test_legacy_body_without_attempt(self) -> None:
         body = json.dumps(
             {"actor": "dummy", "args": [], "kwargs": {}, "correlation_id": None}
         )
-        *_, attempt = _sqs.parse_envelope(body)
+        *_, attempt, message_timestamp = _sqs.parse_envelope(body)
         assert attempt == 1
+        assert message_timestamp is None
 
 
 class TestPlanRetry:

--- a/server/tests/worker/test_runner.py
+++ b/server/tests/worker/test_runner.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 
 import dramatiq
 import pytest
@@ -8,6 +9,7 @@ from opentelemetry.sdk.trace import ReadableSpan
 from pytest_mock import MockerFixture
 
 import polar.tasks  # noqa: F401  (registers actors with the broker)
+from polar.worker import get_message_timestamp
 from polar.worker._runner import TaskTimeoutError, run_task
 
 
@@ -114,3 +116,20 @@ class TestRunTask:
 
         with pytest.raises(TimeoutError, match="upstream timed out"):
             await run_task("dummy")
+
+    async def test_message_timestamp_reflects_enqueue_time(
+        self, mocker: MockerFixture
+    ) -> None:
+        seen: list[datetime.datetime] = []
+
+        async def recording_task() -> None:
+            seen.append(get_message_timestamp())
+
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"dummy": recording_task},
+        )
+
+        await run_task("dummy", message_timestamp=1234567890000)
+
+        assert seen == [datetime.datetime.fromtimestamp(1234567890, tz=datetime.UTC)]


### PR DESCRIPTION
For the dramatiq workers get_message_timestamp returns the enqueue time, since that's when the envelope was constructed.

In the lambda workers we got the current time. This ensures that the message_timestamp stays consistent between the two types of workers.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

