### PR TITLE
docs: Add 'current' and 'next' aliases in api reference doc page urls

### DIFF
--- a/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
@@ -188,7 +188,7 @@ export const FieldEvents = () => {
               renderOptionSuffix={(event) => (
                 <a
                   className="text-xs text-blue-400"
-                  href={`https://polar.sh/docs/api-reference/webhooks/${event}`}
+                  href={`https://polar.sh/docs/api-reference/current/${event.replaceAll('.', '_')}`}
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1099,6 +1099,14 @@
       "destination": "/api-reference"
     },
     {
+      "source": "/api-reference/current/:path*",
+      "destination": "/api-reference/2026-04/:path*"
+    },
+    {
+      "source": "/api-reference/next/:path*",
+      "destination": "/api-reference/2026-10/:path*"
+    },
+    {
       "source": "/developers/sandbox",
       "destination": "/integrate/sandbox"
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add stable API reference aliases and update Webhook Schema links to use them. Previously links pointed to versioned or webhook-specific paths; now they target the live docs via the current alias to avoid breakage across releases.

- Adds rewrites: /api-reference/current/* → /api-reference/2026-04/* and /api-reference/next/* → /api-reference/2026-10/*. Update these destinations when versions roll over.
- Updates the dashboard Webhook Schema link to /docs/api-reference/current/<event>, replacing dots with underscores to match doc slugs (e.g., issue.created → issue_created).

<sup>Written for commit 60a35fdc50de8eaaf22bd8b86770cd05b457ecc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

