### PR TITLE
Make it possible to filter orders in backoffice by meter cycle billing reason

### DIFF
--- a/server/polar/backoffice/orders/endpoints.py
+++ b/server/polar/backoffice/orders/endpoints.py
@@ -221,6 +221,10 @@ async def list(
                             OrderBillingReason.subscription_cycle.value,
                         ),
                         (
+                            "Meter Cycle",
+                            OrderBillingReason.subscription_meter_cycle.value,
+                        ),
+                        (
                             "Subscription Update",
                             OrderBillingReason.subscription_update.value,
                         ),


### PR DESCRIPTION
Fixes https://github.com/polarsource/polar/issues/12850

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds “Meter Cycle” to the backoffice orders billing reason filter so operators can isolate orders generated from metered billing runs. Previously, filtering by billing reason excluded meter cycle; now it includes it with no changes to existing filters.

- Touches only the filter options in `server/polar/backoffice/orders/endpoints.py`, adding `OrderBillingReason.subscription_meter_cycle`.
- No data or schema changes; no permission changes.
- If the backoffice frontend maintains a local list of billing reasons, add the “Meter Cycle” option there to surface it in the UI.

<sup>Written for commit 1625f13e7c4092e015f5c9f30e0938a56daf4163. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

