### PR TITLE
product: allow unit-based pricing on one-time products

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceItem.tsx
@@ -123,12 +123,11 @@ export const ProductPriceItem: React.FC<ProductPriceItemProps> = ({
                           </SelectItem>
                         )}
                         {organization.feature_settings
-                          ?.unit_based_pricing_enabled &&
-                          recurringInterval !== null && (
-                            <SelectItem value="unit_based">
-                              {AMOUNT_TYPE_LABELS.unit_based}
-                            </SelectItem>
-                          )}
+                          ?.unit_based_pricing_enabled && (
+                          <SelectItem value="unit_based">
+                            {AMOUNT_TYPE_LABELS.unit_based}
+                          </SelectItem>
+                        )}
                         {recurringInterval !== null && (
                           <SelectItem value="metered_unit">
                             {AMOUNT_TYPE_LABELS.metered_unit}

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -1,11 +1,7 @@
 'use client'
 
 import { TrialConfigurationForm } from '@/components/TrialConfiguration/TrialConfigurationForm'
-import {
-  isLegacyRecurringPrice,
-  isMeteredPrice,
-  isUnitBasedPrice,
-} from '@/utils/product'
+import { isLegacyRecurringPrice, isMeteredPrice } from '@/utils/product'
 import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import { Input } from '@polar-sh/orbit'
@@ -110,9 +106,7 @@ export const ProductPricingSection = ({
     const currentPrices = getValues('prices')
     if (!currentPrices) return
     const filteredPrices = currentPrices.filter(
-      (price) =>
-        !isMeteredPrice(price as ProductPrice) &&
-        !isUnitBasedPrice(price as ProductPrice),
+      (price) => !isMeteredPrice(price as ProductPrice),
     )
     if (filteredPrices.length !== currentPrices.length) {
       replace(filteredPrices)
@@ -476,7 +470,6 @@ export const ProductPricingSection = ({
 
   const canAddUnitPricing =
     onlyStaticAmountType === 'fixed' &&
-    recurringInterval !== null &&
     !!organization.feature_settings?.unit_based_pricing_enabled
 
   const canAddBasePrice =

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -32376,7 +32376,7 @@ export interface components {
     /**
      * ProductPriceUnitBased
      * @description A unit-based price for a product: the buyer picks a quantity of units,
-     *     pays for it up-front, and changes are prorated.
+     *     pays for it up-front. On subscriptions, quantity changes are prorated.
      */
     ProductPriceUnitBased: {
       /**
@@ -32446,7 +32446,7 @@ export interface components {
     /**
      * ProductPriceUnitBasedCreate
      * @description Schema to create a unit-based price: the buyer picks a quantity of units,
-     *     pays for it up-front, and changes are prorated.
+     *     pays for it up-front. On subscriptions, quantity changes are prorated.
      */
     ProductPriceUnitBasedCreate: {
       /**

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -450,7 +450,7 @@ class ProductPriceMeteredUnitCreate(ProductPriceMeteredCreateBase):
 class ProductPriceUnitBasedCreate(ProductPriceCreateBase):
     """
     Schema to create a unit-based price: the buyer picks a quantity of units,
-    pays for it up-front, and changes are prorated.
+    pays for it up-front. On subscriptions, quantity changes are prorated.
     """
 
     amount_type: Literal[ProductPriceAmountType.unit_based]
@@ -927,7 +927,7 @@ class ProductPriceSeatBased(ProductPriceSeatBasedBase):
 class ProductPriceUnitBased(ProductPriceUnitBasedBase):
     """
     A unit-based price for a product: the buyer picks a quantity of units,
-    pays for it up-front, and changes are prorated.
+    pays for it up-front. On subscriptions, quantity changes are prorated.
     """
 
 

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -628,29 +628,20 @@ class ProductService:
                         }
                     )
                     continue
-                if isinstance(price_schema, ProductPriceUnitBasedCreate):
-                    if not organization.feature_settings.get(
-                        "unit_based_pricing_enabled", False
-                    ):
-                        errors.append(
-                            {
-                                "type": "value_error",
-                                "loc": (*error_prefix, index),
-                                "msg": "Unit-based pricing is not enabled for this organization.",
-                                "input": price_schema,
-                            }
-                        )
-                        continue
-                    if recurring_interval is None:
-                        errors.append(
-                            {
-                                "type": "value_error",
-                                "loc": (*error_prefix, index),
-                                "msg": "Unit-based pricing is not supported on one-time products.",
-                                "input": price_schema,
-                            }
-                        )
-                        continue
+                if isinstance(
+                    price_schema, ProductPriceUnitBasedCreate
+                ) and not organization.feature_settings.get(
+                    "unit_based_pricing_enabled", False
+                ):
+                    errors.append(
+                        {
+                            "type": "value_error",
+                            "loc": (*error_prefix, index),
+                            "msg": "Unit-based pricing is not enabled for this organization.",
+                            "input": price_schema,
+                        }
+                    )
+                    continue
                 if is_metered_price(price) and isinstance(
                     price_schema, ProductPriceMeteredCreateBase
                 ):

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -7450,6 +7450,31 @@ class TestCreateUnitBasedCheckout:
         assert checkout.currency == price.price_currency
 
     @pytest.mark.auth
+    async def test_with_units_on_one_time_product(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        organization: Organization,
+    ) -> None:
+        product = await create_product_unit_based(
+            save_fixture,
+            organization=organization,
+            price_per_unit=2900,
+            recurring_interval=None,
+        )
+
+        checkout = await checkout_service.create(
+            session,
+            CheckoutProductCreate(product_id=product.id, units=10),
+            auth_subject,
+        )
+
+        assert checkout.units == 10
+        assert checkout.amount == 29000
+
+    @pytest.mark.auth
     async def test_without_units_defaults_to_one(
         self,
         session: AsyncSession,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -132,6 +132,7 @@ from tests.fixtures.random_objects import (
     create_payment_method,
     create_product,
     create_product_fixed_and_seat,
+    create_product_unit_based,
     create_subscription,
     create_trialing_subscription,
     create_wallet,
@@ -790,6 +791,50 @@ class TestCreateFromCheckoutOneTime:
         # Seat-based orders defer benefit grants until seats are claimed
         for c in enqueue_job_mock.call_args_list:
             assert c.args[0] != "benefit.enqueue_benefits_grants"
+
+    async def test_unit_based_grants_benefits_immediately(
+        self,
+        enqueue_job_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_unit_based(
+            save_fixture,
+            organization=organization,
+            recurring_interval=None,
+            price_per_unit=1000,
+        )
+
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            status=CheckoutStatus.confirmed,
+            customer=customer,
+            units=4,
+        )
+
+        order = await order_service.create_from_checkout_one_time(session, checkout)
+
+        assert order.units == 4
+        assert order.seats is None
+        assert order.subtotal_amount == 4000
+        assert len(order.items) == 1
+        assert order.items[0].amount == 4000
+        assert order.items[0].label == "Product (4 units)"
+
+        # Unlike seats, unit purchases have nothing to claim: grant right away
+        enqueue_job_mock.assert_any_call(
+            "benefit.enqueue_benefits_grants",
+            task="grant",
+            customer_id=customer.id,
+            product_id=product.id,
+            order_id=order.id,
+        )
+
+        await session.refresh(customer)
+        assert customer.type == CustomerType.individual
 
     async def test_fixed_does_not_upgrade_customer_to_team(
         self,

--- a/server/tests/product/test_service.py
+++ b/server/tests/product/test_service.py
@@ -1339,7 +1339,7 @@ class TestCreateUnitBasedPrice:
         assert price.calculate_amount(3) == 8700
 
     @pytest.mark.auth
-    async def test_one_time_product_rejected(
+    async def test_one_time_product(
         self,
         auth_subject: AuthSubject[User],
         session: AsyncSession,
@@ -1347,16 +1347,22 @@ class TestCreateUnitBasedPrice:
         user_organization: UserOrganization,
         unit_based_pricing_enabled: None,
     ) -> None:
-        with pytest.raises(PolarRequestValidationError):
-            await product_service.create(
-                session,
-                ProductCreateOneTime(
-                    name="Product",
-                    prices=[_unit_price_create()],
-                    organization_id=organization.id,
-                ),
-                auth_subject,
-            )
+        product = await product_service.create(
+            session,
+            ProductCreateOneTime(
+                name="Product",
+                prices=[_unit_price_create(minimum_units=5)],
+                organization_id=organization.id,
+            ),
+            auth_subject,
+        )
+
+        assert product.recurring_interval is None
+        assert len(product.prices) == 1
+        price = product.prices[0]
+        assert is_unit_price(price)
+        assert price.minimum_units == 5
+        assert price.calculate_amount(5) == 14500
 
     @pytest.mark.auth
     async def test_two_unit_prices_rejected(


### PR DESCRIPTION
The initial implementation only allowed unit_based price type products to be recurring subscriptions. This PR allows products to configure one-time purchases for unit-based price types, similarly to how seat based price types already works.

Usage of the unit-based price type is gated behind an internal feature flag