### PR TITLE
Add Stripe migration payment method mapping schema

### DIFF
--- a/server/migrations/versions/2026-08-20-2100_add_payment_method_migration_mappings.py
+++ b/server/migrations/versions/2026-08-20-2100_add_payment_method_migration_mappings.py
@@ -1,0 +1,80 @@
+"""add payment method migration mappings
+
+Revision ID: 4f6d7a8b9c10
+Revises: a83cf131398d
+Create Date: 2026-08-20 21:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "4f6d7a8b9c10"
+down_revision = "a83cf131398d"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.create_table(
+        "merchant_migration_payment_method_mappings",
+        sa.Column("merchant_migration_id", sa.Uuid(), nullable=False),
+        sa.Column("source_customer_id", sa.String(), nullable=False),
+        sa.Column("source_payment_method_id", sa.String(), nullable=False),
+        sa.Column("destination_customer_id", sa.String(), nullable=False),
+        sa.Column("destination_payment_method_id", sa.String(), nullable=False),
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("modified_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("deleted_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["merchant_migration_id"],
+            ["merchant_migrations.id"],
+            name=op.f(
+                "merchant_migration_payment_method_mappings_merchant_migration_id_fkey"
+            ),
+            ondelete="cascade",
+        ),
+        sa.PrimaryKeyConstraint(
+            "id", name=op.f("merchant_migration_payment_method_mappings_pkey")
+        ),
+    )
+    op.create_index(
+        op.f("ix_merchant_migration_payment_method_mappings_created_at"),
+        "merchant_migration_payment_method_mappings",
+        ["created_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_merchant_migration_payment_method_mappings_deleted_at"),
+        "merchant_migration_payment_method_mappings",
+        ["deleted_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_merchant_migration_payment_method_mappings_destination",
+        "merchant_migration_payment_method_mappings",
+        ["merchant_migration_id", "destination_payment_method_id"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_merchant_migration_payment_method_mappings_merchant_migration_id"),
+        "merchant_migration_payment_method_mappings",
+        ["merchant_migration_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_merchant_migration_payment_method_mappings_source",
+        "merchant_migration_payment_method_mappings",
+        ["merchant_migration_id", "source_payment_method_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.drop_table("merchant_migration_payment_method_mappings")

--- a/server/polar/models/__init__.py
+++ b/server/polar/models/__init__.py
@@ -49,6 +49,9 @@ from .merchant_migration_operation import (
     MerchantMigrationOperationSelection,
     MerchantMigrationOperationStatus,
 )
+from .merchant_migration_payment_method_mapping import (
+    MerchantMigrationPaymentMethodMapping,
+)
 from .merchant_migration_record import (
     MerchantMigrationCutoverStatus,
     MerchantMigrationRecord,
@@ -179,6 +182,7 @@ __all__ = [
     "MerchantMigrationOperation",
     "MerchantMigrationOperationSelection",
     "MerchantMigrationOperationStatus",
+    "MerchantMigrationPaymentMethodMapping",
     "MerchantMigrationRecord",
     "MerchantMigrationRecordStatus",
     "MerchantMigrationRecordType",

--- a/server/polar/models/merchant_migration_payment_method_mapping.py
+++ b/server/polar/models/merchant_migration_payment_method_mapping.py
@@ -1,0 +1,43 @@
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, Index, String, Uuid
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+
+from polar.kit.db.models import RecordModel
+
+if TYPE_CHECKING:
+    from polar.models.merchant_migration import MerchantMigration
+
+
+class MerchantMigrationPaymentMethodMapping(RecordModel):
+    __tablename__ = "merchant_migration_payment_method_mappings"
+    __table_args__ = (
+        Index(
+            "ix_merchant_migration_payment_method_mappings_source",
+            "merchant_migration_id",
+            "source_payment_method_id",
+            unique=True,
+        ),
+        Index(
+            "ix_merchant_migration_payment_method_mappings_destination",
+            "merchant_migration_id",
+            "destination_payment_method_id",
+            unique=True,
+        ),
+    )
+
+    merchant_migration_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("merchant_migrations.id", ondelete="cascade"),
+        nullable=False,
+        index=True,
+    )
+    source_customer_id: Mapped[str] = mapped_column(String, nullable=False)
+    source_payment_method_id: Mapped[str] = mapped_column(String, nullable=False)
+    destination_customer_id: Mapped[str] = mapped_column(String, nullable=False)
+    destination_payment_method_id: Mapped[str] = mapped_column(String, nullable=False)
+
+    @declared_attr
+    def merchant_migration(cls) -> Mapped["MerchantMigration"]:
+        return relationship("MerchantMigration", lazy="raise")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Related Issue**: #<!-- issue number -->

Add the database schema needed to persist Stripe's deterministic payment method migration mappings.

## What

- add `merchant_migration_payment_method_mappings`
- uniquely index source and destination payment method IDs within a migration
- register the corresponding SQLAlchemy model

## Why

Stripe's post-migration CSV maps source payment methods to exact destination IDs. Persisting those rows in a normalized table keeps verification batched and avoids loading a large JSON blob for every worker run.

## How

This is the schema-only first PR in a deploy-safe stack. The follow-up application PR adds ingestion and assignment behavior after this schema is deployed.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by the follow-up application PR
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0db2caf9-0977-4c3e-b155-fcae95ce1ac4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0db2caf9-0977-4c3e-b155-fcae95ce1ac4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

