### PR TITLE
feat: improve saved card migration guidance

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
@@ -65,7 +65,10 @@ export default function MigrationDetailPage({
           <Box as="section" flexDirection="column" rowGap="xl">
             <SourceHeader migration={migration} />
             <MigrationStepper migration={migration} />
-            <StepContent migration={migration} />
+            <StepContent
+              migration={migration}
+              organizationId={organization.id}
+            />
           </Box>
         )}
       </Box>
@@ -105,8 +108,10 @@ function SourceHeader({
 
 function StepContent({
   migration,
+  organizationId,
 }: {
   migration: schemas['MerchantMigration']
+  organizationId: string
 }) {
   if (!migration.source_connected) {
     return (
@@ -135,7 +140,10 @@ function StepContent({
       return (
         <Box flexDirection="column" rowGap="l">
           <StepHeading def={def} />
-          <PanTransferPanel migrationId={migration.id} />
+          <PanTransferPanel
+            migrationId={migration.id}
+            organizationId={organizationId}
+          />
         </Box>
       )
     // The switch runs here, and stays reachable at cleanup so the merchant can

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
@@ -135,7 +135,12 @@ function StepContent({
       return (
         <Box flexDirection="column" rowGap="l">
           <StepHeading def={def} />
-          <PanTransferPanel migrationId={migration.id} />
+          <PanTransferPanel
+            migrationId={migration.id}
+            sourceStripeAccountId={
+              migration.source?.stripe_user_id as string | undefined
+            }
+          />
         </Box>
       )
     // The switch runs here, and stays reachable at cleanup so the merchant can

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
@@ -65,10 +65,7 @@ export default function MigrationDetailPage({
           <Box as="section" flexDirection="column" rowGap="xl">
             <SourceHeader migration={migration} />
             <MigrationStepper migration={migration} />
-            <StepContent
-              migration={migration}
-              organizationId={organization.id}
-            />
+            <StepContent migration={migration} />
           </Box>
         )}
       </Box>
@@ -108,10 +105,8 @@ function SourceHeader({
 
 function StepContent({
   migration,
-  organizationId,
 }: {
   migration: schemas['MerchantMigration']
-  organizationId: string
 }) {
   if (!migration.source_connected) {
     return (
@@ -140,10 +135,7 @@ function StepContent({
       return (
         <Box flexDirection="column" rowGap="l">
           <StepHeading def={def} />
-          <PanTransferPanel
-            migrationId={migration.id}
-            organizationId={organizationId}
-          />
+          <PanTransferPanel migrationId={migration.id} />
         </Box>
       )
     // The switch runs here, and stays reachable at cleanup so the merchant can

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/OpsUpdate.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/OpsUpdate.tsx
@@ -11,13 +11,7 @@ export function OpsUpdate({ step }: { step: schemas['PanTransferStep'] }) {
   }
 
   return (
-    <Box
-      flexDirection="column"
-      rowGap="xs"
-      padding="l"
-      borderRadius="m"
-      backgroundColor="background-secondary"
-    >
+    <Box flexDirection="column" rowGap="xs">
       {/* Prose wraps on its own; a pasted link does not. */}
       {step.note && (
         <Box overflowX="auto" maxWidth="100%">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/OpsUpdate.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/OpsUpdate.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { schemas } from '@polar-sh/client'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+
+export function OpsUpdate({ step }: { step: schemas['PanTransferStep'] }) {
+  if (!step.note && !step.expected_at) {
+    return null
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      rowGap="xs"
+      padding="l"
+      borderRadius="m"
+      backgroundColor="background-secondary"
+    >
+      {/* Prose wraps on its own; a pasted link does not. */}
+      {step.note && (
+        <Box overflowX="auto" maxWidth="100%">
+          <Text variant="caption">{step.note}</Text>
+        </Box>
+      )}
+      {step.expected_at && (
+        <Text variant="caption" color="muted">
+          Expected by <FormattedDateTime datetime={step.expected_at} />
+        </Text>
+      )}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
@@ -13,7 +13,13 @@ const METHOD_INTRO: Record<schemas['PanTransferMethod'], string> = {
     "Your provider sends the saved cards to Stripe, and Stripe imports them onto Polar's account. This runs over a few weeks.",
 }
 
-export function PanTransferPanel({ migrationId }: { migrationId: string }) {
+export function PanTransferPanel({
+  migrationId,
+  organizationId,
+}: {
+  migrationId: string
+  organizationId: string
+}) {
   const { data: checklist, isLoading, isError } = usePanTransfer(migrationId)
 
   if (isLoading) {
@@ -78,6 +84,7 @@ export function PanTransferPanel({ migrationId }: { migrationId: string }) {
             current={step.key === checklist.current_step_key}
             destinationAccountId={checklist.destination_account_id}
             migrationId={migrationId}
+            organizationId={organizationId}
           />
         ))}
       </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
@@ -5,7 +5,13 @@ import { Alert, Spinner, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { PanTransferStepItem } from './PanTransferStepItem'
 
-export function PanTransferPanel({ migrationId }: { migrationId: string }) {
+export function PanTransferPanel({
+  migrationId,
+  sourceStripeAccountId,
+}: {
+  migrationId: string
+  sourceStripeAccountId?: string
+}) {
   const { data: checklist, isLoading, isError } = usePanTransfer(migrationId)
 
   if (isLoading) {
@@ -63,6 +69,7 @@ export function PanTransferPanel({ migrationId }: { migrationId: string }) {
             current={step.key === checklist.current_step_key}
             destinationAccountId={checklist.destination_account_id}
             migrationId={migrationId}
+            sourceStripeAccountId={sourceStripeAccountId}
           />
         ))}
       </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
@@ -1,17 +1,9 @@
 'use client'
 
 import { usePanTransfer } from '@/hooks/queries/merchantMigrations'
-import { schemas } from '@polar-sh/client'
 import { Alert, Spinner, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { PanTransferStepItem } from './PanTransferStepItem'
-
-const METHOD_INTRO: Record<schemas['PanTransferMethod'], string> = {
-  pan_copy:
-    "Stripe copies your customers' saved cards onto Polar's Stripe account. Nothing changes for your customers.",
-  pan_import:
-    "Your provider sends the saved cards to Stripe, and Stripe imports them onto Polar's account. This runs over a few weeks.",
-}
 
 export function PanTransferPanel({ migrationId }: { migrationId: string }) {
   const { data: checklist, isLoading, isError } = usePanTransfer(migrationId)
@@ -50,25 +42,18 @@ export function PanTransferPanel({ migrationId }: { migrationId: string }) {
   const finished = done === checklist.steps.length
 
   return (
-    <Box flexDirection="column" rowGap="xl">
+    <Box flexDirection="column" rowGap="l">
       {finished ? (
-        <Alert
-          variant="success"
-          title="Every step is done"
-          description="Your customers' cards are on Polar and their subscriptions have moved over."
-        />
+        <Text variant="caption" color="muted">
+          Every step is complete.
+        </Text>
       ) : (
-        <Box flexDirection="column" rowGap="xs">
-          <Text variant="caption" color="muted">
-            {METHOD_INTRO[checklist.method]}
-          </Text>
-          <Text variant="caption" color="muted">
-            {done} of {checklist.steps.length} steps done
-          </Text>
-        </Box>
+        <Text variant="caption" color="muted">
+          {done} of {checklist.steps.length} complete
+        </Text>
       )}
 
-      <Box as="ol" flexDirection="column" rowGap="xl">
+      <Box as="ol" flexDirection="column" rowGap="l">
         {checklist.steps.map((step) => (
           <PanTransferStepItem
             // Migration-scoped: another migration lands on the same step key,

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
@@ -13,13 +13,7 @@ const METHOD_INTRO: Record<schemas['PanTransferMethod'], string> = {
     "Your provider sends the saved cards to Stripe, and Stripe imports them onto Polar's account. This runs over a few weeks.",
 }
 
-export function PanTransferPanel({
-  migrationId,
-  organizationId,
-}: {
-  migrationId: string
-  organizationId: string
-}) {
+export function PanTransferPanel({ migrationId }: { migrationId: string }) {
   const { data: checklist, isLoading, isError } = usePanTransfer(migrationId)
 
   if (isLoading) {
@@ -84,7 +78,6 @@ export function PanTransferPanel({
             current={step.key === checklist.current_step_key}
             destinationAccountId={checklist.destination_account_id}
             migrationId={migrationId}
-            organizationId={organizationId}
           />
         ))}
       </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
@@ -4,18 +4,21 @@ import { schemas } from '@polar-sh/client'
 import { Alert, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
-import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { SwitchPanel } from '../switch/SwitchPanel'
+import { OpsUpdate } from './OpsUpdate'
 import { StepCopy } from './panTransferCopy'
 import { PanTransferStepForm } from './PanTransferStepForm'
+import { StartCopyStep } from './StartCopyStep'
 
 const SWITCH_STEP_KEY = 'cutover'
+const START_COPY_STEP_KEY = 'start_copy'
 
 interface Props {
   step: schemas['PanTransferStep']
   copy: StepCopy
   destinationAccountId: string | null
   migrationId: string
+  organizationId: string
 }
 
 export function PanTransferStepBody({
@@ -23,7 +26,20 @@ export function PanTransferStepBody({
   copy,
   destinationAccountId,
   migrationId,
+  organizationId,
 }: Props) {
+  if (step.key === START_COPY_STEP_KEY) {
+    return (
+      <StartCopyStep
+        step={step}
+        copy={copy}
+        destinationAccountId={destinationAccountId}
+        migrationId={migrationId}
+        organizationId={organizationId}
+      />
+    )
+  }
+
   const submittable = step.owner === 'merchant' && step.kind !== 'auto'
   // A newer backend: submitting would 422 on a field we never rendered, because
   // the accepted-input contract isn't on the wire.
@@ -87,34 +103,6 @@ export function PanTransferStepBody({
             stepKey={step.key}
           />
         ))
-      )}
-    </Box>
-  )
-}
-
-export function OpsUpdate({ step }: { step: schemas['PanTransferStep'] }) {
-  if (!step.note && !step.expected_at) {
-    return null
-  }
-
-  return (
-    <Box
-      flexDirection="column"
-      rowGap="xs"
-      padding="l"
-      borderRadius="m"
-      backgroundColor="background-secondary"
-    >
-      {/* Prose wraps on its own; a pasted link does not. */}
-      {step.note && (
-        <Box overflowX="auto" maxWidth="100%">
-          <Text variant="caption">{step.note}</Text>
-        </Box>
-      )}
-      {step.expected_at && (
-        <Text variant="caption" color="muted">
-          Expected by <FormattedDateTime datetime={step.expected_at} />
-        </Text>
       )}
     </Box>
   )

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
@@ -3,7 +3,6 @@
 import { schemas } from '@polar-sh/client'
 import { Alert, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
 import { SwitchPanel } from '../switch/SwitchPanel'
 import { OpsUpdate } from './OpsUpdate'
 import { StepCopy } from './panTransferCopy'
@@ -18,7 +17,6 @@ interface Props {
   copy: StepCopy
   destinationAccountId: string | null
   migrationId: string
-  organizationId: string
 }
 
 export function PanTransferStepBody({
@@ -26,7 +24,6 @@ export function PanTransferStepBody({
   copy,
   destinationAccountId,
   migrationId,
-  organizationId,
 }: Props) {
   if (step.key === START_COPY_STEP_KEY) {
     return (
@@ -35,7 +32,6 @@ export function PanTransferStepBody({
         copy={copy}
         destinationAccountId={destinationAccountId}
         migrationId={migrationId}
-        organizationId={organizationId}
       />
     )
   }
@@ -50,23 +46,6 @@ export function PanTransferStepBody({
       <Text variant="caption" color="muted">
         {copy.description}
       </Text>
-
-      {copy.showsDestinationAccount &&
-        (destinationAccountId ? (
-          <Box flexDirection="column" rowGap="xs" maxWidth={380}>
-            <Text variant="caption" color="muted">
-              Polar account ID
-            </Text>
-            <CopyToClipboardInput value={destinationAccountId} variant="mono" />
-          </Box>
-        ) : (
-          // The guidance below says to paste an ID we would not be showing.
-          <Alert
-            variant="danger"
-            title="We can't show the Polar account ID right now"
-            description="Please contact support before you start the copy in Stripe."
-          />
-        ))}
 
       {copy.guidance && (
         <Box as="ol" flexDirection="column" rowGap="xs">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { schemas } from '@polar-sh/client'
-import { Alert, Text } from '@polar-sh/orbit'
+import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { SwitchPanel } from '../switch/SwitchPanel'
 import { OpsUpdate } from './OpsUpdate'
@@ -63,7 +63,11 @@ export function PanTransferStepBody({
         </Box>
       )}
 
-      {copy.warning && <Alert variant="warning" title={copy.warning} />}
+      {copy.warning && (
+        <Text variant="caption" color="muted">
+          Note: {copy.warning}
+        </Text>
+      )}
 
       <OpsUpdate step={step} />
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { schemas } from '@polar-sh/client'
-import { Text } from '@polar-sh/orbit'
+import { Alert, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { SwitchPanel } from '../switch/SwitchPanel'
 import { OpsUpdate } from './OpsUpdate'
@@ -63,11 +63,7 @@ export function PanTransferStepBody({
         </Box>
       )}
 
-      {copy.warning && (
-        <Text variant="caption" color="muted">
-          Note: {copy.warning}
-        </Text>
-      )}
+      {copy.warning && <Alert variant="warning" title={copy.warning} />}
 
       <OpsUpdate step={step} />
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
@@ -17,6 +17,7 @@ interface Props {
   copy: StepCopy
   destinationAccountId: string | null
   migrationId: string
+  sourceStripeAccountId?: string
 }
 
 export function PanTransferStepBody({
@@ -24,6 +25,7 @@ export function PanTransferStepBody({
   copy,
   destinationAccountId,
   migrationId,
+  sourceStripeAccountId,
 }: Props) {
   if (step.key === START_COPY_STEP_KEY) {
     return (
@@ -32,6 +34,7 @@ export function PanTransferStepBody({
         copy={copy}
         destinationAccountId={destinationAccountId}
         migrationId={migrationId}
+        sourceStripeAccountId={sourceStripeAccountId}
       />
     )
   }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
@@ -43,10 +43,10 @@ export function PanTransferStepForm({
       display={compact ? { base: 'flex', md: 'grid' } : 'flex'}
       flexDirection="column"
       gridTemplateColumns={
-        compact ? { base: '1fr', md: 'minmax(0, 1fr) auto' } : undefined
+        compact ? { base: '1fr', md: 'minmax(0, 1fr) 320px' } : undefined
       }
       alignItems={compact ? { base: 'stretch', md: 'center' } : undefined}
-      columnGap={compact ? 'l' : undefined}
+      columnGap={compact ? 'xl' : undefined}
       rowGap="m"
       onSubmit={(event) => {
         event.preventDefault()
@@ -113,7 +113,10 @@ export function PanTransferStepForm({
         )
       })}
 
-      <Box>
+      <Box
+        width={compact ? '100%' : undefined}
+        justifyContent={compact ? { base: 'start', md: 'end' } : undefined}
+      >
         <Button
           type="submit"
           size="sm"

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
@@ -14,12 +14,18 @@ interface Props {
   copy: StepCopy
   migrationId: string
   stepKey: string
+  compact?: boolean
 }
 
 // The mutation lives here, not in the panel, so a failure stays attached to the
 // step that caused it. A shared one keeps showing the last error after a
 // refetch moves the checklist on.
-export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
+export function PanTransferStepForm({
+  copy,
+  migrationId,
+  stepKey,
+  compact = false,
+}: Props) {
   const complete = useCompletePanTransferStep(migrationId)
   const [values, setValues] = useState<Record<string, string>>({})
   const fields = copy.inputs ?? []
@@ -34,7 +40,13 @@ export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
   return (
     <Box
       as="form"
+      display={compact ? { base: 'flex', md: 'grid' } : 'flex'}
       flexDirection="column"
+      gridTemplateColumns={
+        compact ? { base: '1fr', md: 'minmax(0, 1fr) auto' } : undefined
+      }
+      alignItems={compact ? { base: 'stretch', md: 'end' } : undefined}
+      columnGap={compact ? 'l' : undefined}
       rowGap="m"
       onSubmit={(event) => {
         event.preventDefault()
@@ -52,7 +64,7 @@ export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
             key={field.name}
             flexDirection="column"
             rowGap="xs"
-            maxWidth={380}
+            maxWidth={compact ? 520 : 380}
           >
             <Text
               as="label"
@@ -101,12 +113,6 @@ export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
         )
       })}
 
-      {complete.error && (
-        <Text variant="caption" color="danger" role="alert">
-          {complete.error.message}
-        </Text>
-      )}
-
       <Box>
         <Button
           type="submit"
@@ -116,6 +122,14 @@ export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
           {complete.isPending ? 'Saving…' : copy.action}
         </Button>
       </Box>
+
+      {complete.error && (
+        <Box gridColumn={compact ? '1 / -1' : undefined}>
+          <Text variant="caption" color="danger" role="alert">
+            {complete.error.message}
+          </Text>
+        </Box>
+      )}
     </Box>
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
@@ -4,7 +4,11 @@ import { useCompletePanTransferStep } from '@/hooks/queries/merchantMigrations'
 import { Button, Input, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { useState } from 'react'
-import { StepCopy } from './panTransferCopy'
+import {
+  StepCopy,
+  STRIPE_MIGRATION_ID_FIELD,
+  stripeMigrationIdError,
+} from './panTransferCopy'
 
 interface Props {
   copy: StepCopy
@@ -22,6 +26,10 @@ export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
   const missingRequired = fields.some(
     (field) => field.required && !values[field.name]?.trim(),
   )
+  const migrationIdError = stripeMigrationIdError(
+    values[STRIPE_MIGRATION_ID_FIELD] ?? '',
+  )
+  const blocked = missingRequired || migrationIdError !== null
 
   return (
     <Box
@@ -30,28 +38,75 @@ export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
       rowGap="m"
       onSubmit={(event) => {
         event.preventDefault()
+        if (blocked) {
+          return
+        }
         complete.mutate({ key: stepKey, inputs: values })
       }}
     >
-      {fields.map((field) => (
-        <Box key={field.name} flexDirection="column" rowGap="xs" maxWidth={380}>
-          <Text as="label" htmlFor={field.name} variant="caption" color="muted">
-            {field.label}
-            {field.required ? '' : ' (optional)'}
-          </Text>
-          <Input
-            id={field.name}
-            value={values[field.name] ?? ''}
-            placeholder={field.placeholder}
-            onChange={(event) =>
-              setValues((current) => ({
-                ...current,
-                [field.name]: event.target.value,
-              }))
-            }
-          />
-        </Box>
-      ))}
+      {fields.map((field) => {
+        const fieldError =
+          field.name === STRIPE_MIGRATION_ID_FIELD
+            ? migrationIdError
+            : null
+        return (
+          <Box
+            key={field.name}
+            flexDirection="column"
+            rowGap="xs"
+            maxWidth={380}
+          >
+            <Text
+              as="label"
+              htmlFor={field.name}
+              variant="caption"
+              color="muted"
+            >
+              {field.label}
+              {field.required ? '' : ' (optional)'}
+            </Text>
+            <Input
+              id={field.name}
+              value={values[field.name] ?? ''}
+              placeholder={field.placeholder}
+              aria-invalid={fieldError !== null}
+              aria-describedby={
+                fieldError
+                  ? `${field.name}-error`
+                  : field.hint
+                    ? `${field.name}-hint`
+                    : undefined
+              }
+              onChange={(event) =>
+                setValues((current) => ({
+                  ...current,
+                  [field.name]: event.target.value,
+                }))
+              }
+            />
+            {fieldError ? (
+              <Text
+                id={`${field.name}-error`}
+                variant="caption"
+                color="danger"
+                role="alert"
+              >
+                {fieldError}
+              </Text>
+            ) : (
+              field.hint && (
+                <Text
+                  id={`${field.name}-hint`}
+                  variant="caption"
+                  color="muted"
+                >
+                  {field.hint}
+                </Text>
+              )
+            )}
+          </Box>
+        )
+      })}
 
       {complete.error && (
         <Text variant="caption" color="danger" role="alert">
@@ -63,7 +118,7 @@ export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
         <Button
           type="submit"
           size="sm"
-          disabled={complete.isPending || missingRequired}
+          disabled={complete.isPending || blocked}
         >
           {complete.isPending ? 'Saving…' : copy.action}
         </Button>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
@@ -73,6 +73,7 @@ export function PanTransferStepForm({
               color="muted"
             >
               {field.label}
+              {field.required ? '' : ' (optional)'}
             </Text>
             <Input
               id={field.name}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
@@ -45,7 +45,7 @@ export function PanTransferStepForm({
       gridTemplateColumns={
         compact ? { base: '1fr', md: 'minmax(0, 1fr) auto' } : undefined
       }
-      alignItems={compact ? { base: 'stretch', md: 'end' } : undefined}
+      alignItems={compact ? { base: 'stretch', md: 'center' } : undefined}
       columnGap={compact ? 'l' : undefined}
       rowGap="m"
       onSubmit={(event) => {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
@@ -46,9 +46,7 @@ export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
     >
       {fields.map((field) => {
         const fieldError =
-          field.name === STRIPE_MIGRATION_ID_FIELD
-            ? migrationIdError
-            : null
+          field.name === STRIPE_MIGRATION_ID_FIELD ? migrationIdError : null
         return (
           <Box
             key={field.name}
@@ -95,11 +93,7 @@ export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
               </Text>
             ) : (
               field.hint && (
-                <Text
-                  id={`${field.name}-hint`}
-                  variant="caption"
-                  color="muted"
-                >
+                <Text id={`${field.name}-hint`} variant="caption" color="muted">
                   {field.hint}
                 </Text>
               )

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
@@ -61,7 +61,6 @@ export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
               color="muted"
             >
               {field.label}
-              {field.required ? '' : ' (optional)'}
             </Text>
             <Input
               id={field.name}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepItem.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepItem.tsx
@@ -14,6 +14,7 @@ interface Props {
   current: boolean
   destinationAccountId: string | null
   migrationId: string
+  sourceStripeAccountId?: string
 }
 
 export function PanTransferStepItem({
@@ -21,6 +22,7 @@ export function PanTransferStepItem({
   current,
   destinationAccountId,
   migrationId,
+  sourceStripeAccountId,
 }: Props) {
   const copy = STEP_COPY[step.key]
   // Keep the row on an unknown key so the count and order still line up.
@@ -58,6 +60,7 @@ export function PanTransferStepItem({
               copy={copy}
               destinationAccountId={destinationAccountId}
               migrationId={migrationId}
+              sourceStripeAccountId={sourceStripeAccountId}
             />
           ) : (
             <Text variant="caption" color="muted">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepItem.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepItem.tsx
@@ -4,13 +4,14 @@ import { schemas } from '@polar-sh/client'
 import { Status, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import { OpsUpdate } from './OpsUpdate'
 import {
   ownerLabel,
   STEP_COPY,
   StepInputField,
   waitingLabel,
 } from './panTransferCopy'
-import { OpsUpdate, PanTransferStepBody } from './PanTransferStepBody'
+import { PanTransferStepBody } from './PanTransferStepBody'
 import { STATE_LABELS, StepMarker, StepState } from '../stepMarker'
 
 interface Props {
@@ -18,6 +19,7 @@ interface Props {
   current: boolean
   destinationAccountId: string | null
   migrationId: string
+  organizationId: string
 }
 
 export function PanTransferStepItem({
@@ -25,6 +27,7 @@ export function PanTransferStepItem({
   current,
   destinationAccountId,
   migrationId,
+  organizationId,
 }: Props) {
   const copy = STEP_COPY[step.key]
   // Keep the row on an unknown key so the count and order still line up.
@@ -75,12 +78,24 @@ export function PanTransferStepItem({
 
         {current &&
           (copy ? (
-            <PanTransferStepBody
-              step={step}
-              copy={copy}
-              destinationAccountId={destinationAccountId}
-              migrationId={migrationId}
-            />
+            <Box
+              flexDirection="column"
+              padding="xl"
+              rowGap="l"
+              borderRadius="l"
+              borderWidth={1}
+              borderStyle="solid"
+              borderColor="border-primary"
+              backgroundColor="background-card"
+            >
+              <PanTransferStepBody
+                step={step}
+                copy={copy}
+                destinationAccountId={destinationAccountId}
+                migrationId={migrationId}
+                organizationId={organizationId}
+              />
+            </Box>
           ) : (
             <Text variant="caption" color="muted">
               This step needs a newer version of this page. Please refresh.

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepItem.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepItem.tsx
@@ -1,16 +1,11 @@
 'use client'
 
 import { schemas } from '@polar-sh/client'
-import { Status, Text } from '@polar-sh/orbit'
+import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { OpsUpdate } from './OpsUpdate'
-import {
-  ownerLabel,
-  STEP_COPY,
-  StepInputField,
-  waitingLabel,
-} from './panTransferCopy'
+import { STEP_COPY, StepInputField } from './panTransferCopy'
 import { PanTransferStepBody } from './PanTransferStepBody'
 import { STATE_LABELS, StepMarker, StepState } from '../stepMarker'
 
@@ -46,27 +41,9 @@ export function PanTransferStepItem({
       </Box>
 
       <Box flex={1} minWidth={0} flexDirection="column" rowGap="m">
-        <Box alignItems="center" columnGap="s" flexWrap="wrap">
-          <Text
-            variant={current ? 'label' : 'caption'}
-            color={current ? 'default' : 'muted'}
-          >
-            {title}
-          </Text>
-          {current ? (
-            <Status
-              status={waitingLabel(step.owner)}
-              color={step.owner === 'merchant' ? 'blue' : 'gray'}
-              size="small"
-            />
-          ) : (
-            !done && (
-              <Text variant="caption" color="muted">
-                {ownerLabel(step.owner)}
-              </Text>
-            )
-          )}
-        </Box>
+        <Text variant="caption" color={current ? 'default' : 'muted'}>
+          {title}
+        </Text>
 
         {done && <CompletedSummary step={step} fields={copy?.inputs ?? []} />}
 
@@ -76,23 +53,12 @@ export function PanTransferStepItem({
 
         {current &&
           (copy ? (
-            <Box
-              flexDirection="column"
-              padding="xl"
-              rowGap="l"
-              borderRadius="l"
-              borderWidth={1}
-              borderStyle="solid"
-              borderColor="border-primary"
-              backgroundColor="background-card"
-            >
-              <PanTransferStepBody
-                step={step}
-                copy={copy}
-                destinationAccountId={destinationAccountId}
-                migrationId={migrationId}
-              />
-            </Box>
+            <PanTransferStepBody
+              step={step}
+              copy={copy}
+              destinationAccountId={destinationAccountId}
+              migrationId={migrationId}
+            />
           ) : (
             <Text variant="caption" color="muted">
               This step needs a newer version of this page. Please refresh.

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepItem.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepItem.tsx
@@ -19,7 +19,6 @@ interface Props {
   current: boolean
   destinationAccountId: string | null
   migrationId: string
-  organizationId: string
 }
 
 export function PanTransferStepItem({
@@ -27,7 +26,6 @@ export function PanTransferStepItem({
   current,
   destinationAccountId,
   migrationId,
-  organizationId,
 }: Props) {
   const copy = STEP_COPY[step.key]
   // Keep the row on an unknown key so the count and order still line up.
@@ -93,7 +91,6 @@ export function PanTransferStepItem({
                 copy={copy}
                 destinationAccountId={destinationAccountId}
                 migrationId={migrationId}
-                organizationId={organizationId}
               />
             </Box>
           ) : (

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { getServerURL } from '@/utils/api'
+import { schemas } from '@polar-sh/client'
+import { Alert, Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
+import { ArrowUpRight, Download } from 'lucide-react'
+import { OpsUpdate } from './OpsUpdate'
+import { StepCopy, STRIPE_COPY_STATUS_URL } from './panTransferCopy'
+import { PanTransferStepForm } from './PanTransferStepForm'
+
+interface Props {
+  step: schemas['PanTransferStep']
+  copy: StepCopy
+  destinationAccountId: string | null
+  migrationId: string
+  organizationId: string
+}
+
+export function StartCopyStep({
+  step,
+  copy,
+  destinationAccountId,
+  migrationId,
+  organizationId,
+}: Props) {
+  const downloadCsv = () => {
+    const url = new URL(
+      `${getServerURL()}/v1/customers/export?organization_id=${organizationId}`,
+      window.location.origin,
+    )
+    window.open(url, '_blank')
+  }
+
+  return (
+    <Box flexDirection="column" rowGap="xl">
+      <Text variant="caption" color="muted">
+        {copy.description}
+      </Text>
+
+      <Box flexDirection="column" rowGap="m">
+        <Text variant="label">1. Download customer CSV</Text>
+        <Text variant="caption" color="muted">
+          Upload this file in Stripe when you start the copy.
+        </Text>
+        <Box>
+          <Button variant="secondary" size="sm" onClick={downloadCsv}>
+            <Download size={14} />
+            Download customer CSV
+          </Button>
+        </Box>
+      </Box>
+
+      <Box flexDirection="column" rowGap="m">
+        <Text variant="label">2. Start copy in Stripe</Text>
+        {destinationAccountId ? (
+          <Box flexDirection="column" rowGap="xs" maxWidth={380}>
+            <Text variant="caption" color="muted">
+              Polar destination ID
+            </Text>
+            <CopyToClipboardInput value={destinationAccountId} variant="mono" />
+          </Box>
+        ) : (
+          <Alert
+            variant="danger"
+            title="We can't show the Polar account ID right now"
+            description="Please contact support before you start the copy in Stripe."
+          />
+        )}
+        {copy.guidance && (
+          <Box as="ol" flexDirection="column" rowGap="xs">
+            {copy.guidance.map((line, index) => (
+              <Box as="li" key={index} display="flex" columnGap="s">
+                <Text variant="caption" color="muted" tabularNums>
+                  {index + 1}.
+                </Text>
+                <Text variant="caption" color="muted">
+                  {line}
+                </Text>
+              </Box>
+            ))}
+          </Box>
+        )}
+        {copy.warning && <Alert variant="warning" title={copy.warning} />}
+      </Box>
+
+      <Box flexDirection="column" rowGap="m">
+        <Text variant="label">3. Save Stripe migration ID</Text>
+        <Text variant="caption" color="muted">
+          After you start the copy, paste the migration ID from Stripe. It
+          starts with migreq_.
+        </Text>
+        <Box>
+          <Button variant="secondary" size="sm" asChild>
+            <a
+              href={STRIPE_COPY_STATUS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Open Stripe copy status
+              <ArrowUpRight size={14} />
+            </a>
+          </Button>
+        </Box>
+        <OpsUpdate step={step} />
+        {copy.action && (
+          <PanTransferStepForm
+            copy={copy}
+            migrationId={migrationId}
+            stepKey={step.key}
+          />
+        )}
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
@@ -39,8 +39,10 @@ export function StartCopyStep({
         <Box>
           <Button variant="secondary" size="sm" asChild>
             <a href={customerIdsUrl} target="_blank" rel="noopener noreferrer">
-              <Download size={14} />
-              Download customer CSV
+              <Box alignItems="center" columnGap="xs">
+                <Download size={14} aria-hidden />
+                Download customer CSV
+              </Box>
             </a>
           </Button>
         </Box>
@@ -92,8 +94,10 @@ export function StartCopyStep({
               target="_blank"
               rel="noopener noreferrer"
             >
-              Open Stripe copy status
-              <ArrowUpRight size={14} />
+              <Box alignItems="center" columnGap="xs">
+                Open Stripe copy status
+                <ArrowUpRight size={14} aria-hidden />
+              </Box>
             </a>
           </Button>
         </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
@@ -5,7 +5,6 @@ import { schemas } from '@polar-sh/client'
 import { Alert, Button, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
-import { ArrowUpRight, Download } from 'lucide-react'
 import { OpsUpdate } from './OpsUpdate'
 import { StepCopy, STRIPE_COPY_STATUS_URL } from './panTransferCopy'
 import { PanTransferStepForm } from './PanTransferStepForm'
@@ -26,89 +25,85 @@ export function StartCopyStep({
   const customerIdsUrl = `${getServerURL()}/v1/merchant-migrations/${migrationId}/customer-ids.csv`
 
   return (
-    <Box flexDirection="column" rowGap="xl">
+    <Box flexDirection="column" rowGap="l" maxWidth={640}>
       <Text variant="caption" color="muted">
         {copy.description}
       </Text>
 
-      <Box flexDirection="column" rowGap="m">
-        <Text variant="label">1. Download customer CSV</Text>
-        <Text variant="caption" color="muted">
-          Upload this file in Stripe when you start the copy.
-        </Text>
-        <Box>
-          <Button variant="secondary" size="sm" asChild>
-            <a href={customerIdsUrl} target="_blank" rel="noopener noreferrer">
-              <Box alignItems="center" columnGap="xs">
-                <Download size={14} aria-hidden />
-                Download customer CSV
-              </Box>
-            </a>
-          </Button>
+      <Box as="ol" flexDirection="column" rowGap="l">
+        <Box as="li" flexDirection="column" rowGap="s">
+          <Text variant="caption">
+            1. Download the customer CSV and upload it in Stripe.
+          </Text>
+          <Box>
+            <Button variant="ghost" size="sm" asChild>
+              <a
+                href={customerIdsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Download CSV
+              </a>
+            </Button>
+          </Box>
         </Box>
-      </Box>
 
-      <Box flexDirection="column" rowGap="m">
-        <Text variant="label">2. Start copy in Stripe</Text>
-        {destinationAccountId ? (
-          <Box flexDirection="column" rowGap="xs" maxWidth={380}>
+        <Box as="li" flexDirection="column" rowGap="s">
+          <Text variant="caption">
+            2. In Stripe, open Customers → Copy customers and paste this Polar
+            account ID as the recipient.
+          </Text>
+          {destinationAccountId ? (
+            <Box flexDirection="column" rowGap="xs" maxWidth={420}>
+              <Text variant="caption" color="muted">
+                Polar account ID
+              </Text>
+              <CopyToClipboardInput
+                value={destinationAccountId}
+                variant="mono"
+              />
+            </Box>
+          ) : (
+            <Alert
+              variant="danger"
+              title="We can't show the Polar account ID right now"
+              description="Please contact support before you start the copy in Stripe."
+            />
+          )}
+          <Text variant="caption" color="muted">
+            Upload the CSV, paste the account ID, and confirm the copy.
+          </Text>
+          {copy.warning && (
             <Text variant="caption" color="muted">
-              Polar destination ID
+              Note: {copy.warning}
             </Text>
-            <CopyToClipboardInput value={destinationAccountId} variant="mono" />
-          </Box>
-        ) : (
-          <Alert
-            variant="danger"
-            title="We can't show the Polar account ID right now"
-            description="Please contact support before you start the copy in Stripe."
-          />
-        )}
-        {copy.guidance && (
-          <Box as="ol" flexDirection="column" rowGap="xs">
-            {copy.guidance.map((line, index) => (
-              <Box as="li" key={index} display="flex" columnGap="s">
-                <Text variant="caption" color="muted" tabularNums>
-                  {index + 1}.
-                </Text>
-                <Text variant="caption" color="muted">
-                  {line}
-                </Text>
-              </Box>
-            ))}
-          </Box>
-        )}
-        {copy.warning && <Alert variant="warning" title={copy.warning} />}
-      </Box>
-
-      <Box flexDirection="column" rowGap="m">
-        <Text variant="label">3. Save Stripe migration ID</Text>
-        <Text variant="caption" color="muted">
-          After you start the copy, paste the migration ID from Stripe. It
-          starts with migreq_.
-        </Text>
-        <Box>
-          <Button variant="secondary" size="sm" asChild>
-            <a
-              href={STRIPE_COPY_STATUS_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Box alignItems="center" columnGap="xs">
+          )}
+          <Box>
+            <Button variant="ghost" size="sm" asChild>
+              <a
+                href={STRIPE_COPY_STATUS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Open Stripe copy status
-                <ArrowUpRight size={14} aria-hidden />
-              </Box>
-            </a>
-          </Button>
+              </a>
+            </Button>
+          </Box>
         </Box>
-        <OpsUpdate step={step} />
-        {copy.action && (
-          <PanTransferStepForm
-            copy={copy}
-            migrationId={migrationId}
-            stepKey={step.key}
-          />
-        )}
+
+        <Box as="li" flexDirection="column" rowGap="s">
+          <Text variant="caption">
+            3. After starting the copy, paste the optional Stripe migration ID.
+          </Text>
+          <OpsUpdate step={step} />
+          {copy.action && (
+            <PanTransferStepForm
+              copy={copy}
+              migrationId={migrationId}
+              stepKey={step.key}
+            />
+          )}
+        </Box>
       </Box>
     </Box>
   )

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
@@ -32,6 +32,7 @@ export function StartCopyStep({
       </Text>
 
       <Box
+        as="ol"
         flexDirection="column"
         borderTopWidth={1}
         borderStyle="solid"
@@ -60,6 +61,7 @@ export function StartCopyStep({
               <CopyToClipboardInput
                 value={destinationAccountId}
                 variant="mono"
+                ariaLabel="Polar account ID"
               />
             </Box>
           ) : (
@@ -111,6 +113,7 @@ function TaskRow({
 }) {
   return (
     <Box
+      as="li"
       flexDirection={{ base: 'column', md: 'row' }}
       alignItems={{ base: 'stretch', md: 'center' }}
       justifyContent="between"

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
@@ -36,7 +36,7 @@ export function StartCopyStep({
             1. Download the customer CSV and upload it in Stripe.
           </Text>
           <Box>
-            <Button variant="ghost" size="sm" asChild>
+            <Button variant="secondary" size="sm" asChild>
               <a
                 href={customerIdsUrl}
                 target="_blank"
@@ -70,16 +70,11 @@ export function StartCopyStep({
               description="Please contact support before you start the copy in Stripe."
             />
           )}
-          <Text variant="caption" color="muted">
-            Upload the CSV, paste the account ID, and confirm the copy.
-          </Text>
           {copy.warning && (
-            <Text variant="caption" color="muted">
-              Note: {copy.warning}
-            </Text>
+            <Text variant="caption">Important: {copy.warning}</Text>
           )}
           <Box>
-            <Button variant="ghost" size="sm" asChild>
+            <Button variant="secondary" size="sm" asChild>
               <a
                 href={STRIPE_COPY_STATUS_URL}
                 target="_blank"

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
@@ -15,7 +15,6 @@ interface Props {
   copy: StepCopy
   destinationAccountId: string | null
   migrationId: string
-  organizationId: string
 }
 
 export function StartCopyStep({
@@ -23,15 +22,8 @@ export function StartCopyStep({
   copy,
   destinationAccountId,
   migrationId,
-  organizationId,
 }: Props) {
-  const downloadCsv = () => {
-    const url = new URL(
-      `${getServerURL()}/v1/customers/export?organization_id=${organizationId}`,
-      window.location.origin,
-    )
-    window.open(url, '_blank')
-  }
+  const customerIdsUrl = `${getServerURL()}/v1/merchant-migrations/${migrationId}/customer-ids.csv`
 
   return (
     <Box flexDirection="column" rowGap="xl">
@@ -45,9 +37,11 @@ export function StartCopyStep({
           Upload this file in Stripe when you start the copy.
         </Text>
         <Box>
-          <Button variant="secondary" size="sm" onClick={downloadCsv}>
-            <Download size={14} />
-            Download customer CSV
+          <Button variant="secondary" size="sm" asChild>
+            <a href={customerIdsUrl} target="_blank" rel="noopener noreferrer">
+              <Download size={14} />
+              Download customer CSV
+            </a>
           </Button>
         </Box>
       </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
@@ -7,7 +7,7 @@ import { Box } from '@polar-sh/orbit/Box'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
 import type { ReactNode } from 'react'
 import { OpsUpdate } from './OpsUpdate'
-import { StepCopy, STRIPE_COPY_STATUS_URL } from './panTransferCopy'
+import { StepCopy, stripeCopyStatusUrl } from './panTransferCopy'
 import { PanTransferStepForm } from './PanTransferStepForm'
 
 interface Props {
@@ -15,6 +15,7 @@ interface Props {
   copy: StepCopy
   destinationAccountId: string | null
   migrationId: string
+  sourceStripeAccountId?: string
 }
 
 export function StartCopyStep({
@@ -22,6 +23,7 @@ export function StartCopyStep({
   copy,
   destinationAccountId,
   migrationId,
+  sourceStripeAccountId,
 }: Props) {
   const customerIdsUrl = `${getServerURL()}/v1/merchant-migrations/${migrationId}/customer-ids.csv`
 
@@ -77,7 +79,7 @@ export function StartCopyStep({
           <Box>
             <Button variant="secondary" size="sm" asChild>
               <a
-                href={STRIPE_COPY_STATUS_URL}
+                href={stripeCopyStatusUrl(sourceStripeAccountId)}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
@@ -5,6 +5,7 @@ import { schemas } from '@polar-sh/client'
 import { Alert, Button, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
+import type { ReactNode } from 'react'
 import { OpsUpdate } from './OpsUpdate'
 import { StepCopy, STRIPE_COPY_STATUS_URL } from './panTransferCopy'
 import { PanTransferStepForm } from './PanTransferStepForm'
@@ -25,16 +26,18 @@ export function StartCopyStep({
   const customerIdsUrl = `${getServerURL()}/v1/merchant-migrations/${migrationId}/customer-ids.csv`
 
   return (
-    <Box flexDirection="column" rowGap="l" maxWidth={640}>
+    <Box flexDirection="column" rowGap="l" maxWidth={720}>
       <Text variant="caption" color="muted">
         {copy.description}
       </Text>
 
-      <Box as="ol" flexDirection="column" rowGap="l">
-        <Box as="li" flexDirection="column" rowGap="s">
-          <Text variant="caption">
-            1. Download the customer CSV and upload it in Stripe.
-          </Text>
+      <Box
+        flexDirection="column"
+        borderTopWidth={1}
+        borderStyle="solid"
+        borderColor="border-secondary"
+      >
+        <TaskRow title="Upload customer CSV in Stripe">
           <Box>
             <Button variant="secondary" size="sm" asChild>
               <a
@@ -46,18 +49,14 @@ export function StartCopyStep({
               </a>
             </Button>
           </Box>
-        </Box>
+        </TaskRow>
 
-        <Box as="li" flexDirection="column" rowGap="s">
-          <Text variant="caption">
-            2. In Stripe, open Customers → Copy customers and paste this Polar
-            account ID as the recipient.
-          </Text>
+        <TaskRow
+          title="Paste Polar account ID as recipient"
+          description="Stripe → Customers → Copy customers"
+        >
           {destinationAccountId ? (
-            <Box flexDirection="column" rowGap="xs" maxWidth={420}>
-              <Text variant="caption" color="muted">
-                Polar account ID
-              </Text>
+            <Box width={{ base: '100%', md: 320 }}>
               <CopyToClipboardInput
                 value={destinationAccountId}
                 variant="mono"
@@ -70,9 +69,9 @@ export function StartCopyStep({
               description="Please contact support before you start the copy in Stripe."
             />
           )}
-          {copy.warning && (
-            <Text variant="caption">Important: {copy.warning}</Text>
-          )}
+        </TaskRow>
+
+        <TaskRow title="Track copy progress in Stripe">
           <Box>
             <Button variant="secondary" size="sm" asChild>
               <a
@@ -84,22 +83,52 @@ export function StartCopyStep({
               </a>
             </Button>
           </Box>
-        </Box>
-
-        <Box as="li" flexDirection="column" rowGap="s">
-          <Text variant="caption">
-            3. After starting the copy, paste the optional Stripe migration ID.
-          </Text>
-          <OpsUpdate step={step} />
-          {copy.action && (
-            <PanTransferStepForm
-              copy={copy}
-              migrationId={migrationId}
-              stepKey={step.key}
-            />
-          )}
-        </Box>
+        </TaskRow>
       </Box>
+
+      {copy.warning && <Text variant="caption">Important: {copy.warning}</Text>}
+      <OpsUpdate step={step} />
+      {copy.action && (
+        <PanTransferStepForm
+          copy={copy}
+          migrationId={migrationId}
+          stepKey={step.key}
+          compact
+        />
+      )}
+    </Box>
+  )
+}
+
+function TaskRow({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description?: string
+  children: ReactNode
+}) {
+  return (
+    <Box
+      flexDirection={{ base: 'column', md: 'row' }}
+      alignItems={{ base: 'stretch', md: 'center' }}
+      justifyContent="between"
+      gap="m"
+      paddingVertical="m"
+      borderBottomWidth={1}
+      borderStyle="solid"
+      borderColor="border-secondary"
+    >
+      <Box flexDirection="column" rowGap="xs">
+        <Text variant="caption">{title}</Text>
+        {description && (
+          <Text variant="caption" color="muted">
+            {description}
+          </Text>
+        )}
+      </Box>
+      <Box flexShrink={0}>{children}</Box>
     </Box>
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartCopyStep.tsx
@@ -57,7 +57,7 @@ export function StartCopyStep({
           description="Stripe → Customers → Copy customers"
         >
           {destinationAccountId ? (
-            <Box width={{ base: '100%', md: 320 }}>
+            <Box width="100%">
               <CopyToClipboardInput
                 value={destinationAccountId}
                 variant="mono"
@@ -114,11 +114,16 @@ function TaskRow({
   return (
     <Box
       as="li"
-      flexDirection={{ base: 'column', md: 'row' }}
+      display={{ base: 'flex', md: 'grid' }}
+      flexDirection="column"
+      gridTemplateColumns={{
+        base: '1fr',
+        md: 'minmax(0, 1fr) 320px',
+      }}
       alignItems={{ base: 'stretch', md: 'center' }}
-      justifyContent="between"
-      gap="m"
-      paddingVertical="m"
+      columnGap="xl"
+      rowGap="m"
+      paddingVertical="l"
       borderBottomWidth={1}
       borderStyle="solid"
       borderColor="border-secondary"
@@ -131,7 +136,13 @@ function TaskRow({
           </Text>
         )}
       </Box>
-      <Box flexShrink={0}>{children}</Box>
+      <Box
+        width="100%"
+        justifyContent={{ base: 'start', md: 'end' }}
+        flexShrink={0}
+      >
+        {children}
+      </Box>
     </Box>
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   isValidStripeMigrationId,
+  STEP_COPY,
   stripeMigrationIdError,
 } from './panTransferCopy'
 
@@ -18,7 +19,7 @@ describe('isValidStripeMigrationId', () => {
 })
 
 describe('stripeMigrationIdError', () => {
-  it('allows empty optional values', () => {
+  it('leaves empty values to required-field validation', () => {
     expect(stripeMigrationIdError('')).toBeNull()
     expect(stripeMigrationIdError('   ')).toBeNull()
   })
@@ -29,5 +30,18 @@ describe('stripeMigrationIdError', () => {
 
   it('returns null for a valid id', () => {
     expect(stripeMigrationIdError('migreq_ok_1')).toBeNull()
+  })
+})
+
+describe('start copy', () => {
+  it('requires the Stripe migration ID without payment method caveats', () => {
+    expect(STEP_COPY.start_copy.inputs?.[0]).toMatchObject({
+      name: 'stripe_migration_request_id',
+      label: 'Stripe migration ID',
+      required: true,
+    })
+    expect(STEP_COPY.start_copy.warning).toBe(
+      'Only the account owner can start a copy.',
+    )
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   isValidStripeMigrationId,
   STEP_COPY,
+  stripeCopyStatusUrl,
   stripeMigrationIdError,
 } from './panTransferCopy'
 
@@ -43,5 +44,23 @@ describe('start copy', () => {
     expect(STEP_COPY.start_copy.warning).toBe(
       'Only the account owner can start a copy.',
     )
+  })
+
+  it('builds the copy status URL from the source Stripe account', () => {
+    expect(stripeCopyStatusUrl('acct_source')).toBe(
+      'https://dashboard.stripe.com/acct_source/copy-status/shared',
+    )
+    expect(stripeCopyStatusUrl()).toBe(
+      'https://dashboard.stripe.com/copy-status/shared',
+    )
+  })
+})
+
+describe('provider export', () => {
+  it('keeps provider contact optional', () => {
+    expect(STEP_COPY.request_provider_export.inputs?.[1]).toMatchObject({
+      name: 'provider_contact',
+      required: false,
+    })
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isValidStripeMigrationId,
+  stripeMigrationIdError,
+} from './panTransferCopy'
+
+describe('isValidStripeMigrationId', () => {
+  it('accepts migreq_ plus alphanumerics and underscores', () => {
+    expect(isValidStripeMigrationId('migreq_abc123')).toBe(true)
+    expect(isValidStripeMigrationId('migreq_ABC_def_9')).toBe(true)
+  })
+
+  it('rejects missing prefix or empty suffix', () => {
+    expect(isValidStripeMigrationId('migreq_')).toBe(false)
+    expect(isValidStripeMigrationId('req_abc')).toBe(false)
+    expect(isValidStripeMigrationId('migreq-abc')).toBe(false)
+  })
+})
+
+describe('stripeMigrationIdError', () => {
+  it('allows empty optional values', () => {
+    expect(stripeMigrationIdError('')).toBeNull()
+    expect(stripeMigrationIdError('   ')).toBeNull()
+  })
+
+  it('returns an error for malformed non-empty values', () => {
+    expect(stripeMigrationIdError('bad')).toMatch(/migreq_/)
+  })
+
+  it('returns null for a valid id', () => {
+    expect(stripeMigrationIdError('migreq_ok_1')).toBeNull()
+  })
+})

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
@@ -1,5 +1,3 @@
-import { schemas } from '@polar-sh/client'
-
 // The backend checklist stores state only. All wording lives here, keyed by
 // step key, so we can reword a step without a data migration.
 
@@ -58,15 +56,11 @@ export const STEP_COPY: Record<string, StepCopy> = {
   },
   start_copy: {
     title: 'Start the copy in Stripe',
-    description: 'Ask Stripe to copy your saved cards over to Polar.',
-    guidance: [
-      'In Stripe, open Customers and choose Copy customers.',
-      'Upload the CSV, paste the Polar account ID as the recipient, then confirm.',
-    ],
+    description: 'Copy saved cards from your Stripe account to Polar.',
     warning:
       'Only the account owner can start a copy. Wallet cards, Bacs and old SEPA mandates do not copy.',
     inputs: [STRIPE_MIGRATION_ID_INPUT],
-    action: 'I started the copy',
+    action: 'Mark copy started',
   },
   authorize_copy: {
     title: 'Polar accepts the copy',
@@ -166,31 +160,3 @@ export const STEP_COPY: Record<string, StepCopy> = {
       'We start billing the subscriptions you picked. They are charged on their next renewal date.',
   },
 }
-
-type Owner = schemas['PanStepOwner']
-
-// Polar Ops and the Polar app are the same party to a merchant. The split only
-// matters to us.
-const OWNER_LABEL: Record<Owner, string> = {
-  merchant: 'You',
-  polar_ops: 'Polar',
-  polar_app: 'Polar',
-  stripe: 'Stripe',
-  provider: 'Your provider',
-}
-
-const WAITING_LABEL: Record<Owner, string> = {
-  merchant: 'Your turn',
-  polar_ops: 'With Polar',
-  polar_app: 'With Polar',
-  stripe: 'With Stripe',
-  provider: 'With your provider',
-}
-
-// An owner the backend added but this build doesn't know yet still has to read
-// as something, the same way an unknown step key does.
-export const ownerLabel = (owner: Owner): string =>
-  OWNER_LABEL[owner] ?? 'Polar'
-
-export const waitingLabel = (owner: Owner): string =>
-  WAITING_LABEL[owner] ?? 'In progress'

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
@@ -20,8 +20,10 @@ export interface StepCopy {
 
 export const STRIPE_MIGRATION_ID_FIELD = 'stripe_migration_request_id'
 
-export const STRIPE_COPY_STATUS_URL =
-  'https://dashboard.stripe.com/acct_1LzIVeDG1jUQrXwC/copy-status/shared'
+export const stripeCopyStatusUrl = (sourceAccountId?: string): string =>
+  sourceAccountId
+    ? `https://dashboard.stripe.com/${sourceAccountId}/copy-status/shared`
+    : 'https://dashboard.stripe.com/copy-status/shared'
 
 const STRIPE_MIGRATION_ID_RE = /^migreq_[A-Za-z0-9_]+$/
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
@@ -7,6 +7,7 @@ export interface StepInputField {
   name: string
   label: string
   placeholder?: string
+  hint?: string
   required: boolean
 }
 
@@ -20,6 +21,36 @@ export interface StepCopy {
   showsDestinationAccount?: boolean
 }
 
+export const STRIPE_MIGRATION_ID_FIELD = 'stripe_migration_request_id'
+
+export const STRIPE_COPY_STATUS_URL =
+  'https://dashboard.stripe.com/acct_1LzIVeDG1jUQrXwC/copy-status/shared'
+
+const STRIPE_MIGRATION_ID_RE = /^migreq_[A-Za-z0-9_]+$/
+
+export function isValidStripeMigrationId(value: string): boolean {
+  return STRIPE_MIGRATION_ID_RE.test(value)
+}
+
+export function stripeMigrationIdError(value: string): string | null {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+  if (!isValidStripeMigrationId(trimmed)) {
+    return 'Must start with migreq_ followed by letters, numbers, or underscores.'
+  }
+  return null
+}
+
+const STRIPE_MIGRATION_ID_INPUT: StepInputField = {
+  name: STRIPE_MIGRATION_ID_FIELD,
+  label: 'Stripe migration ID',
+  placeholder: 'migreq_…',
+  hint: 'Starts with migreq_. Find it on the Stripe copy status page.',
+  required: false,
+}
+
 export const STEP_COPY: Record<string, StepCopy> = {
   share_destination_account: {
     title: 'Get the Polar account ID',
@@ -30,21 +61,12 @@ export const STEP_COPY: Record<string, StepCopy> = {
     title: 'Start the copy in Stripe',
     description: 'Ask Stripe to copy your saved cards over to Polar.',
     guidance: [
-      'Open your Stripe Dashboard and go to Customers.',
-      'Click Copy customers, then pick a copy method.',
-      'Paste the Polar account ID above as the recipient.',
-      'Confirm the copy.',
+      'In Stripe, open Customers and choose Copy customers.',
+      'Upload the CSV, paste the Polar account ID as the recipient, then confirm.',
     ],
     warning:
       'Only the account owner can start a copy. Wallet cards, Bacs and old SEPA mandates do not copy.',
-    inputs: [
-      {
-        name: 'stripe_migration_request_id',
-        label: 'Stripe request ID',
-        placeholder: 'From the Stripe copy status page',
-        required: false,
-      },
-    ],
+    inputs: [STRIPE_MIGRATION_ID_INPUT],
     action: 'I started the copy',
     showsDestinationAccount: true,
   },
@@ -66,8 +88,7 @@ export const STEP_COPY: Record<string, StepCopy> = {
     // their provider on the next step, so it has to stay readable afterwards.
     inputs: [
       {
-        name: 'stripe_migration_request_id',
-        label: 'Stripe request ID',
+        ...STRIPE_MIGRATION_ID_INPUT,
         required: true,
       },
     ],

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
@@ -42,10 +42,10 @@ export function stripeMigrationIdError(value: string): string | null {
 
 const STRIPE_MIGRATION_ID_INPUT: StepInputField = {
   name: STRIPE_MIGRATION_ID_FIELD,
-  label: 'Stripe migration ID (optional)',
+  label: 'Stripe migration ID',
   placeholder: 'migreq_…',
-  hint: 'After starting the copy, paste it from Stripe copy status. Starts with migreq_.',
-  required: false,
+  hint: 'Starts with migreq_. Find it on the Stripe copy status page.',
+  required: true,
 }
 
 export const STEP_COPY: Record<string, StepCopy> = {
@@ -57,9 +57,13 @@ export const STEP_COPY: Record<string, StepCopy> = {
   start_copy: {
     title: 'Start the copy in Stripe',
     description: 'Copy saved cards from your Stripe account to Polar.',
-    warning:
-      'Only the account owner can start a copy. Wallet cards, Bacs and old SEPA mandates do not copy.',
-    inputs: [STRIPE_MIGRATION_ID_INPUT],
+    warning: 'Only the account owner can start a copy.',
+    inputs: [
+      {
+        ...STRIPE_MIGRATION_ID_INPUT,
+        hint: 'After starting the copy, paste it from Stripe copy status. Starts with migreq_.',
+      },
+    ],
     action: 'Mark copy started',
   },
   authorize_copy: {
@@ -78,14 +82,7 @@ export const STEP_COPY: Record<string, StepCopy> = {
       'We open a migration request with Stripe and share our PCI documents.',
     // Ops fills this in, but the merchant is the one who has to quote it to
     // their provider on the next step, so it has to stay readable afterwards.
-    inputs: [
-      {
-        ...STRIPE_MIGRATION_ID_INPUT,
-        label: 'Stripe migration ID',
-        hint: 'Starts with migreq_. Find it on the Stripe copy status page.',
-        required: true,
-      },
-    ],
+    inputs: [STRIPE_MIGRATION_ID_INPUT],
   },
   request_provider_export: {
     title: 'Ask your provider for the card export',

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
@@ -18,7 +18,6 @@ export interface StepCopy {
   warning?: string
   inputs?: StepInputField[]
   action?: string
-  showsDestinationAccount?: boolean
 }
 
 export const STRIPE_MIGRATION_ID_FIELD = 'stripe_migration_request_id'
@@ -68,7 +67,6 @@ export const STEP_COPY: Record<string, StepCopy> = {
       'Only the account owner can start a copy. Wallet cards, Bacs and old SEPA mandates do not copy.',
     inputs: [STRIPE_MIGRATION_ID_INPUT],
     action: 'I started the copy',
-    showsDestinationAccount: true,
   },
   authorize_copy: {
     title: 'Polar accepts the copy',

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
@@ -42,7 +42,7 @@ export function stripeMigrationIdError(value: string): string | null {
 
 const STRIPE_MIGRATION_ID_INPUT: StepInputField = {
   name: STRIPE_MIGRATION_ID_FIELD,
-  label: 'Stripe migration ID',
+  label: 'Stripe migration ID (optional)',
   placeholder: 'migreq_…',
   hint: 'Starts with migreq_. Find it on the Stripe copy status page.',
   required: false,
@@ -81,6 +81,7 @@ export const STEP_COPY: Record<string, StepCopy> = {
     inputs: [
       {
         ...STRIPE_MIGRATION_ID_INPUT,
+        label: 'Stripe migration ID',
         required: true,
       },
     ],

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
@@ -44,7 +44,7 @@ const STRIPE_MIGRATION_ID_INPUT: StepInputField = {
   name: STRIPE_MIGRATION_ID_FIELD,
   label: 'Stripe migration ID (optional)',
   placeholder: 'migreq_…',
-  hint: 'Starts with migreq_. Find it on the Stripe copy status page.',
+  hint: 'After starting the copy, paste it from Stripe copy status. Starts with migreq_.',
   required: false,
 }
 
@@ -82,6 +82,7 @@ export const STEP_COPY: Record<string, StepCopy> = {
       {
         ...STRIPE_MIGRATION_ID_INPUT,
         label: 'Stripe migration ID',
+        hint: 'Starts with migreq_. Find it on the Stripe copy status page.',
         required: true,
       },
     ],

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5320,6 +5320,28 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/merchant-migrations/{id}/customer-ids.csv': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Export Merchant Migration Customer IDs
+     * @description One imported Stripe customer ID per row, no header — for Stripe Copy upload.
+     *
+     *     **Scopes**: `organizations:write`
+     */
+    get: operations['merchant-migrations:export_customer_ids']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/merchant-migrations/{id}/pan-transfer': {
     parameters: {
       query?: never
@@ -53738,6 +53760,55 @@ export interface operations {
           'application/json':
             | components['schemas']['CatalogImportNotReady']
             | components['schemas']['CatalogImportBlocked']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'merchant-migrations:export_customer_ids': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'text/csv': string
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'text/csv': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'text/csv': components['schemas']['MerchantMigrationNotFound']
         }
       }
       /** @description Validation Error */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -53793,6 +53793,15 @@ export interface operations {
           'text/csv': string
         }
       }
+      /** @description Authentication required. */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'text/csv': components['schemas']['Unauthorized']
+        }
+      }
       /** @description Not allowed to manage this organization. */
       403: {
         headers: {

--- a/clients/packages/ui/src/components/atoms/CopyToClipboardInput.tsx
+++ b/clients/packages/ui/src/components/atoms/CopyToClipboardInput.tsx
@@ -11,6 +11,7 @@ const CopyToClipboardInput = ({
   disabled = false,
   className = '',
   variant = 'default',
+  ariaLabel,
 }: {
   value: string
   onCopy?: () => void
@@ -18,6 +19,7 @@ const CopyToClipboardInput = ({
   disabled?: boolean
   className?: string
   variant?: 'default' | 'mono'
+  ariaLabel?: string
 }) => {
   const [isCopied, setIsCopied] = useState(false)
 
@@ -49,6 +51,7 @@ const CopyToClipboardInput = ({
         )}
         value={value ?? ''}
         readOnly={true}
+        aria-label={ariaLabel}
       />
       {!disabled && (
         <Button

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -1,9 +1,11 @@
+from collections.abc import AsyncGenerator
 from typing import Annotated
 
 from fastapi import Depends, Query
 from pydantic import UUID4
 
 from polar.exceptions import NotPermitted, ResourceNotFound
+from polar.kit.csv import CSVStreamingResponse, IterableCSVWriter
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.models import MerchantMigration
@@ -204,6 +206,39 @@ async def import_catalog(
         record_ids=body.record_ids if body is not None else None,
         exclude_record_ids=body.exclude_record_ids if body is not None else None,
     )
+
+
+@router.get(
+    "/{id}/customer-ids.csv",
+    summary="Export Merchant Migration Customer IDs",
+    response_class=CSVStreamingResponse,
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+    },
+)
+async def export_customer_ids(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> CSVStreamingResponse:
+    """One imported Stripe customer ID per row, no header — for Stripe Copy upload."""
+    source_ids = await merchant_migration_service.stream_imported_customer_source_ids(
+        session, auth_subject, id
+    )
+
+    async def create_csv() -> AsyncGenerator[str]:
+        csv_writer = IterableCSVWriter(dialect="excel")
+        async for source_id in source_ids:
+            yield csv_writer.getrow((source_id,))
+
+    return CSVStreamingResponse(create_csv(), "stripe-customer-ids.csv")
 
 
 @router.get(

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -4,7 +4,7 @@ from typing import Annotated
 from fastapi import Depends, Query
 from pydantic import UUID4
 
-from polar.exceptions import NotPermitted, ResourceNotFound
+from polar.exceptions import NotPermitted, ResourceNotFound, Unauthorized
 from polar.kit.csv import CSVStreamingResponse, IterableCSVWriter
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.pagination import ListResource, PaginationParamsQuery
@@ -213,6 +213,10 @@ async def import_catalog(
     summary="Export Merchant Migration Customer IDs",
     response_class=CSVStreamingResponse,
     responses={
+        401: {
+            "description": "Authentication required.",
+            "model": Unauthorized.schema(),
+        },
         403: {
             "description": "Not allowed to manage this organization.",
             "model": NotPermitted.schema(),
@@ -226,7 +230,9 @@ async def import_catalog(
 async def export_customer_ids(
     id: UUID4,
     auth_subject: MerchantMigrationWrite,
-    session: AsyncReadSession = Depends(get_db_read_session),
+    # The primary: this CSV is downloaded right after import, and replica lag
+    # would omit customer IDs the import receipt already counted.
+    session: AsyncSession = Depends(get_db_session),
 ) -> CSVStreamingResponse:
     """One imported Stripe customer ID per row, no header — for Stripe Copy upload."""
     source_ids = await merchant_migration_service.stream_imported_customer_source_ids(

--- a/server/polar/merchant_migration/pan_transfer.py
+++ b/server/polar/merchant_migration/pan_transfer.py
@@ -13,11 +13,11 @@ Kept free of `polar.models` imports so the model layer can use `PanTransferStep`
 as its column type.
 """
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
-import re
 from typing import Any
 
 from pydantic import Field

--- a/server/polar/merchant_migration/pan_transfer.py
+++ b/server/polar/merchant_migration/pan_transfer.py
@@ -17,6 +17,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
+import re
 from typing import Any
 
 from pydantic import Field
@@ -98,6 +99,8 @@ STEP_VERIFY_CARDS = "verify_cards"
 STEP_RESOLVE_UNCOVERED = "resolve_uncovered"
 STEP_CUTOVER = "cutover"
 STEP_MOVE_SUBSCRIPTIONS = "move_subscriptions"
+STRIPE_MIGRATION_REQUEST_ID_INPUT = "stripe_migration_request_id"
+STRIPE_MIGRATION_REQUEST_ID_PATTERN = re.compile(r"^migreq_[A-Za-z0-9_]+$")
 
 
 class PanTransferError(MerchantMigrationError): ...
@@ -219,7 +222,7 @@ PAN_COPY_TEMPLATES: tuple[PanStepTemplate, ...] = (
         key="start_copy",
         owner=PanStepOwner.merchant,
         kind=PanStepKind.confirm,
-        required_inputs=("stripe_migration_request_id",),
+        required_inputs=(STRIPE_MIGRATION_REQUEST_ID_INPUT,),
     ),
     PanStepTemplate(
         key="authorize_copy",
@@ -259,7 +262,7 @@ PAN_IMPORT_TEMPLATES: tuple[PanStepTemplate, ...] = (
         key="open_stripe_request",
         owner=PanStepOwner.polar_ops,
         kind=PanStepKind.input,
-        required_inputs=("stripe_migration_request_id",),
+        required_inputs=(STRIPE_MIGRATION_REQUEST_ID_INPUT,),
     ),
     PanStepTemplate(
         key="request_provider_export",
@@ -415,6 +418,23 @@ def _validate_inputs(template: PanStepTemplate, inputs: dict[str, str]) -> None:
         }
         for key in sorted(set(template.required_inputs) - set(inputs))
     ]
+    stripe_migration_request_id = inputs.get(STRIPE_MIGRATION_REQUEST_ID_INPUT)
+    if (
+        stripe_migration_request_id is not None
+        and STRIPE_MIGRATION_REQUEST_ID_PATTERN.fullmatch(stripe_migration_request_id)
+        is None
+    ):
+        errors.append(
+            {
+                "type": "string_pattern_mismatch",
+                "loc": ("body", "inputs", STRIPE_MIGRATION_REQUEST_ID_INPUT),
+                "msg": (
+                    "Must start with migreq_ followed by letters, numbers, "
+                    "or underscores."
+                ),
+                "input": stripe_migration_request_id,
+            }
+        )
     if errors:
         raise PolarRequestValidationError(errors)
 

--- a/server/polar/merchant_migration/pan_transfer.py
+++ b/server/polar/merchant_migration/pan_transfer.py
@@ -219,7 +219,7 @@ PAN_COPY_TEMPLATES: tuple[PanStepTemplate, ...] = (
         key="start_copy",
         owner=PanStepOwner.merchant,
         kind=PanStepKind.confirm,
-        optional_inputs=("stripe_migration_request_id",),
+        required_inputs=("stripe_migration_request_id",),
     ),
     PanStepTemplate(
         key="authorize_copy",

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import AsyncGenerator, Sequence
 from typing import Any
 from uuid import UUID
 
@@ -131,6 +131,30 @@ class MerchantMigrationRecordRepository(
             )
         )
         return await self.get_all(statement)
+
+    async def stream_imported_customer_source_ids(
+        self, migration_id: UUID
+    ) -> AsyncGenerator[str]:
+        statement = (
+            self.get_base_statement()
+            .with_only_columns(MerchantMigrationRecord.source_id)
+            .where(
+                MerchantMigrationRecord.merchant_migration_id == migration_id,
+                MerchantMigrationRecord.type == MerchantMigrationRecordType.customer,
+                MerchantMigrationRecord.status
+                == MerchantMigrationRecordStatus.imported,
+            )
+            .order_by(
+                MerchantMigrationRecord.created_at,
+                MerchantMigrationRecord.id,
+            )
+        )
+        results = await self.session.stream_scalars(statement)
+        try:
+            async for source_id in results:
+                yield source_id
+        finally:
+            await results.close()
 
     async def count_by_type_and_status(
         self, migration_ids: Sequence[UUID]

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject, Organization, User, is_organization, is_user
 from polar.authz.repository import select_accessible_org_ids
+from polar.config import settings
 from polar.kit.repository import (
     RepositoryBase,
     RepositorySoftDeletionIDMixin,
@@ -149,7 +150,10 @@ class MerchantMigrationRecordRepository(
                 MerchantMigrationRecord.id,
             )
         )
-        results = await self.session.stream_scalars(statement)
+        results = await self.session.stream_scalars(
+            statement,
+            execution_options={"yield_per": settings.DATABASE_STREAM_YIELD_PER},
+        )
         try:
             async for source_id in results:
                 yield source_id

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Sequence
 from datetime import datetime
 from typing import NamedTuple, TypedDict
 from uuid import UUID
@@ -492,6 +492,19 @@ class MerchantMigrationService:
         the client can show the method and the destination account up front."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
         return self._checklist(migration)
+
+    async def stream_imported_customer_source_ids(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> AsyncGenerator[str]:
+        """Authorize the migration, then return a stream of imported customer
+        source IDs for the Stripe Copy CSV. Auth runs before the generator is
+        returned so 403/404 cannot land mid-stream."""
+        await self._get_manageable(session, auth_subject, migration_id)
+        repository = MerchantMigrationRecordRepository.from_session(session)
+        return repository.stream_imported_customer_source_ids(migration_id)
 
     async def start_pan_transfer(
         self,

--- a/server/tests/backoffice/merchant_migrations/test_endpoints.py
+++ b/server/tests/backoffice/merchant_migrations/test_endpoints.py
@@ -35,6 +35,7 @@ from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
 from polar.models.user_session import UserSession
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from tests.fixtures.database import SaveFixture
+from tests.merchant_migration._helpers import pan_step_required_inputs
 
 
 @pytest_asyncio.fixture
@@ -92,7 +93,7 @@ def _advance_to(key: str) -> list[PanTransferStep]:
             steps,
             current.key,
             actor=actor,
-            inputs={key: "value" for key in template.required_inputs},
+            inputs=pan_step_required_inputs(template),
         )
 
 
@@ -444,14 +445,14 @@ class TestCompleteStep:
         await _post_action(
             backoffice_client,
             f"/merchant-migrations/{migration.id}/steps/start_copy/complete",
-            {"stripe_migration_request_id": "mig_123"},
+            {"stripe_migration_request_id": "migreq_123"},
         )
 
         await _reload(session, migration)
         step = next(
             step for step in migration.pan_transfer_steps if step.key == "start_copy"
         )
-        assert step.inputs == {"stripe_migration_request_id": "mig_123"}
+        assert step.inputs == {"stripe_migration_request_id": "migreq_123"}
 
     async def test_warns_when_completing_on_the_merchants_behalf(
         self,

--- a/server/tests/backoffice/merchant_migrations/test_endpoints.py
+++ b/server/tests/backoffice/merchant_migrations/test_endpoints.py
@@ -86,8 +86,13 @@ def _advance_to(key: str) -> list[PanTransferStep]:
             if current.owner == PanStepOwner.polar_app
             else PanStepActor.ops
         )
+        template = pan_transfer._template(PanTransferMethod.pan_copy, current.key)
         steps = pan_transfer.complete(
-            PanTransferMethod.pan_copy, steps, current.key, actor=actor, inputs={}
+            PanTransferMethod.pan_copy,
+            steps,
+            current.key,
+            actor=actor,
+            inputs={key: "value" for key in template.required_inputs},
         )
 
 

--- a/server/tests/backoffice/merchant_migrations/test_status.py
+++ b/server/tests/backoffice/merchant_migrations/test_status.py
@@ -25,6 +25,7 @@ from polar.models.merchant_migration_record import (
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
+from tests.merchant_migration._helpers import pan_step_required_inputs
 
 NO_FAILURES = 0
 
@@ -63,7 +64,7 @@ def _advance_to(key: str) -> list[PanTransferStep]:
             steps,
             current.key,
             actor=actor,
-            inputs={key: "value" for key in template.required_inputs},
+            inputs=pan_step_required_inputs(template),
         )
 
 
@@ -161,7 +162,7 @@ class TestAttention:
                 steps,
                 current.key,
                 actor=actor,
-                inputs={key: "value" for key in template.required_inputs},
+                inputs=pan_step_required_inputs(template),
             )
         migration = _migration(step=MerchantMigrationStep.copy_cards, steps=steps)
 

--- a/server/tests/backoffice/merchant_migrations/test_status.py
+++ b/server/tests/backoffice/merchant_migrations/test_status.py
@@ -57,8 +57,13 @@ def _advance_to(key: str) -> list[PanTransferStep]:
             if current.owner == PanStepOwner.polar_app
             else PanStepActor.ops
         )
+        template = pan_transfer._template(PanTransferMethod.pan_copy, current.key)
         steps = pan_transfer.complete(
-            PanTransferMethod.pan_copy, steps, current.key, actor=actor, inputs={}
+            PanTransferMethod.pan_copy,
+            steps,
+            current.key,
+            actor=actor,
+            inputs={key: "value" for key in template.required_inputs},
         )
 
 
@@ -150,8 +155,13 @@ class TestAttention:
                 if current.owner == PanStepOwner.polar_app
                 else PanStepActor.ops
             )
+            template = pan_transfer._template(PanTransferMethod.pan_copy, current.key)
             steps = pan_transfer.complete(
-                PanTransferMethod.pan_copy, steps, current.key, actor=actor, inputs={}
+                PanTransferMethod.pan_copy,
+                steps,
+                current.key,
+                actor=actor,
+                inputs={key: "value" for key in template.required_inputs},
             )
         migration = _migration(step=MerchantMigrationStep.copy_cards, steps=steps)
 

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -115,8 +115,13 @@ def pan_steps_until(
         current = pan_transfer.current(steps)
         if current is None or current.key == target_key:
             return steps
+        template = pan_transfer._template(method, current.key)
         steps = pan_transfer.complete(
-            method, steps, current.key, actor=_STEP_ACTORS[current.owner], inputs={}
+            method,
+            steps,
+            current.key,
+            actor=_STEP_ACTORS[current.owner],
+            inputs={key: "value" for key in template.required_inputs},
         )
 
 

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -17,6 +17,7 @@ from polar.merchant_migration.canonical import (
 from polar.merchant_migration.pan_transfer import (
     PanStepActor,
     PanStepOwner,
+    PanStepTemplate,
     PanTransferMethod,
     PanTransferStep,
 )
@@ -103,6 +104,13 @@ _STEP_ACTORS = {
 }
 
 
+def pan_step_required_inputs(template: PanStepTemplate) -> dict[str, str]:
+    return {
+        key: "migreq_test" if key == "stripe_migration_request_id" else "value"
+        for key in template.required_inputs
+    }
+
+
 def pan_steps_until(
     method: PanTransferMethod, target_key: str | None
 ) -> list[PanTransferStep]:
@@ -121,7 +129,7 @@ def pan_steps_until(
             steps,
             current.key,
             actor=_STEP_ACTORS[current.owner],
-            inputs={key: "value" for key in template.required_inputs},
+            inputs=pan_step_required_inputs(template),
         )
 
 

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -752,7 +752,12 @@ class TestCompletePanTransferStep:
 
         response = await client.post(
             f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete",
-            json={"inputs": {"whatever": "x"}},
+            json={
+                "inputs": {
+                    "stripe_migration_request_id": "migreq_123",
+                    "whatever": "x",
+                }
+            },
         )
         # Per-field, so the client can point at the offending input.
         assert response.status_code == 422

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -692,6 +692,34 @@ class TestCompletePanTransferStep:
         ]
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_complete_rejects_invalid_stripe_migration_id(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_destination(mocker)
+        migration = await _create_migration(
+            save_fixture, organization, step=MerchantMigrationStep.create_catalog
+        )
+        await client.post(f"/v1/merchant-migrations/{migration.id}/pan-transfer")
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete",
+            json={"inputs": {"stripe_migration_request_id": "mig_123"}},
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["type"] == "string_pattern_mismatch"
+        assert response.json()["detail"][0]["loc"] == [
+            "body",
+            "inputs",
+            "stripe_migration_request_id",
+        ]
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
     async def test_complete_rejects_an_ops_step(
         self,
         client: AsyncClient,

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -649,7 +649,7 @@ class TestCompletePanTransferStep:
 
         response = await client.post(
             f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete",
-            json={"inputs": {"stripe_migration_request_id": "mig_123"}},
+            json={"inputs": {"stripe_migration_request_id": "migreq_123"}},
         )
         assert response.status_code == 200
         assert response.json()["current_step_key"] == "authorize_copy"
@@ -661,8 +661,35 @@ class TestCompletePanTransferStep:
         assert steps["start_copy"]["status"] == "completed"
         assert steps["start_copy"]["completed_by"] == "merchant"
         assert steps["start_copy"]["inputs"] == {
-            "stripe_migration_request_id": "mig_123"
+            "stripe_migration_request_id": "migreq_123"
         }
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_complete_requires_stripe_migration_id(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_destination(mocker)
+        migration = await _create_migration(
+            save_fixture, organization, step=MerchantMigrationStep.create_catalog
+        )
+        await client.post(f"/v1/merchant-migrations/{migration.id}/pan-transfer")
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete",
+            json={"inputs": {}},
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["loc"] == [
+            "body",
+            "inputs",
+            "stripe_migration_request_id",
+        ]
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
     async def test_complete_rejects_an_ops_step(
@@ -679,7 +706,8 @@ class TestCompletePanTransferStep:
         )
         await client.post(f"/v1/merchant-migrations/{migration.id}/pan-transfer")
         await client.post(
-            f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete"
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete",
+            json={"inputs": {"stripe_migration_request_id": "migreq_123"}},
         )
 
         response = await client.post(

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -16,10 +16,19 @@ from polar.merchant_migration.canonical import (
     CanonicalRecord,
 )
 from polar.merchant_migration.repository import MerchantMigrationRepository
-from polar.models import MerchantMigration, Organization, UserOrganization
+from polar.models import (
+    MerchantMigration,
+    MerchantMigrationRecord,
+    Organization,
+    UserOrganization,
+)
 from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
+)
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
 )
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
@@ -809,6 +818,73 @@ class TestCutover:
         assert body["started"] is False
         assert body["running"] is False
         assert body["total"] == 0
+
+
+@pytest.mark.asyncio
+class TestExportCustomerIds:
+    async def test_anonymous(
+        self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        response = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/customer-ids.csv"
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_exports_imported_customer_ids_only(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        records = (
+            (
+                MerchantMigrationRecordType.customer,
+                MerchantMigrationRecordStatus.imported,
+                "cus_second",
+            ),
+            (
+                MerchantMigrationRecordType.customer,
+                MerchantMigrationRecordStatus.imported,
+                "cus_first",
+            ),
+            (
+                MerchantMigrationRecordType.customer,
+                MerchantMigrationRecordStatus.pending,
+                "cus_pending",
+            ),
+            (
+                MerchantMigrationRecordType.subscription,
+                MerchantMigrationRecordStatus.imported,
+                "sub_imported",
+            ),
+        )
+        for type, status, source_id in records:
+            await save_fixture(
+                MerchantMigrationRecord(
+                    merchant_migration=migration,
+                    organization=organization,
+                    type=type,
+                    status=status,
+                    source_id=source_id,
+                    canonical={},
+                )
+            )
+
+        response = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/customer-ids.csv"
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/csv; charset=utf-8"
+        assert (
+            response.headers["content-disposition"]
+            == 'attachment; filename="stripe-customer-ids.csv"'
+        )
+        assert response.text == "cus_second\r\ncus_first\r\n"
 
 
 async def _create_migration(

--- a/server/tests/merchant_migration/test_pan_transfer.py
+++ b/server/tests/merchant_migration/test_pan_transfer.py
@@ -132,7 +132,7 @@ class TestComplete:
             _copy_steps(),
             "start_copy",
             actor=PanStepActor.merchant,
-            inputs={},
+            inputs={"stripe_migration_request_id": "migreq_123"},
         )
 
         assert steps[1].status == PanStepStatus.completed
@@ -143,16 +143,16 @@ class TestComplete:
         assert current.key == "authorize_copy"
         assert current.started_at is not None
 
-    def test_stores_optional_inputs(self) -> None:
+    def test_stores_required_inputs(self) -> None:
         steps = pan_transfer.complete(
             PanTransferMethod.pan_copy,
             _copy_steps(),
             "start_copy",
             actor=PanStepActor.merchant,
-            inputs={"stripe_migration_request_id": " mig_123 "},
+            inputs={"stripe_migration_request_id": " migreq_123 "},
         )
 
-        assert steps[1].inputs == {"stripe_migration_request_id": "mig_123"}
+        assert steps[1].inputs == {"stripe_migration_request_id": "migreq_123"}
 
     def test_rejects_a_step_that_is_not_current(self) -> None:
         with pytest.raises(PanStepNotActionable):
@@ -170,7 +170,7 @@ class TestComplete:
             _copy_steps(),
             "start_copy",
             actor=PanStepActor.merchant,
-            inputs={},
+            inputs={"stripe_migration_request_id": "migreq_123"},
         )
 
         with pytest.raises(PanStepNotActionable):
@@ -210,7 +210,7 @@ class TestComplete:
             _copy_steps(),
             "start_copy",
             actor=PanStepActor.ops,
-            inputs={},
+            inputs={"stripe_migration_request_id": "migreq_123"},
         )
 
         assert steps[1].completed_by == PanStepActor.ops
@@ -239,6 +239,20 @@ class TestComplete:
                 actor=PanStepActor.ops,
                 inputs={"stripe_migration_request_id": "   "},
             )
+        errors = exc.value.errors()
+        assert [error["type"] for error in errors] == ["missing"]
+        assert errors[0]["loc"] == ("body", "inputs", "stripe_migration_request_id")
+
+    def test_copy_requires_stripe_migration_id(self) -> None:
+        with pytest.raises(PolarRequestValidationError) as exc:
+            pan_transfer.complete(
+                PanTransferMethod.pan_copy,
+                _copy_steps(),
+                "start_copy",
+                actor=PanStepActor.merchant,
+                inputs={},
+            )
+
         errors = exc.value.errors()
         assert [error["type"] for error in errors] == ["missing"]
         assert errors[0]["loc"] == ("body", "inputs", "stripe_migration_request_id")
@@ -321,7 +335,7 @@ class TestPanTransferStepsType:
             _copy_steps(),
             "start_copy",
             actor=PanStepActor.merchant,
-            inputs={"stripe_migration_request_id": "mig_123"},
+            inputs={"stripe_migration_request_id": "migreq_123"},
         )
         column = PanTransferStepsType()
 

--- a/server/tests/merchant_migration/test_pan_transfer.py
+++ b/server/tests/merchant_migration/test_pan_transfer.py
@@ -264,7 +264,10 @@ class TestComplete:
                 _copy_steps(),
                 "start_copy",
                 actor=PanStepActor.merchant,
-                inputs={"whatever": "x"},
+                inputs={
+                    "stripe_migration_request_id": "migreq_123",
+                    "whatever": "x",
+                },
             )
         errors = exc.value.errors()
         assert [error["type"] for error in errors] == ["extra_forbidden"]

--- a/server/tests/merchant_migration/test_pan_transfer.py
+++ b/server/tests/merchant_migration/test_pan_transfer.py
@@ -260,7 +260,7 @@ class TestComplete:
 
     @pytest.mark.parametrize(
         ("method", "key", "actor"),
-        (
+        [
             (
                 PanTransferMethod.pan_copy,
                 "start_copy",
@@ -271,7 +271,7 @@ class TestComplete:
                 "open_stripe_request",
                 PanStepActor.ops,
             ),
-        ),
+        ],
     )
     def test_rejects_invalid_stripe_migration_id(
         self,

--- a/server/tests/merchant_migration/test_pan_transfer.py
+++ b/server/tests/merchant_migration/test_pan_transfer.py
@@ -16,6 +16,7 @@ from polar.merchant_migration.pan_transfer import (
 )
 from polar.models import MerchantMigration
 from polar.models.merchant_migration import MerchantMigrationSourcePlatform
+from tests.merchant_migration._helpers import pan_step_required_inputs
 
 
 def _copy_steps() -> list[PanTransferStep]:
@@ -46,7 +47,7 @@ def _advance_to(
             steps,
             step.key,
             actor=actor,
-            inputs={key: "value" for key in template.required_inputs},
+            inputs=pan_step_required_inputs(template),
         )
 
 
@@ -255,6 +256,41 @@ class TestComplete:
 
         errors = exc.value.errors()
         assert [error["type"] for error in errors] == ["missing"]
+        assert errors[0]["loc"] == ("body", "inputs", "stripe_migration_request_id")
+
+    @pytest.mark.parametrize(
+        ("method", "key", "actor"),
+        (
+            (
+                PanTransferMethod.pan_copy,
+                "start_copy",
+                PanStepActor.merchant,
+            ),
+            (
+                PanTransferMethod.pan_import,
+                "open_stripe_request",
+                PanStepActor.ops,
+            ),
+        ),
+    )
+    def test_rejects_invalid_stripe_migration_id(
+        self,
+        method: PanTransferMethod,
+        key: str,
+        actor: PanStepActor,
+    ) -> None:
+        steps = pan_transfer.build(method)
+        with pytest.raises(PolarRequestValidationError) as exc:
+            pan_transfer.complete(
+                method,
+                steps,
+                key,
+                actor=actor,
+                inputs={"stripe_migration_request_id": "mig_123"},
+            )
+
+        errors = exc.value.errors()
+        assert [error["type"] for error in errors] == ["string_pattern_mismatch"]
         assert errors[0]["loc"] == ("body", "inputs", "stripe_migration_request_id")
 
     def test_rejects_undeclared_inputs(self) -> None:


### PR DESCRIPTION
## Summary

Simplifies the saved-card migration checklist and makes the Stripe handoff actionable.


| Before | After | 
|--------|------|
|<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/53327ca7-7781-4370-be13-3a4cb8c234a5" /> |  <img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/892e95a7-f74b-41d1-a36b-a898aeb05391" /> |


## What

- Uses two columns
- Adds a handy feature to copy only selected customers
- requires the Stripe migration ID and validates its `migreq_…`
- enforces the required migration ID in the backend PAN-copy workflow
- links directly to the requested Stripe copy-status page

## Why

I think loooks better

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] 132 backend migration tests, frontend tests, lint, typechecks, UI walkthrough, and code review pass
- [x] No unrelated changes or drive-by fixes are included

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bf397b9-9208-4685-9964-a2b7192a0048?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bf397b9-9208-4685-9964-a2b7192a0048&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

