### PR TITLE
preview envs: Tidy up and fix common issues

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -28,7 +28,11 @@ permissions:
 jobs:
   preview:
     name: "Preview: ${{ (github.event_name == 'pull_request_target' && 'Destroy') || (github.event_name == 'pull_request' && 'Deploy') || github.event.inputs.action }}"
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Dependabot PRs read the Dependabot secret store, so preview secrets are empty.
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     outputs:
       preview_url: ${{ steps.deploy.outputs.preview_url }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -271,7 +271,8 @@ jobs:
     needs: preview
     if: |
       github.event_name == 'pull_request' &&
-      needs.preview.result == 'success'
+      needs.preview.result == 'success' &&
+      needs.preview.outputs.preview_url != ''
     runs-on: ubuntu-latest
     steps:
       - name: Find existing preview comment

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,10 +30,9 @@ jobs:
     name: "Preview: ${{ (github.event_name == 'pull_request_target' && 'Destroy') || (github.event_name == 'pull_request' && 'Deploy') || github.event.inputs.action }}"
     # Dependabot PRs read the Dependabot secret store, so preview secrets are empty.
     if: >-
-      github.event.pull_request.user.login != 'dependabot[bot]' &&
-      (github.event_name != 'pull_request' ||
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ubuntu-latest
     outputs:
       preview_url: ${{ steps.deploy.outputs.preview_url }}
     concurrency:

--- a/infra/preview/deploy.sh
+++ b/infra/preview/deploy.sh
@@ -91,7 +91,7 @@ if ! git -C "$CHECKOUT" fetch origin "$BRANCH" 2>/dev/null; then
     log "Branch no longer exists on remote (PR likely merged), skipping deploy"
     exit 0
 fi
-if ! git -C "$CHECKOUT" cat-file -e "${SHA}^{commit}" 2>/dev/null; then
+if [[ "$(git -C "$CHECKOUT" rev-parse FETCH_HEAD 2>/dev/null || true)" != "$SHA" ]]; then
     log "Commit ${SHA} is gone from the remote (branch force-pushed), skipping superseded deploy"
     exit 0
 fi

--- a/infra/preview/deploy.sh
+++ b/infra/preview/deploy.sh
@@ -91,6 +91,10 @@ if ! git -C "$CHECKOUT" fetch origin "$BRANCH" 2>/dev/null; then
     log "Branch no longer exists on remote (PR likely merged), skipping deploy"
     exit 0
 fi
+if ! git -C "$CHECKOUT" cat-file -e "${SHA}^{commit}" 2>/dev/null; then
+    log "Commit ${SHA} is gone from the remote (branch force-pushed), skipping superseded deploy"
+    exit 0
+fi
 git -C "$CHECKOUT" checkout -f "$SHA"
 
 # --- Detect what changed ---


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent broken preview environments and noisy comments. Previously we tried to deploy previews for Dependabot PRs and could deploy/comment for commits that no longer existed after a force push; now we skip `dependabot[bot]` PRs, abort superseded deploys, and only comment when a preview URL exists.

- Skip previews for `dependabot[bot]` PRs because preview secrets are unavailable there.
- Abort deploy when the target commit SHA is no longer on the remote (e.g., after a force push) to avoid stale deployments.
- Post the preview comment only when the preview job succeeded and `preview_url` is non-empty.

<sup>Written for commit 89de3715f0037132606aab0dc05d10f56b757c02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

