### PR TITLE
lambda: Ensure that tasks older than max age don't run

### DIFF
--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -201,6 +201,15 @@ async def run_task(
         else int(time.time() * 1000),
     )
 
+    max_age = actor_obj.options.get("max_age")
+    if max_age and int(time.time() * 1000) - message.message_timestamp >= max_age:
+        log.warning(
+            "polar.worker.task_age_limit_exceeded",
+            actor_name=actor_name,
+            max_age=max_age,
+        )
+        return
+
     correlation_id = CorrelationID.set()
     structlog.contextvars.bind_contextvars(
         actor_name=actor_name,

--- a/server/tests/worker/test_runner.py
+++ b/server/tests/worker/test_runner.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import time
 
 import dramatiq
 import pytest
@@ -133,3 +134,55 @@ class TestRunTask:
         await run_task("dummy", message_timestamp=1234567890000)
 
         assert seen == [datetime.datetime.fromtimestamp(1234567890, tz=datetime.UTC)]
+
+
+@pytest.mark.asyncio
+class TestRunTaskAgeLimit:
+    async def test_stale_message_skipped(self, mocker: MockerFixture) -> None:
+        task = mocker.AsyncMock()
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"meter.enqueue_billing": task},
+        )
+
+        await run_task(
+            "meter.enqueue_billing",
+            message_timestamp=int(time.time() * 1000) - 6 * 60 * 1000,
+        )
+
+        task.assert_not_called()
+
+    async def test_fresh_message_runs(self, mocker: MockerFixture) -> None:
+        task = mocker.AsyncMock()
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"meter.enqueue_billing": task},
+        )
+
+        await run_task(
+            "meter.enqueue_billing", message_timestamp=int(time.time() * 1000)
+        )
+
+        task.assert_called_once()
+
+    async def test_missing_timestamp_runs(self, mocker: MockerFixture) -> None:
+        task = mocker.AsyncMock()
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"meter.enqueue_billing": task},
+        )
+
+        await run_task("meter.enqueue_billing")
+
+        task.assert_called_once()
+
+    async def test_actor_without_max_age_runs(self, mocker: MockerFixture) -> None:
+        task = mocker.AsyncMock()
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"dummy": task},
+        )
+
+        await run_task("dummy", message_timestamp=1234567890000)
+
+        task.assert_called_once()


### PR DESCRIPTION
This replicates the behaviour that we have in the dramatiq tasks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

