### PR TITLE
Fix inclusive-tax display in customer portal next charge card

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.test.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.test.tsx
@@ -73,7 +73,10 @@ const createSubscription = (
       : null,
   }) as unknown as schemas['CustomerSubscription']
 
-const mockChargePreview = (baseAmount: number) => {
+const mockChargePreview = (
+  baseAmount: number,
+  overrides: Partial<schemas['SubscriptionChargePreview']> = {},
+) => {
   const preview: schemas['SubscriptionChargePreview'] = {
     base_amount: baseAmount,
     metered_amount: 0,
@@ -83,9 +86,11 @@ const mockChargePreview = (baseAmount: number) => {
     discount_amount: 0,
     net_amount: baseAmount,
     tax_amount: 0,
+    tax_behavior: null,
     total_amount: baseAmount,
     applied_balance_amount: 0,
     due_amount: baseAmount,
+    ...overrides,
   }
 
   vi.mocked(useCustomerSubscriptionChargePreview).mockReturnValue({
@@ -114,6 +119,53 @@ describe('CurrentPeriodOverview', () => {
     )
     expect(container.textContent).not.toContain(
       formatCurrency('compact')(1999, 'usd'),
+    )
+  })
+
+  it('shows the net subtotal and an included-tax label for inclusive tax', () => {
+    mockChargePreview(700, {
+      net_amount: 560,
+      tax_amount: 140,
+      tax_behavior: 'inclusive',
+      total_amount: 700,
+      due_amount: 700,
+    })
+    const subscription = createSubscription(createFixedPrice(700), null, 700)
+    const { container } = render(
+      <CurrentPeriodOverview
+        subscription={subscription}
+        products={[createProduct('product-1', createFixedPrice(700))]}
+        api={{} as Client}
+      />,
+    )
+
+    expect(container.textContent).toContain('Taxes (included)')
+    expect(container.textContent).toContain(
+      formatCurrency('compact')(560, 'usd'),
+    )
+  })
+
+  it('shows the gross subtotal for exclusive tax', () => {
+    mockChargePreview(700, {
+      net_amount: 700,
+      tax_amount: 140,
+      tax_behavior: 'exclusive',
+      total_amount: 840,
+      due_amount: 840,
+    })
+    const subscription = createSubscription(createFixedPrice(700), null, 700)
+    const { container } = render(
+      <CurrentPeriodOverview
+        subscription={subscription}
+        products={[createProduct('product-1', createFixedPrice(700))]}
+        api={{} as Client}
+      />,
+    )
+
+    expect(container.textContent).toContain('Taxes')
+    expect(container.textContent).not.toContain('Taxes (included)')
+    expect(container.textContent).toContain(
+      formatCurrency('compact')(840, 'usd'),
     )
   })
 

--- a/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.tsx
@@ -82,6 +82,7 @@ export const CurrentPeriodOverview = ({
   const prorations = subscriptionPreview?.prorations ?? []
   const hasProrations = prorations.length > 0
   const hasTaxes = subscriptionPreview && subscriptionPreview.tax_amount > 0
+  const isTaxInclusive = subscriptionPreview?.tax_behavior === 'inclusive'
   const hasDiscount =
     subscriptionPreview && subscriptionPreview.discount_amount > 0
 
@@ -234,7 +235,10 @@ export const CurrentPeriodOverview = ({
             <span>Subtotal</span>
             <span>
               {formatCurrency('compact')(
-                subscriptionPreview.subtotal_amount,
+                isTaxInclusive
+                  ? subscriptionPreview.total_amount -
+                      subscriptionPreview.tax_amount
+                  : subscriptionPreview.subtotal_amount,
                 subscription.currency,
               )}
             </span>
@@ -255,7 +259,7 @@ export const CurrentPeriodOverview = ({
 
         {hasTaxes && (
           <div className="dark:text-polar-500 mb-1 flex items-center justify-between text-gray-500">
-            <span>Taxes</span>
+            <span>{isTaxInclusive ? 'Taxes (included)' : 'Taxes'}</span>
             <span>
               {formatCurrency('compact')(
                 subscriptionPreview.tax_amount,

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -34063,6 +34063,8 @@ export interface components {
        * @description Tax amount in cents
        */
       tax_amount: number
+      /** @description Tax behavior of the charge. `inclusive` means the price includes tax, `exclusive` means tax is added on top. If `null`, tax could not be calculated. */
+      tax_behavior: components['schemas']['TaxBehavior'] | null
       /**
        * Total Amount
        * @description Total amount in cents (net + tax, before applying wallet balance)

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -16,7 +16,11 @@ from pydantic.json_schema import SkipJsonSchema
 from polar.custom_field.data import CustomFieldDataOutputMixin
 from polar.customer.schemas.customer import CustomerBase
 from polar.discount.schemas import DiscountMinimal
-from polar.enums import SubscriptionProrationBehavior, SubscriptionRecurringInterval
+from polar.enums import (
+    SubscriptionProrationBehavior,
+    SubscriptionRecurringInterval,
+    TaxBehavior,
+)
 from polar.kit.currency import format_currency
 from polar.kit.metadata import MetadataInputMixin, MetadataOutputMixin
 from polar.kit.schemas import (
@@ -567,6 +571,14 @@ class SubscriptionChargePreview(Schema):
     discount_amount: int = Field(description="Discount amount in cents")
     net_amount: int = Field(description="Net amount in cents before taxes")
     tax_amount: int = Field(description="Tax amount in cents")
+    tax_behavior: TaxBehavior | None = Field(
+        description=(
+            "Tax behavior of the charge. "
+            "`inclusive` means the price includes tax, "
+            "`exclusive` means tax is added on top. "
+            "If `null`, tax could not be calculated."
+        )
+    )
     total_amount: int = Field(
         description="Total amount in cents (net + tax, before applying wallet balance)"
     )

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -3334,6 +3334,7 @@ class SubscriptionService:
             discount_amount=order.discount_amount,
             net_amount=order.net_amount,
             tax_amount=order.tax_amount,
+            tax_behavior=order.tax_behavior,
             total_amount=order.total_amount,
             applied_balance_amount=order.applied_balance_amount,
             due_amount=order.due_amount,

--- a/server/tests/subscription/test_service_charge_preview.py
+++ b/server/tests/subscription/test_service_charge_preview.py
@@ -202,6 +202,7 @@ class TestCalculateChargePreview:
 
         assert preview.net_amount == 1000
         assert preview.tax_amount == 200
+        assert preview.tax_behavior == TaxBehavior.exclusive
         assert preview.total_amount == 1200
 
     async def test_inclusive_tax_carved_out_of_net(
@@ -231,6 +232,7 @@ class TestCalculateChargePreview:
 
         assert preview.net_amount == 800
         assert preview.tax_amount == 200
+        assert preview.tax_behavior == TaxBehavior.inclusive
         assert preview.total_amount == 1000
 
     async def test_metered_amount_included_in_subtotal(


### PR DESCRIPTION
The Next Charge card always rendered the gross subtotal_amount with a
plain "Taxes" label, so a tax-inclusive subscription showed the
incoherent "$7 + $1.40 = $7". Expose tax_behavior on
SubscriptionChargePreview (pinned per subscription at creation) and,
when inclusive, render the net subtotal with a "Taxes (included)"
label, matching the checkout pricing breakdown.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

