### PR TITLE
tf: Move Cloudflare to its own variable set

### DIFF
--- a/terraform/global/credentials.tf
+++ b/terraform/global/credentials.tf
@@ -1,0 +1,14 @@
+resource "tfe_variable_set" "credentials" {
+  name         = "Shared Credentials"
+  description  = "Provider credentials shared by every workspace"
+  organization = "polar-sh"
+  global       = true
+}
+
+resource "tfe_variable" "cloudflare_api_token" {
+  key             = "CLOUDFLARE_API_TOKEN"
+  category        = "env"
+  description     = "Cloudflare API token for handling domain configuration"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.credentials.id
+}

--- a/terraform/global/main.tf
+++ b/terraform/global/main.tf
@@ -95,14 +95,6 @@ resource "tfe_variable" "grafana_cloud_prometheus_password" {
   variable_set_id = tfe_variable_set.global.id
 }
 
-resource "tfe_variable" "cloudflare_api_token" {
-  key             = "CLOUDFLARE_API_TOKEN"
-  category        = "env"
-  description     = "Cloudflare API token for handling domain configuration"
-  sensitive       = true
-  variable_set_id = tfe_variable_set.global.id
-}
-
 resource "tfe_variable" "vercel_api_token" {
   key             = "VERCEL_API_TOKEN"
   category        = "env"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moves CLOUDFLARE_API_TOKEN from the existing global variable set to a new global “Shared Credentials” variable set to centralize provider credentials without changing workspace behavior. Old: token in tfe_variable_set.global. New: token in tfe_variable_set.credentials (global=true). Terraform will recreate the variable.

- Re-set the CLOUDFLARE_API_TOKEN value in the “Shared Credentials” variable set immediately after apply; the sensitive value will not carry over.
- Plan will show one destroy (old variable) and one create (new variable). Verify workspaces still receive the env var via the global set.

<sup>Written for commit c9b69c44aebdb5c614f895d8f6a29c44d48355af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

