### PR TITLE
lambda: Implement group completion for SQS/lambda workers

### DIFF
--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -205,6 +205,9 @@ class RoutingRedisBroker(RedisBroker):
                         CorrelationID.get(),
                         message.message_id,
                         message.options.get("debounce_key"),
+                        message_options=_sqs.extract_group_completion_options(
+                            message.options
+                        ),
                     )
                 ]
             )

--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -5,7 +5,7 @@ import functools
 import inspect
 import math
 import time
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from typing import Any
 
 import dramatiq
@@ -14,6 +14,7 @@ import structlog
 from dramatiq.common import compute_backoff
 from dramatiq.errors import Retry
 from dramatiq.middleware.current_message import CurrentMessage
+from dramatiq.middleware.group_callbacks import GroupCallbacks
 from dramatiq.middleware.retries import DEFAULT_MAX_BACKOFF
 
 from polar import tasks  # noqa: F401  (registers all actors with the broker)
@@ -184,6 +185,7 @@ async def run_task(
     message_timestamp: int | None = None,
     message_id: str | None = None,
     debounce_key: str | None = None,
+    message_options: Mapping[str, Any] | None = None,
 ) -> None:
     registry = build_registry()
     fn = registry.get(actor_name)
@@ -191,7 +193,8 @@ async def run_task(
         raise UnknownActor(actor_name)
 
     kwargs = kwargs or {}
-    actor_obj = dramatiq.get_broker().get_actor(actor_name)
+    broker = dramatiq.get_broker()
+    actor_obj = broker.get_actor(actor_name)
     time_limit_ms = actor_obj.options.get("time_limit", TASK_TIME_LIMIT_DEFAULT_MS)
     timeout_seconds = time_limit_ms / 1000
     if remaining_time_seconds is not None:
@@ -202,6 +205,7 @@ async def run_task(
         args=tuple(args),
         kwargs=kwargs,
         options={
+            **(message_options or {}),
             "retries": receive_count - 1,
             "max_retries": actor_obj.options.get(
                 "max_retries", settings.WORKER_MAX_RETRIES
@@ -262,6 +266,15 @@ async def run_task(
                 )
         if retry is not None:
             raise retry
+        if message.options.get("group_completion_uuid"):
+            group_callbacks = next(
+                middleware
+                for middleware in broker.middleware
+                if isinstance(middleware, GroupCallbacks)
+            )
+            await asyncio.to_thread(
+                group_callbacks.after_process_message, broker, message
+            )
     finally:
         CurrentMessage._MESSAGE.reset(token)
         structlog.contextvars.unbind_contextvars(

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 import time
 from collections import defaultdict
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -33,6 +33,11 @@ MAX_VISIBILITY_TIMEOUT_SECONDS = 43_200
 # Argument budget for a single job, leaving room for the envelope around it.
 MAX_JOB_PAYLOAD_BYTES = 200_000
 
+GROUP_COMPLETION_OPTION_KEYS = (
+    "group_completion_uuid",
+    "group_completion_callbacks",
+)
+
 
 class Job(NamedTuple):
     actor: str
@@ -42,6 +47,25 @@ class Job(NamedTuple):
     correlation_id: str | None = None
     message_id: str | None = None
     debounce_key: str | None = None
+    message_options: dict[str, Any] | None = None
+
+
+class Envelope(NamedTuple):
+    actor: str
+    args: list[Any]
+    kwargs: dict[str, Any]
+    correlation_id: str | None
+    attempt: int
+    message_timestamp: int | None
+    message_id: str | None
+    debounce_key: str | None
+    message_options: dict[str, Any]
+
+
+def extract_group_completion_options(
+    options: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {key: options[key] for key in GROUP_COMPLETION_OPTION_KEYS if key in options}
 
 
 class SQSSendError(Exception):
@@ -151,6 +175,7 @@ def build_envelope(
     message_timestamp: int | None = None,
     message_id: str | None = None,
     debounce_key: str | None = None,
+    message_options: Mapping[str, Any] | None = None,
 ) -> str:
     if message_timestamp is None:
         message_timestamp = int(time.time() * 1000)
@@ -164,27 +189,27 @@ def build_envelope(
             "message_timestamp": message_timestamp,
             "message_id": message_id,
             "debounce_key": debounce_key,
+            "message_options": message_options or {},
         },
         separators=(",", ":"),
         default=json_obj_serializer,
     )
 
 
-def parse_envelope(
-    body: str,
-) -> tuple[
-    str, list[Any], dict[str, Any], str | None, int, int | None, str | None, str | None
-]:
+def parse_envelope(body: str) -> Envelope:
     data = json.loads(body)
-    return (
-        data["actor"],
-        data.get("args", []),
-        data.get("kwargs", {}),
-        data.get("correlation_id"),
-        data.get("attempt", 1),
-        data.get("message_timestamp"),
-        data.get("message_id"),
-        data.get("debounce_key"),
+    return Envelope(
+        actor=data["actor"],
+        args=data.get("args", []),
+        kwargs=data.get("kwargs", {}),
+        correlation_id=data.get("correlation_id"),
+        attempt=data.get("attempt", 1),
+        message_timestamp=data.get("message_timestamp"),
+        message_id=data.get("message_id"),
+        debounce_key=data.get("debounce_key"),
+        message_options=extract_group_completion_options(
+            data.get("message_options", {})
+        ),
     )
 
 
@@ -286,6 +311,7 @@ def send_jobs_sync(jobs: list[Job]) -> None:
                 job.correlation_id,
                 message_id=job.message_id,
                 debounce_key=job.debounce_key,
+                message_options=job.message_options,
             ),
         }
         if job.delay:

--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -49,30 +49,24 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         for record in event.get("Records", []):
             message_id = record["messageId"]
             try:
-                (
-                    actor,
-                    args,
-                    kwargs,
-                    correlation_id,
-                    attempt,
-                    message_timestamp,
-                    task_message_id,
-                    debounce_key,
-                ) = parse_envelope(record["body"])
+                envelope = parse_envelope(record["body"])
                 _loop.run_until_complete(
                     run_task(
-                        actor,
-                        args,
-                        kwargs,
-                        receive_count=_effective_receive_count(record, attempt),
-                        source_correlation_id=correlation_id,
+                        envelope.actor,
+                        envelope.args,
+                        envelope.kwargs,
+                        receive_count=_effective_receive_count(
+                            record, envelope.attempt
+                        ),
+                        source_correlation_id=envelope.correlation_id,
                         remaining_time_seconds=(
                             context.get_remaining_time_in_millis() / 1000
                             - _REMAINING_TIME_MARGIN_SECONDS
                         ),
-                        message_timestamp=message_timestamp,
-                        message_id=task_message_id,
-                        debounce_key=debounce_key,
+                        message_timestamp=envelope.message_timestamp,
+                        message_id=envelope.message_id,
+                        debounce_key=envelope.debounce_key,
+                        message_options=envelope.message_options,
                     )
                 )
             except Retry as exc:
@@ -102,22 +96,13 @@ def _effective_receive_count(record: dict[str, Any], attempt: int) -> int:
 def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> bool:
     """Schedule the failed message's next retry. Returns True if SQS should redeliver it."""
     try:
-        (
-            actor,
-            args,
-            kwargs,
-            correlation_id,
-            attempt,
-            message_timestamp,
-            task_message_id,
-            debounce_key,
-        ) = parse_envelope(record["body"])
+        envelope = parse_envelope(record["body"])
         queue_arn = record["eventSourceARN"]
-        receive_count = _effective_receive_count(record, attempt)
+        receive_count = _effective_receive_count(record, envelope.attempt)
         scheduler_role_arn = settings.WORKER_SQS_SCHEDULER_ROLE_ARN
 
         action, delay_seconds = plan_retry(
-            actor,
+            envelope.actor,
             receive_count,
             exception,
             scheduler_available=scheduler_role_arn is not None,
@@ -127,7 +112,7 @@ def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> bo
             send_to_dlq(consumer_sqs_client, queue_arn, record["body"])
             log.info(
                 "polar.worker.sqs_retry_exhausted",
-                actor=actor,
+                actor=envelope.actor,
                 receive_count=receive_count,
             )
             return False
@@ -139,21 +124,24 @@ def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> bo
                 queue_arn,
                 scheduler_role_arn,
                 build_envelope(
-                    actor,
-                    tuple(args),
-                    kwargs,
-                    correlation_id,
+                    envelope.actor,
+                    tuple(envelope.args),
+                    envelope.kwargs,
+                    envelope.correlation_id,
                     receive_count + 1,
-                    message_timestamp,
-                    message_id=task_message_id,
-                    debounce_key=debounce_key,
+                    envelope.message_timestamp,
+                    message_id=envelope.message_id,
+                    debounce_key=envelope.debounce_key,
+                    message_options=envelope.message_options,
                 ),
                 delay_seconds,
-                build_retry_schedule_name(queue_arn, record["messageId"], attempt),
+                build_retry_schedule_name(
+                    queue_arn, record["messageId"], envelope.attempt
+                ),
             )
             log.info(
                 "polar.worker.sqs_retry_scheduled_eventbridge",
-                actor=actor,
+                actor=envelope.actor,
                 receive_count=receive_count,
                 backoff_seconds=delay_seconds,
             )
@@ -167,7 +155,7 @@ def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> bo
         )
         log.info(
             "polar.worker.sqs_retry_scheduled",
-            actor=actor,
+            actor=envelope.actor,
             receive_count=receive_count,
             backoff_seconds=delay_seconds,
         )

--- a/server/polar/worker/sqs.py
+++ b/server/polar/worker/sqs.py
@@ -47,35 +47,29 @@ async def _poll_loop(actors: list[str], max_iterations: int) -> None:
                     MessageSystemAttributeNames=["ApproximateReceiveCount"],
                 )
                 for message in response.get("Messages", []):
-                    (
-                        actor,
-                        args,
-                        kwargs,
-                        correlation_id,
-                        attempt,
-                        message_timestamp,
-                        message_id,
-                        debounce_key,
-                    ) = parse_envelope(message["Body"])
+                    envelope = parse_envelope(message["Body"])
                     sqs_receive_count = int(
                         message.get("Attributes", {}).get(
                             "ApproximateReceiveCount", "1"
                         )
                     )
-                    receive_count = attempt + (sqs_receive_count - 1)
+                    receive_count = envelope.attempt + (sqs_receive_count - 1)
                     try:
                         await run_task(
-                            actor,
-                            args,
-                            kwargs,
+                            envelope.actor,
+                            envelope.args,
+                            envelope.kwargs,
                             receive_count=receive_count,
-                            source_correlation_id=correlation_id,
-                            message_timestamp=message_timestamp,
-                            message_id=message_id,
-                            debounce_key=debounce_key,
+                            source_correlation_id=envelope.correlation_id,
+                            message_timestamp=envelope.message_timestamp,
+                            message_id=envelope.message_id,
+                            debounce_key=envelope.debounce_key,
+                            message_options=envelope.message_options,
                         )
                     except Exception:
-                        log.exception("polar.worker.sqs_poll_failed", actor=actor)
+                        log.exception(
+                            "polar.worker.sqs_poll_failed", actor=envelope.actor
+                        )
                         continue
                     await asyncio.to_thread(
                         client.delete_message,

--- a/server/tests/worker/test_backoff.py
+++ b/server/tests/worker/test_backoff.py
@@ -92,6 +92,21 @@ class TestSetMessageVisibility:
 
 class TestEnvelopeAttempt:
     def test_round_trips(self) -> None:
+        message_options = {
+            "group_completion_uuid": "group-1",
+            "group_completion_callbacks": [
+                {
+                    "queue_name": "low_priority",
+                    "actor_name": "dummy",
+                    "args": [],
+                    "kwargs": {"redis_key": "callback"},
+                    "options": {},
+                    "message_id": "callback-1",
+                    "message_timestamp": 1234567890000,
+                }
+            ],
+        }
+
         body = _sqs.build_envelope(
             "dummy",
             (1, "x"),
@@ -101,59 +116,45 @@ class TestEnvelopeAttempt:
             1234567890000,
             message_id="msg-1",
             debounce_key="debounce:test",
+            message_options=message_options,
         )
-        (
-            actor,
-            args,
-            kwargs,
-            correlation_id,
-            attempt,
-            message_timestamp,
-            message_id,
-            debounce_key,
-        ) = _sqs.parse_envelope(body)
-        assert actor == "dummy"
-        assert args == [1, "x"]
-        assert kwargs == {"k": 2}
-        assert correlation_id == "corr"
-        assert attempt == 7
-        assert message_timestamp == 1234567890000
-        assert message_id == "msg-1"
-        assert debounce_key == "debounce:test"
+
+        envelope = _sqs.parse_envelope(body)
+        assert envelope.actor == "dummy"
+        assert envelope.args == [1, "x"]
+        assert envelope.kwargs == {"k": 2}
+        assert envelope.correlation_id == "corr"
+        assert envelope.attempt == 7
+        assert envelope.message_timestamp == 1234567890000
+        assert envelope.message_id == "msg-1"
+        assert envelope.debounce_key == "debounce:test"
+        assert envelope.message_options == message_options
 
     def test_defaults_to_one(self) -> None:
         body = _sqs.build_envelope("dummy", (), {}, None)
-        _, _, _, _, attempt, _, message_id, debounce_key = _sqs.parse_envelope(body)
-        assert attempt == 1
-        assert message_id is None
-        assert debounce_key is None
+        envelope = _sqs.parse_envelope(body)
+        assert envelope.attempt == 1
+        assert envelope.message_id is None
+        assert envelope.debounce_key is None
 
     def test_stamps_current_timestamp_by_default(self) -> None:
         before = int(time.time() * 1000)
         body = _sqs.build_envelope("dummy", (), {}, None)
         after = int(time.time() * 1000)
-        _, _, _, _, _, message_timestamp, _, _ = _sqs.parse_envelope(body)
-        assert message_timestamp is not None
-        assert before <= message_timestamp <= after
+        envelope = _sqs.parse_envelope(body)
+        assert envelope.message_timestamp is not None
+        assert before <= envelope.message_timestamp <= after
 
     def test_legacy_body_without_attempt(self) -> None:
         body = json.dumps(
             {"actor": "dummy", "args": [], "kwargs": {}, "correlation_id": None}
         )
-        (
-            _,
-            _,
-            _,
-            _,
-            attempt,
-            message_timestamp,
-            message_id,
-            debounce_key,
-        ) = _sqs.parse_envelope(body)
-        assert attempt == 1
-        assert message_timestamp is None
-        assert message_id is None
-        assert debounce_key is None
+        envelope = _sqs.parse_envelope(body)
+        assert envelope.attempt == 1
+        assert envelope.message_timestamp is None
+        assert envelope.message_id is None
+        assert envelope.debounce_key is None
+        assert envelope.message_options == {}
 
 
 class TestPlanRetry:

--- a/server/tests/worker/test_routing_broker.py
+++ b/server/tests/worker/test_routing_broker.py
@@ -1,11 +1,16 @@
 import dramatiq
 import pytest
 from dramatiq.brokers.redis import RedisBroker
+from dramatiq.composition import group
+from dramatiq.middleware.group_callbacks import GroupCallbacks
+from dramatiq.rate_limits.backends import RedisBackend as RateLimiterBackend
+from fakeredis import FakeRedis
 from pytest_mock import MockerFixture
 
 import polar.tasks  # noqa: F401  (registers actors with the broker)
 from polar.config import settings
-from polar.worker._runner import validate_allowlist
+from polar.worker import _sqs
+from polar.worker._runner import run_task, validate_allowlist
 
 CRON_ACTOR = "organization.unsnooze_expired"
 SUBSCRIPTION_ACTOR = "subscription.cycle"
@@ -87,6 +92,88 @@ class TestRoutingBroker:
         job = send_jobs_sync.call_args.args[0][0]
         assert job.message_id == message.message_id
         assert job.debounce_key == "debounce:test:key"
+
+    @pytest.mark.asyncio
+    async def test_group_completion_callback_runs_through_sqs(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ENABLED", True)
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {"dummy"})
+
+        broker = dramatiq.get_broker()
+        group_callbacks = next(
+            middleware
+            for middleware in broker.middleware
+            if isinstance(middleware, GroupCallbacks)
+        )
+        mocker.patch.object(
+            group_callbacks,
+            "rate_limiter_backend",
+            RateLimiterBackend(client=FakeRedis()),
+        )
+        send_jobs_sync = mocker.patch("polar.worker._broker._sqs.send_jobs_sync")
+
+        dummy_actor = broker.get_actor("dummy")
+        dummy_group = group(
+            [
+                dummy_actor.message(redis_key="child-1"),
+                dummy_actor.message(redis_key="child-2"),
+            ]
+        )
+        dummy_group.add_completion_callback(dummy_actor.message(redis_key="callback"))
+        dummy_group.run()
+
+        child_jobs = [call.args[0][0] for call in send_jobs_sync.call_args_list]
+        assert len(child_jobs) == 2
+        assert {job.message_options["group_completion_uuid"] for job in child_jobs} == {
+            child_jobs[0].message_options["group_completion_uuid"]
+        }
+        assert all(
+            job.message_options["group_completion_callbacks"] for job in child_jobs
+        )
+
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"dummy": mocker.AsyncMock()},
+        )
+        send_jobs_sync.reset_mock()
+
+        child_envelopes = [
+            _sqs.parse_envelope(
+                _sqs.build_envelope(
+                    job.actor,
+                    job.args,
+                    job.kwargs,
+                    job.correlation_id,
+                    message_id=job.message_id,
+                    message_options=job.message_options,
+                )
+            )
+            for job in child_jobs
+        ]
+
+        first_envelope, second_envelope = child_envelopes
+        await run_task(
+            first_envelope.actor,
+            first_envelope.args,
+            first_envelope.kwargs,
+            message_id=first_envelope.message_id,
+            message_options=first_envelope.message_options,
+        )
+        send_jobs_sync.assert_not_called()
+
+        await run_task(
+            second_envelope.actor,
+            second_envelope.args,
+            second_envelope.kwargs,
+            message_id=second_envelope.message_id,
+            message_options=second_envelope.message_options,
+        )
+
+        send_jobs_sync.assert_called_once()
+        callback_job = send_jobs_sync.call_args.args[0][0]
+        assert callback_job.actor == "dummy"
+        assert callback_job.kwargs == {"redis_key": "callback"}
 
 
 class TestValidateAllowlist:

--- a/server/tests/worker/test_runner.py
+++ b/server/tests/worker/test_runner.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import dramatiq
 import pytest
 from dramatiq.errors import Retry
+from dramatiq.middleware.group_callbacks import GroupCallbacks
 from fakeredis import FakeAsyncRedis
 from logfire.testing import CaptureLogfire
 from opentelemetry.sdk.trace import ReadableSpan
@@ -29,6 +30,43 @@ def _task_spans(capfire: CaptureLogfire) -> list[ReadableSpan]:
 
 @pytest.mark.asyncio
 class TestRunTask:
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            pytest.param(Retry(delay=1000), id="retry"),
+            pytest.param(ValueError("boom"), id="exception"),
+        ],
+    )
+    async def test_failure_does_not_notify_group_completion(
+        self, exception: Exception, mocker: MockerFixture
+    ) -> None:
+        async def raising_task() -> None:
+            raise exception
+
+        mocker.patch(
+            "polar.worker._runner.build_registry",
+            return_value={"dummy": raising_task},
+        )
+        group_callbacks = next(
+            middleware
+            for middleware in dramatiq.get_broker().middleware
+            if isinstance(middleware, GroupCallbacks)
+        )
+        after_process_message = mocker.patch.object(
+            group_callbacks, "after_process_message"
+        )
+
+        with pytest.raises(type(exception)):
+            await run_task(
+                "dummy",
+                message_options={
+                    "group_completion_uuid": "group-1",
+                    "group_completion_callbacks": [],
+                },
+            )
+
+        after_process_message.assert_not_called()
+
     async def test_retry_not_recorded_as_span_error(
         self, capfire: CaptureLogfire, mocker: MockerFixture
     ) -> None:


### PR DESCRIPTION
We're using Dramatiq's group completion to ensure that a job runs after all grouped jobs have completed. This is today only used by enqueue_benefits_grants: We run benefit.revoke after they are done we run enqeueue_grants which enqueues a buch of benefit.grant tasks.

To be able to move these tasks over to the new way, we need to have support for this in the lambda workers.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

