### PR TITLE
ci: Re-add missing runs-on for preview job

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -33,6 +33,7 @@ jobs:
       github.event_name != 'pull_request' ||
       (github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
     outputs:
       preview_url: ${{ steps.deploy.outputs.preview_url }}
     concurrency:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the preview workflow by adding a runner so the job can execute. Previously the job had no runs-on and never started; now it runs on `ubuntu-latest`, restoring preview deployments for eligible PRs.

<sup>Written for commit 6fe7e02fb724b8ae531baccda8757efd02434844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

