### PR TITLE
invariant: Don't crash formatting non-serializable failure context

### DIFF
--- a/server/polar/observability/invariants/service.py
+++ b/server/polar/observability/invariants/service.py
@@ -6,7 +6,6 @@ import structlog
 from polar.config import settings
 from polar.integrations.slack.client import SlackClient
 from polar.integrations.slack.payload import SlackPayload, get_branded_slack_payload
-from polar.kit.json import json_obj_serializer
 from polar.logging import Logger
 from polar.postgres import AsyncReadSession
 
@@ -52,7 +51,7 @@ def _format_invariant_failure_payload(error: InvariantError) -> SlackPayload:
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"*Context*\n\n```{json.dumps(error.context, indent=2, default=json_obj_serializer)}```",
+                "text": f"*Context*\n\n```{json.dumps(error.context, indent=2, default=str)}```",
             },
         },
     ]

--- a/server/tests/observability/invariants/test_service.py
+++ b/server/tests/observability/invariants/test_service.py
@@ -1,3 +1,6 @@
+import uuid
+from decimal import Decimal
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -19,6 +22,17 @@ class _ProductionOnlyInvariant(Invariant):
 
     async def check(self) -> None:
         raise InvariantError(type(self), "always fails")
+
+
+class _DecimalContextInvariant(Invariant):
+    ENVIRONMENTS = None
+
+    async def check(self) -> None:
+        raise InvariantError(
+            type(self),
+            "always fails",
+            {"differences": [Decimal(1234)], "ids": [uuid.uuid4()]},
+        )
 
 
 @pytest.mark.asyncio
@@ -57,3 +71,20 @@ async def test_runs_invariant_with_no_environment_restriction(
     await invariant_service.check(session, _AllEnvironmentsInvariant)
 
     check_spy.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_notifies_when_context_is_not_natively_serializable(
+    session: AsyncSession, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(settings, "ENV", Environment.sandbox)
+    mocker.patch.object(settings, "SLACK_BOT_TOKEN", "token")
+    mocker.patch.object(settings, "SLACK_CHANNEL", "channel")
+    post_message_mock = mocker.patch.object(
+        invariant_service._slack, "chat_post_message"
+    )
+
+    await invariant_service.check(session, _DecimalContextInvariant)
+
+    post_message_mock.assert_called_once()
+    assert "1234" in str(post_message_mock.call_args.kwargs["blocks"])


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents crashes when formatting invariant failure context for Slack notifications. Previously, non-JSON-serializable values in context (e.g., Decimal, UUID) caused formatting to fail and drop the notification; now they are stringified and the notification is sent.

- Replace `json_obj_serializer` with json.dumps default=str when building the Context block.
- Add test invariant with `Decimal` and `uuid.UUID`; asserts a Slack message is posted and values are stringified.
- No config or API changes.

<sup>Written for commit 9b3bea96dc7ecdb6f9d0895d94eb7e66868f0a85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

