### PR TITLE
events: Chunk ingested events

### DIFF
--- a/server/polar/worker/_enqueue.py
+++ b/server/polar/worker/_enqueue.py
@@ -39,6 +39,9 @@ _job_queue_manager: contextvars.ContextVar["JobQueueManager | None"] = (
 
 FLUSH_BATCH_SIZE = 50
 
+UUID_JSON_BYTES = 40
+EVENT_INGESTED_CHUNK_SIZE = _sqs.MAX_JOB_PAYLOAD_BYTES // UUID_JSON_BYTES
+
 
 def should_route_to_sqs(actor_name: str) -> bool:
     return settings.WORKER_SQS_ENABLED and actor_name in settings.WORKER_SQS_ACTORS
@@ -72,8 +75,10 @@ class JobQueueManager:
         self._ingested_events.extend(event_ids)
 
     async def flush(self, broker: dramatiq.Broker, redis: Redis) -> None:
-        if len(self._ingested_events) > 0:
-            self.enqueue_job("event.ingested", self._ingested_events)
+        for chunk in itertools.batched(
+            self._ingested_events, EVENT_INGESTED_CHUNK_SIZE
+        ):
+            self.enqueue_job("event.ingested", list(chunk))
 
         if not self._enqueued_jobs:
             self.reset()

--- a/server/tests/worker/test_enqueue_gate.py
+++ b/server/tests/worker/test_enqueue_gate.py
@@ -1,5 +1,6 @@
-from typing import TYPE_CHECKING
-from uuid import uuid4
+import json
+from typing import TYPE_CHECKING, Any
+from uuid import UUID, uuid4
 
 import dramatiq
 import pytest
@@ -10,6 +11,7 @@ from polar.config import settings
 from polar.logging import CorrelationID
 from polar.redis import Redis
 from polar.worker import MAX_JOB_PAYLOAD_BYTES, JobQueueManager
+from polar.worker._enqueue import EVENT_INGESTED_CHUNK_SIZE
 from polar.worker._sqs import (
     SQS_MAX_BATCH_BYTES,
     actor_to_queue_name,
@@ -96,6 +98,47 @@ class TestFlushGate:
         # Non-allowlisted actor still went to Redis; the SQS one did not.
         assert await redis.llen("dramatiq:low_priority") == 1
         assert await redis.llen("dramatiq:high_priority") == 0
+
+
+@pytest.mark.asyncio
+class TestFlushIngestedEventsChunking:
+    async def get_low_priority_jobs(self, redis: Redis) -> list[dict[str, Any]]:
+        message_ids = await redis.lrange("dramatiq:low_priority", 0, -1)
+        messages = await redis.hgetall("dramatiq:low_priority.msgs")
+        return [json.loads(messages[message_id]) for message_id in message_ids]
+
+    async def test_splits_into_ordered_chunks(
+        self, redis: Redis, mocker: MockerFixture
+    ) -> None:
+        mocker.patch("polar.worker._enqueue.EVENT_INGESTED_CHUNK_SIZE", 3)
+
+        CorrelationID.set()
+        event_ids = [uuid4() for _ in range(8)]
+        jqm = JobQueueManager()
+        jqm.enqueue_events(*event_ids)
+        await jqm.flush(dramatiq.get_broker(), redis)
+
+        chunks = [job["args"][0] for job in await self.get_low_priority_jobs(redis)]
+        assert [len(chunk) for chunk in chunks] == [3, 3, 2]
+        assert [UUID(event_id) for chunk in chunks for event_id in chunk] == event_ids
+
+    async def test_each_job_fits_the_sqs_message_limit(self, redis: Redis) -> None:
+        CorrelationID.set()
+        jqm = JobQueueManager()
+        jqm.enqueue_events(*(uuid4() for _ in range(EVENT_INGESTED_CHUNK_SIZE + 1)))
+        await jqm.flush(dramatiq.get_broker(), redis)
+
+        messages = await redis.hgetall("dramatiq:low_priority.msgs")
+        assert len(messages) == 2
+        for encoded_message in messages.values():
+            assert len(encoded_message) <= SQS_MAX_BATCH_BYTES
+
+    async def test_no_job_without_events(self, redis: Redis) -> None:
+        CorrelationID.set()
+        jqm = JobQueueManager()
+        await jqm.flush(dramatiq.get_broker(), redis)
+
+        assert await redis.llen("dramatiq:low_priority") == 0
 
 
 class TestPackBatches:


### PR DESCRIPTION
Otherwise when we ingest too many events SQS will choke

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Chunks `event.ingested` jobs to keep each SQS message under the size limit and prevent drops. Previously all event IDs went in one job; now we split into ordered chunks sized to fit SQS, which may produce multiple jobs per flush.

- Compute `EVENT_INGESTED_CHUNK_SIZE` as `_sqs.MAX_JOB_PAYLOAD_BYTES // UUID_JSON_BYTES` with `UUID_JSON_BYTES = 40`, and batch via `itertools.batched`.
- `flush()` enqueues one job per chunk, preserves event order, and enqueues nothing when there are no events.
- Tests verify ordered chunking, each encoded message stays within `SQS_MAX_BATCH_BYTES`, and empty flush produces no jobs.

<sup>Written for commit b5e38cbee2e603b3ac0ccc960b2dd2e3a9f3e8f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

