### PR TITLE
Add CSV export for finance income with payout date

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/(wide)/income/IncomePage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/(wide)/income/IncomePage.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import TransactionsList from '@/components/Transactions/TransactionsList'
+import ExportIncomeModal from '@/components/Transactions/ExportIncomeModal'
+import { useModal } from '@/components/Modal/useModal'
 import { useOrganizationAccount, useSearchTransactions } from '@/hooks/queries'
 import {
   DataTablePaginationState,
@@ -10,6 +12,9 @@ import {
 } from '@/utils/datatable'
 import { ISODuration } from '@/utils/duration'
 import { schemas } from '@polar-sh/client'
+import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import { usePathname, useRouter } from 'next/navigation'
 
 export default function ClientPage({
@@ -23,6 +28,11 @@ export default function ClientPage({
 }) {
   const router = useRouter()
   const pathname = usePathname()
+  const {
+    isShown: isExportModalShown,
+    show: showExportModal,
+    hide: hideExportModal,
+  } = useModal()
 
   const setPagination = (
     updaterOrValue:
@@ -72,7 +82,18 @@ export default function ClientPage({
   const pageCount = balancesHook.data?.pagination.max_page ?? 1
 
   return (
-    <div className="flex flex-col gap-y-8">
+    <Box flexDirection="column" rowGap="xl">
+      <Box justifyContent="end">
+        <Button
+          variant="secondary"
+          wrapperClassNames="gap-x-2"
+          disabled={!account}
+          onClick={showExportModal}
+        >
+          <FileDownloadOutlined fontSize="inherit" />
+          <Text>Export</Text>
+        </Button>
+      </Box>
       <TransactionsList
         transactions={balances}
         rowCount={rowCount}
@@ -84,6 +105,14 @@ export default function ClientPage({
         isLoading={accountIsLoading || balancesHook.isLoading}
         payoutTransactionDelay={payoutTransactionDelay}
       />
-    </div>
+      {account && (
+        <ExportIncomeModal
+          organization={organization}
+          accountId={account.id}
+          isShown={isExportModalShown}
+          hide={hideExportModal}
+        />
+      )}
+    </Box>
   )
 }

--- a/clients/apps/web/src/components/Transactions/ExportIncomeColumns.tsx
+++ b/clients/apps/web/src/components/Transactions/ExportIncomeColumns.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { ChipSelect } from '@/components/Form/ChipSelect'
+import { schemas } from '@polar-sh/client'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+
+export type ExportColumn = schemas['TransactionExportColumn']
+
+const EXPORT_COLUMN_GROUPS = [
+  {
+    label: 'Transaction',
+    columns: [
+      { value: 'created_at', label: 'Date' },
+      { value: 'description', label: 'Description' },
+      { value: 'type', label: 'Type' },
+      { value: 'status', label: 'Status' },
+      { value: 'payout_date', label: 'Payout Date' },
+    ],
+  },
+  {
+    label: 'Amounts',
+    columns: [
+      { value: 'gross_amount', label: 'Gross' },
+      { value: 'fees_amount', label: 'Fees' },
+      { value: 'tax_amount', label: 'Tax' },
+      { value: 'net_amount', label: 'Net' },
+      { value: 'currency', label: 'Currency' },
+    ],
+  },
+  {
+    label: 'Details',
+    columns: [
+      { value: 'product', label: 'Product' },
+      { value: 'customer_email', label: 'Customer Email' },
+    ],
+  },
+] as const satisfies {
+  readonly label: string
+  readonly columns: readonly { value: ExportColumn; label: string }[]
+}[]
+
+export const ALL_EXPORT_COLUMNS: ExportColumn[] = EXPORT_COLUMN_GROUPS.flatMap(
+  (group) => group.columns.map((column) => column.value),
+)
+
+const EXPORT_COLUMN_LABELS = Object.fromEntries(
+  EXPORT_COLUMN_GROUPS.flatMap((group) =>
+    group.columns.map((column) => [column.value, column.label]),
+  ),
+) as Record<ExportColumn, string>
+
+export const DEFAULT_EXPORT_COLUMNS: ExportColumn[] = [
+  'created_at',
+  'description',
+  'gross_amount',
+  'fees_amount',
+  'tax_amount',
+  'net_amount',
+  'status',
+  'payout_date',
+]
+
+export const incomeExportColumns = (selected: ExportColumn[]): ExportColumn[] =>
+  ALL_EXPORT_COLUMNS.filter((column) => selected.includes(column))
+
+const isDefaultExportColumnSet = (selected: ExportColumn[]): boolean =>
+  selected.length === DEFAULT_EXPORT_COLUMNS.length &&
+  DEFAULT_EXPORT_COLUMNS.every((column) => selected.includes(column))
+
+export const summarizeExportColumns = (selected: ExportColumn[]): string => {
+  if (selected.length === 0) return 'No fields selected'
+  if (selected.length === ALL_EXPORT_COLUMNS.length) return 'All fields'
+  const ordered = incomeExportColumns(selected)
+  const shown = ordered
+    .slice(0, 3)
+    .map((c) => EXPORT_COLUMN_LABELS[c])
+    .join(', ')
+  return ordered.length > 3 ? `${shown} +${ordered.length - 3}` : shown
+}
+
+interface ExportIncomeColumnsProps {
+  selected: ExportColumn[]
+  onChange: (columns: ExportColumn[]) => void
+}
+
+const ExportIncomeColumns: React.FC<ExportIncomeColumnsProps> = ({
+  selected,
+  onChange,
+}) => {
+  const allSelected = selected.length === ALL_EXPORT_COLUMNS.length
+  const isDefault = isDefaultExportColumnSet(selected)
+
+  return (
+    <Box flexDirection="column" rowGap="l">
+      <Box alignItems="center" justifyContent="between" columnGap="l">
+        <Text variant="caption" color="muted">
+          {selected.length} of {ALL_EXPORT_COLUMNS.length} selected
+        </Text>
+        <Box alignItems="center" columnGap="xs">
+          {!isDefault && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="dark:text-polar-500 dark:hover:text-polar-300 h-7 px-2 text-xs font-normal text-gray-500 hover:text-gray-900"
+              onClick={() => onChange(DEFAULT_EXPORT_COLUMNS)}
+            >
+              Reset
+            </Button>
+          )}
+          {!allSelected && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="dark:text-polar-500 dark:hover:text-polar-300 h-7 px-2 text-xs font-normal text-gray-500 hover:text-gray-900"
+              onClick={() => onChange(ALL_EXPORT_COLUMNS)}
+            >
+              Select all
+            </Button>
+          )}
+        </Box>
+      </Box>
+
+      {EXPORT_COLUMN_GROUPS.map((group) => {
+        const groupValues: ExportColumn[] = group.columns.map(
+          (column) => column.value,
+        )
+        return (
+          <Box key={group.label} flexDirection="column" rowGap="s">
+            <Text variant="label" color="muted">
+              {group.label}
+            </Text>
+            <ChipSelect
+              options={[...group.columns]}
+              selected={selected.filter((column) =>
+                groupValues.includes(column),
+              )}
+              onChange={(next) =>
+                onChange([
+                  ...selected.filter((column) => !groupValues.includes(column)),
+                  ...(next as ExportColumn[]),
+                ])
+              }
+            />
+          </Box>
+        )
+      })}
+    </Box>
+  )
+}
+
+export default ExportIncomeColumns

--- a/clients/apps/web/src/components/Transactions/ExportIncomeModal.tsx
+++ b/clients/apps/web/src/components/Transactions/ExportIncomeModal.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import DateRangePicker, {
+  DateRange,
+} from '@/components/Metrics/DateRangePicker'
+import { getServerURL } from '@/utils/api'
+import { schemas } from '@polar-sh/client'
+import {
+  Button,
+  InlineModal,
+  InlineModalHeader,
+  List,
+  ListItem,
+  SegmentedControl,
+  Text,
+} from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { endOfToday, format, startOfDay } from 'date-fns'
+import { ChevronDown } from 'lucide-react'
+import React, { useState } from 'react'
+import ExportIncomeColumns, {
+  ALL_EXPORT_COLUMNS,
+  DEFAULT_EXPORT_COLUMNS,
+  ExportColumn,
+  incomeExportColumns,
+  summarizeExportColumns,
+} from './ExportIncomeColumns'
+
+const formatExportRange = (range: DateRange): string => {
+  const from = format(range.from, 'MMM d, yyyy')
+  const to = format(range.to, 'MMM d, yyyy')
+  return from === to ? from : `${from} – ${to}`
+}
+
+const formatGMTOffset = (date: Date = new Date()): string =>
+  new Intl.DateTimeFormat('en', { timeZoneName: 'shortOffset' })
+    .formatToParts(date)
+    .find((part) => part.type === 'timeZoneName')?.value ?? 'Local'
+
+interface ExportIncomeModalProps {
+  organization: schemas['Organization']
+  accountId: string
+  isShown: boolean
+  hide: () => void
+}
+
+const ExportIncomeModal: React.FC<ExportIncomeModalProps> = ({
+  organization,
+  accountId,
+  isShown,
+  hide,
+}) => {
+  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const localOffsetLabel = formatGMTOffset()
+  const organizationStart = startOfDay(new Date(organization.created_at))
+  const [timezone, setTimezone] = useState<'local' | 'utc'>('local')
+  const [dateRange, setDateRange] = useState<DateRange>({
+    from: organizationStart,
+    to: endOfToday(),
+  })
+  const [columns, setColumns] = useState<ExportColumn[]>(DEFAULT_EXPORT_COLUMNS)
+  const [columnsExpanded, setColumnsExpanded] = useState(false)
+
+  const rangeLabel = formatExportRange(dateRange)
+
+  const onExport = () => {
+    const url = new URL(
+      getServerURL('/v1/transactions/export'),
+      window.location.origin,
+    )
+    url.searchParams.set('account_id', accountId)
+    url.searchParams.set('type', 'balance')
+    url.searchParams.set('exclude_platform_fees', 'true')
+    url.searchParams.set('created_after', dateRange.from.toISOString())
+    url.searchParams.set('created_before', dateRange.to.toISOString())
+    url.searchParams.set('timezone', timezone === 'utc' ? 'UTC' : localTimezone)
+
+    for (const column of incomeExportColumns(columns)) {
+      url.searchParams.append('columns', column)
+    }
+
+    window.open(url, '_blank')
+    hide()
+  }
+
+  return (
+    <InlineModal
+      isShown={isShown}
+      hide={hide}
+      modalContent={
+        <>
+          <InlineModalHeader hide={hide}>
+            <Text variant="heading-xs" as="h2">
+              Export income
+            </Text>
+          </InlineModalHeader>
+
+          <Box
+            flexDirection="column"
+            rowGap="xl"
+            paddingHorizontal="2xl"
+            paddingBottom="2xl"
+          >
+            <Text color="muted">Download your income as a CSV file.</Text>
+
+            <List size="small">
+              <ListItem
+                size="small"
+                className="px-4 py-3 hover:bg-transparent dark:hover:bg-transparent"
+              >
+                <Box flexDirection="column" rowGap="xs" minWidth={0}>
+                  <Text>Time zone</Text>
+                  <Text variant="caption" color="muted" truncate>
+                    Dates in the file are written in this zone
+                  </Text>
+                </Box>
+                <SegmentedControl
+                  size="sm"
+                  options={[
+                    {
+                      value: 'local',
+                      label: localOffsetLabel,
+                    },
+                    { value: 'utc', label: 'UTC' },
+                  ]}
+                  value={timezone}
+                  onChange={(value) => setTimezone(value as 'local' | 'utc')}
+                />
+              </ListItem>
+
+              <ListItem
+                size="small"
+                className="px-4 py-3 hover:bg-transparent dark:hover:bg-transparent"
+              >
+                <Box flexDirection="column" rowGap="xs" minWidth={0}>
+                  <Text>Date range</Text>
+                  <Text variant="caption" color="muted" truncate>
+                    {rangeLabel}
+                  </Text>
+                </Box>
+                <Box flexShrink={0}>
+                  <DateRangePicker
+                    date={dateRange}
+                    onDateChange={setDateRange}
+                    minDate={organizationStart}
+                  />
+                </Box>
+              </ListItem>
+
+              <ListItem
+                size="small"
+                className="px-4 py-3 hover:bg-transparent dark:hover:bg-transparent"
+              >
+                <Box flexDirection="column" rowGap="xs" minWidth={0}>
+                  <Text>Columns</Text>
+                  <Text variant="caption" color="muted" truncate>
+                    {summarizeExportColumns(columns)}
+                  </Text>
+                </Box>
+                <Box flexShrink={0}>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="h-9 px-4"
+                    aria-expanded={columnsExpanded}
+                    onClick={() => setColumnsExpanded((current) => !current)}
+                  >
+                    {columns.length === ALL_EXPORT_COLUMNS.length
+                      ? `All ${ALL_EXPORT_COLUMNS.length}`
+                      : `${columns.length} selected`}
+                    <ChevronDown
+                      className={`ml-2 h-4 w-4 opacity-50 transition-transform duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none ${
+                        columnsExpanded ? 'rotate-180' : ''
+                      }`}
+                    />
+                  </Button>
+                </Box>
+              </ListItem>
+
+              {columnsExpanded ? (
+                <Box
+                  flexDirection="column"
+                  paddingHorizontal="l"
+                  paddingVertical="l"
+                >
+                  <ExportIncomeColumns
+                    selected={columns}
+                    onChange={setColumns}
+                  />
+                </Box>
+              ) : null}
+            </List>
+
+            <Box flexDirection="column" rowGap="s">
+              <Button
+                fullWidth
+                disabled={columns.length === 0}
+                onClick={onExport}
+              >
+                Export CSV
+              </Button>
+              <Text variant="caption" color="muted" align="center">
+                {columns.length} columns | {rangeLabel}
+              </Text>
+            </Box>
+          </Box>
+        </>
+      }
+    />
+  )
+}
+
+export default ExportIncomeModal

--- a/clients/packages/client/src/enums.ts
+++ b/clients/packages/client/src/enums.ts
@@ -17,6 +17,7 @@ export {
   subscriptionExportColumnValues,
   taxBehaviorOptionValues,
   timeIntervalValues,
+  transactionExportColumnValues,
   trialIntervalValues,
   uniqueAggregationFuncValues,
   webhookEventTypeValues,

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -1667,6 +1667,28 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/transactions/export': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Export Income
+     * @description Export income transactions as a CSV file.
+     *
+     *     **Scopes**: `transactions:read`
+     */
+    get: operations['transactions:export']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/transactions/summary': {
     parameters: {
       query?: never
@@ -36521,6 +36543,23 @@ export interface components {
       /** Incurred By Transaction Id */
       incurred_by_transaction_id: string | null
     }
+    /**
+     * TransactionExportColumn
+     * @enum {string}
+     */
+    TransactionExportColumn:
+      | 'created_at'
+      | 'description'
+      | 'gross_amount'
+      | 'fees_amount'
+      | 'tax_amount'
+      | 'net_amount'
+      | 'status'
+      | 'payout_date'
+      | 'currency'
+      | 'product'
+      | 'customer_email'
+      | 'type'
     /** TransactionIssueReward */
     TransactionIssueReward: {
       /**
@@ -42438,6 +42477,50 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ListResource_Transaction_']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'transactions:export': {
+    parameters: {
+      query?: {
+        type?: components['schemas']['TransactionType'] | null
+        account_id?: string | null
+        exclude_platform_fees?: boolean
+        /** @description Only include transactions created after this date. Must include a UTC offset. */
+        created_after?: string | null
+        /** @description Only include transactions created before this date. Must include a UTC offset. */
+        created_before?: string | null
+        /** @description Time zone used to render dates in the CSV. */
+        timezone?: string
+        /** @description Columns to include in the CSV, in order. Defaults to date, description, gross, fees, tax, net, status and payout date. */
+        columns?:
+          | components['schemas']['TransactionExportColumn']
+          | components['schemas']['TransactionExportColumn'][]
+          | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'text/csv': string
         }
       }
       /** @description Validation Error */
@@ -68974,6 +69057,22 @@ export const tierTypeValues: ReadonlyArray<
 export const timeIntervalValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['TimeInterval']
 > = ['year', 'month', 'week', 'day', 'hour']
+export const transactionExportColumnValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['TransactionExportColumn']
+> = [
+  'created_at',
+  'description',
+  'gross_amount',
+  'fees_amount',
+  'tax_amount',
+  'net_amount',
+  'status',
+  'payout_date',
+  'currency',
+  'product',
+  'customer_email',
+  'type',
+]
 export const transactionSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['TransactionSortProperty']
 > = ['created_at', '-created_at', 'amount', '-amount']

--- a/server/polar/transaction/endpoints.py
+++ b/server/polar/transaction/endpoints.py
@@ -1,12 +1,15 @@
 from typing import Annotated
+from zoneinfo import ZoneInfo
 
 from fastapi import Depends, Query
-from pydantic import UUID4
+from pydantic import UUID4, AwareDatetime
 
 from polar.account.service import account as account_service
 from polar.auth.permission import OrganizationPermission
 from polar.exceptions import ResourceNotFound
+from polar.kit.csv import CSVStreamingResponse
 from polar.kit.pagination import ListResource, PaginationParamsQuery
+from polar.kit.schemas import MultipleQueryFilter
 from polar.kit.sorting import Sorting, SortingGetter
 from polar.models.transaction import TransactionType
 from polar.openapi import APITag
@@ -16,6 +19,12 @@ from polar.transaction import (
     auth as transactions_auth,
 )
 
+from .export import (
+    TransactionExportColumn,
+    TransactionExportTimezone,
+    generate_csv,
+    get_filename,
+)
 from .schemas import Transaction, TransactionsSummary
 from .service.transaction import TransactionSortProperty
 from .service.transaction import transaction as transaction_service
@@ -59,6 +68,58 @@ async def search_transactions(
         [Transaction.model_validate(result) for result in results],
         count,
         pagination,
+    )
+
+
+@router.get("/export", summary="Export Income", response_class=CSVStreamingResponse)
+async def export(
+    auth_subject: transactions_auth.TransactionsRead,
+    type: TransactionType | None = Query(None),
+    account_id: UUID4 | None = Query(None),
+    exclude_platform_fees: bool = Query(False),
+    created_after: AwareDatetime | None = Query(
+        None,
+        description=(
+            "Only include transactions created after this date. "
+            "Must include a UTC offset."
+        ),
+    ),
+    created_before: AwareDatetime | None = Query(
+        None,
+        description=(
+            "Only include transactions created before this date. "
+            "Must include a UTC offset."
+        ),
+    ),
+    timezone: Annotated[
+        TransactionExportTimezone,
+        Query(description="Time zone used to render dates in the CSV."),
+    ] = "UTC",
+    columns: MultipleQueryFilter[TransactionExportColumn] | None = Query(
+        None,
+        description=(
+            "Columns to include in the CSV, in order. "
+            "Defaults to date, description, gross, fees, tax, net, "
+            "status and payout date."
+        ),
+    ),
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> CSVStreamingResponse:
+    """Export income transactions as a CSV file."""
+    tzinfo = ZoneInfo(timezone)
+    return CSVStreamingResponse(
+        generate_csv(
+            session,
+            auth_subject,
+            type=type,
+            account_id=account_id,
+            exclude_platform_fees=exclude_platform_fees,
+            created_after=created_after,
+            created_before=created_before,
+            timezone=tzinfo,
+            columns=columns,
+        ),
+        get_filename(created_after, created_before, tzinfo),
     )
 
 

--- a/server/polar/transaction/export.py
+++ b/server/polar/transaction/export.py
@@ -1,0 +1,205 @@
+from collections.abc import AsyncGenerator, Sequence
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Annotated
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import UUID4, AfterValidator
+
+from polar.auth.models import AuthSubject, User
+from polar.kit.csv import IterableCSVWriter
+from polar.kit.db.postgres import AsyncReadSession
+from polar.models import Transaction
+from polar.models.transaction import PlatformFeeType, TransactionType
+
+from .service.transaction import transaction as transaction_service
+
+
+class TransactionExportColumn(StrEnum):
+    created_at = "created_at"
+    description = "description"
+    gross_amount = "gross_amount"
+    fees_amount = "fees_amount"
+    tax_amount = "tax_amount"
+    net_amount = "net_amount"
+    status = "status"
+    payout_date = "payout_date"
+    currency = "currency"
+    product = "product"
+    customer_email = "customer_email"
+    type = "type"
+
+
+TRANSACTION_EXPORT_HEADERS: dict[TransactionExportColumn, str] = {
+    TransactionExportColumn.created_at: "Date",
+    TransactionExportColumn.description: "Description",
+    TransactionExportColumn.gross_amount: "Gross",
+    TransactionExportColumn.fees_amount: "Fees",
+    TransactionExportColumn.tax_amount: "Tax",
+    TransactionExportColumn.net_amount: "Net",
+    TransactionExportColumn.status: "Status",
+    TransactionExportColumn.payout_date: "Payout Date",
+    TransactionExportColumn.currency: "Currency",
+    TransactionExportColumn.product: "Product",
+    TransactionExportColumn.customer_email: "Customer Email",
+    TransactionExportColumn.type: "Type",
+}
+
+TRANSACTION_EXPORT_DEFAULT_COLUMNS: list[TransactionExportColumn] = [
+    TransactionExportColumn.created_at,
+    TransactionExportColumn.description,
+    TransactionExportColumn.gross_amount,
+    TransactionExportColumn.fees_amount,
+    TransactionExportColumn.tax_amount,
+    TransactionExportColumn.net_amount,
+    TransactionExportColumn.status,
+    TransactionExportColumn.payout_date,
+]
+
+
+def _validate_timezone(value: str) -> str:
+    try:
+        ZoneInfo(value)
+    except ValueError, ZoneInfoNotFoundError:
+        raise ValueError(f"{value!r} is not a valid IANA time zone") from None
+    return value
+
+
+TransactionExportTimezone = Annotated[str, AfterValidator(_validate_timezone)]
+
+
+def _datetime(value: datetime | None, tz: ZoneInfo) -> str | None:
+    return value.astimezone(tz).isoformat() if value is not None else None
+
+
+def _amount(value: int | None) -> float | None:
+    return None if value is None else value / 100
+
+
+def _description(transaction: Transaction) -> str:
+    if transaction.order is not None:
+        kind = "Subscription" if transaction.order.subscription_id else "Purchase"
+        product_name = (
+            transaction.order.product.name if transaction.order.product else None
+        )
+        return f"{kind} — {product_name}" if product_name else kind
+    if transaction.issue_reward is not None:
+        return f"Reward — {transaction.issue_reward.issue_reference}"
+    if transaction.pledge is not None:
+        return f"Pledge to {transaction.pledge.issue_reference}"
+    if transaction.platform_fee_type is not None:
+        if transaction.platform_fee_type == PlatformFeeType.platform:
+            return "Polar fee"
+        return f"Payment processor fee ({transaction.platform_fee_type})"
+    if transaction.type == TransactionType.payout:
+        return "Payout"
+    return str(transaction.type)
+
+
+def _status(transaction: Transaction, now: datetime) -> str:
+    if transaction.payout_transaction_id is not None:
+        return "Paid out"
+    if transaction.type == TransactionType.payout:
+        return "Available"
+    delay: timedelta | None = (
+        transaction.account.payout_transaction_delay if transaction.account else None
+    )
+    if delay is None or delay.total_seconds() == 0:
+        return "Available"
+    if transaction.created_at + delay <= now:
+        return "Available"
+    return "Pending"
+
+
+def _payout_date(transaction: Transaction) -> datetime | None:
+    payout_transaction = transaction.payout_transaction
+    if payout_transaction is None:
+        return None
+    payout = payout_transaction.payout
+    if payout is None:
+        return None
+    return payout.paid_at
+
+
+def _product(transaction: Transaction) -> str | None:
+    if transaction.order is None or transaction.order.product is None:
+        return None
+    return transaction.order.product.name
+
+
+def _customer_email(transaction: Transaction) -> str | None:
+    if transaction.order is not None:
+        return transaction.order.customer.email
+    payment = transaction.payment_transaction
+    if payment is not None and payment.payment_customer is not None:
+        return payment.payment_customer.email
+    return None
+
+
+def _row(
+    transaction: Transaction, tz: ZoneInfo, now: datetime
+) -> dict[TransactionExportColumn, str | float | None]:
+    payment = transaction.payment_transaction
+    gross = payment.amount + payment.tax_amount if payment is not None else None
+    tax = -payment.tax_amount if payment is not None else None
+    return {
+        TransactionExportColumn.created_at: _datetime(transaction.created_at, tz),
+        TransactionExportColumn.description: _description(transaction),
+        TransactionExportColumn.gross_amount: _amount(gross),
+        TransactionExportColumn.fees_amount: _amount(transaction.incurred_amount),
+        TransactionExportColumn.tax_amount: _amount(tax),
+        TransactionExportColumn.net_amount: _amount(transaction.net_amount),
+        TransactionExportColumn.status: _status(transaction, now),
+        TransactionExportColumn.payout_date: _datetime(_payout_date(transaction), tz),
+        TransactionExportColumn.currency: transaction.currency,
+        TransactionExportColumn.product: _product(transaction),
+        TransactionExportColumn.customer_email: _customer_email(transaction),
+        TransactionExportColumn.type: transaction.type,
+    }
+
+
+def get_filename(
+    created_after: datetime | None,
+    created_before: datetime | None,
+    timezone: ZoneInfo,
+) -> str:
+    filename = "polar-income"
+    for bound in (created_after, created_before):
+        if bound is not None:
+            filename += f"-{bound.astimezone(timezone).strftime('%Y-%m-%d')}"
+    return f"{filename}.csv"
+
+
+async def generate_csv(
+    session: AsyncReadSession,
+    auth_subject: AuthSubject[User],
+    *,
+    type: TransactionType | None,
+    account_id: UUID4 | None,
+    exclude_platform_fees: bool,
+    created_after: datetime | None,
+    created_before: datetime | None,
+    timezone: ZoneInfo,
+    columns: Sequence[TransactionExportColumn] | None,
+) -> AsyncGenerator[str]:
+    export_columns = columns or TRANSACTION_EXPORT_DEFAULT_COLUMNS
+
+    csv_writer = IterableCSVWriter(dialect="excel")
+    yield csv_writer.getrow(
+        tuple(TRANSACTION_EXPORT_HEADERS[column] for column in export_columns)
+    )
+
+    results = await transaction_service.export(
+        session,
+        auth_subject,
+        type=type,
+        account_id=account_id,
+        exclude_platform_fees=exclude_platform_fees,
+        created_after=created_after,
+        created_before=created_before,
+    )
+
+    now = datetime.now(UTC)
+    for transaction in results:
+        row = _row(transaction, timezone, now)
+        yield csv_writer.getrow(tuple(row[column] for column in export_columns))

--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from sqlalchemy import Select, UnaryExpression, asc, desc, func, or_, select
 from sqlalchemy.exc import NoResultFound
-from sqlalchemy.orm import joinedload, subqueryload
+from sqlalchemy.orm import joinedload, selectinload, subqueryload
 
 from polar.auth.models import AuthSubject
 from polar.auth.permission import OrganizationPermission
@@ -55,7 +55,15 @@ class TransactionService(BaseTransactionService):
             (TransactionSortProperty.created_at, True),
         ),
     ) -> tuple[Sequence[Transaction], int]:
-        statement = self._get_readable_transactions_statement(auth_subject)
+        statement = self._get_search_statement(
+            auth_subject,
+            type=type,
+            account_id=account_id,
+            payment_customer_id=payment_customer_id,
+            payment_organization_id=payment_organization_id,
+            payment_user_id=payment_user_id,
+            exclude_platform_fees=exclude_platform_fees,
+        )
 
         statement = statement.options(
             # Incurred transactions
@@ -72,23 +80,6 @@ class TransactionService(BaseTransactionService):
             subqueryload(Transaction.payment_transaction),
         )
 
-        if type is not None:
-            statement = statement.where(Transaction.type == type)
-        if account_id is not None:
-            statement = statement.where(Transaction.account_id == account_id)
-        if payment_customer_id is not None:
-            statement = statement.where(
-                Transaction.payment_customer_id == payment_customer_id
-            )
-        if payment_organization_id is not None:
-            statement = statement.where(
-                Transaction.payment_organization_id == payment_organization_id
-            )
-        if payment_user_id is not None:
-            statement = statement.where(Transaction.payment_user_id == payment_user_id)
-        if exclude_platform_fees:
-            statement = statement.where(Transaction.platform_fee_type.is_(None))
-
         order_by_clauses: list[UnaryExpression[Any]] = []
         for criterion, is_desc in sorting:
             clause_function = desc if is_desc else asc
@@ -101,6 +92,47 @@ class TransactionService(BaseTransactionService):
         results, count = await paginate(session, statement, pagination=pagination)
 
         return results, count
+
+    async def export(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User],
+        *,
+        type: TransactionType | None = None,
+        account_id: uuid.UUID | None = None,
+        exclude_platform_fees: bool = False,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
+    ) -> Sequence[Transaction]:
+        statement = (
+            self._get_search_statement(
+                auth_subject,
+                type=type,
+                account_id=account_id,
+                exclude_platform_fees=exclude_platform_fees,
+                created_after=created_after,
+                created_before=created_before,
+            )
+            .options(
+                subqueryload(Transaction.account_incurred_transactions),
+                subqueryload(Transaction.pledge),
+                subqueryload(Transaction.issue_reward),
+                subqueryload(Transaction.order).options(
+                    joinedload(Order.product),
+                    joinedload(Order.customer),
+                ),
+                subqueryload(Transaction.payment_transaction).options(
+                    joinedload(Transaction.payment_customer),
+                ),
+                selectinload(Transaction.payout_transaction).selectinload(
+                    Transaction.payout
+                ),
+                selectinload(Transaction.account),
+            )
+            .order_by(desc(Transaction.created_at))
+        )
+        result = await session.execute(statement)
+        return result.unique().scalars().all()
 
     async def lookup(
         self,
@@ -336,6 +368,44 @@ class TransactionService(BaseTransactionService):
 
         result = await session.execute(statement)
         return int(result.scalar_one())
+
+    def _get_search_statement(
+        self,
+        auth_subject: AuthSubject[User],
+        *,
+        type: TransactionType | None = None,
+        account_id: uuid.UUID | None = None,
+        payment_customer_id: uuid.UUID | None = None,
+        payment_organization_id: uuid.UUID | None = None,
+        payment_user_id: uuid.UUID | None = None,
+        exclude_platform_fees: bool = False,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
+    ) -> Select[Any]:
+        statement = self._get_readable_transactions_statement(auth_subject)
+
+        if type is not None:
+            statement = statement.where(Transaction.type == type)
+        if account_id is not None:
+            statement = statement.where(Transaction.account_id == account_id)
+        if payment_customer_id is not None:
+            statement = statement.where(
+                Transaction.payment_customer_id == payment_customer_id
+            )
+        if payment_organization_id is not None:
+            statement = statement.where(
+                Transaction.payment_organization_id == payment_organization_id
+            )
+        if payment_user_id is not None:
+            statement = statement.where(Transaction.payment_user_id == payment_user_id)
+        if exclude_platform_fees:
+            statement = statement.where(Transaction.platform_fee_type.is_(None))
+        if created_after is not None:
+            statement = statement.where(Transaction.created_at >= created_after)
+        if created_before is not None:
+            statement = statement.where(Transaction.created_at <= created_before)
+
+        return statement
 
     def _get_readable_transactions_statement(
         self, auth_subject: AuthSubject[User]

--- a/server/tests/transaction/test_endpoints.py
+++ b/server/tests/transaction/test_endpoints.py
@@ -1,13 +1,24 @@
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 from httpx import AsyncClient
 
 from polar.auth.models import AuthSubject
-from polar.models import Account, Organization, Transaction, User, UserOrganization
+from polar.models import (
+    Account,
+    Organization,
+    PayoutAccount,
+    Transaction,
+    User,
+    UserOrganization,
+)
+from polar.models.payout_attempt import PayoutAttemptStatus
+from polar.models.transaction import PlatformFeeType, TransactionType
 from polar.models.user_organization import OrganizationRole
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_payout
 from tests.transaction.conftest import create_transaction
 
 
@@ -129,3 +140,252 @@ class TestGetSummary:
         json = response.json()
         assert "balance" in json
         assert "payout" in json
+
+
+EXPORT_DEFAULT_HEADER = "Date,Description,Gross,Fees,Tax,Net,Status,Payout Date"
+
+
+@pytest.mark.asyncio
+class TestExportTransactions:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/transactions/export")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="user_second"))
+    async def test_user_not_account_member(
+        self,
+        client: AsyncClient,
+        account: Account,
+        account_transactions: list[Transaction],
+    ) -> None:
+        response = await client.get(
+            "/v1/transactions/export", params={"account_id": str(account.id)}
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/csv; charset=utf-8"
+        csv_lines = response.text.strip().split("\r\n")
+        assert csv_lines == [EXPORT_DEFAULT_HEADER]
+
+    @pytest.mark.auth
+    async def test_user_valid(
+        self,
+        client: AsyncClient,
+        account: Account,
+        user_organization: UserOrganization,
+        account_transactions: list[Transaction],
+    ) -> None:
+        response = await client.get(
+            "/v1/transactions/export",
+            params={"account_id": str(account.id), "type": "balance"},
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/csv; charset=utf-8"
+        assert (
+            response.headers["content-disposition"]
+            == 'attachment; filename="polar-income.csv"'
+        )
+
+        csv_lines = response.text.strip().split("\r\n")
+        balance_count = sum(
+            1 for tx in account_transactions if tx.type == TransactionType.balance
+        )
+        assert csv_lines[0] == EXPORT_DEFAULT_HEADER
+        assert len(csv_lines) == balance_count + 1
+
+    @pytest.mark.auth
+    async def test_filter_by_date_range(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        account: Account,
+        user_organization: UserOrganization,
+    ) -> None:
+        await create_transaction(
+            save_fixture,
+            account=account,
+            created_at=datetime(2024, 1, 15, tzinfo=UTC),
+        )
+        await create_transaction(
+            save_fixture,
+            account=account,
+            created_at=datetime(2024, 6, 15, tzinfo=UTC),
+        )
+
+        response = await client.get(
+            "/v1/transactions/export",
+            params={
+                "account_id": str(account.id),
+                "created_after": "2024-06-01T00:00:00Z",
+                "created_before": "2024-06-30T23:59:59Z",
+            },
+        )
+
+        assert response.status_code == 200
+        assert (
+            response.headers["content-disposition"]
+            == 'attachment; filename="polar-income-2024-06-01-2024-06-30.csv"'
+        )
+        csv_lines = response.text.strip().split("\r\n")
+        assert len(csv_lines) == 2
+        assert "2024-06-15" in csv_lines[1]
+        assert "2024-01-15" not in response.text
+
+    @pytest.mark.auth
+    async def test_naive_date_bounds(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            "/v1/transactions/export",
+            params={"created_after": "2024-06-01T00:00:00"},
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_custom_columns(
+        self,
+        client: AsyncClient,
+        account: Account,
+        user_organization: UserOrganization,
+        account_transactions: list[Transaction],
+    ) -> None:
+        response = await client.get(
+            "/v1/transactions/export",
+            params={
+                "account_id": str(account.id),
+                "columns": ["description", "net_amount", "payout_date", "status"],
+            },
+        )
+
+        assert response.status_code == 200
+        csv_lines = response.text.strip().split("\r\n")
+        assert csv_lines[0] == "Description,Net,Payout Date,Status"
+
+    @pytest.mark.auth
+    async def test_invalid_column(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            "/v1/transactions/export", params={"columns": ["not_a_column"]}
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_timezone(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        account: Account,
+        user_organization: UserOrganization,
+    ) -> None:
+        await create_transaction(
+            save_fixture,
+            account=account,
+            created_at=datetime(2024, 6, 15, 23, 0, tzinfo=UTC),
+        )
+
+        response = await client.get(
+            "/v1/transactions/export",
+            params={"account_id": str(account.id), "timezone": "Europe/Stockholm"},
+        )
+
+        assert response.status_code == 200
+        csv_lines = response.text.strip().split("\r\n")
+        assert "2024-06-16T01:00:00+02:00" in csv_lines[1]
+
+    @pytest.mark.auth
+    async def test_invalid_timezone(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            "/v1/transactions/export", params={"timezone": "Not/AZone"}
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_payout_date(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        account: Account,
+        user_organization: UserOrganization,
+        stripe_payout_account: PayoutAccount,
+    ) -> None:
+        payout_transaction = await create_transaction(
+            save_fixture,
+            type=TransactionType.payout,
+            account=account,
+            amount=-1000,
+        )
+        payout = await create_payout(
+            save_fixture,
+            payout_account=stripe_payout_account,
+            account=account,
+            transaction=payout_transaction,
+            attempts=[PayoutAttemptStatus.succeeded],
+        )
+        paid_at = datetime(2024, 7, 1, 12, 0, tzinfo=UTC)
+        payout.attempts[0].paid_at = paid_at
+        await save_fixture(payout.attempts[0])
+
+        await create_transaction(
+            save_fixture,
+            type=TransactionType.balance,
+            account=account,
+            payout_transaction=payout_transaction,
+        )
+
+        response = await client.get(
+            "/v1/transactions/export",
+            params={
+                "account_id": str(account.id),
+                "type": "balance",
+                "columns": ["status", "payout_date"],
+            },
+        )
+
+        assert response.status_code == 200
+        csv_lines = response.text.strip().split("\r\n")
+        assert csv_lines[0] == "Status,Payout Date"
+        assert len(csv_lines) == 2
+        assert csv_lines[1] == f"Paid out,{paid_at.isoformat()}"
+
+    @pytest.mark.auth
+    async def test_exclude_platform_fees(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        account: Account,
+        user_organization: UserOrganization,
+    ) -> None:
+        included = await create_transaction(save_fixture, account=account)
+        await create_transaction(
+            save_fixture,
+            account=account,
+            platform_fee_type=PlatformFeeType.payment,
+        )
+
+        response = await client.get(
+            "/v1/transactions/export",
+            params={
+                "account_id": str(account.id),
+                "exclude_platform_fees": True,
+                "columns": ["description"],
+            },
+        )
+
+        assert response.status_code == 200
+        csv_lines = response.text.strip().split("\r\n")
+        assert len(csv_lines) == 2
+        assert csv_lines[1] == str(included.type)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds CSV export on the finance income page (`/dashboard/{org}/finance/income`), including a **Payout Date** column.

**Related Issue**: N/A — requested to export income data with payout date.

## What

- New private endpoint `GET /v1/transactions/export` that streams income transactions as CSV
- Default columns match the income table, plus payout date (`paid_at` of the related payout)
- Export button and modal on the income page (date range, timezone, column picker)

## Why

The income page had no export. Individual payout CSVs exist, but they don't cover the full income list or a payout date column. Merchants need this for accounting reconciliation.

## How

- Follows the orders/subscriptions export pattern (`columns`, `timezone`, date bounds)
- Payout date is taken from the related payout's `paid_at` (Stripe arrival date); empty until paid out
- Status uses the same pending / available / paid out rules as the income table
- Endpoint is tagged private (dashboard-only), same as the rest of `/v1/transactions`

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-526065f0-7a28-42ce-9969-8c583472e1ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-526065f0-7a28-42ce-9969-8c583472e1ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

