### PR TITLE
worker: Roll out all actors to lambda test sandbox

### DIFF
--- a/server/polar/worker/_enqueue.py
+++ b/server/polar/worker/_enqueue.py
@@ -43,8 +43,21 @@ UUID_JSON_BYTES = 40
 EVENT_INGESTED_CHUNK_SIZE = _sqs.MAX_JOB_PAYLOAD_BYTES // UUID_JSON_BYTES
 
 
+SQS_ACTORS_WILDCARD = "*"
+
+
+def resolve_sqs_actors() -> set[str]:
+    """Expand the allowlist, resolving the wildcard to every declared actor."""
+    if settings.WORKER_SQS_ACTORS == {SQS_ACTORS_WILDCARD}:
+        return dramatiq.get_broker().get_declared_actors()
+    return settings.WORKER_SQS_ACTORS
+
+
 def should_route_to_sqs(actor_name: str) -> bool:
-    return settings.WORKER_SQS_ENABLED and actor_name in settings.WORKER_SQS_ACTORS
+    if not settings.WORKER_SQS_ENABLED:
+        return False
+    actors = settings.WORKER_SQS_ACTORS
+    return actors == {SQS_ACTORS_WILDCARD} or actor_name in actors
 
 
 class JobQueueManager:

--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -24,6 +24,7 @@ from polar.logging import CorrelationID, Logger
 from . import _sqs
 from ._broker import TASK_TIME_LIMIT_DEFAULT_MS
 from ._debounce import DebounceContext, check_debounce, finalize_debounce
+from ._enqueue import resolve_sqs_actors
 from ._httpx import _close_client, setup_httpx
 from ._redis import RedisMiddleware, _close_redis, setup_redis
 from ._sqlalchemy import dispose_sqlalchemy_engine, setup_sqlalchemy
@@ -89,7 +90,7 @@ def validate_allowlist() -> None:
     default_min_threshold = int(
         settings.WORKER_DEFAULT_DEBOUNCE_MIN_THRESHOLD.total_seconds()
     )
-    for actor_name in settings.WORKER_SQS_ACTORS:
+    for actor_name in resolve_sqs_actors():
         actor_obj = broker.get_actor(actor_name)
         queue_name = _sqs.actor_to_queue_name(actor_name)
         if len(queue_name) > 80:

--- a/server/polar/worker/sqs.py
+++ b/server/polar/worker/sqs.py
@@ -5,9 +5,9 @@ from typing import Any
 import structlog
 import typer
 
-from polar.config import settings
 from polar.logging import Logger
 
+from ._enqueue import resolve_sqs_actors
 from ._runner import bootstrap, run_task, shutdown
 from ._sqs import actor_to_queue_name, parse_envelope, resolve_queue_url, sqs_client
 
@@ -33,12 +33,14 @@ def run(actor: str, body: str = typer.Argument("{}")) -> None:
 
 async def _poll_loop(actors: list[str], max_iterations: int) -> None:
     client = sqs_client
-    queue_urls = {a: resolve_queue_url(client, actor_to_queue_name(a)) for a in actors}
+    queue_urls = {
+        resolve_queue_url(client, actor_to_queue_name(actor)) for actor in actors
+    }
     iterations = 0
     try:
         while max_iterations == 0 or iterations < max_iterations:
             iterations += 1
-            for url in queue_urls.values():
+            for url in queue_urls:
                 response = await asyncio.to_thread(
                     client.receive_message,
                     QueueUrl=url,
@@ -86,7 +88,7 @@ def poll(
     max_iterations: int = typer.Option(0, help="0 = loop forever"),
 ) -> None:
     """Local dev consumer: drain SQS through run_task without building the Lambda image."""
-    actors = [actor] if actor else sorted(settings.WORKER_SQS_ACTORS)
+    actors = [actor] if actor else sorted(resolve_sqs_actors())
     bootstrap()
     asyncio.run(_poll_loop(actors, max_iterations))
 

--- a/server/tests/worker/test_routing_broker.py
+++ b/server/tests/worker/test_routing_broker.py
@@ -2,6 +2,7 @@ import dramatiq
 import pytest
 from dramatiq.brokers.redis import RedisBroker
 from dramatiq.composition import group
+from dramatiq.errors import ActorNotFound
 from dramatiq.middleware.group_callbacks import GroupCallbacks
 from dramatiq.rate_limits.backends import RedisBackend as RateLimiterBackend
 from fakeredis import FakeRedis
@@ -10,6 +11,11 @@ from pytest_mock import MockerFixture
 import polar.tasks  # noqa: F401  (registers actors with the broker)
 from polar.config import settings
 from polar.worker import _sqs
+from polar.worker._enqueue import (
+    SQS_ACTORS_WILDCARD,
+    resolve_sqs_actors,
+    should_route_to_sqs,
+)
 from polar.worker._runner import run_task, validate_allowlist
 
 CRON_ACTOR = "organization.unsnooze_expired"
@@ -196,3 +202,39 @@ class TestValidateAllowlist:
 
         with pytest.raises(ValueError, match="debounce_min_threshold"):
             validate_allowlist()
+
+
+class TestWildcardAllowlist:
+    def test_resolves_to_every_declared_actor(self, mocker: MockerFixture) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {SQS_ACTORS_WILDCARD})
+
+        assert resolve_sqs_actors() == dramatiq.get_broker().get_declared_actors()
+
+    def test_wildcard_alongside_other_names_is_not_a_wildcard(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ENABLED", True)
+        mocker.patch.object(
+            settings, "WORKER_SQS_ACTORS", {SQS_ACTORS_WILDCARD, CRON_ACTOR}
+        )
+
+        assert resolve_sqs_actors() == {SQS_ACTORS_WILDCARD, CRON_ACTOR}
+        assert not should_route_to_sqs(SUBSCRIPTION_ACTOR)
+        with pytest.raises(ActorNotFound):
+            validate_allowlist()
+
+    @pytest.mark.parametrize(("enabled", "expected"), [(True, True), (False, False)])
+    def test_enabled_flag_dominates_the_wildcard(
+        self, mocker: MockerFixture, enabled: bool, expected: bool
+    ) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ENABLED", enabled)
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {SQS_ACTORS_WILDCARD})
+
+        assert should_route_to_sqs(SUBSCRIPTION_ACTOR) is expected
+
+    def test_all_declared_actors_are_sqs_compatible(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {SQS_ACTORS_WILDCARD})
+
+        validate_allowlist()

--- a/terraform/global/sandbox.tf
+++ b/terraform/global/sandbox.tf
@@ -512,37 +512,11 @@ resource "tfe_variable" "vercel_next_public_stripe_payment_method_configuration_
 }
 
 resource "tfe_variable" "worker_sqs_actors_sandbox" {
-  key         = "worker_sqs_actors"
-  category    = "terraform"
-  description = "JSON array of Dramatiq actor names routed to the SQS execution engine for sandbox"
-  sensitive   = false
-  value = jsonencode([
-    "auth.delete_expired",
-    "authentication_session.delete_expired",
-    "checkout.expire_open_checkouts",
-    "customer.state_changed",
-    "customer_email_update.delete_expired",
-    "customer_session.delete_expired",
-    "dummy",
-    "email.send",
-    "email_otp.delete_expired",
-    "email_update.delete_expired_record",
-    "eventstream.publish",
-    "external_event.prune",
-    "license_key.sync_benefit_grant",
-    "member_session.delete_expired",
-    "oauth2_token.delete_expired",
-    "observability.invariants.check",
-    "observability.invariants.enqueue",
-    "order.invoice",
-    "receipt.render",
-    "tinybird.ingest",
-    "webhook_event.archive",
-    "webhook_event.failed",
-    "webhook_event.publish",
-    "webhook_event.send",
-    "webhook_event.success",
-  ])
+  key             = "worker_sqs_actors"
+  category        = "terraform"
+  description     = "JSON array of Dramatiq actor names routed to the SQS execution engine for sandbox, or [\"*\"] for all of them"
+  sensitive       = false
+  value           = jsonencode(["*"])
   variable_set_id = tfe_variable_set.sandbox.id
 }
 

--- a/terraform/global/test.tf
+++ b/terraform/global/test.tf
@@ -498,37 +498,11 @@ resource "tfe_variable" "vercel_next_public_stripe_payment_method_configuration_
 }
 
 resource "tfe_variable" "worker_sqs_actors_test" {
-  key         = "worker_sqs_actors"
-  category    = "terraform"
-  description = "JSON array of Dramatiq actor names routed to the SQS execution engine for test"
-  sensitive   = false
-  value = jsonencode([
-    "auth.delete_expired",
-    "authentication_session.delete_expired",
-    "checkout.expire_open_checkouts",
-    "customer.state_changed",
-    "customer_email_update.delete_expired",
-    "customer_session.delete_expired",
-    "dummy",
-    "email.send",
-    "email_otp.delete_expired",
-    "email_update.delete_expired_record",
-    "eventstream.publish",
-    "external_event.prune",
-    "license_key.sync_benefit_grant",
-    "member_session.delete_expired",
-    "oauth2_token.delete_expired",
-    "observability.invariants.check",
-    "observability.invariants.enqueue",
-    "order.invoice",
-    "receipt.render",
-    "tinybird.ingest",
-    "webhook_event.archive",
-    "webhook_event.failed",
-    "webhook_event.publish",
-    "webhook_event.send",
-    "webhook_event.success",
-  ])
+  key             = "worker_sqs_actors"
+  category        = "terraform"
+  description     = "JSON array of Dramatiq actor names routed to the SQS execution engine for test, or [\"*\"] for all of them"
+  sensitive       = false
+  value           = jsonencode(["*"])
   variable_set_id = tfe_variable_set.test.id
 }
 


### PR DESCRIPTION
This enables the lambda workers for all actors in sandbox and test

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

