### PR TITLE
server/kit/versioning: use stable version ranges

### DIFF
--- a/handbook/docs.json
+++ b/handbook/docs.json
@@ -66,6 +66,7 @@
             "pages": [
               "engineering/backend-development/authorization",
               "engineering/backend-development/rest-api-guidelines",
+              "engineering/backend-development/api-versioning",
               "engineering/backend-development/task-debouncer",
               "engineering/backend-development/operational-errors",
               "engineering/backend-development/metadata",

--- a/handbook/engineering/backend-development/api-versioning.mdx
+++ b/handbook/engineering/backend-development/api-versioning.mdx
@@ -1,0 +1,275 @@
+---
+title: "API Versioning"
+description: "How API versions are selected, evolved, and released without changing frozen contracts"
+---
+
+Polar uses date-based API versions to evolve its public API without changing the
+contract seen by clients pinned to a stable version.
+
+## When to use API versioning
+
+Target the **Next** API version whenever a change affects the public API contract,
+including:
+
+- Adding, removing, or replacing an endpoint.
+- Adding, removing, or changing a request or response field.
+- Changing a field's type, requiredness, validation, or enum values.
+- Changing request parameters, response status codes, error responses, or
+  authentication requirements.
+
+Bug fixes, performance improvements, and internal implementation changes do not
+need API versioning as long as the public contract remains unchanged.
+
+## Version lifecycle
+
+Polar maintains three API versions on a quarterly release cadence:
+
+| Version        | Purpose                                               | Contract changes |
+| -------------- | ----------------------------------------------------- | ---------------- |
+| **Deprecated** | Stable and scheduled for removal at the next release  | Not allowed      |
+| **Current**    | Stable and used when no version is requested          | Not allowed      |
+| **Next**       | In development and used for upcoming contract changes | Allowed          |
+
+During the first week of January, April, July, and October:
+
+1. The Deprecated version is removed.
+2. Current becomes Deprecated.
+3. Next becomes Current and is frozen.
+4. A new Next version is created.
+
+Releases are calendar-driven, even when Next contains no contract changes. Each
+version is therefore supported for approximately nine months: three months in
+each lifecycle stage.
+
+Schema-lock tests enforce the freeze on Deprecated and Current. Even
+backwards-compatible contract changes, such as adding an optional response
+field, must target Next.
+
+<Info>
+  API versioning is currently being rolled out. Until the first full rotation,
+  only Current and Next exist; there is no Deprecated version or
+  `DEPRECATED_API_VERSION` constant yet. The three-version lifecycle and
+  examples below describe the steady state after that rotation.
+</Info>
+
+Versions use the `YYYY-MM` format, such as `2026-04`.
+
+## Selecting an API version
+
+Clients select a version with the `Polar-Version` request header:
+
+```http
+Polar-Version: 2026-04
+```
+
+When the header is omitted, the request uses Current. Successful responses
+include the resolved version in the `Polar-Version` response header. A malformed,
+unknown, or removed version returns `404 Not Found`.
+
+<Warning>
+  Current changes every quarter. External clients should always set the header
+  explicitly, either directly or by using a versioned SDK import.
+</Warning>
+
+### OpenAPI schemas and SDKs
+
+An OpenAPI schema is generated for every supported version and exposed at
+`/YYYY-MM/openapi.json`, for example `/2026-04/openapi.json`.
+
+The Python and TypeScript SDKs ship the schemas and types for every supported API
+version. The import path pins the client to that version and automatically sends
+the corresponding header:
+
+```python
+from polar.v2026_04 import Polar
+```
+
+```ts
+import { createPolar } from "@polar-sh/sdk/2026-04";
+```
+
+## How to change the API
+
+The versioning helpers take exact version sets. They do not mean "this version
+and every version after it." An annotation usually remains in place across two
+release rotations before it can be removed.
+
+### Adding an endpoint
+
+Use `@version` to expose a new endpoint only in Next:
+
+```python
+from polar.kit.versioning import version
+from polar.version import NEXT_API_VERSION
+
+
+@router.get("/new")
+@version(NEXT_API_VERSION)
+async def new() -> dict[str, str]:
+    return {"message": "New endpoint"}
+```
+
+The decorator must be below the router decorator, as shown above, so its metadata
+is present when FastAPI registers the route.
+
+At the first rotation, update it to remain unavailable in the newly Deprecated
+version:
+
+```python
+@version(CURRENT_API_VERSION, NEXT_API_VERSION)
+```
+
+At the following rotation, every supported version contains the endpoint, so the
+decorator can be removed.
+
+### Changing an existing endpoint
+
+Keep the existing undecorated endpoint as the fallback for stable versions and
+register a second endpoint with the same path and method for Next:
+
+```python
+@router.get("/{customer_id}")
+async def get_customer(customer_id: UUID) -> Customer:
+    ...
+
+
+@router.get("/{customer_id}")
+@version(NEXT_API_VERSION)
+async def get_customer_next(customer_id: UUID) -> CustomerNext:
+    ...
+```
+
+The version-specific route overrides the general route for Next. At the first
+rotation, mark the new route for Current and Next; the old route will then serve
+only Deprecated. At the following rotation, delete the old route and remove the
+decorator from the new one.
+
+Use this pattern for request-schema changes as well as changes to an endpoint's
+response or behavior.
+
+### Removing an endpoint
+
+During development, restrict the old endpoint to the two frozen versions so it
+is absent from Next:
+
+```python
+from polar.kit.versioning import version
+from polar.version import CURRENT_API_VERSION, DEPRECATED_API_VERSION
+
+
+@router.get("/old")
+@version(DEPRECATED_API_VERSION, CURRENT_API_VERSION)
+async def old() -> dict[str, str]:
+    ...
+```
+
+During the initial two-version rollout, use
+`@version(CURRENT_API_VERSION)` instead.
+
+At the first rotation, the endpoint becomes Deprecated-only:
+
+```python
+@version(DEPRECATED_API_VERSION)
+```
+
+Delete the endpoint at the following rotation, when that Deprecated version is
+removed.
+
+### Adding an output field
+
+Use `IncludedIn` to serialize a new output field and include it in the OpenAPI
+schema only for Next:
+
+```python
+from typing import Annotated
+
+from polar.kit.versioning import IncludedIn
+from polar.version import NEXT_API_VERSION
+
+
+class Customer(Schema):
+    email: str
+    new_field: Annotated[str, IncludedIn(NEXT_API_VERSION)]
+```
+
+At the first rotation, change the annotation to:
+
+```python
+new_field: Annotated[
+    str,
+    IncludedIn(CURRENT_API_VERSION, NEXT_API_VERSION),
+]
+```
+
+Remove the annotation at the following rotation, when the field exists in every
+supported version.
+
+### Removing an output field
+
+Use `ExcludedIn` to omit an existing output field from Next serialization and
+its OpenAPI schema:
+
+```python
+from typing import Annotated
+
+from polar.kit.versioning import ExcludedIn
+from polar.version import NEXT_API_VERSION
+
+
+class Customer(Schema):
+    email: str
+    old_field: Annotated[str, ExcludedIn(NEXT_API_VERSION)]
+```
+
+At the first rotation, keep it absent from both Current and Next:
+
+```python
+old_field: Annotated[
+    str,
+    ExcludedIn(CURRENT_API_VERSION, NEXT_API_VERSION),
+]
+```
+
+Delete the field at the following rotation, when no supported version exposes
+it.
+
+<Warning>
+  `IncludedIn` and `ExcludedIn` control OpenAPI schema generation and output
+  serialization. They do not change Pydantic input validation. To change an
+  input schema, create a version-specific endpoint with a separate request
+  model.
+</Warning>
+
+### Release transition reference
+
+Use this table when rotating versions:
+
+| Change               | While developing Next           | After first rotation        | After second rotation |
+| -------------------- | ------------------------------- | --------------------------- | --------------------- |
+| Added endpoint       | `@version(Next)`                | `@version(Current, Next)`   | Remove decorator      |
+| Removed endpoint     | `@version(Deprecated, Current)` | `@version(Deprecated)`      | Delete endpoint       |
+| Added output field   | `IncludedIn(Next)`              | `IncludedIn(Current, Next)` | Remove annotation     |
+| Removed output field | `ExcludedIn(Next)`              | `ExcludedIn(Current, Next)` | Delete field          |
+
+At every rotation, update the version constants and all exact-version markers,
+regenerate every supported OpenAPI schema and SDK, and run the schema-lock tests
+before merging.
+
+## How it works under the hood
+
+The versioning middleware reads `Polar-Version`, defaults it to
+`CURRENT_API_VERSION`, rejects unsupported values, and stores the selected
+version in the request context. It also adds the selected version to the response
+headers.
+
+Routes without `@version` are available in every supported version unless a
+version-specific route with the same path and HTTP methods overrides them. Routes
+with `@version` are available only in the exact versions passed to the decorator.
+
+For fields, `IncludedIn` and `ExcludedIn` inspect the active request version when
+serializing Pydantic models and generating JSON Schema. Finally, the application
+filters routes and fields for each supported version to generate the versioned
+OpenAPI documents used by the SDK generator and schema-lock tests.
+
+See the [API versioning design document](/engineering/design-documents/api-versioning)
+for the rationale, lifecycle timeline, and SDK release strategy.

--- a/handbook/engineering/backend-development/api-versioning.mdx
+++ b/handbook/engineering/backend-development/api-versioning.mdx
@@ -54,6 +54,28 @@ field, must target Next.
 
 Versions use the `YYYY-MM` format, such as `2026-04`.
 
+Each concrete version has a stable identity constant for as long as it is
+supported. Lifecycle constants are aliases that change during a rotation:
+
+```python
+from polar.kit.versioning import APIVersion
+
+V2026_04 = APIVersion(year=2026, month=4)
+V2026_10 = APIVersion(year=2026, month=10)
+
+CURRENT_API_VERSION = V2026_04
+NEXT_API_VERSION = V2026_10
+
+VERSIONS = {
+    V2026_04,
+    V2026_10,
+}
+```
+
+Always use identity constants such as `V2026_10` in version markers. Using
+`CURRENT_API_VERSION` or `NEXT_API_VERSION` would change the meaning of the
+marker at the next rotation.
+
 ## Selecting an API version
 
 Clients select a version with the `Polar-Version` request header:
@@ -90,170 +112,203 @@ import { createPolar } from "@polar-sh/sdk/2026-04";
 
 ## How to change the API
 
-The versioning helpers take exact version sets. They do not mean "this version
-and every version after it." An annotation usually remains in place across two
-release rotations before it can be removed.
+The `version` endpoint decorator and `Version` field marker define an inclusive
+version range:
+
+```python
+def version(
+    *,
+    starting_from: APIVersion | None = None,
+    up_to: APIVersion | None = None,
+): ...
+```
+
+`Version` accepts the same range arguments. Omit `starting_from` when there is no
+lower bound and omit `up_to` when there is no upper bound. At least one bound is
+required. When both are provided, the version is available when:
+
+```python
+starting_from <= requested_version <= up_to
+```
+
+Because markers refer to stable version constants, they do not need to change
+when versions move between Next, Current, and Deprecated.
 
 ### Adding an endpoint
 
-Use `@version` to expose a new endpoint only in Next:
+Use `@version(starting_from=...)` to introduce an endpoint in Next and every
+version after it:
 
 ```python
 from polar.kit.versioning import version
-from polar.version import NEXT_API_VERSION
+from polar.version import V2026_10
 
 
 @router.get("/new")
-@version(NEXT_API_VERSION)
+@version(starting_from=V2026_10)
 async def new() -> dict[str, str]:
     return {"message": "New endpoint"}
 ```
 
 The decorator must be below the router decorator, as shown above, so its metadata
-is present when FastAPI registers the route.
-
-At the first rotation, update it to remain unavailable in the newly Deprecated
-version:
-
-```python
-@version(CURRENT_API_VERSION, NEXT_API_VERSION)
-```
-
-At the following rotation, every supported version contains the endpoint, so the
-decorator can be removed.
+is present when FastAPI registers the route. It remains unchanged when
+`V2026_10` becomes Current and then Deprecated.
 
 ### Changing an existing endpoint
 
-Keep the existing undecorated endpoint as the fallback for stable versions and
-register a second endpoint with the same path and method for Next:
+Request schema changes require separate Pydantic models and endpoint
+implementations. For example, to rename the `display_name` input field to `name`,
+keep the original endpoint as the fallback and introduce an override in Next:
 
 ```python
-@router.get("/{customer_id}")
-async def get_customer(customer_id: UUID) -> Customer:
+from uuid import UUID
+
+from polar.kit.schemas import Schema
+from polar.kit.versioning import version
+from polar.version import V2026_10
+
+
+class CustomerUpdateLegacy(Schema):
+    display_name: str
+
+
+class CustomerUpdate(Schema):
+    name: str
+
+
+@router.patch("/{customer_id}")
+async def update(
+    customer_id: UUID,
+    customer_update: CustomerUpdateLegacy,
+) -> Customer:
     ...
 
 
-@router.get("/{customer_id}")
-@version(NEXT_API_VERSION)
-async def get_customer_next(customer_id: UUID) -> CustomerNext:
+@router.patch("/{customer_id}", name="update")
+@version(starting_from=V2026_10)
+async def update_v2026_10(
+    customer_id: UUID,
+    customer_update: CustomerUpdate,
+) -> Customer:
     ...
 ```
 
-The version-specific route overrides the general route for Next. At the first
-rotation, mark the new route for Current and Next; the old route will then serve
-only Deprecated. At the following rotation, delete the old route and remove the
-decorator from the new one.
+The unversioned `update` endpoint serves versions that do not match a
+version-specific override. From `V2026_10` onward, `update_v2026_10` takes
+precedence. The router's built-in `name="update"` argument preserves the route
+name, so both versioned OpenAPI documents expose the operation ID
+`customers:update` and SDKs generate `polar.customers.update`.
 
-Use this pattern for request-schema changes as well as changes to an endpoint's
-response or behavior.
+Delete the fallback endpoint and its legacy schema when no supported version
+predates `V2026_10`. Keep the new implementation and marker until `V2026_10`
+itself is removed; then remove the decorator and rename the Python function to
+`update`. Use the same pattern for response or behavior changes that cannot be
+expressed with a field marker.
 
 ### Removing an endpoint
 
-During development, restrict the old endpoint to the two frozen versions so it
-is absent from Next:
+Use `@version(up_to=...)` with the last version that contains the endpoint:
 
 ```python
 from polar.kit.versioning import version
-from polar.version import CURRENT_API_VERSION, DEPRECATED_API_VERSION
+from polar.version import V2026_04
 
 
 @router.get("/old")
-@version(DEPRECATED_API_VERSION, CURRENT_API_VERSION)
+@version(up_to=V2026_04)
 async def old() -> dict[str, str]:
     ...
 ```
 
-During the initial two-version rollout, use
-`@version(CURRENT_API_VERSION)` instead.
-
-At the first rotation, the endpoint becomes Deprecated-only:
-
-```python
-@version(DEPRECATED_API_VERSION)
-```
-
-Delete the endpoint at the following rotation, when that Deprecated version is
-removed.
+The marker remains unchanged as `V2026_04` becomes Deprecated. Delete the
+endpoint when that version is removed.
 
 ### Adding an output field
 
-Use `IncludedIn` to serialize a new output field and include it in the OpenAPI
-schema only for Next:
+Use `Version(starting_from=...)` to introduce an output field in Next and every
+version after it:
 
 ```python
 from typing import Annotated
 
-from polar.kit.versioning import IncludedIn
-from polar.version import NEXT_API_VERSION
+from polar.kit.versioning import Version
+from polar.version import V2026_10
 
 
 class Customer(Schema):
     email: str
-    new_field: Annotated[str, IncludedIn(NEXT_API_VERSION)]
+    new_field: Annotated[str, Version(starting_from=V2026_10)]
 ```
 
-At the first rotation, change the annotation to:
-
-```python
-new_field: Annotated[
-    str,
-    IncludedIn(CURRENT_API_VERSION, NEXT_API_VERSION),
-]
-```
-
-Remove the annotation at the following rotation, when the field exists in every
-supported version.
+The marker remains unchanged during rotations.
 
 ### Removing an output field
 
-Use `ExcludedIn` to omit an existing output field from Next serialization and
-its OpenAPI schema:
+Use `Version(up_to=...)` with the last version that exposes the field:
 
 ```python
 from typing import Annotated
 
-from polar.kit.versioning import ExcludedIn
-from polar.version import NEXT_API_VERSION
+from polar.kit.versioning import Version
+from polar.version import V2026_04
 
 
 class Customer(Schema):
     email: str
-    old_field: Annotated[str, ExcludedIn(NEXT_API_VERSION)]
+    old_field: Annotated[str, Version(up_to=V2026_04)]
 ```
 
-At the first rotation, keep it absent from both Current and Next:
+Delete the field when `V2026_04` is removed.
+
+### Limiting availability to a bounded range
+
+Provide both bounds when an endpoint or field exists only during part of the API
+history:
 
 ```python
-old_field: Annotated[
+temporary_field: Annotated[
     str,
-    ExcludedIn(CURRENT_API_VERSION, NEXT_API_VERSION),
+    Version(starting_from=V2026_04, up_to=V2026_10),
 ]
 ```
 
-Delete the field at the following rotation, when no supported version exposes
-it.
+The same syntax applies to endpoints:
+
+```python
+@version(starting_from=V2026_04, up_to=V2026_10)
+```
 
 <Warning>
-  `IncludedIn` and `ExcludedIn` control OpenAPI schema generation and output
-  serialization. They do not change Pydantic input validation. To change an
-  input schema, create a version-specific endpoint with a separate request
-  model.
+  `Version` controls OpenAPI schema generation and output serialization. It does
+  not change Pydantic validation: the field must still be valid on the model even
+  in versions where it is hidden. To change an input schema, create a
+  version-specific endpoint with a separate request model instead of using
+  `Version`.
 </Warning>
 
-### Release transition reference
+### Cleaning up a removed version
 
-Use this table when rotating versions:
+During a rotation, update the lifecycle aliases and `VERSIONS`, then regenerate
+every supported OpenAPI schema and SDK and run the schema-lock tests. Version
+markers do not move merely because a version changes lifecycle stage.
 
-| Change               | While developing Next           | After first rotation        | After second rotation |
-| -------------------- | ------------------------------- | --------------------------- | --------------------- |
-| Added endpoint       | `@version(Next)`                | `@version(Current, Next)`   | Remove decorator      |
-| Removed endpoint     | `@version(Deprecated, Current)` | `@version(Deprecated)`      | Delete endpoint       |
-| Added output field   | `IncludedIn(Next)`              | `IncludedIn(Current, Next)` | Remove annotation     |
-| Removed output field | `ExcludedIn(Next)`              | `ExcludedIn(Current, Next)` | Delete field          |
+Also delete an unversioned fallback once every supported version matches its
+version-specific override. Since the fallback has no boundary marker of its own,
+look for these route pairs when removing the last version before an override's
+`starting_from` boundary.
 
-At every rotation, update the version constants and all exact-version markers,
-regenerate every supported OpenAPI schema and SDK, and run the schema-lock tests
-before merging.
+When removing the oldest supported version, find every reference to its identity
+constant. Since no remaining version can be older than it, cleanup follows three
+rules:
+
+| How the removed version is used | Cleanup |
+| --- | --- |
+| As `up_to` | Delete the endpoint implementation or field; its last supported version is gone |
+| As the only `starting_from` bound | Remove the field marker; for an endpoint, remove the decorator and rename the function to its route `name` |
+| As `starting_from` with a later `up_to` | Remove `starting_from` but keep the `up_to` bound |
+
+After resolving those references, delete the identity constant. Any missed
+imports will fail immediately during type checking or test collection.
 
 ## How it works under the hood
 
@@ -262,14 +317,16 @@ The versioning middleware reads `Polar-Version`, defaults it to
 version in the request context. It also adds the selected version to the response
 headers.
 
-Routes without `@version` are available in every supported version unless a
-version-specific route with the same path and HTTP methods overrides them. Routes
-with `@version` are available only in the exact versions passed to the decorator.
+Routes without `@version` are fallbacks for every supported version. A matching
+versioned route with the same path and HTTP methods takes precedence. At startup,
+overlapping versioned ranges are rejected if they match the same supported
+version. The router decorator's built-in `name` argument can override the route
+name used to generate the OpenAPI operation ID and SDK method name.
 
-For fields, `IncludedIn` and `ExcludedIn` inspect the active request version when
-serializing Pydantic models and generating JSON Schema. Finally, the application
-filters routes and fields for each supported version to generate the versioned
-OpenAPI documents used by the SDK generator and schema-lock tests.
+For fields, `Version` applies the same range comparison when serializing Pydantic
+models and generating JSON Schema. Finally, the application filters routes and
+fields for each supported version to generate the versioned OpenAPI documents
+used by the SDK generator and schema-lock tests.
 
 See the [API versioning design document](/engineering/design-documents/api-versioning)
 for the rationale, lifecycle timeline, and SDK release strategy.

--- a/handbook/engineering/design-documents/api-versioning.mdx
+++ b/handbook/engineering/design-documents/api-versioning.mdx
@@ -12,6 +12,12 @@ description: "Proposal for a date-based API versioning strategy with strict chan
 
 </Info>
 
+<Warning>
+  This was a working design document and may not reflect the final implementation.
+  The [API Versioning backend development guide](/engineering/backend-development/api-versioning)
+  is the current source of truth for the strategy and its tooling.
+</Warning>
+
 ## Abstract
 
 This RFC proposes a date-based API versioning strategy for Polar with the following characteristics:

--- a/server/polar/kit/routing.py
+++ b/server/polar/kit/routing.py
@@ -66,17 +66,16 @@ class IncludedInSchemaAPIRoute(APIRoute):
 class SpeakeasyNameOverrideAPIRoute(APIRoute):
     """
     A subclass of `APIRoute` that automatically adds `x-speakeasy-name-override` property
-    following the route function name.
+    following the resolved route name.
     """
 
     def __init__(self, path: str, endpoint: Callable[..., Any], **kwargs: Any) -> None:
         super().__init__(path, endpoint, **kwargs)
-        endpoint_name = endpoint.__name__
         openapi_extra = self.openapi_extra or {}
         if "x-speakeasy-name-override" not in openapi_extra:
             self.openapi_extra = {
                 **openapi_extra,
-                "x-speakeasy-name-override": endpoint_name,
+                "x-speakeasy-name-override": self.name,
             }
 
 

--- a/server/polar/kit/versioning.py
+++ b/server/polar/kit/versioning.py
@@ -79,58 +79,62 @@ def api_version_context(version: APIVersion) -> Generator[None]:
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
-class _VersionAvailability:
-    versions: frozenset[APIVersion]
-    include_matches: bool
+class _VersionRange:
+    starting_from: APIVersion | None = None
+    up_to: APIVersion | None = None
 
-    def is_available(self, version: APIVersion) -> bool:
-        return (version in self.versions) is self.include_matches
+    def __post_init__(self) -> None:
+        if self.starting_from is None and self.up_to is None:
+            raise ValueError("At least one API version bound is required")
+        if (
+            self.starting_from is not None
+            and self.up_to is not None
+            and self.starting_from > self.up_to
+        ):
+            raise ValueError("starting_from must be earlier than or equal to up_to")
+
+    def includes(self, version: APIVersion) -> bool:
+        return (self.starting_from is None or version >= self.starting_from) and (
+            self.up_to is None or version <= self.up_to
+        )
 
     def __get_pydantic_json_schema__(
         self, core_schema: CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
         version = _ACTIVE_API_VERSION.get()
-        if version is not None and not self.is_available(version):
+        if version is not None and not self.includes(version):
             raise PydanticOmit
         return handler(core_schema)
 
 
-def _versioned_field(
-    versions: tuple[APIVersion, ...], *, include_matches: bool
+def Version(
+    *,
+    starting_from: APIVersion | None = None,
+    up_to: APIVersion | None = None,
 ) -> FieldInfo:
-    if not versions:
-        raise ValueError("At least one API version is required")
-
-    availability = _VersionAvailability(frozenset(versions), include_matches)
+    version_range = _VersionRange(starting_from=starting_from, up_to=up_to)
 
     def exclude_if_unavailable(_: typing.Any) -> bool:
         version = _ACTIVE_API_VERSION.get()
-        return version is not None and not availability.is_available(version)
+        return version is not None and not version_range.includes(version)
 
     field_info = Field(exclude_if=exclude_if_unavailable)
-    field_info.metadata.append(availability)
+    field_info.metadata.append(version_range)
     return field_info
 
 
-def IncludedIn(*versions: APIVersion) -> FieldInfo:
-    return _versioned_field(versions, include_matches=True)
-
-
-def ExcludedIn(*versions: APIVersion) -> FieldInfo:
-    return _versioned_field(versions, include_matches=False)
-
-
 def version[**P, R](
-    *versions: APIVersion,
+    *,
+    starting_from: APIVersion | None = None,
+    up_to: APIVersion | None = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
-    Decorator to specify the API versions supported by an endpoint.
+    Decorator to specify the API version range supported by an endpoint.
     """
-    if not versions:
-        raise ValueError("At least one API version is required")
+    version_range = _VersionRange(starting_from=starting_from, up_to=up_to)
 
     def decorator(endpoint: Callable[P, R]) -> Callable[P, R]:
-        setattr(endpoint, "_api_versions", frozenset(versions))
+        setattr(endpoint, "_api_version_range", version_range)
         return endpoint
 
     return decorator
@@ -184,19 +188,19 @@ class APIVersionMiddleware:
 
 
 class VersionedAPIRoute(APIRoute):
-    api_versions: frozenset[APIVersion] | None
+    api_version_range: _VersionRange | None
     overridden_versions: frozenset[APIVersion]
 
     def __init__(
         self, path: str, endpoint: Callable[..., typing.Any], **kwargs: typing.Any
     ) -> None:
-        self.api_versions = getattr(endpoint, "_api_versions", None)
+        self.api_version_range = getattr(endpoint, "_api_version_range", None)
         self.overridden_versions = frozenset()
         super().__init__(path, endpoint, **kwargs)
 
     def is_available_in(self, version: APIVersion) -> bool:
-        if self.api_versions is not None:
-            return version in self.api_versions
+        if self.api_version_range is not None:
+            return self.api_version_range.includes(version)
         return version not in self.overridden_versions
 
     def matches(self, scope: Scope) -> tuple[Match, Scope]:
@@ -221,7 +225,7 @@ def _get_route_key(route: APIRoute) -> _RouteKey:
 def finalize_versioned_routes(
     routes: Iterable[BaseRoute], versions: Iterable[APIVersion]
 ) -> None:
-    supported_versions = frozenset(versions)
+    supported_versions = tuple(sorted(set(versions)))
     route_versions_map: dict[_RouteKey, list[VersionedAPIRoute]] = {}
 
     for route in routes:
@@ -230,32 +234,42 @@ def finalize_versioned_routes(
 
     for route_key, route_versions in route_versions_map.items():
         versioned_routes = [
-            route for route in route_versions if route.api_versions is not None
+            route for route in route_versions if route.api_version_range is not None
         ]
         if not versioned_routes:
             continue
 
-        general_routes = [
-            route for route in route_versions if route.api_versions is None
+        fallback_routes = [
+            route for route in route_versions if route.api_version_range is None
         ]
-        if len(general_routes) > 1:
+        if len(fallback_routes) > 1:
             path, methods = route_key
-            route_names = ", ".join(route.name for route in general_routes)
+            route_names = ", ".join(route.name for route in fallback_routes)
             raise ValueError(
-                f"Multiple general routes match {'/'.join(sorted(methods))} {path}: "
+                f"Multiple fallback routes match {'/'.join(sorted(methods))} {path}: "
                 f"{route_names}"
             )
 
         routes_by_version: dict[APIVersion, VersionedAPIRoute] = {}
         for route in versioned_routes:
-            assert route.api_versions is not None
-            unsupported_versions = route.api_versions - supported_versions
-            if unsupported_versions:
+            assert route.api_version_range is not None
+            unsupported_bounds = {
+                version
+                for version in (
+                    route.api_version_range.starting_from,
+                    route.api_version_range.up_to,
+                )
+                if version is not None and version not in supported_versions
+            }
+            if unsupported_bounds:
                 raise ValueError(
                     f"Route {route.name} targets unsupported API versions: "
-                    f"{', '.join(map(str, sorted(unsupported_versions)))}"
+                    f"{', '.join(map(str, sorted(unsupported_bounds)))}"
                 )
-            for api_version in route.api_versions:
+
+            for api_version in supported_versions:
+                if not route.is_available_in(api_version):
+                    continue
                 conflicting_route = routes_by_version.get(api_version)
                 if conflicting_route is not None:
                     path, methods = route_key
@@ -267,7 +281,7 @@ def finalize_versioned_routes(
                 routes_by_version[api_version] = route
 
         overridden_versions = frozenset(routes_by_version)
-        for route in general_routes:
+        for route in fallback_routes:
             route.overridden_versions = overridden_versions
 
 

--- a/server/polar/version.py
+++ b/server/polar/version.py
@@ -1,8 +1,12 @@
 from polar.kit.versioning import APIVersion
 
-CURRENT_API_VERSION = APIVersion(year=2026, month=4)
-NEXT_API_VERSION = APIVersion(year=2026, month=10)
+V2026_04 = APIVersion(year=2026, month=4)
+V2026_10 = APIVersion(year=2026, month=10)
+
+CURRENT_API_VERSION = V2026_04
+NEXT_API_VERSION = V2026_10
+
 VERSIONS = {
-    CURRENT_API_VERSION,
-    NEXT_API_VERSION,
+    V2026_04,
+    V2026_10,
 }

--- a/server/tests/kit/test_versioning.py
+++ b/server/tests/kit/test_versioning.py
@@ -3,17 +3,19 @@ from typing import Annotated
 
 import pytest
 from fastapi import Depends, FastAPI
+from fastapi.openapi.utils import get_openapi
 from fastapi.testclient import TestClient
 from pydantic import BaseModel, Field
 
 from polar.kit.versioning import (
     APIVersion,
-    ExcludedIn,
-    IncludedIn,
+    Version,
     add_versioned_routers,
     api_version_context,
+    routes_for_version,
     version,
 )
+from polar.openapi import APITag
 from polar.routing import APIRouter
 
 CURRENT_VERSION = APIVersion(2026, 4)
@@ -22,11 +24,13 @@ NEXT_VERSION = APIVersion(2026, 10)
 
 class VersionedProduct(BaseModel):
     name: str
-    shared_field: Annotated[str, IncludedIn(CURRENT_VERSION, NEXT_VERSION)] = "shared"
-    current_field: Annotated[str, ExcludedIn(NEXT_VERSION)] = "current"
+    shared_field: Annotated[
+        str, Version(starting_from=CURRENT_VERSION, up_to=NEXT_VERSION)
+    ] = "shared"
+    current_field: Annotated[str, Version(up_to=CURRENT_VERSION)] = "current"
     next_field: Annotated[
         str,
-        IncludedIn(NEXT_VERSION),
+        Version(starting_from=NEXT_VERSION),
         Field(description="Only available in the next API version."),
     ] = "next"
 
@@ -51,10 +55,12 @@ def test_version_decorator_only_adds_metadata() -> None:
     def endpoint(value: int) -> int:
         return value + 1
 
-    decorated_endpoint = version(api_version)(endpoint)
+    decorated_endpoint = version(starting_from=api_version)(endpoint)
 
     assert decorated_endpoint is endpoint
-    assert getattr(decorated_endpoint, "_api_versions") == frozenset({api_version})
+    version_range = getattr(decorated_endpoint, "_api_version_range")
+    assert version_range.starting_from == api_version
+    assert version_range.up_to is None
     assert decorated_endpoint(1) == 2
 
 
@@ -103,26 +109,26 @@ def test_versioned_fields_are_included_in_versioned_openapi_schema() -> None:
 def test_versioned_routes() -> None:
     current_version = APIVersion(2026, 4)
     next_version = APIVersion(2026, 10)
-    router = APIRouter()
+    router = APIRouter(tags=["items", APITag.public])
 
     def dependency() -> str:
         return "original"
 
     @router.get("/items")
-    async def general_endpoint(
+    async def get_items(
         value: Annotated[str, Depends(dependency)],
     ) -> dict[str, str]:
-        return {"endpoint": "general", "dependency": value}
+        return {"endpoint": "current", "dependency": value}
 
-    @router.get("/items")
-    @version(next_version)
-    async def next_endpoint(
+    @router.get("/items", name="get_items")
+    @version(starting_from=next_version)
+    async def get_items_v2026_10(
         value: Annotated[str, Depends(dependency)],
     ) -> dict[str, str]:
         return {"endpoint": "next", "dependency": value}
 
     @router.get("/next-only")
-    @version(next_version)
+    @version(starting_from=next_version)
     async def next_only_endpoint() -> str:
         return "next-only"
 
@@ -134,7 +140,7 @@ def test_versioned_routes() -> None:
     client = TestClient(app)
 
     response = client.get("/items")
-    assert response.json() == {"endpoint": "general", "dependency": "overridden"}
+    assert response.json() == {"endpoint": "current", "dependency": "overridden"}
     assert response.headers["Polar-Version"] == "2026-04"
 
     response = client.get("/items", headers={"Polar-Version": "2026-10"})
@@ -147,18 +153,28 @@ def test_versioned_routes() -> None:
         == 200
     )
 
+    for api_version in (current_version, next_version):
+        schema = get_openapi(
+            title="Test",
+            version=str(api_version),
+            routes=routes_for_version(app.routes, api_version),
+        )
+        operation = schema["paths"]["/items"]["get"]
+        assert operation["operationId"] == "items:get_items"
+        assert operation["x-speakeasy-name-override"] == "get_items"
 
-def test_rejects_ambiguous_exact_routes() -> None:
+
+def test_rejects_overlapping_versioned_routes() -> None:
     next_version = APIVersion(2026, 10)
     router = APIRouter()
 
     @router.get("/items")
-    @version(next_version)
+    @version(starting_from=next_version)
     async def first_endpoint() -> str:
         return "first"
 
     @router.get("/items")
-    @version(next_version)
+    @version(up_to=next_version)
     async def second_endpoint() -> str:
         return "second"
 


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

Implements the range-based API versioning strategy and documents it as the current backend workflow.

API version markers now use stable version identities and inclusive boundaries, so quarterly rotations only update lifecycle aliases. Existing endpoints can remain unversioned fallbacks while a version-specific implementation overrides them for matching versions.

## What

- Replace exact-version endpoint markers with `@version(starting_from=..., up_to=...)`.
- Replace `IncludedIn` and `ExcludedIn` schema markers with `Version(starting_from=..., up_to=...)`.
- Add stable constants such as `V2026_04` and `V2026_10`, with Current and Next expressed as aliases.
- Treat unversioned routes as fallbacks when a version-specific route has the same path and methods.
- Reject overlapping versioned route ranges and unsupported boundary versions during route finalization.
- Preserve operation IDs and generated SDK method names through FastAPI's built-in route `name` argument.
- Make the Speakeasy name override use the resolved route name rather than the Python function name.
- Add the API versioning backend development guide and mark the original design document as a historical working document.

## Why

Exact-version markers would need to be rewritten throughout the codebase during every quarterly rotation. Stable identity constants with open or bounded ranges keep each marker tied to the API contract where the change was introduced or removed.

Endpoint overloading is also required for common request-schema changes. The fallback behavior lets the original endpoint serve older versions without an additional `up_to` marker, while the built-in route name keeps both OpenAPI documents mapped to the same SDK method, such as `polar.customers.update`.

## How

A shared internal version-range object performs inclusive comparisons for endpoint routing, response serialization, and JSON Schema generation. During application setup, the router evaluates each range against the supported versions, detects ambiguous overlaps, and records which versions should bypass an unversioned fallback.

The handbook documents the lifecycle, client header behavior, endpoint and field changes, input-schema overrides, cleanup rules, and the current two-version rollout state.

## Validation

- `uv run task lint`
- `uv run task lint_types`
- `POLAR_ENV=testing uv run python -m pytest tests/kit/test_versioning.py tests/test_openapi.py tests/test_app.py tests/test_sdk.py`
- `uv run -m scripts.generate_openapi versions`
- Verified both version schemas retain the same operation ID and Speakeasy method name for an overridden endpoint.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

