### PR TITLE
Support per-product customer portal URL overrides

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -446,8 +446,17 @@ class Settings(BaseSettings):
             and self.POLAR_ACCESS_TOKEN
         )
 
-    # Customer portal URL overrides per organization
-    CUSTOMER_PORTAL_URL_OVERRIDES: dict[str, str] = {}
+    # Customer portal URL overrides per organization: either a single URL for the
+    # whole organization, or a mapping of product ID to URL
+    CUSTOMER_PORTAL_URL_OVERRIDES: dict[str, str | dict[str, str]] = {}
+
+    def get_customer_portal_url_override(
+        self, organization_id: str, product_id: str | None
+    ) -> str | None:
+        override = self.CUSTOMER_PORTAL_URL_OVERRIDES.get(organization_id)
+        if isinstance(override, dict):
+            return override.get(product_id) if product_id is not None else None
+        return override
 
     # Invoices
     S3_CUSTOMER_INVOICES_BUCKET_NAME: str = "polar-customer-invoices"

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -2521,8 +2521,8 @@ class OrderService:
                 )
                 for key, value in url_params.items()
             }
-            override_url = settings.CUSTOMER_PORTAL_URL_OVERRIDES.get(
-                str(organization.id)
+            override_url = settings.get_customer_portal_url_override(
+                str(organization.id), str(product.id) if product is not None else None
             )
             if override_url is not None:
                 url = f"{override_url}?{urlencode({'email': recipient_email})}"

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -1,5 +1,6 @@
 from typing import Any, Literal
 
+import pytest
 from sqlalchemy.dialects.postgresql.asyncpg import PGDialect_asyncpg
 from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
 from sqlalchemy.engine import make_url
@@ -60,3 +61,48 @@ class TestBuildPostgresDsn:
         connect_args = get_connect_args(build_dsn("asyncpg", fallback_port=None))
 
         assert connect_args["port"] == [6432, 6432]
+
+
+class TestGetCustomerPortalUrlOverride:
+    def test_no_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "CUSTOMER_PORTAL_URL_OVERRIDES", {})
+
+        assert settings.get_customer_portal_url_override("org_id", "product_id") is None
+
+    def test_organization_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            settings,
+            "CUSTOMER_PORTAL_URL_OVERRIDES",
+            {"org_id": "https://example.com/portal"},
+        )
+
+        assert (
+            settings.get_customer_portal_url_override("org_id", "product_id")
+            == "https://example.com/portal"
+        )
+
+    def test_product_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            settings,
+            "CUSTOMER_PORTAL_URL_OVERRIDES",
+            {"org_id": {"product_id": "https://example.com/product-portal"}},
+        )
+
+        assert (
+            settings.get_customer_portal_url_override("org_id", "product_id")
+            == "https://example.com/product-portal"
+        )
+
+    def test_product_not_in_organization_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            settings,
+            "CUSTOMER_PORTAL_URL_OVERRIDES",
+            {"org_id": {"product_id": "https://example.com/product-portal"}},
+        )
+
+        assert (
+            settings.get_customer_portal_url_override("org_id", "other_product_id")
+            is None
+        )


### PR DESCRIPTION
`POLAR_CUSTOMER_PORTAL_URL_OVERRIDES` now accepts either a single URL per organization or a mapping of product ID's to URL's, resolved through `get_customer_portal_url_override`


Claude-Session: https://claude.ai/code/session_011PN9jkRdCBt2PcRjU7qEGd

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

