### PR TITLE
Fix concurrent checkout link product archiving

### DIFF
--- a/server/polar/checkout_link/repository.py
+++ b/server/polar/checkout_link/repository.py
@@ -146,6 +146,8 @@ class CheckoutLinkRepository(
                 )
             )
             .options(selectinload(CheckoutLink.checkout_link_products))
+            .order_by(CheckoutLink.id)
+            .with_for_update(of=CheckoutLink)
         )
         checkout_links = await self.get_all(statement)
         for checkout_link in checkout_links:

--- a/server/tests/checkout_link/test_repository.py
+++ b/server/tests/checkout_link/test_repository.py
@@ -26,9 +26,7 @@ from tests.fixtures.random_objects import (
 )
 
 
-async def _archive_product(
-    sessionmaker: AsyncSessionMaker, product_id: UUID
-) -> None:
+async def _archive_product(sessionmaker: AsyncSessionMaker, product_id: UUID) -> None:
     async with sessionmaker() as session:
         repository = CheckoutLinkRepository.from_session(session)
         await repository.archive_product(product_id)
@@ -112,29 +110,20 @@ class TestArchiveProduct:
                 )
                 for index in range(3)
             ]
-            checkout_link = await create_checkout_link(
-                save_fixture, products=products
-            )
+            checkout_link = await create_checkout_link(save_fixture, products=products)
             await setup_session.commit()
 
         try:
             await asyncio.gather(
-                *(
-                    _archive_product(sessionmaker, product.id)
-                    for product in products
-                )
+                *(_archive_product(sessionmaker, product.id) for product in products)
             )
 
             async with sessionmaker() as verification_session:
-                repository = CheckoutLinkRepository.from_session(
-                    verification_session
-                )
+                repository = CheckoutLinkRepository.from_session(verification_session)
                 updated_checkout_link = await repository.get_by_id(
                     checkout_link.id,
                     include_deleted=True,
-                    options=(
-                        selectinload(CheckoutLink.checkout_link_products),
-                    ),
+                    options=(selectinload(CheckoutLink.checkout_link_products),),
                 )
 
             assert updated_checkout_link is not None
@@ -143,9 +132,7 @@ class TestArchiveProduct:
         finally:
             async with sessionmaker() as cleanup_session:
                 await cleanup_session.execute(
-                    delete(Organization).where(
-                        Organization.id == organization.id
-                    )
+                    delete(Organization).where(Organization.id == organization.id)
                 )
                 await cleanup_session.execute(
                     delete(Account).where(Account.id == account.id)

--- a/server/tests/checkout_link/test_repository.py
+++ b/server/tests/checkout_link/test_repository.py
@@ -1,11 +1,38 @@
+import asyncio
+from uuid import UUID
+
 import pytest
+from sqlalchemy import delete
 from sqlalchemy.orm import selectinload
 
 from polar.checkout_link.repository import CheckoutLinkRepository
-from polar.models import CheckoutLink, Product
-from polar.postgres import AsyncSession
-from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_checkout_link
+from polar.config import settings
+from polar.kit.db.postgres import (
+    AsyncSession,
+    AsyncSessionMaker,
+    create_async_engine,
+    create_async_sessionmaker,
+)
+from polar.models import Account, CheckoutLink, Organization, Product
+from tests.fixtures.database import (
+    SaveFixture,
+    get_database_url,
+    save_fixture_factory,
+)
+from tests.fixtures.random_objects import (
+    create_checkout_link,
+    create_organization,
+    create_product,
+)
+
+
+async def _archive_product(
+    sessionmaker: AsyncSessionMaker, product_id: UUID
+) -> None:
+    async with sessionmaker() as session:
+        repository = CheckoutLinkRepository.from_session(session)
+        await repository.archive_product(product_id)
+        await session.commit()
 
 
 @pytest.mark.asyncio
@@ -59,3 +86,69 @@ class TestArchiveProduct:
         assert updated_checkout_link is not None
         assert updated_checkout_link.deleted_at is None
         assert len(updated_checkout_link.checkout_link_products) == 1
+
+    async def test_concurrent_archives_soft_delete_empty_link(
+        self, worker_id: str
+    ) -> None:
+        engine = create_async_engine(
+            dsn=get_database_url(worker_id),
+            application_name=f"test_{worker_id}_checkout_link_archive_concurrency",
+            pool_size=4,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+
+        async with sessionmaker() as setup_session:
+            save_fixture = save_fixture_factory(setup_session)
+            account = Account(currency="usd", processor_fees_applicable=True)
+            await save_fixture(account)
+            organization = await create_organization(save_fixture, account)
+            products = [
+                await create_product(
+                    save_fixture,
+                    organization=organization,
+                    recurring_interval=None,
+                    name=f"Concurrent product {index}",
+                )
+                for index in range(3)
+            ]
+            checkout_link = await create_checkout_link(
+                save_fixture, products=products
+            )
+            await setup_session.commit()
+
+        try:
+            await asyncio.gather(
+                *(
+                    _archive_product(sessionmaker, product.id)
+                    for product in products
+                )
+            )
+
+            async with sessionmaker() as verification_session:
+                repository = CheckoutLinkRepository.from_session(
+                    verification_session
+                )
+                updated_checkout_link = await repository.get_by_id(
+                    checkout_link.id,
+                    include_deleted=True,
+                    options=(
+                        selectinload(CheckoutLink.checkout_link_products),
+                    ),
+                )
+
+            assert updated_checkout_link is not None
+            assert updated_checkout_link.deleted_at is not None
+            assert updated_checkout_link.checkout_link_products == []
+        finally:
+            async with sessionmaker() as cleanup_session:
+                await cleanup_session.execute(
+                    delete(Organization).where(
+                        Organization.id == organization.id
+                    )
+                )
+                await cleanup_session.execute(
+                    delete(Account).where(Account.id == account.id)
+                )
+                await cleanup_session.commit()
+            await engine.dispose()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Related Issue**: [Sentry SERVER-4YR](https://polar-sh.sentry.io/issues/SERVER-4YR)

Prevents concurrent product archive requests from leaving an active checkout link with no products.

## What

- Lock affected checkout-link rows in deterministic ID order while removing archived products.
- Add a PostgreSQL regression test that archives all three products through independent concurrent sessions.

## Why

At 06:59:25 UTC, three product archive requests started within 1.4 ms and all returned 200. Each transaction read the same stale checkout-link product collection, removed only its own product, and saw other products remaining, so none soft-deleted the link. The first checkout-link GET failed response validation at 06:59:27 UTC because the active link had no products.

Fixes SERVER-4YR

## How

`CheckoutLinkRepository.archive_product` now acquires `FOR UPDATE` locks on affected checkout-link rows before eager-loading their product associations. PostgreSQL serializes the archive transactions, so each request observes prior removals and the final request soft-deletes the empty link. Ordering locks by checkout-link ID avoids inconsistent lock ordering when products share several links.

## Verification

- Checkout-link repository suite: 3 passed.
- Concurrent archive regression: passed 5 consecutive runs.
- Existing product archive service tests: 2 passed.
- Full backend lint and type checks passed (1,710 files type-checked).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://polar-sh.slack.com/archives/C092YJ5TLR0/p1787381987869039?thread_ts=1787381987.869039&cid=C092YJ5TLR0)

<div><a href="https://cursor.com/agents/bc-94a8c4e2-3980-5470-bbfa-8d9342a7078d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94a8c4e2-3980-5470-bbfa-8d9342a7078d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

