### PR TITLE
fix(merchant-migration): read Stripe multi-currency prices

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckRecordsDrawer.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckRecordsDrawer.tsx
@@ -90,7 +90,10 @@ export function PrecheckRecordsDrawer({
         ) : (
           <Box as="ul" flexDirection="column">
             {items.map((item) => (
-              <RecordRow key={item.source_id} item={item} />
+              <RecordRow
+                key={`${item.source_id}:${item.currency}`}
+                item={item}
+              />
             ))}
           </Box>
         )}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -261,7 +261,9 @@ export function ReviewTableView({
             pagination={pagination}
             onPaginationChange={onPaginationChange}
             isLoading={false}
-            getRowId={(row) => row.record_id ?? row.source_id}
+            getRowId={(row) =>
+              row.record_id ?? `${row.source_id}:${row.currency}`
+            }
             onRowClick={(row) => setOpenRow(row.original)}
           />
         )}

--- a/server/polar/backoffice/merchant_migrations/mrr.py
+++ b/server/polar/backoffice/merchant_migrations/mrr.py
@@ -17,6 +17,7 @@ from polar.merchant_migration.canonical import (
     CanonicalSubscriptionStatus,
     PriceKey,
     price_key,
+    subscription_price_key_values,
 )
 from polar.merchant_migration.repository import CanonicalRow
 from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
@@ -178,12 +179,10 @@ def breakdown(
             continue
         if not _is_earning(canonical):
             continue
-        source_id = canonical.get("price_source_id", "")
-        currency = canonical.get("currency")
-        key = (
-            price_key(source_id, currency)
-            if currency is not None
-            else legacy_price_keys.get(source_id)
+        key = subscription_price_key_values(
+            canonical.get("price_source_id", ""),
+            canonical.get("currency"),
+            legacy_price_keys,
         )
         price = prices.get(key) if key is not None else None
         if price is None:

--- a/server/polar/backoffice/merchant_migrations/mrr.py
+++ b/server/polar/backoffice/merchant_migrations/mrr.py
@@ -15,6 +15,8 @@ from uuid import UUID
 
 from polar.merchant_migration.canonical import (
     CanonicalSubscriptionStatus,
+    PriceKey,
+    price_key,
 )
 from polar.merchant_migration.repository import CanonicalRow
 from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
@@ -117,14 +119,17 @@ def _monthly_amount(
 
 def _price_index(
     products: Sequence[CanonicalRow],
-) -> dict[str, tuple[int, str, str | None, int]]:
-    """Map every source price id to (amount, currency, interval, interval count).
+) -> tuple[
+    dict[PriceKey, tuple[int, str, str | None, int]],
+    dict[str, PriceKey],
+]:
+    """Map every source price and currency to its amount and interval.
 
-    Built across all the products handed in, not just one migration's: source
-    price ids are unique per provider, so a shared index also covers a
-    subscription whose product was staged by an earlier run.
+    Built across all the products handed in, not just one migration's, so it
+    also covers a subscription whose product was staged by an earlier run.
     """
-    index: dict[str, tuple[int, str, str | None, int]] = {}
+    index: dict[PriceKey, tuple[int, str, str | None, int]] = {}
+    legacy_keys: dict[str, PriceKey] = {}
     for _, _, _, canonical in products:
         interval = canonical.get("recurring_interval")
         interval_count = canonical.get("recurring_interval_count") or 1
@@ -132,13 +137,15 @@ def _price_index(
             amount = price.get("amount")
             if amount is None:
                 continue
-            index[price["source_id"]] = (
+            key = price_key(price["source_id"], price["currency"])
+            index[key] = (
                 amount,
                 price["currency"],
                 interval,
                 interval_count,
             )
-    return index
+            legacy_keys.setdefault(price["source_id"], key)
+    return index, legacy_keys
 
 
 _BUCKETS = {
@@ -159,7 +166,7 @@ def breakdown(
     Amounts accumulate as plain ints and are wrapped into `Money` once per
     migration, so a large catalog doesn't allocate a frozen copy per row.
     """
-    prices = _price_index(products)
+    prices, legacy_price_keys = _price_index(products)
     buckets: dict[UUID, dict[str, dict[str, int]]] = {
         migration_id: {"on_polar": {}, "to_move": {}, "staying": {}}
         for migration_id in migration_ids
@@ -171,7 +178,14 @@ def breakdown(
             continue
         if not _is_earning(canonical):
             continue
-        price = prices.get(canonical.get("price_source_id", ""))
+        source_id = canonical.get("price_source_id", "")
+        currency = canonical.get("currency")
+        key = (
+            price_key(source_id, currency)
+            if currency is not None
+            else legacy_price_keys.get(source_id)
+        )
+        price = prices.get(key) if key is not None else None
         if price is None:
             continue
         amount, currency, interval, interval_count = price

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -45,6 +45,20 @@ _SUBSCRIPTION_EXPAND = [
 ]
 
 
+def _canonical_price_id(price_id: str, currency: str, default_currency: str) -> str:
+    """The canonical id for one currency of a source price.
+
+    A Stripe price can carry an amount in several currencies at once
+    (`currency_options`), and each maps to its own Polar price, so the price id
+    alone doesn't identify one. The default currency keeps the bare price id:
+    every single-currency price is one, and it's the id already-staged
+    migrations were read with.
+    """
+    if currency.lower() == default_currency.lower():
+        return price_id
+    return f"{price_id}:{currency.lower()}"
+
+
 class StripeAdapter:
     def __init__(self, access_token: str) -> None:
         self._client = stripe_lib.StripeClient(
@@ -152,7 +166,9 @@ class StripeAdapter:
             params={
                 "active": True,
                 "limit": PAGE_SIZE,
-                "expand": ["data.product"],
+                # `currency_options` is not returned unless expanded, and without
+                # it a multi-currency price reads as priced in one currency only.
+                "expand": ["data.product", "data.currency_options"],
             }
         )
         async for price in prices.auto_paging_iter():
@@ -176,7 +192,7 @@ class StripeAdapter:
                     prices=[],
                 )
                 grouped[key] = canonical
-            canonical.prices.append(self._map_price(price))
+            canonical.prices.extend(self._map_prices(price))
         for canonical in grouped.values():
             yield canonical
 
@@ -243,13 +259,26 @@ class StripeAdapter:
             return e.code == "resource_missing"
         return subscription.status == "canceled"
 
-    def _map_price(self, price: stripe_lib.Price) -> CanonicalPrice:
-        return CanonicalPrice(
-            source_id=price.id,
-            currency=price.currency,
-            amount=price.unit_amount,
-            pricing_scheme=self._map_pricing_scheme(price),
-        )
+    def _map_prices(self, price: stripe_lib.Price) -> list[CanonicalPrice]:
+        """One canonical price per currency the source price sells in.
+
+        A Polar product holds one price per currency, so a Stripe price with
+        `currency_options` becomes several: taking only its default currency
+        would report a product as unpriced in currencies it does sell in.
+        """
+        pricing_scheme = self._map_pricing_scheme(price)
+        amounts: dict[str, int | None] = {price.currency: price.unit_amount}
+        for currency, option in (price.get("currency_options") or {}).items():
+            amounts[currency] = option.get("unit_amount")
+        return [
+            CanonicalPrice(
+                source_id=_canonical_price_id(price.id, currency, price.currency),
+                currency=currency,
+                amount=amount,
+                pricing_scheme=pricing_scheme,
+            )
+            for currency, amount in amounts.items()
+        ]
 
     def _map_pricing_scheme(self, price: stripe_lib.Price) -> CanonicalPricingScheme:
         if price.billing_scheme == "tiered":
@@ -267,7 +296,7 @@ class StripeAdapter:
         return CanonicalSubscription(
             source_id=subscription.id,
             customer_source_id=self._id_of(subscription.customer),
-            price_source_id=self._id_of(first_item["price"]),
+            price_source_id=self._price_source_id(subscription, first_item),
             status=self._map_status(subscription.status),
             collection_method=self._map_collection_method(
                 subscription.collection_method
@@ -288,6 +317,19 @@ class StripeAdapter:
             stopped_for_migration=self._stopped_for_migration(subscription),
             anchor_day=self._anchor_day(subscription),
         )
+
+    def _price_source_id(self, subscription: stripe_lib.Subscription, item: Any) -> str:
+        """The canonical price this subscription bills. A multi-currency source
+        price carries an amount per currency, and the subscription's currency
+        says which of them it charges."""
+        price = item["price"]
+        if isinstance(price, str):
+            return price
+        price_currency = price.get("currency")
+        billed_currency = subscription.get("currency")
+        if price_currency is None or billed_currency is None:
+            return price["id"]
+        return _canonical_price_id(price["id"], billed_currency, price_currency)
 
     def _anchor_day(self, subscription: stripe_lib.Subscription) -> int | None:
         anchor = self._to_datetime(subscription.billing_cycle_anchor)

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -305,13 +305,9 @@ class StripeAdapter:
 
     def _price_source_id(self, subscription: stripe_lib.Subscription, item: Any) -> str:
         price = item["price"]
-        if isinstance(price, str):
-            return price
-        price_currency = price.get("currency")
-        billed_currency = subscription.get("currency")
-        if price_currency is None or billed_currency is None:
-            return price["id"]
-        return _canonical_price_id(price["id"], billed_currency, price_currency)
+        return _canonical_price_id(
+            price["id"], subscription.currency, price["currency"]
+        )
 
     def _anchor_day(self, subscription: stripe_lib.Subscription) -> int | None:
         anchor = self._to_datetime(subscription.billing_cycle_anchor)

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -46,14 +46,7 @@ _SUBSCRIPTION_EXPAND = [
 
 
 def _canonical_price_id(price_id: str, currency: str, default_currency: str) -> str:
-    """The canonical id for one currency of a source price.
-
-    A Stripe price can carry an amount in several currencies at once
-    (`currency_options`), and each maps to its own Polar price, so the price id
-    alone doesn't identify one. The default currency keeps the bare price id:
-    every single-currency price is one, and it's the id already-staged
-    migrations were read with.
-    """
+    """Keep the default currency on the bare price id so already-staged rows still match."""
     if currency.lower() == default_currency.lower():
         return price_id
     return f"{price_id}:{currency.lower()}"
@@ -166,8 +159,6 @@ class StripeAdapter:
             params={
                 "active": True,
                 "limit": PAGE_SIZE,
-                # `currency_options` is not returned unless expanded, and without
-                # it a multi-currency price reads as priced in one currency only.
                 "expand": ["data.product", "data.currency_options"],
             }
         )
@@ -260,12 +251,6 @@ class StripeAdapter:
         return subscription.status == "canceled"
 
     def _map_prices(self, price: stripe_lib.Price) -> list[CanonicalPrice]:
-        """One canonical price per currency the source price sells in.
-
-        A Polar product holds one price per currency, so a Stripe price with
-        `currency_options` becomes several: taking only its default currency
-        would report a product as unpriced in currencies it does sell in.
-        """
         pricing_scheme = self._map_pricing_scheme(price)
         amounts: dict[str, int | None] = {price.currency: price.unit_amount}
         for currency, option in (price.get("currency_options") or {}).items():
@@ -319,9 +304,6 @@ class StripeAdapter:
         )
 
     def _price_source_id(self, subscription: stripe_lib.Subscription, item: Any) -> str:
-        """The canonical price this subscription bills. A multi-currency source
-        price carries an amount per currency, and the subscription's currency
-        says which of them it charges."""
         price = item["price"]
         if isinstance(price, str):
             return price

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -45,13 +45,6 @@ _SUBSCRIPTION_EXPAND = [
 ]
 
 
-def _canonical_price_id(price_id: str, currency: str, default_currency: str) -> str:
-    """Keep the default currency on the bare price id so already-staged rows still match."""
-    if currency.lower() == default_currency.lower():
-        return price_id
-    return f"{price_id}:{currency.lower()}"
-
-
 class StripeAdapter:
     def __init__(self, access_token: str) -> None:
         self._client = stripe_lib.StripeClient(
@@ -257,7 +250,7 @@ class StripeAdapter:
             amounts[currency] = option.get("unit_amount")
         return [
             CanonicalPrice(
-                source_id=_canonical_price_id(price.id, currency, price.currency),
+                source_id=price.id,
                 currency=currency,
                 amount=amount,
                 pricing_scheme=pricing_scheme,
@@ -281,7 +274,7 @@ class StripeAdapter:
         return CanonicalSubscription(
             source_id=subscription.id,
             customer_source_id=self._id_of(subscription.customer),
-            price_source_id=self._price_source_id(subscription, first_item),
+            price_source_id=self._id_of(first_item["price"]),
             status=self._map_status(subscription.status),
             collection_method=self._map_collection_method(
                 subscription.collection_method
@@ -301,12 +294,7 @@ class StripeAdapter:
             trial_end=self._to_datetime(subscription.trial_end),
             stopped_for_migration=self._stopped_for_migration(subscription),
             anchor_day=self._anchor_day(subscription),
-        )
-
-    def _price_source_id(self, subscription: stripe_lib.Subscription, item: Any) -> str:
-        price = item["price"]
-        return _canonical_price_id(
-            price["id"], subscription.currency, price["currency"]
+            currency=subscription.currency,
         )
 
     def _anchor_day(self, subscription: stripe_lib.Subscription) -> int | None:

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -186,12 +186,22 @@ def subscription_price_key(
     subscription: CanonicalSubscription,
     legacy_keys: Mapping[str, PriceKey] | None = None,
 ) -> PriceKey | None:
-    if subscription.currency is not None:
-        return price_key(subscription.price_source_id, subscription.currency)
-    legacy_key = _legacy_price_key(subscription.price_source_id)
+    return subscription_price_key_values(
+        subscription.price_source_id, subscription.currency, legacy_keys
+    )
+
+
+def subscription_price_key_values(
+    source_id: str,
+    currency: str | None,
+    legacy_keys: Mapping[str, PriceKey] | None = None,
+) -> PriceKey | None:
+    if currency is not None:
+        return price_key(source_id, currency)
+    legacy_key = _legacy_price_key(source_id)
     if legacy_key is not None:
         return legacy_key
-    return (legacy_keys or {}).get(subscription.price_source_id)
+    return (legacy_keys or {}).get(source_id)
 
 
 def serialize(record: CanonicalRecord) -> dict[str, Any]:

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -64,9 +64,6 @@ class CanonicalPaymentMethod:
 
 @dataclass
 class CanonicalPrice:
-    # One price in one currency, since that's what a Polar price is. A source
-    # price sold in several currencies at once therefore maps to one canonical
-    # price per currency, and the adapter makes their source ids unique.
     source_id: str
     currency: str
     # None when the source has no representable integer amount (e.g. a sub-cent

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -1,6 +1,7 @@
 """Provider-agnostic records the adapters normalize into, so the precheck
 engine and importer don't need to know which billing provider data came from."""
 
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
@@ -8,6 +9,7 @@ from typing import Any
 
 from fastapi.encoders import jsonable_encoder
 
+from polar.kit.currency import PresentmentCurrency
 from polar.models.merchant_migration_record import MerchantMigrationRecordType
 
 
@@ -129,6 +131,7 @@ class CanonicalSubscription:
     # The renewal day before any month-end clamping. A period boundary can't be
     # trusted for it: a 31st anchor reads as Feb 28 in a February period.
     anchor_day: int | None = None
+    currency: str | None = None
 
     type = MerchantMigrationRecordType.subscription
 
@@ -144,6 +147,51 @@ class CanonicalAccount:
 
 
 CanonicalRecord = CanonicalProduct | CanonicalCustomer | CanonicalSubscription
+PriceKey = tuple[str, str]
+
+
+def _legacy_price_key(source_id: str) -> PriceKey | None:
+    price_id, separator, currency = source_id.rpartition(":")
+    if not separator:
+        return None
+    try:
+        PresentmentCurrency(currency.lower())
+    except ValueError:
+        return None
+    return price_id, currency.lower()
+
+
+def normalize_price_source_id(source_id: str) -> str:
+    legacy_key = _legacy_price_key(source_id)
+    return legacy_key[0] if legacy_key is not None else source_id
+
+
+def price_key(source_id: str, currency: str) -> PriceKey:
+    return normalize_price_source_id(source_id), currency.lower()
+
+
+def canonical_price_key(price: CanonicalPrice) -> PriceKey:
+    return price_key(price.source_id, price.currency)
+
+
+def legacy_price_keys(products: Iterable[CanonicalProduct]) -> dict[str, PriceKey]:
+    keys: dict[str, PriceKey] = {}
+    for product in products:
+        for price in product.prices:
+            keys.setdefault(price.source_id, canonical_price_key(price))
+    return keys
+
+
+def subscription_price_key(
+    subscription: CanonicalSubscription,
+    legacy_keys: Mapping[str, PriceKey] | None = None,
+) -> PriceKey | None:
+    if subscription.currency is not None:
+        return price_key(subscription.price_source_id, subscription.currency)
+    legacy_key = _legacy_price_key(subscription.price_source_id)
+    if legacy_key is not None:
+        return legacy_key
+    return (legacy_keys or {}).get(subscription.price_source_id)
 
 
 def serialize(record: CanonicalRecord) -> dict[str, Any]:
@@ -216,6 +264,7 @@ def deserialize(
                 trial_end=_parse_datetime(data.get("trial_end")),
                 stopped_for_migration=data.get("stopped_for_migration", False),
                 anchor_day=data.get("anchor_day"),
+                currency=data.get("currency"),
             )
         case _:
             raise ValueError(f"Cannot deserialize record of type {type}")

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -64,6 +64,9 @@ class CanonicalPaymentMethod:
 
 @dataclass
 class CanonicalPrice:
+    # One price in one currency, since that's what a Polar price is. A source
+    # price sold in several currencies at once therefore maps to one canonical
+    # price per currency, and the adapter makes their source ids unique.
     source_id: str
     currency: str
     # None when the source has no representable integer amount (e.g. a sub-cent

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -36,7 +36,6 @@ from .canonical import (
     CanonicalSubscriptionStatus,
     deserialize,
     normalize_price_source_id,
-    subscription_price_key,
 )
 from .cards import AmbiguousCopiedCard, link_payment_method
 from .precheck import subscription_import_reason
@@ -192,7 +191,7 @@ class SubscriptionCutover:
             # over would cancel it on the source and then never bill it.
             if not subscription.organization.can_renew_subscriptions:
                 return _skip(_RENEWALS_DISABLED)
-            reason = self._source_reason(source, record)
+            reason = self._source_reason(source, record, subscription.currency)
             if reason is not None:
                 return _skip(reason)
 
@@ -289,7 +288,10 @@ class SubscriptionCutover:
         )
 
     def _source_reason(
-        self, source: CanonicalSubscription, record: MerchantMigrationRecord
+        self,
+        source: CanonicalSubscription,
+        record: MerchantMigrationRecord,
+        imported_currency: str,
     ) -> str | None:
         """Why the source says this subscription shouldn't move today."""
         if source.status == CanonicalSubscriptionStatus.canceled:
@@ -314,10 +316,7 @@ class SubscriptionCutover:
                 staged.price_source_id
             ) != normalize_price_source_id(source.price_source_id):
                 return _PLAN_CHANGED
-            staged_price = subscription_price_key(staged)
-            if staged_price is not None and staged_price != subscription_price_key(
-                source
-            ):
+            if source.currency != imported_currency:
                 return _PLAN_CHANGED
         return self._renewal_reason(source)
 

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -35,6 +35,8 @@ from .canonical import (
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
     deserialize,
+    normalize_price_source_id,
+    subscription_price_key,
 )
 from .cards import AmbiguousCopiedCard, link_payment_method
 from .precheck import subscription_import_reason
@@ -307,11 +309,16 @@ class SubscriptionCutover:
         except KeyError, TypeError, ValueError:
             # Raising would stall the chain, so it stops at this record instead.
             return _UNREADABLE
-        if (
-            isinstance(staged, CanonicalSubscription)
-            and staged.price_source_id != source.price_source_id
-        ):
-            return _PLAN_CHANGED
+        if isinstance(staged, CanonicalSubscription):
+            if normalize_price_source_id(
+                staged.price_source_id
+            ) != normalize_price_source_id(source.price_source_id):
+                return _PLAN_CHANGED
+            staged_price = subscription_price_key(staged)
+            if staged_price is not None and staged_price != subscription_price_key(
+                source
+            ):
+                return _PLAN_CHANGED
         return self._renewal_reason(source)
 
     def _renewal_reason(self, source: CanonicalSubscription) -> str | None:

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -43,9 +43,14 @@ from polar.subscription.service import subscription as subscription_service
 
 from .canonical import (
     CanonicalCustomer,
+    CanonicalPrice,
     CanonicalProduct,
     CanonicalSubscription,
+    PriceKey,
+    canonical_price_key,
     deserialize,
+    legacy_price_keys,
+    subscription_price_key,
 )
 from .precheck import (
     ProductImportPlan,
@@ -252,7 +257,7 @@ class CatalogImporter:
         assert product.recurring_interval is not None
         prices: list[ProductPriceCreate] = []
         for price in product.prices:
-            if price.source_id not in plan.importable_price_ids:
+            if canonical_price_key(price) not in plan.importable_prices:
                 continue
             assert price.amount is not None
             prices.append(
@@ -352,8 +357,11 @@ class CatalogImporter:
             self.organization.default_presentment_currency,
         )
         product_by_price = {
-            price.source_id: product for product in products for price in product.prices
+            canonical_price_key(price): product
+            for product in products
+            for price in product.prices
         }
+        legacy_keys = legacy_price_keys(products)
         # Their ledger rows already carry target ids in-session, so resolve from
         # these maps instead of a query per subscription.
         customer_target_by_source = self._imported_targets(customer_records)
@@ -374,6 +382,7 @@ class CatalogImporter:
             result = await self._create_subscription(
                 subscription,
                 product_by_price,
+                legacy_keys,
                 customer_target_by_source,
                 product_target_by_source,
             )
@@ -397,14 +406,18 @@ class CatalogImporter:
     async def _create_subscription(
         self,
         subscription: CanonicalSubscription,
-        product_by_price: dict[str, CanonicalProduct],
+        product_by_price: dict[PriceKey, CanonicalProduct],
+        legacy_keys: dict[str, PriceKey],
         customer_target_by_source: dict[str, UUID],
         product_target_by_source: dict[str, UUID],
     ) -> ImportedSubscription:
         customer_target = customer_target_by_source.get(subscription.customer_source_id)
         if customer_target is None:
             return ImportedSubscription(skip=_CUSTOMER_NOT_IMPORTED)
-        canonical_product = product_by_price.get(subscription.price_source_id)
+        key = subscription_price_key(subscription, legacy_keys)
+        if key is None:
+            return ImportedSubscription(skip=_PRODUCT_NOT_IMPORTED)
+        canonical_product = product_by_price.get(key)
         if canonical_product is None:
             return ImportedSubscription(skip=_PRODUCT_NOT_IMPORTED)
         product_target = product_target_by_source.get(canonical_product.source_id)
@@ -423,9 +436,7 @@ class CatalogImporter:
         ):
             return ImportedSubscription(skip=_CUSTOMER_ALREADY_SUBSCRIBED)
 
-        price = self._find_price(
-            polar_product, canonical_product, subscription.price_source_id
-        )
+        price = self._find_price(polar_product, canonical_product, key)
         if price is None:
             return ImportedSubscription()
 
@@ -494,12 +505,16 @@ class CatalogImporter:
         self,
         product: Product,
         canonical_product: CanonicalProduct,
-        price_source_id: str,
+        key: PriceKey,
     ) -> ProductPriceFixed | None:
         # Prices carry no durable source id, and an imported product holds one
         # fixed price per currency, so the currency identifies it.
-        canonical_price = next(
-            (p for p in canonical_product.prices if p.source_id == price_source_id),
+        canonical_price: CanonicalPrice | None = next(
+            (
+                price
+                for price in canonical_product.prices
+                if canonical_price_key(price) == key
+            ),
             None,
         )
         if canonical_price is None:

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -33,6 +33,10 @@ from .canonical import (
     CanonicalRecord,
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
+    PriceKey,
+    canonical_price_key,
+    legacy_price_keys,
+    subscription_price_key,
 )
 from .schemas import (
     MerchantMigrationRecordItem,
@@ -677,23 +681,27 @@ def _item(
     )
 
 
-def _price_display_by_source_id(
+def _price_display_by_key(
     products: Sequence[CanonicalProduct],
-) -> dict[str, PriceDisplay]:
+) -> dict[PriceKey, PriceDisplay]:
     return {
-        price.source_id: PriceDisplay.of(product, price)
+        canonical_price_key(price): PriceDisplay.of(product, price)
         for product in products
         for price in product.prices
     }
 
 
 def _representative_price(
-    product: CanonicalProduct, importable_price_ids: set[str]
+    product: CanonicalProduct, importable_prices: set[PriceKey]
 ) -> PriceDisplay:
     """The price to show on a product row: one that will actually be imported,
     falling back to the first when the product is skipped."""
     price = next(
-        (price for price in product.prices if price.source_id in importable_price_ids),
+        (
+            price
+            for price in product.prices
+            if canonical_price_key(price) in importable_prices
+        ),
         product.prices[0] if product.prices else None,
     )
     return PriceDisplay.of(product, price) if price else PriceDisplay()
@@ -755,7 +763,7 @@ def _product_items(
                 _interval_label(product),
                 skip=plan.skip,
                 note=note,
-                price=_representative_price(product, plan.importable_price_ids),
+                price=_representative_price(product, plan.importable_prices),
             )
         )
     return items
@@ -831,7 +839,8 @@ def _subscription_items(
         subscriptions, products, customers, default_currency
     )
     email_by_source = {c.source_id: c.email for c in customers if c.email}
-    price_by_source = _price_display_by_source_id(products)
+    price_by_key = _price_display_by_key(products)
+    legacy_keys = legacy_price_keys(products)
     items: list[MerchantMigrationRecordItem] = []
     for subscription in subscriptions:
         payment_method = subscription.payment_method
@@ -846,6 +855,7 @@ def _subscription_items(
         title = email_by_source.get(
             subscription.customer_source_id, subscription.customer_source_id
         )
+        key = subscription_price_key(subscription, legacy_keys)
         items.append(
             _item(
                 PrecheckEntity.subscriptions,
@@ -854,7 +864,7 @@ def _subscription_items(
                 _humanize_subscription_status(subscription.status),
                 skip=plans[subscription.source_id],
                 note=note,
-                price=price_by_source.get(subscription.price_source_id),
+                price=price_by_key.get(key) if key is not None else None,
             )
         )
     return items
@@ -929,11 +939,11 @@ def classify_records(
 class ProductImportPlan:
     """The importer's decision for one canonical product (keyed by its
     ``source_id``, the ``(product, interval)`` composite). Either a skip with a
-    reason, or the set of price ``source_id``s to create under the Polar product.
+    reason, or the set of ``(source_id, currency)`` prices to create.
     """
 
     skip: Reason | None
-    importable_price_ids: set[str]
+    importable_prices: set[PriceKey]
 
     @property
     def importable(self) -> bool:
@@ -962,20 +972,20 @@ def plan_product_imports(
         if skip is not None:
             plans[product.source_id] = ProductImportPlan(skip, set())
             continue
-        price_ids = {
-            price.source_id
+        prices = {
+            canonical_price_key(price)
             for price in product.prices
             if _drop_reason(
                 precheck_engine._check_price(product, price), PRICE_DROP_CODES
             )
             is None
         }
-        if not price_ids:
+        if not prices:
             plans[product.source_id] = ProductImportPlan(
                 Reason("no_importable_price", _NO_IMPORTABLE_PRICE_REASON), set()
             )
         else:
-            plans[product.source_id] = ProductImportPlan(None, price_ids)
+            plans[product.source_id] = ProductImportPlan(None, prices)
     return plans
 
 
@@ -1013,19 +1023,24 @@ def plan_subscription_imports(
     subscription can't import if its own checks fail or the product/price or
     customer it depends on won't import."""
     importable_prices = {
-        price_id
+        price
         for plan in plan_product_imports(products, default_currency).values()
-        for price_id in plan.importable_price_ids
+        for price in plan.importable_prices
     }
     importable_customers = {
         source_id
         for source_id, skip in plan_customer_imports(customers).items()
         if skip is None
     }
+    legacy_keys = legacy_price_keys(products)
     plans: dict[str, Reason | None] = {}
     for subscription in subscriptions:
         skip = subscription_import_reason(subscription)
-        if skip is None and subscription.price_source_id not in importable_prices:
+        if (
+            skip is None
+            and subscription_price_key(subscription, legacy_keys)
+            not in importable_prices
+        ):
             skip = Reason(
                 "subscription_product_not_importable", _SUBSCRIPTION_PRODUCT_REASON
             )

--- a/server/tests/backoffice/merchant_migrations/test_mrr.py
+++ b/server/tests/backoffice/merchant_migrations/test_mrr.py
@@ -306,7 +306,7 @@ class TestMultipleCurrencies:
 
     def test_legacy_suffixed_price_id_still_resolves(self) -> None:
         rows = [
-            _product("price_1:eur", 2500, currency="eur"),
+            _product("price_1", 2500, currency="eur"),
             _subscription(
                 "sub_1",
                 "price_1:eur",

--- a/server/tests/backoffice/merchant_migrations/test_mrr.py
+++ b/server/tests/backoffice/merchant_migrations/test_mrr.py
@@ -63,6 +63,7 @@ def _subscription(
     quantity: int = 1,
     paused_collection: bool = False,
     migration_id: UUID = MIGRATION,
+    currency: str | None = None,
 ) -> CanonicalRow:
     subscription = CanonicalSubscription(
         source_id=source_id,
@@ -77,6 +78,7 @@ def _subscription(
         line_item_count=1,
         quantity=quantity,
         payment_method=None,
+        currency=currency,
     )
     return (
         migration_id,
@@ -279,6 +281,42 @@ class TestMultipleCurrencies:
         result = _breakdown(rows)
 
         assert result.on_polar.amounts == {"usd": 2900, "eur": 2500}
+
+    def test_one_source_price_keeps_currency_options_apart(self) -> None:
+        rows = [
+            _product("price_1", 2900, currency="usd"),
+            _product("price_1", 2500, currency="eur"),
+            _subscription(
+                "sub_1",
+                "price_1",
+                MerchantMigrationRecordStatus.imported,
+                currency="usd",
+            ),
+            _subscription(
+                "sub_2",
+                "price_1",
+                MerchantMigrationRecordStatus.imported,
+                currency="eur",
+            ),
+        ]
+
+        result = _breakdown(rows)
+
+        assert result.on_polar.amounts == {"usd": 2900, "eur": 2500}
+
+    def test_legacy_suffixed_price_id_still_resolves(self) -> None:
+        rows = [
+            _product("price_1:eur", 2500, currency="eur"),
+            _subscription(
+                "sub_1",
+                "price_1:eur",
+                MerchantMigrationRecordStatus.imported,
+            ),
+        ]
+
+        result = _breakdown(rows)
+
+        assert result.on_polar.amounts == {"eur": 2500}
 
     def test_by_size_puts_the_biggest_currency_first(self) -> None:
         amount = Money({"eur": 100, "usd": 900})

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -139,7 +139,7 @@ def canonical_subscription(
     stopped_for_migration: bool = False,
     anchor_day: int | None = None,
     payment_method: CanonicalPaymentMethod | None = None,
-    currency: str | None = None,
+    currency: str | None = "usd",
 ) -> CanonicalSubscription:
     """Renews outside the safety window, so a test only states its own field."""
     return CanonicalSubscription(
@@ -172,7 +172,7 @@ async def stage_subscription_record(
     *,
     source_id: str = "sub_1",
     price_source_id: str = "price_1",
-    currency: str | None = None,
+    currency: str | None = "usd",
 ) -> MerchantMigrationRecord:
     """An imported subscription in the ledger: what the cutover reads."""
     record = MerchantMigrationRecord(

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -139,6 +139,7 @@ def canonical_subscription(
     stopped_for_migration: bool = False,
     anchor_day: int | None = None,
     payment_method: CanonicalPaymentMethod | None = None,
+    currency: str | None = None,
 ) -> CanonicalSubscription:
     """Renews outside the safety window, so a test only states its own field."""
     return CanonicalSubscription(
@@ -159,6 +160,7 @@ def canonical_subscription(
         trial_end=trial_end,
         stopped_for_migration=stopped_for_migration,
         anchor_day=anchor_day,
+        currency=currency,
     )
 
 
@@ -170,6 +172,7 @@ async def stage_subscription_record(
     *,
     source_id: str = "sub_1",
     price_source_id: str = "price_1",
+    currency: str | None = None,
 ) -> MerchantMigrationRecord:
     """An imported subscription in the ledger: what the cutover reads."""
     record = MerchantMigrationRecord(
@@ -180,7 +183,11 @@ async def stage_subscription_record(
         source_id=source_id,
         target_id=subscription.id,
         canonical=serialize(
-            canonical_subscription(source_id=source_id, price_source_id=price_source_id)
+            canonical_subscription(
+                source_id=source_id,
+                price_source_id=price_source_id,
+                currency=currency,
+            )
         ),
     )
     await save_fixture(record)

--- a/server/tests/merchant_migration/test_canonical.py
+++ b/server/tests/merchant_migration/test_canonical.py
@@ -10,8 +10,10 @@ from polar.merchant_migration.canonical import (
     CanonicalProduct,
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
+    deserialize,
     serialize,
 )
+from polar.models.merchant_migration_record import MerchantMigrationRecordType
 
 
 class TestSerialize:
@@ -70,6 +72,7 @@ class TestSerialize:
             payment_method=CanonicalPaymentMethod(
                 source_id="pm_1", type=CanonicalPaymentMethodType.card
             ),
+            currency="usd",
         )
 
         result = serialize(subscription)
@@ -77,6 +80,7 @@ class TestSerialize:
         assert result["current_period_start"] == "2026-01-01T00:00:00+00:00"
         assert result["current_period_end"] == "2026-02-01T00:00:00+00:00"
         assert result["status"] == "active"
+        assert result["currency"] == "usd"
         assert result["payment_method"] == {
             "source_id": "pm_1",
             "type": "card",
@@ -99,3 +103,53 @@ class TestSerialize:
             "name": None,
             "country": None,
         }
+
+
+class TestDeserialize:
+    def test_subscription_currency(self) -> None:
+        subscription = CanonicalSubscription(
+            source_id="sub_1",
+            customer_source_id="cus_1",
+            price_source_id="price_1",
+            status=CanonicalSubscriptionStatus.active,
+            collection_method=CanonicalCollectionMethod.charge_automatically,
+            current_period_start=None,
+            current_period_end=None,
+            trialing=False,
+            paused_collection=False,
+            line_item_count=1,
+            quantity=1,
+            payment_method=None,
+            currency="usd",
+        )
+
+        result = deserialize(
+            MerchantMigrationRecordType.subscription, serialize(subscription)
+        )
+
+        assert isinstance(result, CanonicalSubscription)
+        assert result.currency == "usd"
+
+    def test_legacy_subscription_without_currency(self) -> None:
+        canonical = serialize(
+            CanonicalSubscription(
+                source_id="sub_1",
+                customer_source_id="cus_1",
+                price_source_id="price_1:usd",
+                status=CanonicalSubscriptionStatus.active,
+                collection_method=CanonicalCollectionMethod.charge_automatically,
+                current_period_start=None,
+                current_period_end=None,
+                trialing=False,
+                paused_collection=False,
+                line_item_count=1,
+                quantity=1,
+                payment_method=None,
+            )
+        )
+        canonical.pop("currency")
+
+        result = deserialize(MerchantMigrationRecordType.subscription, canonical)
+
+        assert isinstance(result, CanonicalSubscription)
+        assert result.currency is None

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -187,6 +187,19 @@ class TestRun:
         assert paused_subscription.current_period_end == renewal
         assert paused_subscription.payment_method_id == copied_card.id
 
+    async def test_legacy_suffixed_price_matches_explicit_currency(
+        self,
+        cutover: RunCutover,
+        copied_card: PaymentMethod,
+        record: MerchantMigrationRecord,
+    ) -> None:
+        record.canonical["price_source_id"] = "price_1:usd"
+        record.canonical.pop("currency", None)
+
+        outcome = await cutover(_source(currency="usd"))
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+
     async def test_moves_subscription_loaded_from_database(
         self,
         session: AsyncSession,
@@ -512,6 +525,21 @@ class TestSkips:
         assert outcome.status == MerchantMigrationCutoverStatus.skipped
         if expected_reason is not None:
             assert expected_reason in (outcome.message or "")
+        _assert_left_alone(adapter, paused_subscription)
+
+    async def test_billed_currency_changed(
+        self,
+        cutover: RunCutover,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        record.canonical["currency"] = "eur"
+        adapter = _source(currency="usd")
+
+        outcome = await cutover(adapter)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "plan changed on the source" in (outcome.message or "")
         _assert_left_alone(adapter, paused_subscription)
 
     async def test_source_subscription_gone(

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -530,11 +530,9 @@ class TestSkips:
     async def test_billed_currency_changed(
         self,
         cutover: RunCutover,
-        record: MerchantMigrationRecord,
         paused_subscription: Subscription,
     ) -> None:
-        record.canonical["currency"] = "eur"
-        adapter = _source(currency="usd")
+        adapter = _source(currency="eur")
 
         outcome = await cutover(adapter)
 

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -126,6 +126,7 @@ def build_subscription(
     quantity: int = 1,
     payment_method: CanonicalPaymentMethod | None = None,
     has_discount: bool = False,
+    currency: str | None = None,
 ) -> CanonicalSubscription:
     return CanonicalSubscription(
         source_id=source_id,
@@ -141,6 +142,7 @@ def build_subscription(
         quantity=quantity,
         payment_method=payment_method,
         has_discount=has_discount,
+        currency=currency,
     )
 
 
@@ -955,6 +957,24 @@ class TestClassifyCascade:
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "subscription_product_not_importable"
 
+    def test_subscription_uses_currency_option_on_shared_price_id(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                prices=[
+                    build_price(source_id="price_1", currency="eur", amount=900),
+                    build_price(source_id="price_1", currency="usd", amount=1000),
+                ]
+            ),
+            build_customer(),
+            build_subscription(currency="usd"),
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
+
+        assert items[0].status == PrecheckRecordStatus.importable
+        assert items[0].currency == "usd"
+        assert items[0].amount == 1000
+
 
 class TestPlanProductImports:
     def test_importable_product_lists_its_prices(self) -> None:
@@ -964,7 +984,7 @@ class TestPlanProductImports:
 
         plan = plans[product.source_id]
         assert plan.importable is True
-        assert plan.importable_price_ids == {"price_1"}
+        assert plan.importable_prices == {("price_1", "usd")}
 
     def test_one_time_product_is_skipped(self) -> None:
         product = build_product(source_id="prod_1:one_time", recurring_interval=None)
@@ -989,7 +1009,7 @@ class TestPlanProductImports:
         plan = plan_product_imports([product], "usd")[product.source_id]
 
         assert plan.importable is True
-        assert plan.importable_price_ids == {"price_ok"}
+        assert plan.importable_prices == {("price_ok", "usd")}
 
     def test_product_with_no_importable_price_is_skipped(self) -> None:
         product = build_product(
@@ -1026,7 +1046,7 @@ class TestPlanProductImports:
         assert plan.importable is False
         assert plan.skip is not None
         assert plan.skip.code == "product_name_too_short"
-        assert plan.importable_price_ids == set()
+        assert plan.importable_prices == set()
 
     def test_default_currency_price_keeps_the_other_currencies(self) -> None:
         product = build_product(
@@ -1039,7 +1059,10 @@ class TestPlanProductImports:
         plan = plan_product_imports([product], "usd")[product.source_id]
 
         assert plan.importable is True
-        assert plan.importable_price_ids == {"price_usd", "price_eur"}
+        assert plan.importable_prices == {
+            ("price_usd", "usd"),
+            ("price_eur", "eur"),
+        }
 
     def test_products_sharing_a_name_both_import(self) -> None:
         first = build_product(source_id="prod_1:month:1", product_source_id="prod_1")

--- a/server/tests/merchant_migration/test_repository.py
+++ b/server/tests/merchant_migration/test_repository.py
@@ -93,6 +93,7 @@ class TestUpsert:
                 payment_method=CanonicalPaymentMethod(
                     source_id="pm_1", type=CanonicalPaymentMethodType.card
                 ),
+                currency="usd",
             ),
         )
         await session.flush()
@@ -107,6 +108,7 @@ class TestUpsert:
         # datetimes round-trip through JSONB as ISO strings
         assert reloaded.canonical["current_period_start"] == "2026-01-01T00:00:00+00:00"
         assert reloaded.canonical["payment_method"]["type"] == "card"
+        assert reloaded.canonical["currency"] == "usd"
 
     async def test_is_idempotent_per_source(
         self,

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -690,6 +690,54 @@ def _catalog_with_subscription() -> list[CanonicalRecord]:
     ]
 
 
+def _multi_currency_catalog() -> list[CanonicalRecord]:
+    """What one Stripe price sold in EUR and USD reads as, with a subscription
+    billed in EUR: the extra currency carries its own price source id."""
+    return [
+        CanonicalProduct(
+            source_id="prod_1:month:1",
+            product_source_id="prod_1",
+            name="Pro",
+            recurring_interval="month",
+            recurring_interval_count=1,
+            prices=[
+                CanonicalPrice(
+                    source_id="price_1",
+                    currency="eur",
+                    amount=900,
+                    pricing_scheme=CanonicalPricingScheme.fixed,
+                ),
+                CanonicalPrice(
+                    source_id="price_1:usd",
+                    currency="usd",
+                    amount=1000,
+                    pricing_scheme=CanonicalPricingScheme.fixed,
+                ),
+            ],
+        ),
+        CanonicalCustomer(
+            source_id="cus_1",
+            email="alice@example.com",
+            name="Alice",
+            country="US",
+        ),
+        CanonicalSubscription(
+            source_id="sub_1",
+            customer_source_id="cus_1",
+            price_source_id="price_1",
+            status=CanonicalSubscriptionStatus.active,
+            collection_method=CanonicalCollectionMethod.charge_automatically,
+            current_period_start=None,
+            current_period_end=None,
+            trialing=False,
+            paused_collection=False,
+            line_item_count=1,
+            quantity=1,
+            payment_method=None,
+        ),
+    ]
+
+
 async def _products(session: AsyncSession, organization: Organization) -> list[Product]:
     result = await session.execute(
         select(Product)
@@ -1430,6 +1478,47 @@ class TestImportCatalog:
         assert record.status == MerchantMigrationRecordStatus.skipped
         assert record.error is not None
         assert "USD" in record.error
+
+    @pytest.mark.auth
+    async def test_multi_currency_price_imports_every_currency(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # One source price sold in EUR and USD becomes one Polar price per
+        # currency, and a subscription keeps the currency it was billed in.
+        migration = await _staged_migration(
+            mocker,
+            session,
+            save_fixture,
+            auth_subject,
+            organization,
+            records=_multi_currency_catalog(),
+        )
+
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.products].imported == 1
+        assert results[PrecheckEntity.subscriptions].imported == 1
+
+        products = await _products(session, organization)
+        assert len(products) == 1
+        assert {
+            (price.price_currency, price.price_amount)
+            for price in products[0].prices
+            if isinstance(price, ProductPriceFixed)
+        } == {("eur", 900), ("usd", 1000)}
+
+        result = await session.execute(
+            select(Subscription).where(Subscription.organization_id == organization.id)
+        )
+        subscription = result.scalars().unique().one()
+        assert subscription.currency == "eur"
 
 
 @pytest.mark.asyncio

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -691,8 +691,6 @@ def _catalog_with_subscription() -> list[CanonicalRecord]:
 
 
 def _multi_currency_catalog() -> list[CanonicalRecord]:
-    """What one Stripe price sold in EUR and USD reads as, with a subscription
-    billed in EUR: the extra currency carries its own price source id."""
     return [
         CanonicalProduct(
             source_id="prod_1:month:1",
@@ -1489,8 +1487,6 @@ class TestImportCatalog:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
-        # One source price sold in EUR and USD becomes one Polar price per
-        # currency, and a subscription keeps the currency it was billed in.
         migration = await _staged_migration(
             mocker,
             session,

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -706,7 +706,7 @@ def _multi_currency_catalog() -> list[CanonicalRecord]:
                     pricing_scheme=CanonicalPricingScheme.fixed,
                 ),
                 CanonicalPrice(
-                    source_id="price_1:usd",
+                    source_id="price_1",
                     currency="usd",
                     amount=1000,
                     pricing_scheme=CanonicalPricingScheme.fixed,
@@ -722,7 +722,7 @@ def _multi_currency_catalog() -> list[CanonicalRecord]:
         CanonicalSubscription(
             source_id="sub_1",
             customer_source_id="cus_1",
-            price_source_id="price_1:usd",
+            price_source_id="price_1",
             status=CanonicalSubscriptionStatus.active,
             collection_method=CanonicalCollectionMethod.charge_automatically,
             current_period_start=None,
@@ -732,6 +732,7 @@ def _multi_currency_catalog() -> list[CanonicalRecord]:
             line_item_count=1,
             quantity=1,
             payment_method=None,
+            currency="usd",
         ),
     ]
 
@@ -1478,6 +1479,7 @@ class TestImportCatalog:
         assert "USD" in record.error
 
     @pytest.mark.auth
+    @pytest.mark.parametrize("legacy_shape", [False, True], ids=["current", "legacy"])
     async def test_multi_currency_price_imports_every_currency(
         self,
         mocker: MockerFixture,
@@ -1486,14 +1488,24 @@ class TestImportCatalog:
         auth_subject: AuthSubject[User],
         organization: Organization,
         user_organization: UserOrganization,
+        legacy_shape: bool,
     ) -> None:
+        records = _multi_currency_catalog()
+        if legacy_shape:
+            product = records[0]
+            canonical_subscription = records[-1]
+            assert isinstance(product, CanonicalProduct)
+            assert isinstance(canonical_subscription, CanonicalSubscription)
+            product.prices[1].source_id = "price_1:usd"
+            canonical_subscription.price_source_id = "price_1:usd"
+            canonical_subscription.currency = None
         migration = await _staged_migration(
             mocker,
             session,
             save_fixture,
             auth_subject,
             organization,
-            records=_multi_currency_catalog(),
+            records=records,
         )
 
         report = await service.import_catalog(session, auth_subject, migration.id)

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -722,7 +722,7 @@ def _multi_currency_catalog() -> list[CanonicalRecord]:
         CanonicalSubscription(
             source_id="sub_1",
             customer_source_id="cus_1",
-            price_source_id="price_1",
+            price_source_id="price_1:usd",
             status=CanonicalSubscriptionStatus.active,
             collection_method=CanonicalCollectionMethod.charge_automatically,
             current_period_start=None,
@@ -1514,7 +1514,7 @@ class TestImportCatalog:
             select(Subscription).where(Subscription.organization_id == organization.id)
         )
         subscription = result.scalars().unique().one()
-        assert subscription.currency == "eur"
+        assert subscription.currency == "usd"
 
 
 @pytest.mark.asyncio

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -339,6 +339,27 @@ class TestExtractProducts:
             for price in products[0].prices
         ] == [("price_1", "eur", 900), ("price_1:usd", "usd", 1000)]
 
+    async def test_only_maps_configured_currency_options(
+        self, mocker: MockerFixture
+    ) -> None:
+        adapter, client = _adapter(mocker)
+        _listed_prices(
+            mocker,
+            client,
+            _stripe_price(
+                currency="eur",
+                unit_amount=900,
+                currency_options={
+                    "eur": {"unit_amount": 900},
+                    "gbp": {"unit_amount": 800},
+                },
+            ),
+        )
+
+        products = await _extracted_products(adapter)
+
+        assert {price.currency for price in products[0].prices} == {"eur", "gbp"}
+
     async def test_currency_options_are_expanded(self, mocker: MockerFixture) -> None:
         adapter, client = _adapter(mocker)
         _listed_prices(mocker, client)

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Any
 
@@ -12,6 +13,8 @@ from polar.merchant_migration.adapters.stripe import (
 from polar.merchant_migration.canonical import (
     CanonicalPaymentMethod,
     CanonicalPaymentMethodType,
+    CanonicalPricingScheme,
+    CanonicalProduct,
     CanonicalSubscriptionStatus,
 )
 
@@ -210,6 +213,7 @@ def _stripe_subscription(
     trial_end: int | None = None,
     billing_cycle_anchor: int | None = 1_700_000_000,
     cancellation_comment: str | None = None,
+    currency: str = "usd",
     items: list[dict[str, Any]] | None = None,
     payment_method: dict[str, Any] | None = None,
 ) -> stripe_lib.Subscription:
@@ -217,6 +221,7 @@ def _stripe_subscription(
         {
             "id": "sub_1",
             "customer": "cus_1",
+            "currency": currency,
             "status": status,
             "collection_method": "charge_automatically",
             "cancel_at_period_end": cancel_at_period_end,
@@ -233,7 +238,7 @@ def _stripe_subscription(
                 if items is not None
                 else [
                     {
-                        "price": {"id": "price_1"},
+                        "price": {"id": "price_1", "currency": "usd"},
                         "quantity": 1,
                         "current_period_start": 1_700_000_000,
                         "current_period_end": 1_702_000_000,
@@ -243,6 +248,110 @@ def _stripe_subscription(
         },
         None,
     )
+
+
+def _stripe_price(
+    *,
+    id: str = "price_1",
+    currency: str = "usd",
+    unit_amount: int | None = 1000,
+    currency_options: dict[str, Any] | None = None,
+) -> stripe_lib.Price:
+    price: dict[str, Any] = {
+        "id": id,
+        "object": "price",
+        "currency": currency,
+        "unit_amount": unit_amount,
+        "billing_scheme": "per_unit",
+        "recurring": {
+            "interval": "month",
+            "interval_count": 1,
+            "usage_type": "licensed",
+        },
+        "product": {
+            "id": "prod_1",
+            "object": "product",
+            "active": True,
+            "name": "Pro",
+        },
+    }
+    if currency_options is not None:
+        price["currency_options"] = currency_options
+    return stripe_lib.Price.construct_from(price, None)
+
+
+def _listed_prices(
+    mocker: MockerFixture, client: Any, *prices: stripe_lib.Price
+) -> None:
+    async def paging() -> AsyncIterator[stripe_lib.Price]:
+        for price in prices:
+            yield price
+
+    listing = mocker.MagicMock()
+    listing.auto_paging_iter = paging
+    client.v1.prices.list_async = mocker.AsyncMock(return_value=listing)
+
+
+async def _extracted_products(adapter: StripeAdapter) -> list[CanonicalProduct]:
+    return [product async for product in adapter._extract_products()]
+
+
+@pytest.mark.asyncio
+class TestExtractProducts:
+    async def test_single_currency_price_keeps_the_source_id(
+        self, mocker: MockerFixture
+    ) -> None:
+        adapter, client = _adapter(mocker)
+        _listed_prices(mocker, client, _stripe_price())
+
+        products = await _extracted_products(adapter)
+
+        assert len(products) == 1
+        price = products[0].prices[0]
+        assert (price.source_id, price.currency, price.amount) == (
+            "price_1",
+            "usd",
+            1000,
+        )
+        assert price.pricing_scheme == CanonicalPricingScheme.fixed
+
+    async def test_multi_currency_price_yields_one_price_per_currency(
+        self, mocker: MockerFixture
+    ) -> None:
+        """A Stripe price sold in several currencies is one Polar price per
+        currency, so the product isn't reported as unpriced in any of them."""
+        adapter, client = _adapter(mocker)
+        _listed_prices(
+            mocker,
+            client,
+            _stripe_price(
+                currency="eur",
+                unit_amount=900,
+                currency_options={
+                    "eur": {"unit_amount": 900},
+                    "usd": {"unit_amount": 1000},
+                },
+            ),
+        )
+
+        products = await _extracted_products(adapter)
+
+        assert len(products) == 1
+        assert [
+            (price.source_id, price.currency, price.amount)
+            for price in products[0].prices
+        ] == [("price_1", "eur", 900), ("price_1:usd", "usd", 1000)]
+
+    async def test_currency_options_are_expanded(self, mocker: MockerFixture) -> None:
+        # Stripe leaves `currency_options` out of the response unless asked for
+        # it, which reads as a multi-currency price having a single currency.
+        adapter, client = _adapter(mocker)
+        _listed_prices(mocker, client)
+
+        await _extracted_products(adapter)
+
+        _, kwargs = client.v1.prices.list_async.call_args
+        assert "data.currency_options" in kwargs["params"]["expand"]
 
 
 @pytest.mark.asyncio
@@ -259,6 +368,42 @@ class TestGetSubscription:
         assert subscription.status == CanonicalSubscriptionStatus.active
         assert subscription.cancel_at_period_end is True
         assert subscription.current_period_end is not None
+
+    async def test_reads_the_price_it_is_billed_in(self, mocker: MockerFixture) -> None:
+        """On a multi-currency price the subscription's own currency says which
+        price it charges, so it must not land on the price's default one."""
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
+            return_value=_stripe_subscription(
+                currency="usd",
+                items=[
+                    {
+                        "price": {"id": "price_1", "currency": "eur"},
+                        "quantity": 1,
+                        "current_period_start": 1_700_000_000,
+                        "current_period_end": 1_702_000_000,
+                    }
+                ],
+            )
+        )
+
+        subscription = await adapter.get_subscription("sub_1")
+
+        assert subscription is not None
+        assert subscription.price_source_id == "price_1:usd"
+
+    async def test_default_currency_keeps_the_bare_price_id(
+        self, mocker: MockerFixture
+    ) -> None:
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
+            return_value=_stripe_subscription(currency="usd")
+        )
+
+        subscription = await adapter.get_subscription("sub_1")
+
+        assert subscription is not None
+        assert subscription.price_source_id == "price_1"
 
     async def test_carries_the_card_details_the_copy_keeps(
         self, mocker: MockerFixture

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -337,7 +337,7 @@ class TestExtractProducts:
         assert [
             (price.source_id, price.currency, price.amount)
             for price in products[0].prices
-        ] == [("price_1", "eur", 900), ("price_1:usd", "usd", 1000)]
+        ] == [("price_1", "eur", 900), ("price_1", "usd", 1000)]
 
     async def test_only_maps_configured_currency_options(
         self, mocker: MockerFixture
@@ -404,7 +404,8 @@ class TestGetSubscription:
         subscription = await adapter.get_subscription("sub_1")
 
         assert subscription is not None
-        assert subscription.price_source_id == "price_1:usd"
+        assert subscription.price_source_id == "price_1"
+        assert subscription.currency == "usd"
 
     async def test_default_currency_keeps_the_bare_price_id(
         self, mocker: MockerFixture
@@ -418,6 +419,7 @@ class TestGetSubscription:
 
         assert subscription is not None
         assert subscription.price_source_id == "price_1"
+        assert subscription.currency == "usd"
 
     async def test_carries_the_card_details_the_copy_keeps(
         self, mocker: MockerFixture

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -317,8 +317,6 @@ class TestExtractProducts:
     async def test_multi_currency_price_yields_one_price_per_currency(
         self, mocker: MockerFixture
     ) -> None:
-        """A Stripe price sold in several currencies is one Polar price per
-        currency, so the product isn't reported as unpriced in any of them."""
         adapter, client = _adapter(mocker)
         _listed_prices(
             mocker,
@@ -342,8 +340,6 @@ class TestExtractProducts:
         ] == [("price_1", "eur", 900), ("price_1:usd", "usd", 1000)]
 
     async def test_currency_options_are_expanded(self, mocker: MockerFixture) -> None:
-        # Stripe leaves `currency_options` out of the response unless asked for
-        # it, which reads as a multi-currency price having a single currency.
         adapter, client = _adapter(mocker)
         _listed_prices(mocker, client)
 
@@ -369,8 +365,6 @@ class TestGetSubscription:
         assert subscription.current_period_end is not None
 
     async def test_reads_the_price_it_is_billed_in(self, mocker: MockerFixture) -> None:
-        """On a multi-currency price the subscription's own currency says which
-        price it charges, so it must not land on the price's default one."""
         adapter, client = _adapter(mocker)
         client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
             return_value=_stripe_subscription(

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -252,13 +252,12 @@ def _stripe_subscription(
 
 def _stripe_price(
     *,
-    id: str = "price_1",
     currency: str = "usd",
     unit_amount: int | None = 1000,
     currency_options: dict[str, Any] | None = None,
 ) -> stripe_lib.Price:
     price: dict[str, Any] = {
-        "id": id,
+        "id": "price_1",
         "object": "price",
         "currency": currency,
         "unit_amount": unit_amount,


### PR DESCRIPTION
## Summary

A merchant reported that a Stripe product priced in both EUR and USD was flagged as `Product 'X' has no price in USD, your organization's default currency, so it and its subscriptions won't be imported`, even though the USD price exists. Both amounts live on a single Stripe price via `currency_options` (the dashboard's "Add a price by currency"), and the migration adapter never read that field.

This should fix the bug.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06db7162-335f-4410-bce0-6f271625cad5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06db7162-335f-4410-bce0-6f271625cad5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

