### PR TITLE
lambda: Implement debounce for lambda workers

### DIFF
--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -197,12 +197,14 @@ class RoutingRedisBroker(RedisBroker):
         if should_route_to_sqs(message.actor_name):
             _sqs.send_jobs_sync(
                 [
-                    (
+                    _sqs.Job(
                         message.actor_name,
                         message.args,
                         message.kwargs,
                         delay,
                         CorrelationID.get(),
+                        message.message_id,
+                        message.options.get("debounce_key"),
                     )
                 ]
             )

--- a/server/polar/worker/_debounce.py
+++ b/server/polar/worker/_debounce.py
@@ -1,3 +1,4 @@
+import dataclasses
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Never
@@ -76,6 +77,93 @@ async def set_debounce_key(
     log.debug("Set debounce key", key=key, delay=delay)
 
     return key, delay
+
+
+@dataclasses.dataclass
+class DebounceContext:
+    debounce_key: str
+    enqueue_timestamp: int | None
+    max_threshold_execution: bool = False
+
+
+async def check_debounce(
+    redis: RedisAsyncIO,
+    actor: dramatiq.Actor[Any, Any],
+    message_id: str,
+    debounce_key: str,
+) -> DebounceContext | None:
+    log.debug("Checking debounce key", debounce_key=debounce_key)
+
+    debounce_data = await redis.hgetall(debounce_key)
+    if not debounce_data:
+        return DebounceContext(debounce_key=debounce_key, enqueue_timestamp=None)
+
+    if int(debounce_data.get("executed", 0)):
+        log.debug("Debounce key already executed, skipping", debounce_key=debounce_key)
+        TASK_DEBOUNCED.labels(queue=actor.queue_name, task_name=actor.actor_name).inc()
+        return None
+
+    message_owner = debounce_data["message_id"]
+    enqueue_timestamp = int(debounce_data["enqueue_timestamp"])
+
+    if message_owner == message_id:
+        return DebounceContext(
+            debounce_key=debounce_key, enqueue_timestamp=enqueue_timestamp
+        )
+
+    max_threshold: int = actor.options.get(
+        "debounce_max_threshold",
+        int(settings.WORKER_DEFAULT_DEBOUNCE_MAX_THRESHOLD.total_seconds()),
+    )
+    if enqueue_timestamp + max_threshold < now_timestamp():
+        log.info(
+            "Max debounce threshold reached, executing",
+            debounce_key=debounce_key,
+            owner_message_id=message_owner,
+        )
+        return DebounceContext(
+            debounce_key=debounce_key,
+            enqueue_timestamp=enqueue_timestamp,
+            max_threshold_execution=True,
+        )
+
+    log.info(
+        "Debounce owned by another message, skipping",
+        debounce_key=debounce_key,
+        owner_message_id=message_owner,
+    )
+    TASK_DEBOUNCED.labels(queue=actor.queue_name, task_name=actor.actor_name).inc()
+    return None
+
+
+async def finalize_debounce(
+    redis: RedisAsyncIO,
+    actor: dramatiq.Actor[Any, Any],
+    context: DebounceContext,
+    exception: BaseException | None,
+) -> None:
+    debounce_key = context.debounce_key
+    if context.enqueue_timestamp is not None:
+        delay = now_timestamp() - context.enqueue_timestamp
+        TASK_DEBOUNCE_DELAY.labels(
+            queue=actor.queue_name, task_name=actor.actor_name
+        ).observe(delay)
+
+    if context.max_threshold_execution:
+        log.debug(
+            "Bumping debounce key enqueue timestamp after max threshold execution",
+            debounce_key=debounce_key,
+        )
+        async with redis.pipeline(transaction=True) as pipe:
+            await pipe.hset(debounce_key, "enqueue_timestamp", now_timestamp())
+            await pipe.expire(debounce_key, DEBOUNCE_KEY_TTL)
+            await pipe.execute()
+    elif exception is None and context.enqueue_timestamp is not None:
+        log.debug("Marking debounce key as executed", debounce_key=debounce_key)
+        async with redis.pipeline(transaction=True) as pipe:
+            await pipe.hset(debounce_key, "executed", 1)
+            await pipe.hdel(debounce_key, "enqueue_timestamp")
+            await pipe.execute()
 
 
 class DebounceMiddleware(dramatiq.Middleware):
@@ -203,4 +291,10 @@ class DebounceMiddleware(dramatiq.Middleware):
         raise dramatiq.middleware.SkipMessage()
 
 
-__all__ = ["DebounceMiddleware", "set_debounce_key"]
+__all__ = [
+    "DebounceContext",
+    "DebounceMiddleware",
+    "check_debounce",
+    "finalize_debounce",
+    "set_debounce_key",
+]

--- a/server/polar/worker/_enqueue.py
+++ b/server/polar/worker/_enqueue.py
@@ -144,12 +144,29 @@ class JobQueueManager:
         # Send SQS last so an SQS failure can't drop the Redis jobs above.
         if sqs_jobs:
             correlation_id = CorrelationID.get()
-            await _sqs.send_jobs(
-                [
-                    (actor_name, args, kwargs, delay, correlation_id)
-                    for actor_name, args, kwargs, delay in sqs_jobs
-                ]
-            )
+            prepared_sqs_jobs: list[_sqs.Job] = []
+            for actor_name, args, kwargs, delay in sqs_jobs:
+                fn = broker.get_actor(actor_name)
+                message_id = str(uuid.uuid4())
+                debounce_key: str | None = None
+
+                debounce = await set_debounce_key(redis, fn, message_id, args, kwargs)
+                if debounce is not None:
+                    debounce_key, debounce_delay = debounce
+                    delay = max(delay or 0, debounce_delay)
+
+                prepared_sqs_jobs.append(
+                    _sqs.Job(
+                        actor_name,
+                        args,
+                        kwargs,
+                        delay,
+                        correlation_id,
+                        message_id,
+                        debounce_key,
+                    )
+                )
+            await _sqs.send_jobs(prepared_sqs_jobs)
 
         self.reset()
 

--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -22,8 +22,9 @@ from polar.logging import CorrelationID, Logger
 
 from . import _sqs
 from ._broker import TASK_TIME_LIMIT_DEFAULT_MS
+from ._debounce import DebounceContext, check_debounce, finalize_debounce
 from ._httpx import _close_client, setup_httpx
-from ._redis import _close_redis, setup_redis
+from ._redis import RedisMiddleware, _close_redis, setup_redis
 from ._sqlalchemy import dispose_sqlalchemy_engine, setup_sqlalchemy
 
 log: Logger = structlog.get_logger()
@@ -84,15 +85,23 @@ def build_registry() -> dict[str, Any]:
 def validate_allowlist() -> None:
     """Reject allowlisted actors that can't behave correctly over SQS."""
     broker = dramatiq.get_broker()
+    default_min_threshold = int(
+        settings.WORKER_DEFAULT_DEBOUNCE_MIN_THRESHOLD.total_seconds()
+    )
     for actor_name in settings.WORKER_SQS_ACTORS:
         actor_obj = broker.get_actor(actor_name)
         queue_name = _sqs.actor_to_queue_name(actor_name)
         if len(queue_name) > 80:
             raise ValueError(f"SQS queue name {queue_name!r} exceeds 80 characters")
         if actor_obj.options.get("debounce_key") is not None:
-            raise ValueError(
-                f"Actor {actor_name!r} uses debounce, unsupported over SQS"
+            min_threshold = actor_obj.options.get(
+                "debounce_min_threshold", default_min_threshold
             )
+            if min_threshold > _sqs.MAX_DELAY_SECONDS:
+                raise ValueError(
+                    f"Actor {actor_name!r} debounce_min_threshold exceeds the "
+                    f"{_sqs.MAX_DELAY_SECONDS}s SQS delay cap"
+                )
 
 
 def get_actor_max_retries(actor_name: str) -> int:
@@ -173,6 +182,8 @@ async def run_task(
     source_correlation_id: str | None = None,
     remaining_time_seconds: float | None = None,
     message_timestamp: int | None = None,
+    message_id: str | None = None,
+    debounce_key: str | None = None,
 ) -> None:
     registry = build_registry()
     fn = registry.get(actor_name)
@@ -218,19 +229,37 @@ async def run_task(
     )
     token = CurrentMessage._MESSAGE.set(message)
     try:
+        debounce_context: DebounceContext | None = None
+        if message_id is not None and debounce_key is not None:
+            debounce_context = await check_debounce(
+                RedisMiddleware.get(), actor_obj, message_id, debounce_key
+            )
+            if debounce_context is None:
+                return
+
         # Retries are expected: re-raise outside the span so Logfire doesn't record an error
         retry: Retry | None = None
-        with _task_span(actor_name, message, correlation_id, source_correlation_id):
-            try:
-                timeout_cm = asyncio.timeout(timeout_seconds)
-                async with timeout_cm:
-                    await fn(*args, **kwargs)
-            except TimeoutError:
-                if timeout_cm.expired():
-                    raise TaskTimeoutError(actor_name, timeout_seconds) from None
-                raise
-            except Retry as e:
-                retry = e
+        failure: BaseException | None = None
+        try:
+            with _task_span(actor_name, message, correlation_id, source_correlation_id):
+                try:
+                    timeout_cm = asyncio.timeout(timeout_seconds)
+                    async with timeout_cm:
+                        await fn(*args, **kwargs)
+                except TimeoutError:
+                    if timeout_cm.expired():
+                        raise TaskTimeoutError(actor_name, timeout_seconds) from None
+                    raise
+                except Retry as e:
+                    retry = e
+        except BaseException as e:
+            failure = e
+            raise
+        finally:
+            if debounce_context is not None:
+                await finalize_debounce(
+                    RedisMiddleware.get(), actor_obj, debounce_context, failure or retry
+                )
         if retry is not None:
             raise retry
     finally:

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -5,7 +5,7 @@ import time
 from collections import defaultdict
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import boto3
 import dramatiq
@@ -33,7 +33,15 @@ MAX_VISIBILITY_TIMEOUT_SECONDS = 43_200
 # Argument budget for a single job, leaving room for the envelope around it.
 MAX_JOB_PAYLOAD_BYTES = 200_000
 
-type Job = tuple[str, tuple[Any, ...], dict[str, Any], int | None, str | None]
+
+class Job(NamedTuple):
+    actor: str
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+    delay: int | None = None
+    correlation_id: str | None = None
+    message_id: str | None = None
+    debounce_key: str | None = None
 
 
 class SQSSendError(Exception):
@@ -141,6 +149,8 @@ def build_envelope(
     correlation_id: str | None,
     attempt: int = 1,
     message_timestamp: int | None = None,
+    message_id: str | None = None,
+    debounce_key: str | None = None,
 ) -> str:
     if message_timestamp is None:
         message_timestamp = int(time.time() * 1000)
@@ -152,6 +162,8 @@ def build_envelope(
             "correlation_id": correlation_id,
             "attempt": attempt,
             "message_timestamp": message_timestamp,
+            "message_id": message_id,
+            "debounce_key": debounce_key,
         },
         separators=(",", ":"),
         default=json_obj_serializer,
@@ -160,7 +172,9 @@ def build_envelope(
 
 def parse_envelope(
     body: str,
-) -> tuple[str, list[Any], dict[str, Any], str | None, int, int | None]:
+) -> tuple[
+    str, list[Any], dict[str, Any], str | None, int, int | None, str | None, str | None
+]:
     data = json.loads(body)
     return (
         data["actor"],
@@ -169,6 +183,8 @@ def parse_envelope(
         data.get("correlation_id"),
         data.get("attempt", 1),
         data.get("message_timestamp"),
+        data.get("message_id"),
+        data.get("debounce_key"),
     )
 
 
@@ -259,14 +275,21 @@ def send_jobs_sync(jobs: list[Job]) -> None:
     client = get_sqs_client()
 
     by_queue: dict[str, list[SendMessageBatchRequestEntryTypeDef]] = defaultdict(list)
-    for actor, args, kwargs, delay, correlation_id in jobs:
-        entries = by_queue[actor_to_queue_name(actor)]
+    for job in jobs:
+        entries = by_queue[actor_to_queue_name(job.actor)]
         entry: SendMessageBatchRequestEntryTypeDef = {
             "Id": str(len(entries)),
-            "MessageBody": build_envelope(actor, args, kwargs, correlation_id),
+            "MessageBody": build_envelope(
+                job.actor,
+                job.args,
+                job.kwargs,
+                job.correlation_id,
+                message_id=job.message_id,
+                debounce_key=job.debounce_key,
+            ),
         }
-        if delay:
-            entry["DelaySeconds"] = min(round(delay / 1000), MAX_DELAY_SECONDS)
+        if job.delay:
+            entry["DelaySeconds"] = min(round(job.delay / 1000), MAX_DELAY_SECONDS)
         entries.append(entry)
 
     for queue_name, entries in by_queue.items():

--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -49,9 +49,16 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         for record in event.get("Records", []):
             message_id = record["messageId"]
             try:
-                actor, args, kwargs, correlation_id, attempt, message_timestamp = (
-                    parse_envelope(record["body"])
-                )
+                (
+                    actor,
+                    args,
+                    kwargs,
+                    correlation_id,
+                    attempt,
+                    message_timestamp,
+                    task_message_id,
+                    debounce_key,
+                ) = parse_envelope(record["body"])
                 _loop.run_until_complete(
                     run_task(
                         actor,
@@ -64,6 +71,8 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                             - _REMAINING_TIME_MARGIN_SECONDS
                         ),
                         message_timestamp=message_timestamp,
+                        message_id=task_message_id,
+                        debounce_key=debounce_key,
                     )
                 )
             except Retry as exc:
@@ -93,9 +102,16 @@ def _effective_receive_count(record: dict[str, Any], attempt: int) -> int:
 def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> bool:
     """Schedule the failed message's next retry. Returns True if SQS should redeliver it."""
     try:
-        actor, args, kwargs, correlation_id, attempt, message_timestamp = (
-            parse_envelope(record["body"])
-        )
+        (
+            actor,
+            args,
+            kwargs,
+            correlation_id,
+            attempt,
+            message_timestamp,
+            task_message_id,
+            debounce_key,
+        ) = parse_envelope(record["body"])
         queue_arn = record["eventSourceARN"]
         receive_count = _effective_receive_count(record, attempt)
         scheduler_role_arn = settings.WORKER_SQS_SCHEDULER_ROLE_ARN
@@ -129,6 +145,8 @@ def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> bo
                     correlation_id,
                     receive_count + 1,
                     message_timestamp,
+                    message_id=task_message_id,
+                    debounce_key=debounce_key,
                 ),
                 delay_seconds,
                 build_retry_schedule_name(queue_arn, record["messageId"], attempt),

--- a/server/polar/worker/sqs.py
+++ b/server/polar/worker/sqs.py
@@ -54,6 +54,8 @@ async def _poll_loop(actors: list[str], max_iterations: int) -> None:
                         correlation_id,
                         attempt,
                         message_timestamp,
+                        message_id,
+                        debounce_key,
                     ) = parse_envelope(message["Body"])
                     sqs_receive_count = int(
                         message.get("Attributes", {}).get(
@@ -69,6 +71,8 @@ async def _poll_loop(actors: list[str], max_iterations: int) -> None:
                             receive_count=receive_count,
                             source_correlation_id=correlation_id,
                             message_timestamp=message_timestamp,
+                            message_id=message_id,
+                            debounce_key=debounce_key,
                         )
                     except Exception:
                         log.exception("polar.worker.sqs_poll_failed", actor=actor)

--- a/server/tests/worker/test_backoff.py
+++ b/server/tests/worker/test_backoff.py
@@ -93,28 +93,46 @@ class TestSetMessageVisibility:
 class TestEnvelopeAttempt:
     def test_round_trips(self) -> None:
         body = _sqs.build_envelope(
-            "dummy", (1, "x"), {"k": 2}, "corr", 7, 1234567890000
+            "dummy",
+            (1, "x"),
+            {"k": 2},
+            "corr",
+            7,
+            1234567890000,
+            message_id="msg-1",
+            debounce_key="debounce:test",
         )
-        actor, args, kwargs, correlation_id, attempt, message_timestamp = (
-            _sqs.parse_envelope(body)
-        )
+        (
+            actor,
+            args,
+            kwargs,
+            correlation_id,
+            attempt,
+            message_timestamp,
+            message_id,
+            debounce_key,
+        ) = _sqs.parse_envelope(body)
         assert actor == "dummy"
         assert args == [1, "x"]
         assert kwargs == {"k": 2}
         assert correlation_id == "corr"
         assert attempt == 7
         assert message_timestamp == 1234567890000
+        assert message_id == "msg-1"
+        assert debounce_key == "debounce:test"
 
     def test_defaults_to_one(self) -> None:
         body = _sqs.build_envelope("dummy", (), {}, None)
-        *_, attempt, _ = _sqs.parse_envelope(body)
+        _, _, _, _, attempt, _, message_id, debounce_key = _sqs.parse_envelope(body)
         assert attempt == 1
+        assert message_id is None
+        assert debounce_key is None
 
     def test_stamps_current_timestamp_by_default(self) -> None:
         before = int(time.time() * 1000)
         body = _sqs.build_envelope("dummy", (), {}, None)
         after = int(time.time() * 1000)
-        *_, message_timestamp = _sqs.parse_envelope(body)
+        _, _, _, _, _, message_timestamp, _, _ = _sqs.parse_envelope(body)
         assert message_timestamp is not None
         assert before <= message_timestamp <= after
 
@@ -122,9 +140,20 @@ class TestEnvelopeAttempt:
         body = json.dumps(
             {"actor": "dummy", "args": [], "kwargs": {}, "correlation_id": None}
         )
-        *_, attempt, message_timestamp = _sqs.parse_envelope(body)
+        (
+            _,
+            _,
+            _,
+            _,
+            attempt,
+            message_timestamp,
+            message_id,
+            debounce_key,
+        ) = _sqs.parse_envelope(body)
         assert attempt == 1
         assert message_timestamp is None
+        assert message_id is None
+        assert debounce_key is None
 
 
 class TestPlanRetry:

--- a/server/tests/worker/test_debounce.py
+++ b/server/tests/worker/test_debounce.py
@@ -2,14 +2,28 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fakeredis import FakeAsyncRedis
 
-from polar.worker._debounce import set_debounce_key
+from polar.worker._debounce import (
+    DebounceContext,
+    check_debounce,
+    finalize_debounce,
+    now_timestamp,
+    set_debounce_key,
+)
 
 
 def make_actor(**options: object) -> MagicMock:
     actor = MagicMock()
     actor.options = options
+    actor.queue_name = "low_priority"
+    actor.actor_name = "dummy"
     return actor
+
+
+@pytest.fixture
+def fake_redis() -> FakeAsyncRedis:
+    return FakeAsyncRedis(decode_responses=True)
 
 
 @pytest.fixture
@@ -72,3 +86,120 @@ class TestSetDebounceKey:
         assert key == f"debounce:test:debounce_me:{item_id}"
         assert delay == 2000  # 2 seconds * 1000ms
         redis.pipeline.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestCheckDebounce:
+    async def test_missing_hash_runs(self, fake_redis: FakeAsyncRedis) -> None:
+        actor = make_actor()
+
+        context = await check_debounce(fake_redis, actor, "msg-1", "debounce:test:key")
+
+        assert context == DebounceContext(
+            debounce_key="debounce:test:key", enqueue_timestamp=None
+        )
+
+    async def test_executed_skips(self, fake_redis: FakeAsyncRedis) -> None:
+        actor = make_actor(debounce_key=lambda: "test:key")
+        debounce = await set_debounce_key(fake_redis, actor, "owner", (), {})
+        assert debounce is not None
+        key, _ = debounce
+        await fake_redis.hset(key, "executed", 1)
+
+        assert await check_debounce(fake_redis, actor, "owner", key) is None
+
+    async def test_owner_runs(self, fake_redis: FakeAsyncRedis) -> None:
+        actor = make_actor(debounce_key=lambda: "test:key")
+        debounce = await set_debounce_key(fake_redis, actor, "owner", (), {})
+        assert debounce is not None
+        key, _ = debounce
+
+        context = await check_debounce(fake_redis, actor, "owner", key)
+
+        assert context is not None
+        assert context.enqueue_timestamp is not None
+        assert not context.max_threshold_execution
+
+    async def test_non_owner_skips(self, fake_redis: FakeAsyncRedis) -> None:
+        actor = make_actor(debounce_key=lambda: "test:key")
+        debounce = await set_debounce_key(fake_redis, actor, "owner", (), {})
+        assert debounce is not None
+        key, _ = debounce
+
+        assert await check_debounce(fake_redis, actor, "other", key) is None
+
+    async def test_non_owner_past_max_threshold_runs(
+        self, fake_redis: FakeAsyncRedis
+    ) -> None:
+        actor = make_actor(debounce_key=lambda: "test:key", debounce_max_threshold=5)
+        debounce = await set_debounce_key(fake_redis, actor, "owner", (), {})
+        assert debounce is not None
+        key, _ = debounce
+        await fake_redis.hset(key, "enqueue_timestamp", now_timestamp() - 10)
+
+        context = await check_debounce(fake_redis, actor, "other", key)
+
+        assert context is not None
+        assert context.max_threshold_execution
+
+
+@pytest.mark.asyncio
+class TestFinalizeDebounce:
+    async def test_success_marks_executed(self, fake_redis: FakeAsyncRedis) -> None:
+        actor = make_actor(debounce_key=lambda: "test:key")
+        debounce = await set_debounce_key(fake_redis, actor, "owner", (), {})
+        assert debounce is not None
+        key, _ = debounce
+        context = await check_debounce(fake_redis, actor, "owner", key)
+        assert context is not None
+
+        await finalize_debounce(fake_redis, actor, context, None)
+
+        assert await fake_redis.hget(key, "executed") == "1"
+        assert not await fake_redis.hexists(key, "enqueue_timestamp")
+        assert await fake_redis.ttl(key) > 0
+
+    async def test_exception_does_not_mark_executed(
+        self, fake_redis: FakeAsyncRedis
+    ) -> None:
+        actor = make_actor(debounce_key=lambda: "test:key")
+        debounce = await set_debounce_key(fake_redis, actor, "owner", (), {})
+        assert debounce is not None
+        key, _ = debounce
+        context = await check_debounce(fake_redis, actor, "owner", key)
+        assert context is not None
+
+        await finalize_debounce(fake_redis, actor, context, ValueError("boom"))
+
+        assert await fake_redis.hget(key, "executed") == "0"
+        assert await fake_redis.hexists(key, "enqueue_timestamp")
+
+    async def test_max_threshold_execution_bumps_window_even_on_failure(
+        self, fake_redis: FakeAsyncRedis
+    ) -> None:
+        actor = make_actor(debounce_key=lambda: "test:key", debounce_max_threshold=5)
+        debounce = await set_debounce_key(fake_redis, actor, "owner", (), {})
+        assert debounce is not None
+        key, _ = debounce
+        old_timestamp = now_timestamp() - 10
+        await fake_redis.hset(key, "enqueue_timestamp", old_timestamp)
+        context = await check_debounce(fake_redis, actor, "other", key)
+        assert context is not None
+
+        await finalize_debounce(fake_redis, actor, context, ValueError("boom"))
+
+        bumped_timestamp = await fake_redis.hget(key, "enqueue_timestamp")
+        assert bumped_timestamp is not None
+        assert int(bumped_timestamp) > old_timestamp
+        assert await fake_redis.hget(key, "executed") == "0"
+        assert await fake_redis.ttl(key) > 0
+
+    async def test_expired_hash_leaves_no_key(self, fake_redis: FakeAsyncRedis) -> None:
+        actor = make_actor()
+        context = DebounceContext(
+            debounce_key="debounce:test:key", enqueue_timestamp=None
+        )
+
+        await finalize_debounce(fake_redis, actor, context, None)
+
+        assert await fake_redis.exists("debounce:test:key") == 0

--- a/server/tests/worker/test_enqueue_gate.py
+++ b/server/tests/worker/test_enqueue_gate.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 import polar.tasks  # noqa: F401  (registers actors with the broker)
 from polar.config import settings
 from polar.logging import CorrelationID
+from polar.models.webhook_endpoint import WebhookEventType
 from polar.redis import Redis
 from polar.worker import MAX_JOB_PAYLOAD_BYTES, JobQueueManager
 from polar.worker._sqs import (
@@ -96,6 +97,35 @@ class TestFlushGate:
         # Non-allowlisted actor still went to Redis; the SQS one did not.
         assert await redis.llen("dramatiq:low_priority") == 1
         assert await redis.llen("dramatiq:high_priority") == 0
+
+    async def test_debounced_actor_carries_debounce_key_and_delay(
+        self, redis: Redis, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ENABLED", True)
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {"customer.webhook"})
+        send_jobs = mocker.patch("polar.worker._enqueue._sqs.send_jobs")
+
+        CorrelationID.set()
+        customer_id = uuid4()
+        jqm = JobQueueManager()
+        jqm.enqueue_job(
+            "customer.webhook", WebhookEventType.customer_state_changed, customer_id
+        )
+        await jqm.flush(dramatiq.get_broker(), redis)
+
+        send_jobs.assert_awaited_once()
+        assert send_jobs.await_args is not None
+        sent = send_jobs.await_args.args[0]
+        job = sent[0]
+        expected_key = (
+            "debounce:customer.webhook:"
+            f"{WebhookEventType.customer_state_changed}:{customer_id}"
+        )
+        assert job.actor == "customer.webhook"
+        assert job.debounce_key == expected_key
+        assert job.message_id is not None
+        assert job.delay == 1000
+        assert await redis.exists(expected_key) == 1
 
 
 class TestPackBatches:

--- a/server/tests/worker/test_routing_broker.py
+++ b/server/tests/worker/test_routing_broker.py
@@ -71,6 +71,23 @@ class TestRoutingBroker:
         assert sent[0][0] == SUBSCRIPTION_ACTOR
         assert sent[0][2] == {"subscription_id": subscription_id}
 
+    def test_allowlisted_actor_forwards_debounce_key_to_sqs(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ENABLED", True)
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {"customer.webhook"})
+        mocker.patch.object(RedisBroker, "enqueue")
+        send_jobs_sync = mocker.patch("polar.worker._broker._sqs.send_jobs_sync")
+
+        broker = dramatiq.get_broker()
+        message = broker.get_actor("customer.webhook").message()
+        message = message.copy(options={"debounce_key": "debounce:test:key"})
+        broker.enqueue(message)
+
+        job = send_jobs_sync.call_args.args[0][0]
+        assert job.message_id == message.message_id
+        assert job.debounce_key == "debounce:test:key"
+
 
 class TestValidateAllowlist:
     def test_accepts_cron_actor(self, mocker: MockerFixture) -> None:
@@ -78,8 +95,17 @@ class TestValidateAllowlist:
 
         validate_allowlist()
 
-    def test_rejects_debounced_actor(self, mocker: MockerFixture) -> None:
+    def test_accepts_debounced_actor(self, mocker: MockerFixture) -> None:
         mocker.patch.object(settings, "WORKER_SQS_ACTORS", {"customer.webhook"})
 
-        with pytest.raises(ValueError, match="debounce"):
+        validate_allowlist()
+
+    def test_rejects_debounce_min_threshold_over_sqs_delay_cap(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {"customer.webhook"})
+        actor = dramatiq.get_broker().get_actor("customer.webhook")
+        mocker.patch.dict(actor.options, {"debounce_min_threshold": 901})
+
+        with pytest.raises(ValueError, match="debounce_min_threshold"):
             validate_allowlist()

--- a/server/tests/worker/test_runner.py
+++ b/server/tests/worker/test_runner.py
@@ -1,16 +1,19 @@
 import asyncio
 import datetime
 import time
+from unittest.mock import AsyncMock
 
 import dramatiq
 import pytest
 from dramatiq.errors import Retry
+from fakeredis import FakeAsyncRedis
 from logfire.testing import CaptureLogfire
 from opentelemetry.sdk.trace import ReadableSpan
 from pytest_mock import MockerFixture
 
 import polar.tasks  # noqa: F401  (registers actors with the broker)
 from polar.worker import get_message_timestamp
+from polar.worker._debounce import now_timestamp
 from polar.worker._runner import TaskTimeoutError, run_task
 
 
@@ -186,3 +189,93 @@ class TestRunTaskAgeLimit:
         await run_task("dummy", message_timestamp=1234567890000)
 
         task.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestRunTaskDebounce:
+    DEBOUNCE_KEY = "debounce:dummy:key"
+
+    @pytest.fixture
+    def fake_redis(self, mocker: MockerFixture) -> FakeAsyncRedis:
+        fake_redis = FakeAsyncRedis(decode_responses=True)
+        mocker.patch(
+            "polar.worker._runner.RedisMiddleware.get", return_value=fake_redis
+        )
+        return fake_redis
+
+    @pytest.fixture
+    def task_fn(self, mocker: MockerFixture) -> AsyncMock:
+        task_fn = AsyncMock()
+        mocker.patch(
+            "polar.worker._runner.build_registry", return_value={"dummy": task_fn}
+        )
+        return task_fn
+
+    async def test_executed_key_skips_task(
+        self, fake_redis: FakeAsyncRedis, task_fn: AsyncMock
+    ) -> None:
+        await fake_redis.hset(
+            self.DEBOUNCE_KEY,
+            mapping={
+                "enqueue_timestamp": now_timestamp(),
+                "message_id": "owner",
+                "executed": 1,
+            },
+        )
+
+        await run_task("dummy", message_id="owner", debounce_key=self.DEBOUNCE_KEY)
+
+        task_fn.assert_not_awaited()
+
+    async def test_owner_runs_and_marks_executed(
+        self, fake_redis: FakeAsyncRedis, task_fn: AsyncMock
+    ) -> None:
+        await fake_redis.hset(
+            self.DEBOUNCE_KEY,
+            mapping={
+                "enqueue_timestamp": now_timestamp(),
+                "message_id": "owner",
+                "executed": 0,
+            },
+        )
+
+        await run_task("dummy", message_id="owner", debounce_key=self.DEBOUNCE_KEY)
+
+        task_fn.assert_awaited_once()
+        assert await fake_redis.hget(self.DEBOUNCE_KEY, "executed") == "1"
+
+    async def test_retry_does_not_mark_executed(
+        self, fake_redis: FakeAsyncRedis, task_fn: AsyncMock
+    ) -> None:
+        task_fn.side_effect = Retry(delay=1000)
+        await fake_redis.hset(
+            self.DEBOUNCE_KEY,
+            mapping={
+                "enqueue_timestamp": now_timestamp(),
+                "message_id": "owner",
+                "executed": 0,
+            },
+        )
+
+        with pytest.raises(Retry):
+            await run_task("dummy", message_id="owner", debounce_key=self.DEBOUNCE_KEY)
+
+        assert await fake_redis.hget(self.DEBOUNCE_KEY, "executed") == "0"
+
+    async def test_exception_does_not_mark_executed(
+        self, fake_redis: FakeAsyncRedis, task_fn: AsyncMock
+    ) -> None:
+        task_fn.side_effect = ValueError("boom")
+        await fake_redis.hset(
+            self.DEBOUNCE_KEY,
+            mapping={
+                "enqueue_timestamp": now_timestamp(),
+                "message_id": "owner",
+                "executed": 0,
+            },
+        )
+
+        with pytest.raises(ValueError, match="boom"):
+            await run_task("dummy", message_id="owner", debounce_key=self.DEBOUNCE_KEY)
+
+        assert await fake_redis.hget(self.DEBOUNCE_KEY, "executed") == "0"


### PR DESCRIPTION
To be able to fully migrate all of our dramatiq tasks to lambda we need to support the debounce functionality.

This reimplements what we have in the dramatiq debounce middleware, for the lambda / sqs workers.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

