### PR TITLE
Convert seat/unit subscription update validation errors to PolarRequestValidationError

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -25382,17 +25382,6 @@ export interface components {
       /** Detail */
       detail: string
     }
-    /** NotASeatBasedSubscription */
-    NotASeatBasedSubscription: {
-      /**
-       * Error
-       * @example NotASeatBasedSubscription
-       * @constant
-       */
-      error: 'NotASeatBasedSubscription'
-      /** Detail */
-      detail: string
-    }
     /** NotOpenCheckout */
     NotOpenCheckout: {
       /**
@@ -42559,15 +42548,6 @@ export interface operations {
           'application/json': components['schemas']['SubscriptionChargePreview']
         }
       }
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['NotASeatBasedSubscription']
-        }
-      }
       /** @description Forbidden */
       403: {
         headers: {
@@ -53730,15 +53710,6 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['SubscriptionChargePreview']
-        }
-      }
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['NotASeatBasedSubscription']
         }
       }
       /** @description Previewing this change is not allowed. */

--- a/server/polar/customer_portal/endpoints/subscription.py
+++ b/server/polar/customer_portal/endpoints/subscription.py
@@ -19,10 +19,7 @@ from polar.subscription.schemas import (
     SubscriptionChargePreview,
     SubscriptionID,
 )
-from polar.subscription.service import (
-    AlreadyCanceledSubscription,
-    NotASeatBasedSubscription,
-)
+from polar.subscription.service import AlreadyCanceledSubscription
 from polar.subscription.service import subscription as subscription_service
 
 from .. import auth
@@ -184,7 +181,6 @@ async def get_cancel_preview(
     summary="Preview Subscription Change",
     response_model=SubscriptionChargePreview,
     responses={
-        400: {"model": NotASeatBasedSubscription.schema()},
         403: {
             "description": "Previewing this change is not allowed.",
             "model": AlreadyCanceledSubscription.schema()

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -50,7 +50,6 @@ from .schemas import (
 from .service import (
     AlreadyCanceledSubscription,
     InactiveSubscription,
-    NotASeatBasedSubscription,
     SubscriptionLocked,
     SubscriptionUpdateContext,
 )
@@ -324,7 +323,6 @@ async def get_cancel_preview(
     response_model=SubscriptionChargePreview,
     responses={
         403: {"model": AlreadyCanceledSubscription.schema()},
-        400: {"model": NotASeatBasedSubscription.schema()},
         404: SubscriptionNotFound,
     },
     tags=[APITag.private],

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1843,7 +1843,7 @@ class SubscriptionService:
                 subscription, currency_prices, proration_behavior
             )
             self._promote_units_for_unit_transition(
-                subscription, currency_prices, proration_behavior
+                subscription, currency_prices, proration_behavior, product_id
             )
 
             subscription_update_repository = SubscriptionUpdateRepository.from_session(
@@ -3057,7 +3057,7 @@ class SubscriptionService:
                 subscription, currency_prices, proration_behavior
             )
             self._promote_units_for_unit_transition(
-                subscription, currency_prices, proration_behavior
+                subscription, currency_prices, proration_behavior, product_id
             )
             event = build_system_event(
                 SystemEvent.subscription_product_updated,
@@ -3208,6 +3208,7 @@ class SubscriptionService:
         subscription: Subscription,
         currency_prices: PriceSet,
         proration_behavior: SubscriptionProrationBehavior,
+        product_id: uuid.UUID,
     ) -> None:
         """Ensure `subscription.units` is valid for the target unit price before
         proration and `apply_update` run. Non-unit → unit promotes to the floor
@@ -3236,7 +3237,7 @@ class SubscriptionService:
                                 f"Current unit count of {units} is below the "
                                 f"minimum of {minimum_units} units for this product."
                             ),
-                            "input": unit_price.product_id,
+                            "input": product_id,
                         }
                     ]
                 )
@@ -3251,7 +3252,7 @@ class SubscriptionService:
                                 f"Current unit count of {units} is above the "
                                 f"maximum of {maximum_units} units for this product."
                             ),
-                            "input": unit_price.product_id,
+                            "input": product_id,
                         }
                     ]
                 )

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -229,79 +229,6 @@ class CannotReinstateSubscription(SubscriptionError):
         super().__init__(message, 400)
 
 
-class NotASeatBasedSubscription(SubscriptionError):
-    def __init__(self, subscription: Subscription) -> None:
-        self.subscription = subscription
-        message = "This subscription does not support seat-based pricing."
-        super().__init__(message, 400)
-
-
-class SeatsAlreadyAssigned(SubscriptionError):
-    def __init__(
-        self, subscription: Subscription, assigned_count: int, requested_seats: int
-    ) -> None:
-        self.subscription = subscription
-        self.assigned_count = assigned_count
-        self.requested_seats = requested_seats
-        message = (
-            f"Cannot decrease seats to {requested_seats}. "
-            f"Currently {assigned_count} seats are assigned. "
-            f"Revoke seats first."
-        )
-        super().__init__(message, 400)
-
-
-class BelowMinimumSeats(SubscriptionError):
-    def __init__(
-        self, subscription: Subscription, minimum_seats: int, requested_seats: int
-    ) -> None:
-        self.subscription = subscription
-        self.minimum_seats = minimum_seats
-        self.requested_seats = requested_seats
-        message = f"Minimum {minimum_seats} seats required."
-        super().__init__(message, 400)
-
-
-class AboveMaximumSeats(SubscriptionError):
-    def __init__(
-        self, subscription: Subscription, maximum_seats: int, requested_seats: int
-    ) -> None:
-        self.subscription = subscription
-        self.maximum_seats = maximum_seats
-        self.requested_seats = requested_seats
-        message = f"Maximum {maximum_seats} seats allowed."
-        super().__init__(message, 400)
-
-
-class NotAUnitBasedSubscription(SubscriptionError):
-    def __init__(self, subscription: Subscription) -> None:
-        self.subscription = subscription
-        message = "This subscription does not support unit-based pricing."
-        super().__init__(message, 400)
-
-
-class BelowMinimumUnits(SubscriptionError):
-    def __init__(
-        self, subscription: Subscription, minimum_units: int, requested_units: int
-    ) -> None:
-        self.subscription = subscription
-        self.minimum_units = minimum_units
-        self.requested_units = requested_units
-        message = f"Minimum {minimum_units} units required."
-        super().__init__(message, 400)
-
-
-class AboveMaximumUnits(SubscriptionError):
-    def __init__(
-        self, subscription: Subscription, maximum_units: int, requested_units: int
-    ) -> None:
-        self.subscription = subscription
-        self.maximum_units = maximum_units
-        self.requested_units = requested_units
-        message = f"Maximum {maximum_units} units allowed."
-        super().__init__(message, 400)
-
-
 class SubscriptionMeterCycleLag(SubscriptionError):
     """The meter clock fell more than one period behind; needs manual intervention."""
 
@@ -1714,7 +1641,16 @@ class SubscriptionService:
 
         unit_price = subscription.get_price_by_type(ProductPriceUnit)
         if unit_price is None:
-            raise NotAUnitBasedSubscription(subscription)
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "units"),
+                        "msg": "This subscription does not support unit-based pricing.",
+                        "input": units,
+                    }
+                ]
+            )
 
         self._validate_units_against_price(subscription, unit_price, units)
 
@@ -1749,11 +1685,29 @@ class SubscriptionService:
     ) -> None:
         minimum_units = unit_price.get_minimum_purchasable_units()
         if units < minimum_units:
-            raise BelowMinimumUnits(subscription, minimum_units, units)
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "units"),
+                        "msg": f"Minimum {minimum_units} units required.",
+                        "input": units,
+                    }
+                ]
+            )
 
         maximum_units = unit_price.get_maximum_units()
         if maximum_units is not None and units > maximum_units:
-            raise AboveMaximumUnits(subscription, maximum_units, units)
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "units"),
+                        "msg": f"Maximum {maximum_units} units allowed.",
+                        "input": units,
+                    }
+                ]
+            )
 
     async def validate_seats_change(
         self,
@@ -1767,21 +1721,61 @@ class SubscriptionService:
 
         seat_price = subscription.get_price_by_type(ProductPriceSeatUnit)
         if seat_price is None:
-            raise NotASeatBasedSubscription(subscription)
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "seats"),
+                        "msg": "This subscription does not support seat-based pricing.",
+                        "input": seats,
+                    }
+                ]
+            )
 
         minimum_seats = seat_price.get_minimum_seats()
         if seats < minimum_seats:
-            raise BelowMinimumSeats(subscription, minimum_seats, seats)
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "seats"),
+                        "msg": f"Minimum {minimum_seats} seats required.",
+                        "input": seats,
+                    }
+                ]
+            )
 
         maximum_seats = seat_price.get_maximum_seats()
         if maximum_seats is not None and seats > maximum_seats:
-            raise AboveMaximumSeats(subscription, maximum_seats, seats)
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "seats"),
+                        "msg": f"Maximum {maximum_seats} seats allowed.",
+                        "input": seats,
+                    }
+                ]
+            )
 
         assigned_count = await seat_service.count_assigned_seats_for_subscription(
             session, subscription
         )
         if seats < assigned_count:
-            raise SeatsAlreadyAssigned(subscription, assigned_count, seats)
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "seats"),
+                        "msg": (
+                            f"Cannot decrease seats to {seats}. "
+                            f"Currently {assigned_count} seats are assigned. "
+                            f"Revoke seats first."
+                        ),
+                        "input": seats,
+                    }
+                ]
+            )
 
     async def update_product(
         self,
@@ -3233,10 +3227,34 @@ class SubscriptionService:
                 return
             minimum_units = unit_price.get_minimum_purchasable_units()
             if units < minimum_units:
-                raise BelowMinimumUnits(subscription, minimum_units, units)
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "value_error",
+                            "loc": ("body", "product_id"),
+                            "msg": (
+                                f"Current unit count of {units} is below the "
+                                f"minimum of {minimum_units} units for this product."
+                            ),
+                            "input": unit_price.product_id,
+                        }
+                    ]
+                )
             maximum_units = unit_price.get_maximum_units()
             if maximum_units is not None and units > maximum_units:
-                raise AboveMaximumUnits(subscription, maximum_units, units)
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "value_error",
+                            "loc": ("body", "product_id"),
+                            "msg": (
+                                f"Current unit count of {units} is above the "
+                                f"maximum of {maximum_units} units for this product."
+                            ),
+                            "input": unit_price.product_id,
+                        }
+                    ]
+                )
             return
 
         if proration_behavior == SubscriptionProrationBehavior.next_period:

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -229,6 +229,167 @@ class CannotReinstateSubscription(SubscriptionError):
         super().__init__(message, 400)
 
 
+class NotASeatBasedSubscription(PolarRequestValidationError):
+    def __init__(self, subscription: Subscription, requested_seats: int) -> None:
+        self.subscription = subscription
+        self.requested_seats = requested_seats
+        super().__init__(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "seats"),
+                    "msg": "This subscription does not support seat-based pricing.",
+                    "input": requested_seats,
+                }
+            ]
+        )
+
+
+class SeatsAlreadyAssigned(PolarRequestValidationError):
+    def __init__(
+        self, subscription: Subscription, assigned_count: int, requested_seats: int
+    ) -> None:
+        self.subscription = subscription
+        self.assigned_count = assigned_count
+        self.requested_seats = requested_seats
+        super().__init__(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "seats"),
+                    "msg": (
+                        f"Cannot decrease seats to {requested_seats}. "
+                        f"Currently {assigned_count} seats are assigned. "
+                        f"Revoke seats first."
+                    ),
+                    "input": requested_seats,
+                }
+            ]
+        )
+
+
+class BelowMinimumSeats(PolarRequestValidationError):
+    def __init__(
+        self, subscription: Subscription, minimum_seats: int, requested_seats: int
+    ) -> None:
+        self.subscription = subscription
+        self.minimum_seats = minimum_seats
+        self.requested_seats = requested_seats
+        super().__init__(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "seats"),
+                    "msg": f"Minimum {minimum_seats} seats required.",
+                    "input": requested_seats,
+                }
+            ]
+        )
+
+
+class AboveMaximumSeats(PolarRequestValidationError):
+    def __init__(
+        self, subscription: Subscription, maximum_seats: int, requested_seats: int
+    ) -> None:
+        self.subscription = subscription
+        self.maximum_seats = maximum_seats
+        self.requested_seats = requested_seats
+        super().__init__(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "seats"),
+                    "msg": f"Maximum {maximum_seats} seats allowed.",
+                    "input": requested_seats,
+                }
+            ]
+        )
+
+
+class NotAUnitBasedSubscription(PolarRequestValidationError):
+    def __init__(self, subscription: Subscription, requested_units: int) -> None:
+        self.subscription = subscription
+        self.requested_units = requested_units
+        super().__init__(
+            [
+                {
+                    "type": "value_error",
+                    "loc": ("body", "units"),
+                    "msg": "This subscription does not support unit-based pricing.",
+                    "input": requested_units,
+                }
+            ]
+        )
+
+
+class BelowMinimumUnits(PolarRequestValidationError):
+    def __init__(
+        self,
+        subscription: Subscription,
+        minimum_units: int,
+        requested_units: int,
+        *,
+        product_id: uuid.UUID | None = None,
+    ) -> None:
+        self.subscription = subscription
+        self.minimum_units = minimum_units
+        self.requested_units = requested_units
+        # A product change keeps the live unit count, so the offending input is
+        # the target product, not a submitted unit count.
+        error: ValidationError
+        if product_id is not None:
+            error = {
+                "type": "value_error",
+                "loc": ("body", "product_id"),
+                "msg": (
+                    f"Current unit count of {requested_units} is below the "
+                    f"minimum of {minimum_units} units for this product."
+                ),
+                "input": product_id,
+            }
+        else:
+            error = {
+                "type": "value_error",
+                "loc": ("body", "units"),
+                "msg": f"Minimum {minimum_units} units required.",
+                "input": requested_units,
+            }
+        super().__init__([error])
+
+
+class AboveMaximumUnits(PolarRequestValidationError):
+    def __init__(
+        self,
+        subscription: Subscription,
+        maximum_units: int,
+        requested_units: int,
+        *,
+        product_id: uuid.UUID | None = None,
+    ) -> None:
+        self.subscription = subscription
+        self.maximum_units = maximum_units
+        self.requested_units = requested_units
+        error: ValidationError
+        if product_id is not None:
+            error = {
+                "type": "value_error",
+                "loc": ("body", "product_id"),
+                "msg": (
+                    f"Current unit count of {requested_units} is above the "
+                    f"maximum of {maximum_units} units for this product."
+                ),
+                "input": product_id,
+            }
+        else:
+            error = {
+                "type": "value_error",
+                "loc": ("body", "units"),
+                "msg": f"Maximum {maximum_units} units allowed.",
+                "input": requested_units,
+            }
+        super().__init__([error])
+
+
 class SubscriptionMeterCycleLag(SubscriptionError):
     """The meter clock fell more than one period behind; needs manual intervention."""
 
@@ -1641,16 +1802,7 @@ class SubscriptionService:
 
         unit_price = subscription.get_price_by_type(ProductPriceUnit)
         if unit_price is None:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "units"),
-                        "msg": "This subscription does not support unit-based pricing.",
-                        "input": units,
-                    }
-                ]
-            )
+            raise NotAUnitBasedSubscription(subscription, units)
 
         self._validate_units_against_price(subscription, unit_price, units)
 
@@ -1685,29 +1837,11 @@ class SubscriptionService:
     ) -> None:
         minimum_units = unit_price.get_minimum_purchasable_units()
         if units < minimum_units:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "units"),
-                        "msg": f"Minimum {minimum_units} units required.",
-                        "input": units,
-                    }
-                ]
-            )
+            raise BelowMinimumUnits(subscription, minimum_units, units)
 
         maximum_units = unit_price.get_maximum_units()
         if maximum_units is not None and units > maximum_units:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "units"),
-                        "msg": f"Maximum {maximum_units} units allowed.",
-                        "input": units,
-                    }
-                ]
-            )
+            raise AboveMaximumUnits(subscription, maximum_units, units)
 
     async def validate_seats_change(
         self,
@@ -1721,61 +1855,21 @@ class SubscriptionService:
 
         seat_price = subscription.get_price_by_type(ProductPriceSeatUnit)
         if seat_price is None:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "seats"),
-                        "msg": "This subscription does not support seat-based pricing.",
-                        "input": seats,
-                    }
-                ]
-            )
+            raise NotASeatBasedSubscription(subscription, seats)
 
         minimum_seats = seat_price.get_minimum_seats()
         if seats < minimum_seats:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "seats"),
-                        "msg": f"Minimum {minimum_seats} seats required.",
-                        "input": seats,
-                    }
-                ]
-            )
+            raise BelowMinimumSeats(subscription, minimum_seats, seats)
 
         maximum_seats = seat_price.get_maximum_seats()
         if maximum_seats is not None and seats > maximum_seats:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "seats"),
-                        "msg": f"Maximum {maximum_seats} seats allowed.",
-                        "input": seats,
-                    }
-                ]
-            )
+            raise AboveMaximumSeats(subscription, maximum_seats, seats)
 
         assigned_count = await seat_service.count_assigned_seats_for_subscription(
             session, subscription
         )
         if seats < assigned_count:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "seats"),
-                        "msg": (
-                            f"Cannot decrease seats to {seats}. "
-                            f"Currently {assigned_count} seats are assigned. "
-                            f"Revoke seats first."
-                        ),
-                        "input": seats,
-                    }
-                ]
-            )
+            raise SeatsAlreadyAssigned(subscription, assigned_count, seats)
 
     async def update_product(
         self,
@@ -3228,33 +3322,13 @@ class SubscriptionService:
                 return
             minimum_units = unit_price.get_minimum_purchasable_units()
             if units < minimum_units:
-                raise PolarRequestValidationError(
-                    [
-                        {
-                            "type": "value_error",
-                            "loc": ("body", "product_id"),
-                            "msg": (
-                                f"Current unit count of {units} is below the "
-                                f"minimum of {minimum_units} units for this product."
-                            ),
-                            "input": product_id,
-                        }
-                    ]
+                raise BelowMinimumUnits(
+                    subscription, minimum_units, units, product_id=product_id
                 )
             maximum_units = unit_price.get_maximum_units()
             if maximum_units is not None and units > maximum_units:
-                raise PolarRequestValidationError(
-                    [
-                        {
-                            "type": "value_error",
-                            "loc": ("body", "product_id"),
-                            "msg": (
-                                f"Current unit count of {units} is above the "
-                                f"maximum of {maximum_units} units for this product."
-                            ),
-                            "input": product_id,
-                        }
-                    ]
+                raise AboveMaximumUnits(
+                    subscription, maximum_units, units, product_id=product_id
                 )
             return
 

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -1152,9 +1152,10 @@ class TestSubscriptionUpdateSeats:
         )
 
         # Then: Error response
-        assert response.status_code == 400
+        assert response.status_code == 422
         error = response.json()
-        assert "7 seats are assigned" in error["detail"]
+        assert error["detail"][0]["loc"] == ["body", "seats"]
+        assert "7 seats are assigned" in error["detail"][0]["msg"]
 
     @pytest.mark.auth
     async def test_not_seat_based_subscription(
@@ -1177,9 +1178,10 @@ class TestSubscriptionUpdateSeats:
         )
 
         # Then: Error response
-        assert response.status_code == 400
+        assert response.status_code == 422
         error = response.json()
-        assert "not support seat-based pricing" in error["detail"]
+        assert error["detail"][0]["loc"] == ["body", "seats"]
+        assert "not support seat-based pricing" in error["detail"][0]["msg"]
 
     @pytest.mark.auth
     async def test_trialing_subscription(

--- a/server/tests/subscription/test_endpoints_change_preview.py
+++ b/server/tests/subscription/test_endpoints_change_preview.py
@@ -122,7 +122,7 @@ class TestPreviewChange:
             json={"seats": 5},
         )
 
-        assert response.status_code == 400
+        assert response.status_code == 422
 
     @pytest.mark.auth
     async def test_rejects_both_product_and_seats(

--- a/server/tests/subscription/test_endpoints_change_preview.py
+++ b/server/tests/subscription/test_endpoints_change_preview.py
@@ -123,6 +123,10 @@ class TestPreviewChange:
         )
 
         assert response.status_code == 422
+        error = response.json()
+        assert error["error"] == "PolarRequestValidationError"
+        assert error["detail"][0]["loc"] == ["body", "seats"]
+        assert error["detail"][0]["input"] == 5
 
     @pytest.mark.auth
     async def test_rejects_both_product_and_seats(

--- a/server/tests/subscription/test_endpoints_change_preview.py
+++ b/server/tests/subscription/test_endpoints_change_preview.py
@@ -124,7 +124,7 @@ class TestPreviewChange:
 
         assert response.status_code == 422
         error = response.json()
-        assert error["error"] == "PolarRequestValidationError"
+        assert error["error"] == "NotASeatBasedSubscription"
         assert error["detail"][0]["loc"] == ["body", "seats"]
         assert error["detail"][0]["input"] == 5
 

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -83,18 +83,14 @@ from polar.subscription.schemas import (
     SubscriptionUpdateSeats,
 )
 from polar.subscription.service import (
-    AboveMaximumSeats,
     AlreadyCanceledSubscription,
-    BelowMinimumSeats,
     CannotPauseSubscription,
     CannotReinstateSubscription,
     MissingCheckoutCustomer,
     NoScheduledPause,
     NotARecurringProduct,
-    NotASeatBasedSubscription,
     NotBillableSubscription,
     NotPausedSubscription,
-    SeatsAlreadyAssigned,
     SubscriptionMeterCycleLag,
     SubscriptionUpdateContext,
 )
@@ -7438,7 +7434,7 @@ class TestUpdateSeats:
 
         # When: Try to decrease to 5 seats
         # Then: Raises error
-        with pytest.raises(SeatsAlreadyAssigned) as exc_info:
+        with pytest.raises(PolarRequestValidationError) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -7446,8 +7442,9 @@ class TestUpdateSeats:
                     session, ctx, subscription, seats=5
                 )
 
-        assert exc_info.value.assigned_count == 7
-        assert exc_info.value.requested_seats == 5
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("body", "seats")
+        assert "7 seats are assigned" in errors[0]["msg"]
 
     async def test_seat_decrease_successful(
         self,
@@ -7536,7 +7533,7 @@ class TestUpdateSeats:
 
         # When: Try to set seats=0
         # Then: Raises error
-        with pytest.raises(BelowMinimumSeats) as exc_info:
+        with pytest.raises(PolarRequestValidationError) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -7544,8 +7541,9 @@ class TestUpdateSeats:
                     session, ctx, subscription, seats=0
                 )
 
-        assert exc_info.value.minimum_seats == 1
-        assert exc_info.value.requested_seats == 0
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("body", "seats")
+        assert "Minimum 1 seats required" in errors[0]["msg"]
 
     async def test_below_custom_minimum_seats(
         self,
@@ -7582,7 +7580,7 @@ class TestUpdateSeats:
         )
 
         # When: Try to set seats below custom minimum
-        with pytest.raises(BelowMinimumSeats) as exc_info:
+        with pytest.raises(PolarRequestValidationError) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -7590,8 +7588,9 @@ class TestUpdateSeats:
                     session, ctx, subscription, seats=2
                 )
 
-        assert exc_info.value.minimum_seats == 3
-        assert exc_info.value.requested_seats == 2
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("body", "seats")
+        assert "Minimum 3 seats required" in errors[0]["msg"]
 
     async def test_above_maximum_seats(
         self,
@@ -7628,7 +7627,7 @@ class TestUpdateSeats:
         )
 
         # When: Try to set seats above maximum
-        with pytest.raises(AboveMaximumSeats) as exc_info:
+        with pytest.raises(PolarRequestValidationError) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -7636,8 +7635,9 @@ class TestUpdateSeats:
                     session, ctx, subscription, seats=15
                 )
 
-        assert exc_info.value.maximum_seats == 10
-        assert exc_info.value.requested_seats == 15
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("body", "seats")
+        assert "Maximum 10 seats allowed" in errors[0]["msg"]
 
     async def test_seats_within_custom_limits(
         self,
@@ -7702,7 +7702,7 @@ class TestUpdateSeats:
 
         # When: Try to update seats
         # Then: Raises error
-        with pytest.raises(NotASeatBasedSubscription):
+        with pytest.raises(PolarRequestValidationError):
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -7448,7 +7448,10 @@ class TestUpdateSeats:
 
         assert exc_info.value.assigned_count == 7
         assert exc_info.value.requested_seats == 5
-        assert exc_info.value.errors()[0]["loc"] == ("body", "seats")
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("body", "seats")
+        assert "7 seats are assigned" in errors[0]["msg"]
+        assert errors[0]["input"] == 5
 
     async def test_seat_decrease_successful(
         self,
@@ -7547,6 +7550,10 @@ class TestUpdateSeats:
 
         assert exc_info.value.minimum_seats == 1
         assert exc_info.value.requested_seats == 0
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("body", "seats")
+        assert "Minimum 1 seats required" in errors[0]["msg"]
+        assert errors[0]["input"] == 0
 
     async def test_below_custom_minimum_seats(
         self,
@@ -7593,6 +7600,10 @@ class TestUpdateSeats:
 
         assert exc_info.value.minimum_seats == 3
         assert exc_info.value.requested_seats == 2
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("body", "seats")
+        assert "Minimum 3 seats required" in errors[0]["msg"]
+        assert errors[0]["input"] == 2
 
     async def test_above_maximum_seats(
         self,
@@ -7639,6 +7650,10 @@ class TestUpdateSeats:
 
         assert exc_info.value.maximum_seats == 10
         assert exc_info.value.requested_seats == 15
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("body", "seats")
+        assert "Maximum 10 seats allowed" in errors[0]["msg"]
+        assert errors[0]["input"] == 15
 
     async def test_seats_within_custom_limits(
         self,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -83,14 +83,18 @@ from polar.subscription.schemas import (
     SubscriptionUpdateSeats,
 )
 from polar.subscription.service import (
+    AboveMaximumSeats,
     AlreadyCanceledSubscription,
+    BelowMinimumSeats,
     CannotPauseSubscription,
     CannotReinstateSubscription,
     MissingCheckoutCustomer,
     NoScheduledPause,
     NotARecurringProduct,
+    NotASeatBasedSubscription,
     NotBillableSubscription,
     NotPausedSubscription,
+    SeatsAlreadyAssigned,
     SubscriptionMeterCycleLag,
     SubscriptionUpdateContext,
 )
@@ -7434,7 +7438,7 @@ class TestUpdateSeats:
 
         # When: Try to decrease to 5 seats
         # Then: Raises error
-        with pytest.raises(PolarRequestValidationError) as exc_info:
+        with pytest.raises(SeatsAlreadyAssigned) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -7442,9 +7446,9 @@ class TestUpdateSeats:
                     session, ctx, subscription, seats=5
                 )
 
-        errors = exc_info.value.errors()
-        assert errors[0]["loc"] == ("body", "seats")
-        assert "7 seats are assigned" in errors[0]["msg"]
+        assert exc_info.value.assigned_count == 7
+        assert exc_info.value.requested_seats == 5
+        assert exc_info.value.errors()[0]["loc"] == ("body", "seats")
 
     async def test_seat_decrease_successful(
         self,
@@ -7533,7 +7537,7 @@ class TestUpdateSeats:
 
         # When: Try to set seats=0
         # Then: Raises error
-        with pytest.raises(PolarRequestValidationError) as exc_info:
+        with pytest.raises(BelowMinimumSeats) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -7541,9 +7545,8 @@ class TestUpdateSeats:
                     session, ctx, subscription, seats=0
                 )
 
-        errors = exc_info.value.errors()
-        assert errors[0]["loc"] == ("body", "seats")
-        assert "Minimum 1 seats required" in errors[0]["msg"]
+        assert exc_info.value.minimum_seats == 1
+        assert exc_info.value.requested_seats == 0
 
     async def test_below_custom_minimum_seats(
         self,
@@ -7580,7 +7583,7 @@ class TestUpdateSeats:
         )
 
         # When: Try to set seats below custom minimum
-        with pytest.raises(PolarRequestValidationError) as exc_info:
+        with pytest.raises(BelowMinimumSeats) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -7588,9 +7591,8 @@ class TestUpdateSeats:
                     session, ctx, subscription, seats=2
                 )
 
-        errors = exc_info.value.errors()
-        assert errors[0]["loc"] == ("body", "seats")
-        assert "Minimum 3 seats required" in errors[0]["msg"]
+        assert exc_info.value.minimum_seats == 3
+        assert exc_info.value.requested_seats == 2
 
     async def test_above_maximum_seats(
         self,
@@ -7627,7 +7629,7 @@ class TestUpdateSeats:
         )
 
         # When: Try to set seats above maximum
-        with pytest.raises(PolarRequestValidationError) as exc_info:
+        with pytest.raises(AboveMaximumSeats) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -7635,9 +7637,8 @@ class TestUpdateSeats:
                     session, ctx, subscription, seats=15
                 )
 
-        errors = exc_info.value.errors()
-        assert errors[0]["loc"] == ("body", "seats")
-        assert "Maximum 10 seats allowed" in errors[0]["msg"]
+        assert exc_info.value.maximum_seats == 10
+        assert exc_info.value.requested_seats == 15
 
     async def test_seats_within_custom_limits(
         self,
@@ -7702,7 +7703,7 @@ class TestUpdateSeats:
 
         # When: Try to update seats
         # Then: Raises error
-        with pytest.raises(PolarRequestValidationError):
+        with pytest.raises(NotASeatBasedSubscription):
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:

--- a/server/tests/subscription/test_service_units.py
+++ b/server/tests/subscription/test_service_units.py
@@ -15,7 +15,12 @@ from polar.models.product_price import ProductPriceUnit
 from polar.postgres import AsyncSession
 from polar.product.tiers import Tiers, TierType
 from polar.subscription.repository import SubscriptionUpdateRepository
-from polar.subscription.service import SubscriptionUpdateContext
+from polar.subscription.service import (
+    AboveMaximumUnits,
+    BelowMinimumUnits,
+    NotAUnitBasedSubscription,
+    SubscriptionUpdateContext,
+)
 from polar.subscription.service import subscription as subscription_service
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.events import get_all_by_name
@@ -277,7 +282,7 @@ class TestUpdateUnits:
                 proration_behavior=SubscriptionProrationBehavior.next_period,
             )
 
-        with pytest.raises(PolarRequestValidationError) as exc_info:
+        with pytest.raises(BelowMinimumUnits) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -289,9 +294,9 @@ class TestUpdateUnits:
                     proration_behavior=SubscriptionProrationBehavior.prorate,
                 )
 
-        errors = exc_info.value.errors()
-        assert errors[0]["loc"] == ("body", "units")
-        assert "Minimum 10 units required" in errors[0]["msg"]
+        assert exc_info.value.minimum_units == 10
+        assert exc_info.value.requested_units == 5
+        assert exc_info.value.errors()[0]["loc"] == ("body", "units")
 
     async def test_same_units_is_noop(
         self,
@@ -348,7 +353,7 @@ class TestUpdateUnits:
             save_fixture, product=product, customer=customer, units=5
         )
 
-        with pytest.raises(PolarRequestValidationError):
+        with pytest.raises(BelowMinimumUnits):
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -377,7 +382,7 @@ class TestUpdateUnits:
             save_fixture, product=product, customer=customer, units=5
         )
 
-        with pytest.raises(PolarRequestValidationError):
+        with pytest.raises(AboveMaximumUnits):
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -397,7 +402,7 @@ class TestUpdateUnits:
             save_fixture, product=product, customer=customer
         )
 
-        with pytest.raises(PolarRequestValidationError):
+        with pytest.raises(NotAUnitBasedSubscription):
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -520,7 +525,7 @@ class TestUnitProductChange:
             save_fixture, product=old_unit_product, customer=customer, units=3
         )
 
-        with pytest.raises(PolarRequestValidationError) as exc_info:
+        with pytest.raises(BelowMinimumUnits) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -532,9 +537,9 @@ class TestUnitProductChange:
                     proration_behavior=SubscriptionProrationBehavior.invoice,
                 )
 
-        errors = exc_info.value.errors()
-        assert errors[0]["loc"] == ("body", "product_id")
-        assert "below the minimum of 5 units" in errors[0]["msg"]
+        assert exc_info.value.minimum_units == 5
+        assert exc_info.value.requested_units == 3
+        assert exc_info.value.errors()[0]["loc"] == ("body", "product_id")
 
     async def test_non_unit_to_unit_upgrade_rejects_next_period(
         self,

--- a/server/tests/subscription/test_service_units.py
+++ b/server/tests/subscription/test_service_units.py
@@ -15,12 +15,7 @@ from polar.models.product_price import ProductPriceUnit
 from polar.postgres import AsyncSession
 from polar.product.tiers import Tiers, TierType
 from polar.subscription.repository import SubscriptionUpdateRepository
-from polar.subscription.service import (
-    AboveMaximumUnits,
-    BelowMinimumUnits,
-    NotAUnitBasedSubscription,
-    SubscriptionUpdateContext,
-)
+from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.events import get_all_by_name
@@ -282,7 +277,7 @@ class TestUpdateUnits:
                 proration_behavior=SubscriptionProrationBehavior.next_period,
             )
 
-        with pytest.raises(BelowMinimumUnits) as exc_info:
+        with pytest.raises(PolarRequestValidationError) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -294,8 +289,9 @@ class TestUpdateUnits:
                     proration_behavior=SubscriptionProrationBehavior.prorate,
                 )
 
-        assert exc_info.value.minimum_units == 10
-        assert exc_info.value.requested_units == 5
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("body", "units")
+        assert "Minimum 10 units required" in errors[0]["msg"]
 
     async def test_same_units_is_noop(
         self,
@@ -352,7 +348,7 @@ class TestUpdateUnits:
             save_fixture, product=product, customer=customer, units=5
         )
 
-        with pytest.raises(BelowMinimumUnits):
+        with pytest.raises(PolarRequestValidationError):
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -381,7 +377,7 @@ class TestUpdateUnits:
             save_fixture, product=product, customer=customer, units=5
         )
 
-        with pytest.raises(AboveMaximumUnits):
+        with pytest.raises(PolarRequestValidationError):
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -401,7 +397,7 @@ class TestUpdateUnits:
             save_fixture, product=product, customer=customer
         )
 
-        with pytest.raises(NotAUnitBasedSubscription):
+        with pytest.raises(PolarRequestValidationError):
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -524,7 +520,7 @@ class TestUnitProductChange:
             save_fixture, product=old_unit_product, customer=customer, units=3
         )
 
-        with pytest.raises(BelowMinimumUnits) as exc_info:
+        with pytest.raises(PolarRequestValidationError) as exc_info:
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
             ) as ctx:
@@ -536,8 +532,9 @@ class TestUnitProductChange:
                     proration_behavior=SubscriptionProrationBehavior.invoice,
                 )
 
-        assert exc_info.value.minimum_units == 5
-        assert exc_info.value.requested_units == 3
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("body", "product_id")
+        assert "below the minimum of 5 units" in errors[0]["msg"]
 
     async def test_non_unit_to_unit_upgrade_rejects_next_period(
         self,

--- a/server/tests/subscription/test_service_units.py
+++ b/server/tests/subscription/test_service_units.py
@@ -296,7 +296,10 @@ class TestUpdateUnits:
 
         assert exc_info.value.minimum_units == 10
         assert exc_info.value.requested_units == 5
-        assert exc_info.value.errors()[0]["loc"] == ("body", "units")
+        errors = exc_info.value.errors()
+        assert errors[0]["loc"] == ("body", "units")
+        assert "Minimum 10 units required" in errors[0]["msg"]
+        assert errors[0]["input"] == 5
 
     async def test_same_units_is_noop(
         self,


### PR DESCRIPTION
## Summary

**Related Issue**: Closes https://github.com/polarsource/polar/issues/13912

Converts the seat and unit subscription-update validation errors from flat 400 `SubscriptionError` responses to structured 422 `PolarRequestValidationError` responses, matching the rest of `subscription/service.py`.

## What

- `NotASeatBasedSubscription`, `BelowMinimumSeats`, `AboveMaximumSeats`, `SeatsAlreadyAssigned`, `NotAUnitBasedSubscription`, `BelowMinimumUnits`, and `AboveMaximumUnits` now extend `PolarRequestValidationError` (same pattern as `BenefitPropertiesValidationError`) instead of `SubscriptionError`, so the typed exceptions and their attributes (`minimum_seats`, `assigned_count`, …) are kept, the response's `error` field keeps the specific class name, and the body is the structured 422 `detail` list.
  - `validate_seats_change` errors point at `("body", "seats")`, `validate_units_change` / `_validate_units_against_price` at `("body", "units")`.
  - The unit-bounds check in `_promote_units_for_unit_transition` (unit→unit product switch) raises the same classes with a `product_id` kwarg, pointing at `("body", "product_id")` with the submitted product id as `input`, consistent with the neighboring `next_period` validation errors in the same path.
- Removed the now-dead `400: NotASeatBasedSubscription.schema()` response declarations (and imports) from the `change-preview` endpoints in `subscription/endpoints.py` and `customer_portal/endpoints/subscription.py` — these errors render through the 422 validation handler now.
- Regenerated `clients/packages/client/src/v1.ts`.

## Why

These validations reject invalid request payload values (seats/units out of bounds, seats/units on a subscription that doesn't support them), which is exactly what `PolarRequestValidationError` is for — a structured 422 with `loc`/`msg`/`input` — while the flat 400 was inconsistent with the surrounding update validation in the same service. Subclassing rather than raising the base error keeps the granularity: callers and tests still catch the specific types, and API consumers still see the specific error name. Raised in [this discussion](https://github.com/polarsource/polar/pull/13871#discussion_r3821086137).

## How

Each error class builds its validation error detail in its constructor with the same message text as before, keeping messages and typed attributes while changing the status code and response shape. Existing tests were updated to the new status/shape and still assert the specific exception types and attributes (no new tests added).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LUXDy3ZVkswPcV5DeQELYq