### PR TITLE
Checkout metered UX improvements

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
@@ -642,63 +642,6 @@ describe('CheckoutPricingBreakdown', () => {
       expect(screen.getByTestId('detail-row-API Calls')).toBeInTheDocument()
     })
 
-    it('shows included credit units before the rate', () => {
-      const meteredPrice = createMeteredPrice({
-        id: 'price_metered_1',
-        unit_amount: '900',
-        meter: {
-          id: 'meter_1',
-          name: 'API Calls',
-          unit: 'scalar' as const,
-          custom_label: null,
-          custom_multiplier: null,
-        },
-      })
-      const base = createCheckout()
-      const checkout = createCheckout({
-        amount: 999,
-        net_amount: 999,
-        tax_amount: null,
-        total_amount: 999,
-        prices: {
-          prod_1: [base.product_price, meteredPrice],
-        },
-        product: {
-          ...base.product,
-          benefits: [
-            {
-              id: 'benefit_1',
-              created_at: new Date().toISOString(),
-              modified_at: null,
-              type: 'meter_credit',
-              description: '10,000 API calls',
-              selectable: true,
-              deletable: true,
-              is_deleted: false,
-              organization_id: 'org_1',
-              properties: {
-                units: 10000,
-                rollover: false,
-                meter_id: 'meter_1',
-              },
-            },
-          ],
-        },
-      })
-
-      render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
-
-      fireEvent.click(
-        screen.getByRole('button', {
-          name: /additional metered charges may apply/i,
-        }),
-      )
-
-      const row = screen.getByTestId('detail-row-API Calls')
-      expect(row).toHaveTextContent('10,000 included, then')
-      expect(row).toHaveTextContent('$9.00')
-    })
-
     it('strikes through the original rate when a percentage discount is active', () => {
       const meteredPrice = createMeteredPrice({
         id: 'price_metered_1',

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
@@ -1,5 +1,5 @@
 import { schemas } from '@polar-sh/client'
-import { render, screen, within } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   createBaseCheckout,
@@ -629,8 +629,74 @@ describe('CheckoutPricingBreakdown', () => {
 
       render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
 
-      expect(screen.getByText(/additional metered usage/i)).toBeInTheDocument()
+      expect(
+        screen.queryByTestId('detail-row-API Calls'),
+      ).not.toBeInTheDocument()
+
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: /additional metered charges may apply/i,
+        }),
+      )
+
       expect(screen.getByTestId('detail-row-API Calls')).toBeInTheDocument()
+    })
+
+    it('shows included credit units before the rate', () => {
+      const meteredPrice = createMeteredPrice({
+        id: 'price_metered_1',
+        unit_amount: '900',
+        meter: {
+          id: 'meter_1',
+          name: 'API Calls',
+          unit: 'scalar' as const,
+          custom_label: null,
+          custom_multiplier: null,
+        },
+      })
+      const base = createCheckout()
+      const checkout = createCheckout({
+        amount: 999,
+        net_amount: 999,
+        tax_amount: null,
+        total_amount: 999,
+        prices: {
+          prod_1: [base.product_price, meteredPrice],
+        },
+        product: {
+          ...base.product,
+          benefits: [
+            {
+              id: 'benefit_1',
+              created_at: new Date().toISOString(),
+              modified_at: null,
+              type: 'meter_credit',
+              description: '10,000 API calls',
+              selectable: true,
+              deletable: true,
+              is_deleted: false,
+              organization_id: 'org_1',
+              properties: {
+                units: 10000,
+                rollover: false,
+                meter_id: 'meter_1',
+              },
+            },
+          ],
+        },
+      })
+
+      render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
+
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: /additional metered charges may apply/i,
+        }),
+      )
+
+      const row = screen.getByTestId('detail-row-API Calls')
+      expect(row).toHaveTextContent('10,000 included, then')
+      expect(row).toHaveTextContent('$9.00')
     })
 
     it('strikes through the original rate when a percentage discount is active', () => {
@@ -665,6 +731,12 @@ describe('CheckoutPricingBreakdown', () => {
       })
 
       render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
+
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: /additional metered charges may apply/i,
+        }),
+      )
 
       const row = screen.getByTestId('detail-row-Workspaces')
       expect(row).toHaveTextContent('$9.00')
@@ -706,6 +778,12 @@ describe('CheckoutPricingBreakdown', () => {
       })
 
       render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
+
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: /additional metered charges may apply/i,
+        }),
+      )
 
       const row = screen.getByTestId('detail-row-Workspaces')
       expect(row).toHaveTextContent('$9.00')

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -19,12 +19,11 @@ import {
 } from '../guards'
 import { getSeatRows } from '../utils/seats'
 import { getDiscountDisplay } from '../utils/discount'
-import { getMeteredPrices } from '../utils/product'
 import { getUnitRows } from '../utils/units'
 import { unreachable } from '../utils/unreachable'
 import AmountLabel from './AmountLabel'
 import DetailRow from './DetailRow'
-import MeteredPriceLabel from './MeteredPriceLabel'
+import MeteredChargesDetails from './MeteredChargesDetails'
 import SeatDetailRow from './SeatDetailRow'
 import UnitDetailRow from './UnitDetailRow'
 
@@ -92,13 +91,6 @@ const CheckoutPricingBreakdown = ({
   const intervalCount = hasProductCheckout(checkout)
     ? checkout.product.recurring_interval_count
     : null
-
-  const { product, prices, currency } = checkout
-  const meteredPrices = useMemo(
-    () =>
-      product && prices ? getMeteredPrices(prices[product.id], currency) : [],
-    [product, prices, currency],
-  )
 
   const discountEndLabel = useMemo(() => {
     if (!checkout.discount || checkout.discount.duration === 'forever') {
@@ -293,25 +285,7 @@ const CheckoutPricingBreakdown = ({
               locale={locale}
             />
           </DetailRow>
-          {meteredPrices.length > 0 && (
-            <DetailRow
-              title={t('checkout.pricing.additionalMeteredUsage')}
-              className="dark:border-polar-700 mt-2 border-t border-gray-200 pt-4"
-            />
-          )}
-          {meteredPrices.map((meteredPrice) => (
-            <DetailRow
-              title={meteredPrice.meter.name}
-              key={meteredPrice.id}
-              emphasis
-            >
-              <MeteredPriceLabel
-                price={meteredPrice}
-                locale={locale}
-                discount={checkout.discount}
-              />
-            </DetailRow>
-          ))}
+          <MeteredChargesDetails checkout={checkout} locale={locale} />
         </>
       ) : (
         <span>{t('checkout.pricing.free')}</span>

--- a/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
@@ -1,0 +1,170 @@
+import { schemas } from '@polar-sh/client'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  createCheckout,
+  createFixedPrice,
+  createMeteredPrice,
+} from '../test-utils/makeCheckout'
+import MeteredChargesDetails from './MeteredChargesDetails'
+
+function createMeterCreditBenefit(
+  meterId: string,
+  units: number,
+): schemas['CheckoutProduct']['benefits'][number] {
+  return {
+    id: `benefit_${meterId}_${units}`,
+    created_at: new Date().toISOString(),
+    modified_at: null,
+    type: 'meter_credit',
+    description: `${units} units included`,
+    selectable: true,
+    deletable: true,
+    is_deleted: false,
+    organization_id: 'org_1',
+    properties: {
+      units,
+      rollover: false,
+      meter_id: meterId,
+    },
+  }
+}
+
+function createMeteredCheckout({
+  benefits = [],
+}: {
+  benefits?: schemas['CheckoutProduct']['benefits']
+} = {}) {
+  const base = createCheckout()
+  const meteredPrice = createMeteredPrice({
+    id: 'price_metered_1',
+    unit_amount: '900',
+    meter: {
+      id: 'meter_1',
+      name: 'API Calls',
+      unit: 'scalar' as const,
+      custom_label: null,
+      custom_multiplier: null,
+    },
+  })
+  return createCheckout({
+    prices: {
+      prod_1: [base.product_price, meteredPrice],
+    },
+    product: {
+      ...base.product,
+      benefits,
+    },
+  })
+}
+
+describe('MeteredChargesDetails', () => {
+  it('renders nothing without metered prices', () => {
+    const checkout = createCheckout({
+      prices: { prod_1: [createFixedPrice()] },
+    })
+
+    const { container } = render(
+      <MeteredChargesDetails checkout={checkout} locale="en" />,
+    )
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('is collapsed by default', () => {
+    render(
+      <MeteredChargesDetails checkout={createMeteredCheckout()} locale="en" />,
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: /additional metered charges may apply/i,
+      }),
+    ).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('detail-row-API Calls')).not.toBeInTheDocument()
+  })
+
+  it('expands and collapses on click', () => {
+    render(
+      <MeteredChargesDetails checkout={createMeteredCheckout()} locale="en" />,
+    )
+    const toggle = screen.getByRole('button', {
+      name: /additional metered charges may apply/i,
+    })
+
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    const row = screen.getByTestId('detail-row-API Calls')
+    expect(row).toHaveTextContent('$9.00')
+
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('detail-row-API Calls')).not.toBeInTheDocument()
+  })
+
+  it('shows included units from meter credit benefits before the rate', () => {
+    render(
+      <MeteredChargesDetails
+        checkout={createMeteredCheckout({
+          benefits: [createMeterCreditBenefit('meter_1', 10000)],
+        })}
+        locale="en"
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /additional metered charges may apply/i,
+      }),
+    )
+
+    expect(screen.getByTestId('detail-row-API Calls')).toHaveTextContent(
+      '10,000 included, then',
+    )
+  })
+
+  it('sums units across multiple credit benefits on the same meter', () => {
+    render(
+      <MeteredChargesDetails
+        checkout={createMeteredCheckout({
+          benefits: [
+            createMeterCreditBenefit('meter_1', 10000),
+            createMeterCreditBenefit('meter_1', 5000),
+          ],
+        })}
+        locale="en"
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /additional metered charges may apply/i,
+      }),
+    )
+
+    expect(screen.getByTestId('detail-row-API Calls')).toHaveTextContent(
+      '15,000 included, then',
+    )
+  })
+
+  it('ignores credit benefits for other meters', () => {
+    render(
+      <MeteredChargesDetails
+        checkout={createMeteredCheckout({
+          benefits: [createMeterCreditBenefit('meter_other', 10000)],
+        })}
+        locale="en"
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /additional metered charges may apply/i,
+      }),
+    )
+
+    const row = screen.getByTestId('detail-row-API Calls')
+    expect(row).not.toHaveTextContent('included')
+    expect(row).toHaveTextContent('$9.00')
+  })
+})

--- a/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
@@ -24,7 +24,6 @@ function createMeterCreditBenefit(
     organization_id: 'org_1',
     properties: {
       units,
-      rollover: false,
       meter_id: meterId,
     },
   }

--- a/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
@@ -119,8 +119,44 @@ describe('MeteredChargesDetails', () => {
     )
 
     expect(screen.getByTestId('detail-row-API Calls')).toHaveTextContent(
-      '10,000 included, then',
+      '10,000 units included',
     )
+  })
+
+  it('labels included units with the meter unit noun', () => {
+    const base = createCheckout()
+    const meteredPrice = createMeteredPrice({
+      id: 'price_metered_1',
+      unit_amount: '0.001',
+      meter: {
+        id: 'meter_1',
+        name: 'AI Tokens',
+        unit: 'token' as const,
+        custom_label: null,
+        custom_multiplier: null,
+      },
+    })
+    const checkout = createCheckout({
+      prices: {
+        prod_1: [base.product_price, meteredPrice],
+      },
+      product: {
+        ...base.product,
+        benefits: [createMeterCreditBenefit('meter_1', 10_000_000)],
+      },
+    })
+
+    render(<MeteredChargesDetails checkout={checkout} locale="en" />)
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /additional metered charges may apply/i,
+      }),
+    )
+
+    const row = screen.getByTestId('detail-row-AI Tokens')
+    expect(row).toHaveTextContent('10,000,000 tokens included')
+    expect(row).toHaveTextContent('/ 1M tokens')
   })
 
   it('sums units across multiple credit benefits on the same meter', () => {
@@ -143,7 +179,7 @@ describe('MeteredChargesDetails', () => {
     )
 
     expect(screen.getByTestId('detail-row-API Calls')).toHaveTextContent(
-      '15,000 included, then',
+      '15,000 units included',
     )
   })
 

--- a/clients/packages/checkout/src/components/MeteredChargesDetails.tsx
+++ b/clients/packages/checkout/src/components/MeteredChargesDetails.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { schemas } from '@polar-sh/client'
+import {
+  DEFAULT_LOCALE,
+  useTranslations,
+  type AcceptedLocale,
+} from '@polar-sh/i18n'
+import { cn } from '@polar-sh/ui/lib/utils'
+import { useMemo, useState } from 'react'
+import { getMeteredPrices } from '../utils/product'
+import DetailRow from './DetailRow'
+import MeteredPriceLabel from './MeteredPriceLabel'
+import ChevronDownIcon from './icons/ChevronDownIcon'
+
+interface MeteredChargesDetailsProps {
+  checkout: schemas['CheckoutPublic']
+  locale?: AcceptedLocale
+}
+
+const MeteredChargesDetails = ({
+  checkout,
+  locale = DEFAULT_LOCALE,
+}: MeteredChargesDetailsProps) => {
+  const t = useTranslations(locale)
+  const [expanded, setExpanded] = useState(false)
+
+  const { product, prices, currency } = checkout
+  const meteredPrices = useMemo(
+    () =>
+      product && prices ? getMeteredPrices(prices[product.id], currency) : [],
+    [product, prices, currency],
+  )
+
+  const includedUnitsByMeter = useMemo(() => {
+    const included = new Map<string, number>()
+    for (const benefit of product?.benefits ?? []) {
+      if (benefit.type === 'meter_credit' && 'properties' in benefit) {
+        const { meter_id, units } = benefit.properties
+        included.set(meter_id, (included.get(meter_id) ?? 0) + units)
+      }
+    }
+    return included
+  }, [product])
+
+  const numberFormat = useMemo(() => new Intl.NumberFormat(locale), [locale])
+
+  if (meteredPrices.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="dark:border-polar-700 mt-2 flex flex-col gap-y-2 border-t border-gray-200 pt-4">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+        className="dark:text-polar-500 flex cursor-pointer flex-row items-center justify-between gap-x-8 text-gray-500"
+      >
+        <span>{t('checkout.pricing.meteredChargesMayApply')}</span>
+        <ChevronDownIcon
+          className={cn(
+            'h-4 w-4 transition-transform',
+            expanded && 'rotate-180',
+          )}
+        />
+      </button>
+      {expanded &&
+        meteredPrices.map((meteredPrice) => {
+          const includedUnits = includedUnitsByMeter.get(meteredPrice.meter.id)
+          return (
+            <DetailRow
+              key={meteredPrice.id}
+              title={meteredPrice.meter.name}
+              subtitle={
+                includedUnits
+                  ? t('checkout.pricing.meteredIncludedThen', {
+                      units: numberFormat.format(includedUnits),
+                    })
+                  : undefined
+              }
+              className="text-gray-600"
+            >
+              <MeteredPriceLabel
+                price={meteredPrice}
+                locale={locale}
+                discount={checkout.discount}
+              />
+            </DetailRow>
+          )
+        })}
+    </div>
+  )
+}
+
+export default MeteredChargesDetails

--- a/clients/packages/checkout/src/components/MeteredChargesDetails.tsx
+++ b/clients/packages/checkout/src/components/MeteredChargesDetails.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_LOCALE,
   useTranslations,
   type AcceptedLocale,
+  type TranslateFn,
 } from '@polar-sh/i18n'
 import { cn } from '@polar-sh/ui/lib/utils'
 import { useId, useState } from 'react'
@@ -29,11 +30,14 @@ const getIncludedUnitsByMeter = (
 
 const getUnitNoun = (
   meter: schemas['ProductPriceMeteredUnit']['meter'],
+  t: TranslateFn,
 ): string => {
-  if (meter.unit === 'custom') {
-    return meter.custom_label ?? 'units'
+  if (meter.unit === 'custom' && meter.custom_label) {
+    return meter.custom_label
   }
-  return meter.unit === 'token' ? 'tokens' : 'units'
+  return meter.unit === 'token'
+    ? t('checkout.pricing.meterUnits.token')
+    : t('checkout.pricing.meterUnits.scalar')
 }
 
 interface MeteredChargesDetailsProps {
@@ -92,7 +96,7 @@ const MeteredChargesDetails = ({
                 subtitle={
                   includedUnits
                     ? t('checkout.pricing.meteredIncluded', {
-                        units: `${numberFormat.format(includedUnits)} ${getUnitNoun(meteredPrice.meter)}`,
+                        units: `${numberFormat.format(includedUnits)} ${getUnitNoun(meteredPrice.meter, t)}`,
                       })
                     : undefined
                 }

--- a/clients/packages/checkout/src/components/MeteredChargesDetails.tsx
+++ b/clients/packages/checkout/src/components/MeteredChargesDetails.tsx
@@ -7,11 +7,34 @@ import {
   type AcceptedLocale,
 } from '@polar-sh/i18n'
 import { cn } from '@polar-sh/ui/lib/utils'
-import { useMemo, useState } from 'react'
+import { useId, useState } from 'react'
+import { hasProductCheckout } from '../guards'
 import { getMeteredPrices } from '../utils/product'
 import DetailRow from './DetailRow'
 import MeteredPriceLabel from './MeteredPriceLabel'
 import ChevronDownIcon from './icons/ChevronDownIcon'
+
+const getIncludedUnitsByMeter = (
+  benefits: schemas['CheckoutProduct']['benefits'],
+): Map<string, number> => {
+  const included = new Map<string, number>()
+  for (const benefit of benefits) {
+    if (benefit.type === 'meter_credit') {
+      const { meter_id, units } = benefit.properties
+      included.set(meter_id, (included.get(meter_id) ?? 0) + units)
+    }
+  }
+  return included
+}
+
+const getUnitNoun = (
+  meter: schemas['ProductPriceMeteredUnit']['meter'],
+): string => {
+  if (meter.unit === 'custom') {
+    return meter.custom_label ?? 'units'
+  }
+  return meter.unit === 'token' ? 'tokens' : 'units'
+}
 
 interface MeteredChargesDetailsProps {
   checkout: schemas['CheckoutPublic']
@@ -24,71 +47,67 @@ const MeteredChargesDetails = ({
 }: MeteredChargesDetailsProps) => {
   const t = useTranslations(locale)
   const [expanded, setExpanded] = useState(false)
+  const rowsId = useId()
+
+  if (!hasProductCheckout(checkout)) {
+    return null
+  }
 
   const { product, prices, currency } = checkout
-  const meteredPrices = useMemo(
-    () =>
-      product && prices ? getMeteredPrices(prices[product.id], currency) : [],
-    [product, prices, currency],
-  )
-
-  const includedUnitsByMeter = useMemo(() => {
-    const included = new Map<string, number>()
-    for (const benefit of product?.benefits ?? []) {
-      if (benefit.type === 'meter_credit' && 'properties' in benefit) {
-        const { meter_id, units } = benefit.properties
-        included.set(meter_id, (included.get(meter_id) ?? 0) + units)
-      }
-    }
-    return included
-  }, [product])
-
-  const numberFormat = useMemo(() => new Intl.NumberFormat(locale), [locale])
-
+  const meteredPrices = getMeteredPrices(prices[product.id] ?? [], currency)
   if (meteredPrices.length === 0) {
     return null
   }
+
+  const includedUnitsByMeter = getIncludedUnitsByMeter(product.benefits)
+  const numberFormat = new Intl.NumberFormat(locale)
 
   return (
     <div className="dark:border-polar-700 mt-2 flex flex-col gap-y-2 border-t border-gray-200 pt-4">
       <button
         type="button"
         aria-expanded={expanded}
+        aria-controls={rowsId}
         onClick={() => setExpanded((value) => !value)}
         className="dark:text-polar-500 flex cursor-pointer flex-row items-center justify-between gap-x-8 text-gray-500"
       >
         <span>{t('checkout.pricing.meteredChargesMayApply')}</span>
         <ChevronDownIcon
           className={cn(
-            'h-4 w-4 transition-transform',
+            'h-4 w-4 shrink-0 transition-transform',
             expanded && 'rotate-180',
           )}
         />
       </button>
-      {expanded &&
-        meteredPrices.map((meteredPrice) => {
-          const includedUnits = includedUnitsByMeter.get(meteredPrice.meter.id)
-          return (
-            <DetailRow
-              key={meteredPrice.id}
-              title={meteredPrice.meter.name}
-              subtitle={
-                includedUnits
-                  ? t('checkout.pricing.meteredIncludedThen', {
-                      units: numberFormat.format(includedUnits),
-                    })
-                  : undefined
-              }
-              className="text-gray-600"
-            >
-              <MeteredPriceLabel
-                price={meteredPrice}
-                locale={locale}
-                discount={checkout.discount}
-              />
-            </DetailRow>
-          )
-        })}
+      {expanded && (
+        <div id={rowsId} className="flex flex-col gap-y-2">
+          {meteredPrices.map((meteredPrice) => {
+            const includedUnits = includedUnitsByMeter.get(
+              meteredPrice.meter.id,
+            )
+            return (
+              <DetailRow
+                key={meteredPrice.id}
+                title={meteredPrice.meter.name}
+                subtitle={
+                  includedUnits
+                    ? t('checkout.pricing.meteredIncluded', {
+                        units: `${numberFormat.format(includedUnits)} ${getUnitNoun(meteredPrice.meter)}`,
+                      })
+                    : undefined
+                }
+                emphasis
+              >
+                <MeteredPriceLabel
+                  price={meteredPrice}
+                  locale={locale}
+                  discount={checkout.discount}
+                />
+              </DetailRow>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/clients/packages/checkout/src/components/icons/ChevronDownIcon.tsx
+++ b/clients/packages/checkout/src/components/icons/ChevronDownIcon.tsx
@@ -10,6 +10,8 @@ const ChevronDownIcon = ({ className }: { className?: string }) => {
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
       className={className}
     >
       <path d="m6 9 6 6 6-6" />

--- a/clients/packages/checkout/src/components/icons/ChevronDownIcon.tsx
+++ b/clients/packages/checkout/src/components/icons/ChevronDownIcon.tsx
@@ -1,0 +1,20 @@
+const ChevronDownIcon = ({ className }: { className?: string }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  )
+}
+
+export default ChevronDownIcon

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -11541,8 +11541,9 @@ export interface components {
     }
     /**
      * BenefitMeterCreditPublic
-     * @description A public benefit of type `meter_credit`, exposing the number of units
-     *     granted so storefronts and checkouts can show included usage.
+     * @description A benefit of type `meter_credit`.
+     *
+     *     Grants a number of units on a specific meter.
      */
     BenefitMeterCreditPublic: {
       /**
@@ -11563,8 +11564,8 @@ export interface components {
        */
       modified_at: string | null
       /**
-       * Type
-       * @constant
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
        */
       type: 'meter_credit'
       /**
@@ -11593,7 +11594,20 @@ export interface components {
        * @description The ID of the organization owning the benefit.
        */
       organization_id: string
-      properties: components['schemas']['BenefitMeterCreditSubscriberProperties']
+      properties: components['schemas']['BenefitMeterCreditPublicProperties']
+    }
+    /**
+     * BenefitMeterCreditPublicProperties
+     * @description Properties for a benefit of type `meter_credit`.
+     */
+    BenefitMeterCreditPublicProperties: {
+      /** Units */
+      units: number
+      /**
+       * Meter Id
+       * Format: uuid4
+       */
+      meter_id: string
     }
     /** BenefitMeterCreditSubscriber */
     BenefitMeterCreditSubscriber: {
@@ -11720,8 +11734,18 @@ export interface components {
        * @description Last modification timestamp of the object.
        */
       modified_at: string | null
-      /** @description The type of the benefit. */
-      type: components['schemas']['BenefitType']
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type:
+        | 'custom'
+        | 'discord'
+        | 'downloadables'
+        | 'feature_flag'
+        | 'github_repository'
+        | 'license_keys'
+        | 'slack_shared_channel'
       /**
        * Description
        * @description The description of the benefit.
@@ -13513,7 +13537,7 @@ export interface components {
         | components['schemas']['ProductPrice']
       )[]
       /**
-       * BenefitPublic
+       * Benefits
        * @description List of benefits granted by the product.
        */
       benefits: components['schemas']['BenefitPublic'][]
@@ -13899,7 +13923,7 @@ export interface components {
         | components['schemas']['ProductPrice']
       )[]
       /**
-       * BenefitPublic
+       * Benefits
        * @description List of benefits granted by the product.
        */
       benefits: components['schemas']['BenefitPublic'][]
@@ -17797,7 +17821,7 @@ export interface components {
         | components['schemas']['ProductPrice']
       )[]
       /**
-       * BenefitPublic
+       * Benefits
        * @description List of benefits granted by the product.
        */
       benefits: components['schemas']['BenefitPublic'][]
@@ -18463,7 +18487,7 @@ export interface components {
         | components['schemas']['ProductPrice']
       )[]
       /**
-       * BenefitPublic
+       * Benefits
        * @description List of benefits granted by the product.
        */
       benefits: components['schemas']['BenefitPublic'][]
@@ -19734,7 +19758,7 @@ export interface components {
         | components['schemas']['ProductPrice']
       )[]
       /**
-       * BenefitPublic
+       * Benefits
        * @description List of benefits granted by the product.
        */
       benefits: components['schemas']['BenefitPublic'][]
@@ -67350,6 +67374,20 @@ export const benefitMeterCreditTypeValues: ReadonlyArray<
 export const benefitMeterCreditCreateTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitMeterCreditCreate']['type']
 > = ['meter_credit']
+export const benefitMeterCreditPublicTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['BenefitMeterCreditPublic']['type']
+> = ['meter_credit']
+export const benefitPublicGenericTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['BenefitPublicGeneric']['type']
+> = [
+  'custom',
+  'discord',
+  'downloadables',
+  'feature_flag',
+  'github_repository',
+  'license_keys',
+  'slack_shared_channel',
+]
 export const benefitRevokedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitRevokedEvent']['name']
 > = ['benefit.revoked']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -11539,6 +11539,62 @@ export interface components {
        */
       meter_id: string
     }
+    /**
+     * BenefitMeterCreditPublic
+     * @description A public benefit of type `meter_credit`, exposing the number of units
+     *     granted so storefronts and checkouts can show included usage.
+     */
+    BenefitMeterCreditPublic: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the benefit.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Type
+       * @constant
+       */
+      type: 'meter_credit'
+      /**
+       * Description
+       * @description The description of the benefit.
+       */
+      description: string
+      /**
+       * Selectable
+       * @description Whether the benefit is selectable when creating a product.
+       */
+      selectable: boolean
+      /**
+       * Deletable
+       * @description Whether the benefit is deletable.
+       */
+      deletable: boolean
+      /**
+       * Is Deleted
+       * @description Whether the benefit is deleted.
+       */
+      is_deleted: boolean
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the benefit.
+       */
+      organization_id: string
+      properties: components['schemas']['BenefitMeterCreditSubscriberProperties']
+    }
     /** BenefitMeterCreditSubscriber */
     BenefitMeterCreditSubscriber: {
       /**
@@ -11642,8 +11698,11 @@ export interface components {
         | components['schemas']['BenefitMeterCreditCreateProperties']
         | null
     }
-    /** BenefitPublic */
-    BenefitPublic: {
+    BenefitPublic:
+      | components['schemas']['BenefitMeterCreditPublic']
+      | components['schemas']['BenefitPublicGeneric']
+    /** BenefitPublicGeneric */
+    BenefitPublicGeneric: {
       /**
        * Id
        * Format: uuid4

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -187,7 +187,9 @@
     "checkout.pricing.units.range": "{min} - {max} {unitLabelPlural}",
     "checkout.pricing.units.minimum": "Minimum {min} {unitLabelPlural}",
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -374,7 +376,9 @@
     "checkout.pricing.units.numberOfUnits": "Number of {unitLabelPlural}",
     "checkout.pricing.units.count.=1": "# {unitLabel}",
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -561,7 +565,9 @@
     "checkout.pricing.units.numberOfUnits": "Number of {unitLabelPlural}",
     "checkout.pricing.units.count.=1": "# {unitLabel}",
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -751,7 +757,9 @@
     "checkout.pricing.units.range": "{min} - {max} {unitLabelPlural}",
     "checkout.pricing.units.minimum": "Minimum {min} {unitLabelPlural}",
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -941,7 +949,9 @@
     "checkout.pricing.units.range": "{min} - {max} {unitLabelPlural}",
     "checkout.pricing.units.minimum": "Minimum {min} {unitLabelPlural}",
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1120,7 +1130,9 @@
     "checkout.pricing.units.numberOfUnits": "Number of {unitLabelPlural}",
     "checkout.pricing.units.count.=1": "# {unitLabel}",
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1302,7 +1314,9 @@
     "checkout.pricing.units.range": "{min} - {max} {unitLabelPlural}",
     "checkout.pricing.units.minimum": "Minimum {min} {unitLabelPlural}",
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1481,7 +1495,9 @@
     "checkout.pricing.units.numberOfUnits": "Number of {unitLabelPlural}",
     "checkout.pricing.units.count.=1": "# {unitLabel}",
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1660,7 +1676,9 @@
     "checkout.pricing.units.numberOfUnits": "Number of {unitLabelPlural}",
     "checkout.pricing.units.count.=1": "# {unitLabel}",
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1839,7 +1857,9 @@
     "checkout.pricing.units.numberOfUnits": "Number of {unitLabelPlural}",
     "checkout.pricing.units.count.=1": "# {unitLabel}",
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2021,7 +2041,9 @@
     "checkout.pricing.units.range": "{min} - {max} {unitLabelPlural}",
     "checkout.pricing.units.minimum": "Minimum {min} {unitLabelPlural}",
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "tr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2203,7 +2225,9 @@
     "checkout.pricing.units.range": "{min} - {max} {unitLabelPlural}",
     "checkout.pricing.units.minimum": "Minimum {min} {unitLabelPlural}",
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   },
   "pl": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2385,6 +2409,8 @@
     "checkout.pricing.units.range": "{min} - {max} {unitLabelPlural}",
     "checkout.pricing.units.minimum": "Minimum {min} {unitLabelPlural}",
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
-    "checkout.pricing.units.updateFailed": "Failed to update units"
+    "checkout.pricing.units.updateFailed": "Failed to update units",
+    "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
+    "checkout.pricing.meteredIncludedThen": "{units} included, then"
   }
 }

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -189,7 +189,7 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -378,7 +378,7 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -567,7 +567,7 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -759,7 +759,7 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -951,7 +951,7 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1132,7 +1132,7 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1316,7 +1316,7 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1497,7 +1497,7 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1678,7 +1678,7 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1859,7 +1859,7 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2043,7 +2043,7 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "tr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2227,7 +2227,7 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   },
   "pl": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2411,6 +2411,6 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncludedThen": "{units} included, then"
+    "checkout.pricing.meteredIncluded": "{units} included"
   }
 }

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -189,7 +189,9 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -378,7 +380,9 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -567,7 +571,9 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -759,7 +765,9 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -951,7 +959,9 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1132,7 +1142,9 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1316,7 +1328,9 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1497,7 +1511,9 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1678,7 +1694,9 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1859,7 +1877,9 @@
     "checkout.pricing.units.count.other": "# {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2043,7 +2063,9 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "tr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2227,7 +2249,9 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   },
   "pl": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2411,6 +2435,8 @@
     "checkout.pricing.units.maximum": "Maximum {max} {unitLabelPlural}",
     "checkout.pricing.units.updateFailed": "Failed to update units",
     "checkout.pricing.meteredChargesMayApply": "Additional metered charges may apply",
-    "checkout.pricing.meteredIncluded": "{units} included"
+    "checkout.pricing.meteredIncluded": "{units} included",
+    "checkout.pricing.meterUnits.token": "tokens",
+    "checkout.pricing.meterUnits.scalar": "units"
   }
 }

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -108,6 +108,10 @@ export default {
       meteredChargesMayApply:
         'Zusätzliche nutzungsabhängige Gebühren können anfallen',
       meteredIncluded: '{units} inklusive',
+      meterUnits: {
+        token: 'Tokens',
+        scalar: 'Einheiten',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -107,7 +107,7 @@ export default {
       },
       meteredChargesMayApply:
         'Zusätzliche nutzungsabhängige Gebühren können anfallen',
-      meteredIncludedThen: '{units} inklusive, danach',
+      meteredIncluded: '{units} inklusive',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -105,6 +105,9 @@ export default {
         },
         updateFailed: 'Einheiten konnten nicht aktualisiert werden',
       },
+      meteredChargesMayApply:
+        'Zusätzliche nutzungsabhängige Gebühren können anfallen',
+      meteredIncludedThen: '{units} inklusive, danach',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -104,6 +104,18 @@ export default {
         _llmContext:
           'Shown next to a metered price when the product grants included usage credits. {units} is a pre-formatted quantity phrase including the unit noun, e.g. "10,000 tokens", so the sentence reads "10,000 tokens included". The per-unit overage rate is displayed separately on the same row.',
       },
+      meterUnits: {
+        token: {
+          value: 'tokens',
+          _llmContext:
+            'Plural noun for AI/LLM tokens, used in quantity phrases like "10,000 tokens included".',
+        },
+        scalar: {
+          value: 'units',
+          _llmContext:
+            'Generic plural noun for metered usage units, used in quantity phrases like "10,000 units included".',
+        },
+      },
       perSeat: 'per seat',
       basePrice: {
         value: 'Base price',

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -99,10 +99,10 @@ export default {
         _llmContext:
           'Collapsed toggle label in the checkout pricing breakdown; clicking it reveals the list of usage-based (metered) prices.',
       },
-      meteredIncludedThen: {
-        value: '{units} included, then',
+      meteredIncluded: {
+        value: '{units} included',
         _llmContext:
-          'Shown next to a metered price when the product grants included usage credits, e.g. "10,000 included, then" followed by the per-unit rate. {units} is a formatted number.',
+          'Shown next to a metered price when the product grants included usage credits. {units} is a pre-formatted quantity phrase including the unit noun, e.g. "10,000 tokens", so the sentence reads "10,000 tokens included". The per-unit overage rate is displayed separately on the same row.',
       },
       perSeat: 'per seat',
       basePrice: {

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -94,6 +94,16 @@ export default {
         },
       },
       additionalMeteredUsage: 'Additional metered usage',
+      meteredChargesMayApply: {
+        value: 'Additional metered charges may apply',
+        _llmContext:
+          'Collapsed toggle label in the checkout pricing breakdown; clicking it reveals the list of usage-based (metered) prices.',
+      },
+      meteredIncludedThen: {
+        value: '{units} included, then',
+        _llmContext:
+          'Shown next to a metered price when the product grants included usage credits, e.g. "10,000 included, then" followed by the per-unit rate. {units} is a formatted number.',
+      },
       perSeat: 'per seat',
       basePrice: {
         value: 'Base price',

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -106,7 +106,7 @@ export default {
         updateFailed: 'No se pudieron actualizar las unidades',
       },
       meteredChargesMayApply: 'Pueden aplicarse cargos adicionales por uso',
-      meteredIncludedThen: '{units} incluidos, luego',
+      meteredIncluded: '{units} incluidos',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -105,6 +105,8 @@ export default {
         },
         updateFailed: 'No se pudieron actualizar las unidades',
       },
+      meteredChargesMayApply: 'Pueden aplicarse cargos adicionales por uso',
+      meteredIncludedThen: '{units} incluidos, luego',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -107,6 +107,10 @@ export default {
       },
       meteredChargesMayApply: 'Pueden aplicarse cargos adicionales por uso',
       meteredIncluded: '{units} incluidos',
+      meterUnits: {
+        token: 'tokens',
+        scalar: 'unidades',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -107,7 +107,7 @@ export default {
       },
       meteredChargesMayApply:
         'Des frais supplémentaires au compteur peuvent s’appliquer',
-      meteredIncludedThen: '{units} inclus, puis',
+      meteredIncluded: '{units} inclus',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -105,6 +105,9 @@ export default {
         },
         updateFailed: 'Impossible de mettre à jour les unités',
       },
+      meteredChargesMayApply:
+        'Des frais supplémentaires au compteur peuvent s’appliquer',
+      meteredIncludedThen: '{units} inclus, puis',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -108,6 +108,10 @@ export default {
       meteredChargesMayApply:
         'Des frais supplémentaires au compteur peuvent s’appliquer',
       meteredIncluded: '{units} inclus',
+      meterUnits: {
+        token: 'jetons',
+        scalar: 'unités',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -107,6 +107,10 @@ export default {
       },
       meteredChargesMayApply: 'További használatalapú díjak merülhetnek fel',
       meteredIncluded: 'tartalmazza: {units}',
+      meterUnits: {
+        token: 'tokenek',
+        scalar: 'egységek',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -105,6 +105,8 @@ export default {
         },
         updateFailed: 'Nem sikerült frissíteni az egységeket',
       },
+      meteredChargesMayApply: 'További használatalapú díjak merülhetnek fel',
+      meteredIncludedThen: '{units} benne van, utána',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -106,7 +106,7 @@ export default {
         updateFailed: 'Nem sikerült frissíteni az egységeket',
       },
       meteredChargesMayApply: 'További használatalapú díjak merülhetnek fel',
-      meteredIncludedThen: '{units} benne van, utána',
+      meteredIncluded: 'tartalmazza: {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -108,6 +108,10 @@ export default {
       meteredChargesMayApply:
         'Potrebbero essere applicati costi aggiuntivi a consumo',
       meteredIncluded: 'Inclusi {units}',
+      meterUnits: {
+        token: 'token',
+        scalar: 'unità',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -107,7 +107,7 @@ export default {
       },
       meteredChargesMayApply:
         'Potrebbero essere applicati costi aggiuntivi a consumo',
-      meteredIncludedThen: '{units} inclusi, poi',
+      meteredIncluded: 'Inclusi {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -105,6 +105,9 @@ export default {
         },
         updateFailed: 'Impossibile aggiornare le unità',
       },
+      meteredChargesMayApply:
+        'Potrebbero essere applicati costi aggiuntivi a consumo',
+      meteredIncludedThen: '{units} inclusi, poi',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -106,7 +106,7 @@ export default {
         updateFailed: '数量の更新に失敗しました',
       },
       meteredChargesMayApply: '追加の従量課金が発生する場合があります',
-      meteredIncludedThen: '{units}まで含まれ、その後',
+      meteredIncluded: '{units}分込み',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -105,6 +105,8 @@ export default {
         },
         updateFailed: '数量の更新に失敗しました',
       },
+      meteredChargesMayApply: '追加の従量課金が発生する場合があります',
+      meteredIncludedThen: '{units}まで含まれ、その後',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -107,6 +107,10 @@ export default {
       },
       meteredChargesMayApply: '追加の従量課金が発生する場合があります',
       meteredIncluded: '{units}分込み',
+      meterUnits: {
+        token: 'トークン',
+        scalar: '単位',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -107,6 +107,10 @@ export default {
       },
       meteredChargesMayApply: '추가 사용량 요금이 부과될 수 있습니다',
       meteredIncluded: '{units} 포함',
+      meterUnits: {
+        token: '토큰',
+        scalar: '단위',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -106,7 +106,7 @@ export default {
         updateFailed: '유닛을 업데이트하지 못했습니다',
       },
       meteredChargesMayApply: '추가 사용량 요금이 부과될 수 있습니다',
-      meteredIncludedThen: '{units} 포함, 이후',
+      meteredIncluded: '{units} 포함',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -105,6 +105,8 @@ export default {
         },
         updateFailed: '유닛을 업데이트하지 못했습니다',
       },
+      meteredChargesMayApply: '추가 사용량 요금이 부과될 수 있습니다',
+      meteredIncludedThen: '{units} 포함, 이후',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -108,6 +108,10 @@ export default {
       meteredChargesMayApply:
         'Er kunnen extra kosten op basis van verbruik van toepassing zijn',
       meteredIncluded: 'Inclusief {units}',
+      meterUnits: {
+        token: 'tokens',
+        scalar: 'eenheden',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -107,7 +107,7 @@ export default {
       },
       meteredChargesMayApply:
         'Er kunnen extra kosten op basis van verbruik van toepassing zijn',
-      meteredIncludedThen: '{units} inbegrepen, daarna',
+      meteredIncluded: 'Inclusief {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -105,6 +105,9 @@ export default {
         },
         updateFailed: 'Eenheden bijwerken mislukt',
       },
+      meteredChargesMayApply:
+        'Er kunnen extra kosten op basis van verbruik van toepassing zijn',
+      meteredIncludedThen: '{units} inbegrepen, daarna',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pl.ts
+++ b/clients/packages/i18n/src/locales/pl.ts
@@ -107,7 +107,7 @@ export default {
       },
       meteredChargesMayApply:
         'Mogą obowiązywać dodatkowe opłaty naliczane według zużycia',
-      meteredIncludedThen: '{units} w cenie, potem',
+      meteredIncluded: 'w tym {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pl.ts
+++ b/clients/packages/i18n/src/locales/pl.ts
@@ -105,6 +105,9 @@ export default {
         },
         updateFailed: 'Nie udało się zaktualizować liczby jednostek',
       },
+      meteredChargesMayApply:
+        'Mogą obowiązywać dodatkowe opłaty naliczane według zużycia',
+      meteredIncludedThen: '{units} w cenie, potem',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pl.ts
+++ b/clients/packages/i18n/src/locales/pl.ts
@@ -108,6 +108,10 @@ export default {
       meteredChargesMayApply:
         'Mogą obowiązywać dodatkowe opłaty naliczane według zużycia',
       meteredIncluded: 'w tym {units}',
+      meterUnits: {
+        token: 'tokeny',
+        scalar: 'jednostki',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -108,6 +108,10 @@ export default {
       meteredChargesMayApply:
         'Podem aplicar-se custos adicionais por utilização',
       meteredIncluded: '{units} incluídos',
+      meterUnits: {
+        token: 'tokens',
+        scalar: 'unidades',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -105,6 +105,9 @@ export default {
         },
         updateFailed: 'Não foi possível atualizar as unidades',
       },
+      meteredChargesMayApply:
+        'Podem aplicar-se custos adicionais por utilização',
+      meteredIncludedThen: '{units} incluídas, depois',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -107,7 +107,7 @@ export default {
       },
       meteredChargesMayApply:
         'Podem aplicar-se custos adicionais por utilização',
-      meteredIncludedThen: '{units} incluídas, depois',
+      meteredIncluded: '{units} incluídos',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -105,6 +105,9 @@ export default {
         },
         updateFailed: 'Falha ao atualizar as unidades',
       },
+      meteredChargesMayApply:
+        'Cobranças adicionais por uso podem ser aplicadas',
+      meteredIncludedThen: '{units} incluídos, depois',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -107,7 +107,7 @@ export default {
       },
       meteredChargesMayApply:
         'Cobranças adicionais por uso podem ser aplicadas',
-      meteredIncludedThen: '{units} incluídos, depois',
+      meteredIncluded: '{units} incluídos',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -108,6 +108,10 @@ export default {
       meteredChargesMayApply:
         'Cobranças adicionais por uso podem ser aplicadas',
       meteredIncluded: '{units} incluídos',
+      meterUnits: {
+        token: 'tokens',
+        scalar: 'unidades',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -107,6 +107,10 @@ export default {
       },
       meteredChargesMayApply: 'Ytterligare rörliga avgifter kan tillkomma',
       meteredIncluded: '{units} ingår',
+      meterUnits: {
+        token: 'tokens',
+        scalar: 'enheter',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -105,6 +105,8 @@ export default {
         },
         updateFailed: 'Det gick inte att uppdatera antalet',
       },
+      meteredChargesMayApply: 'Ytterligare rörliga avgifter kan tillkomma',
+      meteredIncludedThen: '{units} ingår, därefter',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -106,7 +106,7 @@ export default {
         updateFailed: 'Det gick inte att uppdatera antalet',
       },
       meteredChargesMayApply: 'Ytterligare rörliga avgifter kan tillkomma',
-      meteredIncludedThen: '{units} ingår, därefter',
+      meteredIncluded: '{units} ingår',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/tr.ts
+++ b/clients/packages/i18n/src/locales/tr.ts
@@ -105,6 +105,8 @@ export default {
         },
         updateFailed: 'Üniteler güncellenemedi',
       },
+      meteredChargesMayApply: 'Ek kullanım ücreti uygulanabilir',
+      meteredIncludedThen: '{units} dahil, sonra',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/tr.ts
+++ b/clients/packages/i18n/src/locales/tr.ts
@@ -107,6 +107,10 @@ export default {
       },
       meteredChargesMayApply: 'Ek kullanım ücreti uygulanabilir',
       meteredIncluded: '{units} dahil',
+      meterUnits: {
+        token: 'tokenlar',
+        scalar: 'birimler',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/tr.ts
+++ b/clients/packages/i18n/src/locales/tr.ts
@@ -106,7 +106,7 @@ export default {
         updateFailed: 'Üniteler güncellenemedi',
       },
       meteredChargesMayApply: 'Ek kullanım ücreti uygulanabilir',
-      meteredIncludedThen: '{units} dahil, sonra',
+      meteredIncluded: '{units} dahil',
     },
     trial: {
       hero: {

--- a/server/polar/benefit/schemas.py
+++ b/server/polar/benefit/schemas.py
@@ -1,6 +1,6 @@
-from typing import Annotated
+from typing import Annotated, Any
 
-from pydantic import UUID4, Discriminator
+from pydantic import UUID4, Discriminator, Tag
 
 from polar.benefit.strategies.custom.properties import BenefitGrantCustomProperties
 from polar.benefit.strategies.discord.properties import BenefitGrantDiscordProperties
@@ -66,6 +66,7 @@ from .strategies.license_keys.schemas import (
 from .strategies.meter_credit.schemas import (
     BenefitMeterCredit,
     BenefitMeterCreditCreate,
+    BenefitMeterCreditPublic,
     BenefitMeterCreditUpdate,
 )
 from .strategies.slack_shared_channel.schemas import (
@@ -209,4 +210,21 @@ BenefitGrantWebhook = Annotated[
 
 
 # Properties that are public (when embedding products benefits in storefront and checkout)
-class BenefitPublic(BenefitPublicBase): ...
+class BenefitPublicGeneric(BenefitPublicBase): ...
+
+
+def _benefit_public_discriminator(value: Any) -> str:
+    type_value = (
+        value.get("type") if isinstance(value, dict) else getattr(value, "type", None)
+    )
+    return "meter_credit" if type_value == BenefitType.meter_credit else "generic"
+
+
+BenefitPublic = Annotated[
+    Annotated[BenefitMeterCreditPublic, Tag("meter_credit")]
+    | Annotated[BenefitPublicGeneric, Tag("generic")],
+    Discriminator(_benefit_public_discriminator),
+    SetSchemaReference("BenefitPublic"),
+    MergeJSONSchema({"title": "BenefitPublic"}),
+    ClassName("BenefitPublic"),
+]

--- a/server/polar/benefit/schemas.py
+++ b/server/polar/benefit/schemas.py
@@ -1,6 +1,6 @@
-from typing import Annotated, Any
+from typing import Annotated, Literal
 
-from pydantic import UUID4, Discriminator, Tag
+from pydantic import UUID4, Discriminator
 
 from polar.benefit.strategies.custom.properties import BenefitGrantCustomProperties
 from polar.benefit.strategies.discord.properties import BenefitGrantDiscordProperties
@@ -210,20 +210,21 @@ BenefitGrantWebhook = Annotated[
 
 
 # Properties that are public (when embedding products benefits in storefront and checkout)
-class BenefitPublicGeneric(BenefitPublicBase): ...
-
-
-def _benefit_public_discriminator(value: Any) -> str:
-    type_value = (
-        value.get("type") if isinstance(value, dict) else getattr(value, "type", None)
-    )
-    return "meter_credit" if type_value == BenefitType.meter_credit else "generic"
+class BenefitPublicGeneric(BenefitPublicBase):
+    type: Literal[
+        BenefitType.custom,
+        BenefitType.discord,
+        BenefitType.github_repository,
+        BenefitType.downloadables,
+        BenefitType.license_keys,
+        BenefitType.feature_flag,
+        BenefitType.slack_shared_channel,
+    ]
 
 
 BenefitPublic = Annotated[
-    Annotated[BenefitMeterCreditPublic, Tag("meter_credit")]
-    | Annotated[BenefitPublicGeneric, Tag("generic")],
-    Discriminator(_benefit_public_discriminator),
+    BenefitMeterCreditPublic | BenefitPublicGeneric,
+    Discriminator("type"),
     SetSchemaReference("BenefitPublic"),
     MergeJSONSchema({"title": "BenefitPublic"}),
     ClassName("BenefitPublic"),

--- a/server/polar/benefit/strategies/meter_credit/schemas.py
+++ b/server/polar/benefit/strategies/meter_credit/schemas.py
@@ -76,11 +76,21 @@ class BenefitMeterCreditSubscriber(BenefitSubscriberBase):
     properties: BenefitMeterCreditSubscriberProperties
 
 
+class BenefitMeterCreditPublicProperties(Schema):
+    """
+    Properties for a benefit of type `meter_credit`.
+    """
+
+    units: int
+    meter_id: UUID4
+
+
 class BenefitMeterCreditPublic(BenefitPublicBase):
     """
-    A public benefit of type `meter_credit`, exposing the number of units
-    granted so storefronts and checkouts can show included usage.
+    A benefit of type `meter_credit`.
+
+    Grants a number of units on a specific meter.
     """
 
     type: Literal[BenefitType.meter_credit]
-    properties: BenefitMeterCreditSubscriberProperties
+    properties: BenefitMeterCreditPublicProperties

--- a/server/polar/benefit/strategies/meter_credit/schemas.py
+++ b/server/polar/benefit/strategies/meter_credit/schemas.py
@@ -9,6 +9,7 @@ from polar.models.benefit import BenefitType
 from ..base.schemas import (
     BenefitBase,
     BenefitCreateBase,
+    BenefitPublicBase,
     BenefitSubscriberBase,
     BenefitUpdateBase,
     BenefitUpdateVisibilityMixin,
@@ -71,5 +72,15 @@ class BenefitMeterCredit(BenefitBase):
 
 
 class BenefitMeterCreditSubscriber(BenefitSubscriberBase):
+    type: Literal[BenefitType.meter_credit]
+    properties: BenefitMeterCreditSubscriberProperties
+
+
+class BenefitMeterCreditPublic(BenefitPublicBase):
+    """
+    A public benefit of type `meter_credit`, exposing the number of units
+    granted so storefronts and checkouts can show included usage.
+    """
+
     type: Literal[BenefitType.meter_credit]
     properties: BenefitMeterCreditSubscriberProperties

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -1074,8 +1074,5 @@ def _filter_benefit_public_list(
 BenefitPublicList = Annotated[
     list[BenefitPublic],
     BeforeValidator(_filter_benefit_public_list),
-    Field(
-        title="BenefitPublic",
-        description="List of benefits granted by the product.",
-    ),
+    Field(description="List of benefits granted by the product."),
 ]

--- a/server/tests/product/test_schemas.py
+++ b/server/tests/product/test_schemas.py
@@ -4,10 +4,13 @@ from typing import Any
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
+from polar.benefit.schemas import BenefitPublicGeneric
+from polar.benefit.strategies.meter_credit.schemas import BenefitMeterCreditPublic
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.currency import PresentmentCurrency
 from polar.kit.visibility import Visibility
-from polar.models import Organization
+from polar.models import Meter, Organization
+from polar.models.benefit import BenefitType
 from polar.models.product_price import ProductPriceAmountType
 from polar.product.meter_interval import meter_interval_divides_billing_interval
 from polar.product.schemas import (
@@ -499,6 +502,80 @@ class TestBenefitPublicList:
 
         assert len(benefits) == 1
         assert benefits[0].description == "Public benefit"
+
+    async def test_meter_credit_exposes_public_properties(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        meter: Meter,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.meter_credit,
+            properties={
+                "units": 10000,
+                "rollover": True,
+                "meter_id": str(meter.id),
+            },
+        )
+
+        adapter: TypeAdapter[BenefitPublicList] = TypeAdapter(BenefitPublicList)
+        benefits = adapter.validate_python([benefit], from_attributes=True)
+
+        assert len(benefits) == 1
+        serialized = benefits[0]
+        assert isinstance(serialized, BenefitMeterCreditPublic)
+        assert serialized.properties.units == 10000
+        assert serialized.properties.meter_id == meter.id
+        assert not hasattr(serialized.properties, "rollover")
+
+    async def test_excludes_non_public_meter_credit_benefits(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        meter: Meter,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.meter_credit,
+            properties={
+                "units": 10000,
+                "rollover": False,
+                "meter_id": str(meter.id),
+            },
+        )
+        benefit.visibility = Visibility.private
+        await save_fixture(benefit)
+
+        adapter: TypeAdapter[BenefitPublicList] = TypeAdapter(BenefitPublicList)
+        benefits = adapter.validate_python([benefit], from_attributes=True)
+
+        assert benefits == []
+
+    @pytest.mark.parametrize(
+        "benefit_type",
+        [t for t in BenefitType if t != BenefitType.meter_credit],
+    )
+    async def test_other_types_serialize_as_generic(
+        self,
+        benefit_type: BenefitType,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=benefit_type,
+        )
+
+        adapter: TypeAdapter[BenefitPublicList] = TypeAdapter(BenefitPublicList)
+        benefits = adapter.validate_python([benefit], from_attributes=True)
+
+        assert len(benefits) == 1
+        assert isinstance(benefits[0], BenefitPublicGeneric)
+        assert benefits[0].type == benefit_type
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR will make two tweaks two our checkout regarding metered pricing due to some feedback:

* Collapse metered usage details
* Show included meter credits before the rate, e.g. `10,000 included, then $0.001 /unit`

## Screenshots

| Before | After (collapsed) | After (expanded) |
|--------|--------|--------|
| <img width="1840" height="1134" alt="Screenshot 2026-08-21 at 13 10 49" src="https://github.com/user-attachments/assets/bff7e9e1-32ed-4fdc-a4c1-baca7ab780c4" /> | <img width="1840" height="1134" alt="Screenshot 2026-08-21 at 13 10 36" src="https://github.com/user-attachments/assets/c767c3c8-c875-4ac5-8cf1-37405a9abd53" /> | <img width="1840" height="1134" alt="Screenshot 2026-08-21 at 13 19 54" src="https://github.com/user-attachments/assets/c389eea7-b757-47e0-9796-f32dd9418e73" /> |









<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

