### PR TITLE
server/kit/versioning: add version-aware schema fields

### DIFF
--- a/sdk/generator/justfile
+++ b/sdk/generator/justfile
@@ -26,8 +26,8 @@ generate-all:
   uv run -m cli generate openapi/* ../python --language python --clear
   uv run -m cli generate openapi/* ../typescript --language typescript --clear
 
-docs-openapi version="0.0.0":
-  uv run -m cli docs-openapi --version {{version}}
+docs-openapi:
+  uv run -m cli docs-openapi openapi/*
 
 release version:
   uv run -m cli release {{version}}

--- a/server/polar/kit/versioning.py
+++ b/server/polar/kit/versioning.py
@@ -1,18 +1,28 @@
+import contextlib
+import contextvars
 import dataclasses
 import functools
 import re
 import typing
-from collections.abc import Awaitable, Callable, Iterable, Sequence
+from collections.abc import (
+    Awaitable,
+    Callable,
+    Generator,
+    Iterable,
+    Sequence,
+)
 
 from fastapi import APIRouter, FastAPI
 from fastapi.routing import APIRoute
+from pydantic import Field, GetJsonSchemaHandler
+from pydantic.fields import FieldInfo
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema, PydanticOmit
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.responses import JSONResponse
 from starlette.routing import BaseRoute, Match
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocketClose
-
-from polar.openapi import get_openapi
 
 _API_VERSION_PATTERN = re.compile(r"^(\d{4})-(\d{2})$")
 
@@ -52,6 +62,62 @@ class APIVersion:
         headers = Headers(scope=scope)
         raw_version = headers.get(VERSION_HEADER)
         return cls.parse(raw_version) if raw_version else default
+
+
+_ACTIVE_API_VERSION = contextvars.ContextVar[APIVersion | None](
+    "active_api_version", default=None
+)
+
+
+@contextlib.contextmanager
+def api_version_context(version: APIVersion) -> Generator[None]:
+    token = _ACTIVE_API_VERSION.set(version)
+    try:
+        yield
+    finally:
+        _ACTIVE_API_VERSION.reset(token)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _VersionAvailability:
+    versions: frozenset[APIVersion]
+    include_matches: bool
+
+    def is_available(self, version: APIVersion) -> bool:
+        return (version in self.versions) is self.include_matches
+
+    def __get_pydantic_json_schema__(
+        self, core_schema: CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        version = _ACTIVE_API_VERSION.get()
+        if version is not None and not self.is_available(version):
+            raise PydanticOmit
+        return handler(core_schema)
+
+
+def _versioned_field(
+    versions: tuple[APIVersion, ...], *, include_matches: bool
+) -> FieldInfo:
+    if not versions:
+        raise ValueError("At least one API version is required")
+
+    availability = _VersionAvailability(frozenset(versions), include_matches)
+
+    def exclude_if_unavailable(_: typing.Any) -> bool:
+        version = _ACTIVE_API_VERSION.get()
+        return version is not None and not availability.is_available(version)
+
+    field_info = Field(exclude_if=exclude_if_unavailable)
+    field_info.metadata.append(availability)
+    return field_info
+
+
+def IncludedIn(*versions: APIVersion) -> FieldInfo:
+    return _versioned_field(versions, include_matches=True)
+
+
+def ExcludedIn(*versions: APIVersion) -> FieldInfo:
+    return _versioned_field(versions, include_matches=False)
 
 
 def version[**P, R](
@@ -113,7 +179,8 @@ class APIVersionMiddleware:
                 headers[VERSION_HEADER] = str(api_version)
             await send(message)
 
-        await self.app(scope, receive, send_wrapper)
+        with api_version_context(api_version):
+            await self.app(scope, receive, send_wrapper)
 
 
 class VersionedAPIRoute(APIRoute):
@@ -221,6 +288,8 @@ def _create_openapi_endpoint(
 ) -> Callable[[], Awaitable[JSONResponse]]:
     @functools.cache
     def get_schema() -> dict[str, typing.Any]:
+        from polar.openapi import get_openapi
+
         return get_openapi(version=version, routes=routes, webhooks=webhooks)
 
     async def openapi() -> JSONResponse:

--- a/server/polar/openapi.py
+++ b/server/polar/openapi.py
@@ -6,6 +6,7 @@ from fastapi.openapi.utils import get_openapi as _get_openapi
 from starlette.routing import BaseRoute
 
 from polar.kit.metadata import add_metadata_query_schema
+from polar.kit.versioning import api_version_context
 from polar.oauth2.schemas import add_oauth2_form_schemas
 
 if TYPE_CHECKING:
@@ -63,29 +64,30 @@ class APITag(StrEnum):
 def get_openapi(
     version: "APIVersion", routes: Sequence[BaseRoute], webhooks: Sequence[BaseRoute]
 ) -> dict[str, Any]:
-    openapi_schema = _get_openapi(
-        title="Polar API",
-        version=str(version),
-        summary="Polar HTTP and Webhooks API",
-        description="Read the docs at https://polar.sh/docs/api-reference",
-        routes=routes,
-        webhooks=webhooks,
-        tags=APITag.metadata(),  # type: ignore
-        servers=[
-            {
-                "url": "https://api.polar.sh",
-                "description": "Production environment",
-                "x-speakeasy-server-id": "production",
-                "x-polar-environment": "production",
-            },
-            {
-                "url": "https://sandbox-api.polar.sh",
-                "description": "Sandbox environment",
-                "x-speakeasy-server-id": "sandbox",
-                "x-polar-environment": "sandbox",
-            },
-        ],
-    )
+    with api_version_context(version):
+        openapi_schema = _get_openapi(
+            title="Polar API",
+            version=str(version),
+            summary="Polar HTTP and Webhooks API",
+            description="Read the docs at https://polar.sh/docs/api-reference",
+            routes=routes,
+            webhooks=webhooks,
+            tags=APITag.metadata(),  # type: ignore
+            servers=[
+                {
+                    "url": "https://api.polar.sh",
+                    "description": "Production environment",
+                    "x-speakeasy-server-id": "production",
+                    "x-polar-environment": "production",
+                },
+                {
+                    "url": "https://sandbox-api.polar.sh",
+                    "description": "Sandbox environment",
+                    "x-speakeasy-server-id": "sandbox",
+                    "x-polar-environment": "sandbox",
+                },
+            ],
+        )
     openapi_schema = add_metadata_query_schema(openapi_schema)
     openapi_schema = add_oauth2_form_schemas(openapi_schema)
 

--- a/server/tests/kit/test_versioning.py
+++ b/server/tests/kit/test_versioning.py
@@ -4,9 +4,35 @@ from typing import Annotated
 import pytest
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
+from pydantic import BaseModel, Field
 
-from polar.kit.versioning import APIVersion, add_versioned_routers, version
+from polar.kit.versioning import (
+    APIVersion,
+    ExcludedIn,
+    IncludedIn,
+    add_versioned_routers,
+    api_version_context,
+    version,
+)
 from polar.routing import APIRouter
+
+CURRENT_VERSION = APIVersion(2026, 4)
+NEXT_VERSION = APIVersion(2026, 10)
+
+
+class VersionedProduct(BaseModel):
+    name: str
+    shared_field: Annotated[str, IncludedIn(CURRENT_VERSION, NEXT_VERSION)] = "shared"
+    current_field: Annotated[str, ExcludedIn(NEXT_VERSION)] = "current"
+    next_field: Annotated[
+        str,
+        IncludedIn(NEXT_VERSION),
+        Field(description="Only available in the next API version."),
+    ] = "next"
+
+
+class VersionedSubscription(BaseModel):
+    product: VersionedProduct
 
 
 def test_api_version_is_ordered_hashable_and_immutable() -> None:
@@ -30,6 +56,48 @@ def test_version_decorator_only_adds_metadata() -> None:
     assert decorated_endpoint is endpoint
     assert getattr(decorated_endpoint, "_api_versions") == frozenset({api_version})
     assert decorated_endpoint(1) == 2
+
+
+def test_versioned_fields_are_serialized_for_requested_version() -> None:
+    subscription = VersionedSubscription(product=VersionedProduct(name="Pro"))
+
+    with api_version_context(CURRENT_VERSION):
+        assert subscription.model_dump() == {
+            "product": {
+                "name": "Pro",
+                "shared_field": "shared",
+                "current_field": "current",
+            }
+        }
+
+    with api_version_context(NEXT_VERSION):
+        assert subscription.model_dump() == {
+            "product": {
+                "name": "Pro",
+                "shared_field": "shared",
+                "next_field": "next",
+            }
+        }
+
+
+def test_versioned_fields_are_included_in_versioned_openapi_schema() -> None:
+    with api_version_context(CURRENT_VERSION):
+        current_schema = VersionedSubscription.model_json_schema()
+    current_product = current_schema["$defs"]["VersionedProduct"]
+    assert set(current_product["properties"]) == {
+        "name",
+        "shared_field",
+        "current_field",
+    }
+
+    with api_version_context(NEXT_VERSION):
+        next_schema = VersionedSubscription.model_json_schema()
+    next_product = next_schema["$defs"]["VersionedProduct"]
+    assert set(next_product["properties"]) == {"name", "shared_field", "next_field"}
+    assert (
+        next_product["properties"]["next_field"]["description"]
+        == "Only available in the next API version."
+    )
 
 
 def test_versioned_routes() -> None:


### PR DESCRIPTION
## Summary

- add request-scoped API version context for Pydantic serialization
- add `IncludedIn(...)` and `ExcludedIn(...)` field annotations that project runtime output and OpenAPI schemas from the same rules
- bind direct and served OpenAPI generation to the target API version
- update the SDK docs OpenAPI recipe to consume the generated versioned specifications
- cover nested serialization, schema projection, multi-version inclusion, and composition with `Field(...)`

## Usage

```python
from typing import Annotated

from pydantic import BaseModel, Field

from polar.kit.versioning import ExcludedIn, IncludedIn
from polar.version import NEXT_API_VERSION


class Product(BaseModel):
    name: str
    next_field: Annotated[
        str,
        IncludedIn(NEXT_API_VERSION),
        Field(description="Only available in the next API version."),
    ] = "next"
    legacy_field: Annotated[
        str,
        ExcludedIn(NEXT_API_VERSION),
    ] = "legacy"
```

The same annotations control both Pydantic serialization for the requested `Polar-Version` and the generated OpenAPI component for that version. They work recursively when `Product` is nested in another schema.

## Validation

- `uv run pytest tests/kit/test_versioning.py -q`
- `uv run pytest tests/kit/test_versioning.py tests/test_openapi.py tests/test_app.py -q`
- `uv run ruff check polar/kit/versioning.py polar/openapi.py tests/kit/test_versioning.py`
- `uv run ruff format --check polar/kit/versioning.py polar/openapi.py tests/kit/test_versioning.py`
- `uv run mypy polar/kit/versioning.py polar/openapi.py tests/kit/test_versioning.py`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

