### PR TITLE
fix: debounce webhook_event.failed task enqueues

### DIFF
--- a/server/polar/webhook/tasks.py
+++ b/server/polar/webhook/tasks.py
@@ -182,7 +182,11 @@ async def _webhook_event_send(
         if delivery_count >= settings.WEBHOOK_MAX_RETRIES:
             if event.succeeded is not True:
                 event.succeeded = False
-            enqueue_job("webhook_event.failed", webhook_event_id=webhook_event_id)
+            enqueue_job(
+                "webhook_event.failed",
+                webhook_event_id=webhook_event_id,
+                webhook_endpoint_id=event.webhook_endpoint_id,
+            )
         # Retry – compute backoff from delivery attempts only, so that
         # unrelated NotLatestEvent retries don't inflate the delay.
         else:
@@ -199,7 +203,11 @@ async def _webhook_event_send(
         delivery.succeeded = False
         event.succeeded = False
         delivery.response = str(e)
-        enqueue_job("webhook_event.failed", webhook_event_id=webhook_event_id)
+        enqueue_job(
+            "webhook_event.failed",
+            webhook_event_id=webhook_event_id,
+            webhook_endpoint_id=event.webhook_endpoint_id,
+        )
     # Success
     else:
         delivery.succeeded = True
@@ -219,8 +227,22 @@ async def webhook_event_success(webhook_event_id: UUID) -> None:
         return await webhook_service.on_event_success(session, webhook_event_id)
 
 
-@actor(actor_name="webhook_event.failed", priority=TaskPriority.HIGH)
-async def webhook_event_failed(webhook_event_id: UUID) -> None:
+def _webhook_event_failed_debounce_key(
+    webhook_event_id: UUID, webhook_endpoint_id: UUID | None = None
+) -> str | None:
+    if webhook_endpoint_id is None:
+        return None
+    return f"webhook_event.failed:{webhook_endpoint_id}"
+
+
+@actor(
+    actor_name="webhook_event.failed",
+    priority=TaskPriority.HIGH,
+    debounce_key=_webhook_event_failed_debounce_key,
+)
+async def webhook_event_failed(
+    webhook_event_id: UUID, webhook_endpoint_id: UUID | None = None
+) -> None:
     async with AsyncSessionMaker() as session:
         return await webhook_service.on_event_failed(session, webhook_event_id)
 

--- a/server/tests/webhooks/test_tasks.py
+++ b/server/tests/webhooks/test_tasks.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,7 +9,10 @@ from polar.models import WebhookEndpoint, WebhookEvent
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.postgres import AsyncSession
 from polar.webhook.service import webhook as webhook_service
-from polar.webhook.tasks import _webhook_event_send
+from polar.webhook.tasks import (
+    _webhook_event_failed_debounce_key,
+    _webhook_event_send,
+)
 from tests.fixtures.database import SaveFixture
 
 
@@ -245,3 +249,14 @@ class TestOnEventFailed:
         for pending_event in pending_events:
             await session.refresh(pending_event)
             assert pending_event.skipped is True
+
+
+class TestWebhookEventFailedDebounceKey:
+    def test_collapses_concurrent_events_for_same_endpoint(self) -> None:
+        endpoint_id = uuid.uuid4()
+        first = _webhook_event_failed_debounce_key(uuid.uuid4(), endpoint_id)
+        second = _webhook_event_failed_debounce_key(uuid.uuid4(), endpoint_id)
+        assert first == second
+
+    def test_no_key_without_endpoint(self) -> None:
+        assert _webhook_event_failed_debounce_key(uuid.uuid4()) is None


### PR DESCRIPTION
Fixes #11607 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Debounces `webhook_event.failed` task enqueues per webhook endpoint to avoid duplicate failure handlers when multiple events fail concurrently. Previously each failed delivery enqueued its own task; now failures for the same endpoint collapse to a single debounced job. Behavior for events without an endpoint ID is unchanged.

- Add debounce key derived from `webhook_endpoint_id` and wire it into the `webhook_event.failed` actor.
- Update enqueues in `_webhook_event_send` to include `webhook_endpoint_id`; actor now accepts an optional `webhook_endpoint_id` parameter.
- If you enqueue `webhook_event.failed` elsewhere, include `webhook_endpoint_id` to benefit from debouncing; without it, the task still runs but is not debounced.
- Tests cover key stability for the same endpoint and absence of a key when no endpoint is provided.

<sup>Written for commit 43e7829619becd36cf21e7f6e77f788e07d046c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

