### PR TITLE
fix: prevent duplicate paid plan checkouts

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -30889,6 +30889,17 @@ export interface components {
       /** Detail */
       detail: string
     }
+    /** PolarSelfPaidSubscriptionAlreadyExists */
+    PolarSelfPaidSubscriptionAlreadyExists: {
+      /**
+       * Error
+       * @example PolarSelfPaidSubscriptionAlreadyExists
+       * @constant
+       */
+      error: 'PolarSelfPaidSubscriptionAlreadyExists'
+      /** Detail */
+      detail: string
+    }
     /** PolarSelfPaymentMethodInUse */
     PolarSelfPaymentMethodInUse: {
       /**
@@ -41252,6 +41263,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PolarSelfPaidSubscriptionAlreadyExists']
         }
       }
       /** @description Validation Error */

--- a/server/polar/integrations/polar/exceptions.py
+++ b/server/polar/integrations/polar/exceptions.py
@@ -32,6 +32,16 @@ class PolarSelfNoActiveSubscription(PolarError):
         self.organization_id = organization_id
 
 
+class PolarSelfPaidSubscriptionAlreadyExists(PolarError):
+    def __init__(self, organization_id: uuid.UUID) -> None:
+        super().__init__(
+            "This organization already has an active paid subscription. "
+            "Refresh the page to change plans.",
+            status_code=409,
+        )
+        self.organization_id = organization_id
+
+
 class PolarSelfOrderNotFound(PolarError):
     def __init__(self, order_id: str) -> None:
         super().__init__(f"Order {order_id!r} not found.", status_code=404)

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -38,7 +38,6 @@ from polar.v2026_04.outputs import (
     CustomerBenefitGrantSlackSharedChannel,
     LegacyRecurringProductPriceFixed,
     ProductPriceFixed,
-    ProductPriceSeatBased,
 )
 from polar.v2026_04.webhooks import (
     WebhookBenefitGrantCreatedPayload,
@@ -339,7 +338,10 @@ class PolarSelfService:
         existing = await client.get_active_subscription(
             external_customer_id=str(organization_id)
         )
-        if existing is not None and not self._subscription_is_free(existing):
+        if (
+            existing is not None
+            and self._product_fixed_price_amount(existing.product) != 0
+        ):
             raise PolarSelfPaidSubscriptionAlreadyExists(organization_id)
         # Auto-apply the Startup Program discount when an eligible organization
         # checks out the Scale plan.
@@ -976,18 +978,6 @@ class PolarSelfService:
             if isinstance(price, ProductPriceFixed | LegacyRecurringProductPriceFixed):
                 return price.price_amount
         return 0
-
-    def _subscription_is_free(self, subscription: "Subscription") -> bool:
-        for price in subscription.prices:
-            if isinstance(price, ProductPriceFixed | LegacyRecurringProductPriceFixed):
-                if price.price_amount != 0:
-                    return False
-            elif isinstance(price, ProductPriceSeatBased):
-                if any(tier.price_per_seat != 0 for tier in price.seat_tiers.tiers):
-                    return False
-            else:
-                return False
-        return True
 
     def _resolve_organization_id(
         self, customer: "Customer | SubscriptionCustomer"

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -38,6 +38,7 @@ from polar.v2026_04.outputs import (
     CustomerBenefitGrantSlackSharedChannel,
     LegacyRecurringProductPriceFixed,
     ProductPriceFixed,
+    ProductPriceSeatBased,
 )
 from polar.v2026_04.webhooks import (
     WebhookBenefitGrantCreatedPayload,
@@ -59,6 +60,7 @@ from .exceptions import (
     PolarSelfNotConfigured,
     PolarSelfNotPaidOrder,
     PolarSelfOrderNotFound,
+    PolarSelfPaidSubscriptionAlreadyExists,
     PolarSelfPlanNotFound,
     PolarSelfWebhookError,
     SupportBenefitError,
@@ -337,6 +339,8 @@ class PolarSelfService:
         existing = await client.get_active_subscription(
             external_customer_id=str(organization_id)
         )
+        if existing is not None and not self._subscription_is_free(existing):
+            raise PolarSelfPaidSubscriptionAlreadyExists(organization_id)
         # Auto-apply the Startup Program discount when an eligible organization
         # checks out the Scale plan.
         discount_id = await startup_program_service.resolve_checkout_discount_id(
@@ -972,6 +976,18 @@ class PolarSelfService:
             if isinstance(price, ProductPriceFixed | LegacyRecurringProductPriceFixed):
                 return price.price_amount
         return 0
+
+    def _subscription_is_free(self, subscription: "Subscription") -> bool:
+        for price in subscription.prices:
+            if isinstance(price, ProductPriceFixed | LegacyRecurringProductPriceFixed):
+                if price.price_amount != 0:
+                    return False
+            elif isinstance(price, ProductPriceSeatBased):
+                if any(tier.price_per_seat != 0 for tier in price.seat_tiers.tiers):
+                    return False
+            else:
+                return False
+        return True
 
     def _resolve_organization_id(
         self, customer: "Customer | SubscriptionCustomer"

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -29,6 +29,7 @@ from polar.exceptions import (
     ResourceNotFound,
 )
 from polar.integrations.polar.exceptions import (
+    PolarSelfPaidSubscriptionAlreadyExists,
     PolarSelfPaymentMethodInUse,
 )
 from polar.integrations.polar.schemas import (
@@ -1007,6 +1008,7 @@ async def get_subscription(
     summary="Start Subscription Checkout",
     responses={
         201: {"description": "Checkout session created."},
+        409: {"model": PolarSelfPaidSubscriptionAlreadyExists.schema()},
         404: OrganizationNotFound,
     },
     tags=[APITag.private],

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -32,6 +32,7 @@ from polar.integrations.polar.exceptions import (
     PolarSelfNotConfigured,
     PolarSelfNotPaidOrder,
     PolarSelfOrderNotFound,
+    PolarSelfPaidSubscriptionAlreadyExists,
     PolarSelfPlanNotFound,
     PolarSelfWebhookError,
     SupportBenefitError,
@@ -1349,9 +1350,11 @@ def _make_subscription(
     id: str = "sub_1",
     product_id: str = "prod_1",
     amount: int = 0,
+    price_amount: int | None = None,
     cancel_at_period_end: bool = False,
     discount_id: str | None = None,
 ) -> Subscription:
+    product = _make_product(id=product_id, price_amount=price_amount)
     return deserialize(
         {
             "created_at": "2026-01-01T00:00:00Z",
@@ -1384,9 +1387,9 @@ def _make_subscription(
             "customer_cancellation_comment": None,
             "metadata": {},
             "customer": _CUSTOMER_DICT,
-            "product": dataclasses.asdict(_make_product(id=product_id)),
+            "product": dataclasses.asdict(product),
             "discount": None,
-            "prices": [],
+            "prices": [dataclasses.asdict(price) for price in product.prices],
             "meters": [],
             "pending_update": None,
         },
@@ -1594,6 +1597,68 @@ class TestStartCheckout:
             )
 
         client_mock.create_checkout.assert_not_awaited()
+
+    @pytest.mark.parametrize("amount", [2000, 0])
+    async def test_existing_paid_subscription_rejected(
+        self,
+        amount: int,
+        configured: None,
+        client_mock: MagicMock,
+        organization_repository_mock: MagicMock,
+        read_session_mock: AsyncReadSession,
+    ) -> None:
+        client_mock.list_recurring_products.return_value = [
+            _make_product(id="prod_paid", metadata={"order": 1}),
+        ]
+        client_mock.get_active_subscription.return_value = _make_subscription(
+            id="sub_existing",
+            product_id="prod_pro",
+            amount=amount,
+            price_amount=2000,
+        )
+
+        with pytest.raises(PolarSelfPaidSubscriptionAlreadyExists) as exc_info:
+            await polar_self.start_checkout(
+                session=read_session_mock,
+                organization_id=ORG_A,
+                product_id="prod_paid",
+            )
+
+        assert exc_info.value.status_code == 409
+        client_mock.create_checkout.assert_not_awaited()
+
+    async def test_existing_free_subscription_upgraded_through_checkout(
+        self,
+        configured: None,
+        client_mock: MagicMock,
+        organization_repository_mock: MagicMock,
+        read_session_mock: AsyncReadSession,
+    ) -> None:
+        client_mock.list_recurring_products.return_value = [
+            _make_product(id="prod_paid", metadata={"order": 1}),
+        ]
+        client_mock.get_active_subscription.return_value = _make_subscription(
+            id="sub_free",
+            product_id="prod_free",
+            price_amount=0,
+        )
+
+        await polar_self.start_checkout(
+            session=read_session_mock,
+            organization_id=ORG_A,
+            product_id="prod_paid",
+        )
+
+        client_mock.create_checkout.assert_awaited_once_with(
+            product_id="prod_paid",
+            external_customer_id=str(ORG_A),
+            subscription_id="sub_free",
+            customer_ip_address=None,
+            success_url=None,
+            return_url=None,
+            embed_origin=None,
+            discount_id=None,
+        )
 
     async def test_does_not_touch_existing_discount_on_checkout(
         self,

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -1598,10 +1598,8 @@ class TestStartCheckout:
 
         client_mock.create_checkout.assert_not_awaited()
 
-    @pytest.mark.parametrize("amount", [2000, 0])
     async def test_existing_paid_subscription_rejected(
         self,
-        amount: int,
         configured: None,
         client_mock: MagicMock,
         organization_repository_mock: MagicMock,
@@ -1613,7 +1611,7 @@ class TestStartCheckout:
         client_mock.get_active_subscription.return_value = _make_subscription(
             id="sub_existing",
             product_id="prod_pro",
-            amount=amount,
+            amount=2000,
             price_amount=2000,
         )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Related Issue**: [SERVER-4YB](https://polar-sh.sentry.io/issues/SERVER-4YB)

Prevents stale billing UI from starting a second checkout after an organization has already completed a paid plan checkout.

## What

- Detect an existing paid self-billing subscription before calling the Polar checkout API.
- Return a typed `409 Conflict` that asks the user to refresh and change plans.
- Keep existing free-subscription upgrades routed through checkout.
- Add regression coverage for the stale paid-subscription state and the valid free-subscription path.
- Regenerate the internal TypeScript client for the typed conflict response.

## Why

A checkout completed and created a paid Pro subscription, then a stale dashboard request attempted another checkout seven seconds later. The downstream checkout API rejected the paid subscription with a 422, which the self-client surfaced as a 500 and triggered Sentry.

## Verification

- `POLAR_ENV=testing uv run python -m pytest tests/integrations/polar/test_service.py -q` — 149 passed
- `POLAR_ENV=testing uv run python -m pytest tests/integrations/polar/test_service.py::TestStartCheckout -q` — 9 passed
- `uv run task lint` — passed
- `uv run task lint_types` — passed, 1,710 source files
- `pnpm run generate` in `clients/packages/client` — generated and built successfully

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

Fixes SERVER-4YB
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a54e57f1-4c17-43b5-a254-7ad5d56a5edf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a54e57f1-4c17-43b5-a254-7ad5d56a5edf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

