### PR TITLE
Align business customer checkbox spacing with custom field checkboxes

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -599,7 +599,7 @@ const BaseCheckoutForm = ({
                     name="is_business_customer"
                     render={({ field }) => (
                       <FormItem className="-mt-4">
-                        <div className="flex flex-row items-center space-y-0 space-x-2">
+                        <div className="flex flex-row items-center space-y-0 space-x-3">
                           <FormControl>
                             <Checkbox
                               className={cn(

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -599,7 +599,7 @@ const BaseCheckoutForm = ({
                     name="is_business_customer"
                     render={({ field }) => (
                       <FormItem className="-mt-4">
-                        <div className="flex flex-row items-center space-y-0 space-x-3">
+                        <div className="flex flex-row items-center space-y-0 space-x-2">
                           <FormControl>
                             <Checkbox
                               className={cn(

--- a/clients/packages/checkout/src/components/CustomFieldInput.tsx
+++ b/clients/packages/checkout/src/components/CustomFieldInput.tsx
@@ -180,7 +180,7 @@ const CustomFieldCheckboxInput: React.FC<CustomFieldCheckboxInputProps> = ({
 }) => {
   return (
     <FormItem>
-      <div className="flex flex-row items-center space-y-0 space-x-3">
+      <div className="flex flex-row items-center space-y-0 space-x-2">
         <FormControl>
           <Checkbox
             defaultChecked={field.value}


### PR DESCRIPTION
The "I'm purchasing as a business" checkbox row used space-x-2 while
checkbox custom fields rendered below it use space-x-3, leaving their
labels slightly misaligned on checkout.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UT3YhA4x6mrJkwHs9R5Rpd

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

