### PR TITLE
fix(merchant-migration): load prices so cutover webhooks validate

### DIFF
--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 import stripe as stripe_lib
 import structlog
-from sqlalchemy.orm import joinedload, noload
+from sqlalchemy.orm import joinedload, noload, selectinload
 
 from polar.kit.utils import utc_now
 from polar.logging import Logger
@@ -282,7 +282,7 @@ class SubscriptionCutover:
                 joinedload(Subscription.customer).noload(Customer.owner),
                 joinedload(Subscription.organization),
                 noload(Subscription.meters),
-                noload(Subscription.subscription_product_prices),
+                selectinload(Subscription.subscription_product_prices),
             ),
         )
 

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -187,6 +187,27 @@ class TestRun:
         assert paused_subscription.current_period_end == renewal
         assert paused_subscription.payment_method_id == copied_card.id
 
+    async def test_moves_subscription_loaded_from_database(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        copied_card: PaymentMethod,
+        paused_subscription: Subscription,
+    ) -> None:
+        subscription_id = paused_subscription.id
+        session.expunge_all()
+        adapter = _source()
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        subscription = await session.get(Subscription, subscription_id)
+        assert subscription is not None
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert adapter.stopped == ["sub_1"]
+        assert subscription.status == SubscriptionStatus.active
+        assert subscription.payment_method_id == copied_card.id
+
     async def test_charges_a_card_that_landed_after_the_card_check(
         self,
         mocker: MockerFixture,


### PR DESCRIPTION
## Summary

Fixes sandbox cutover failures ([SERVER-4Y7](https://polar-sh.sentry.io/issues/SERVER-4Y7)): Polar stopped the source subscription, then crashed while serializing `subscription.updated` because prices were not loaded.

## What

- Load `subscription_product_prices` during cutover instead of `noload`.
- Add a regression test that expunges the session so the worker path is exercised.

## Why

Webhook schemas require legacy `price` / `price_id` from `prices[0]`. With prices noloaded, Pydantic validation failed after Stripe was already stopped, rolling Polar back and stranding the customer until retries (which hit the same bug).

## How

Cutover now `selectinload`s prices. The identity-map object later reused for webhook serialization then has `prices[0]`, so `activate_imported` can finish.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

