### PR TITLE
fix(payout): skip paid_at assertion for manual payout invoices

### DIFF
--- a/server/polar/invoice/service.py
+++ b/server/polar/invoice/service.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 
 from polar.config import settings
+from polar.enums import PayoutAccountType
 from polar.exceptions import PolarError
 from polar.integrations.aws.s3 import S3Service
 from polar.kit.utils import utc_now
@@ -113,7 +114,8 @@ class InvoiceService:
         # Sanity check to make sure the amounts add up correctly
         assert payout.fees_amount == abs(current_payout_fees_amount)
         assert payout.amount == gross_amount + payout_fees_amount + payment_fees_amount
-        assert payout.paid_at is not None
+        if payout.processor != PayoutAccountType.manual:
+            assert payout.paid_at is not None
 
         items = [
             InvoiceItem(
@@ -168,7 +170,11 @@ class InvoiceService:
                 "Payouts (reverse invoices) are therefore without taxes."
             ),
             extra_heading_items=[
-                InvoiceHeadingItem(label="Paid at", value=payout.paid_at),
+                *(
+                    [InvoiceHeadingItem(label="Paid at", value=payout.paid_at)]
+                    if payout.paid_at is not None
+                    else []
+                ),
                 InvoiceHeadingItem(
                     label="Payout Method", value=payout.processor.get_display_name()
                 ),

--- a/server/tests/invoice/test_service.py
+++ b/server/tests/invoice/test_service.py
@@ -1,12 +1,23 @@
+from datetime import timedelta
+from functools import partial
+
 import pytest
 import pytest_asyncio
+from pytest_mock import MockerFixture
 
+from polar.enums import PayoutAccountType
+from polar.invoice.generator import Invoice
 from polar.invoice.service import invoice as invoice_service
 from polar.kit.address import Address, CountryAlpha2
-from polar.models import Customer, Order, Product
+from polar.kit.utils import utc_now
+from polar.locker import Locker
+from polar.models import Account, Customer, Order, Organization, Product, User
+from polar.payout.service import payout as payout_service
+from polar.postgres import AsyncSession
 from polar.tax.tax_id import TaxIDFormat
+from tests.fixtures import random_objects as ro
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_order
+from tests.fixtures.random_objects import create_order, create_payout_account
 
 
 @pytest_asyncio.fixture
@@ -82,3 +93,57 @@ class TestComputeOrderChecksum:
         order_with_billing.tax_id = ("FR61954506077", TaxIDFormat.eu_vat)
 
         assert invoice_service.compute_order_checksum(order_with_billing) != before
+
+
+ten_days_ago = utc_now() - timedelta(days=10)
+create_payment_transaction = partial(
+    ro.create_payment_transaction, amount=10000, created_at=ten_days_ago
+)
+create_balance_transaction = partial(
+    ro.create_balance_transaction, amount=10000, created_at=ten_days_ago
+)
+
+
+@pytest.mark.asyncio
+class TestCreatePayoutInvoice:
+    async def test_manual_payout_without_paid_at(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        # A manual payout never goes through a processor, so it has no attempt
+        # and `paid_at` stays None. Invoice generation must still succeed.
+        account.billing_name = "Acme Inc."
+        account.billing_address = Address(country=CountryAlpha2("US"))
+        await save_fixture(account)
+
+        await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.manual
+        )
+        payment_transaction = await create_payment_transaction(save_fixture)
+        await create_balance_transaction(
+            save_fixture, account=account, payment_transaction=payment_transaction
+        )
+
+        payout = await payout_service.create(session, locker, organization)
+        assert payout.processor == PayoutAccountType.manual
+        assert payout.paid_at is None
+
+        render_mock = mocker.patch(
+            "polar.invoice.service.render_invoice_pdf", return_value=b"%PDF-1.4"
+        )
+        mocker.patch("polar.invoice.service.S3Service")
+
+        invoice_path = await invoice_service.create_payout_invoice(session, payout)
+
+        assert invoice_path is not None
+        rendered_invoice: Invoice = render_mock.call_args.args[0]
+        heading_labels = [
+            item.label for item in (rendered_invoice.extra_heading_items or [])
+        ]
+        assert "Paid at" not in heading_labels


### PR DESCRIPTION
## Problem

Generating an invoice for a **manual** payout crashes the `payout.invoice` background task, which then retries forever. Observed in Logfire: payout `d738a37d-f2df-4bde-9067-4257ba66578f` failed 52× since Aug 24 (still ongoing), each time with:

```
File "polar/invoice/service.py", line 116, in create_payout_invoice
    assert payout.paid_at is not None
AssertionError
```

## Root cause

`Payout.paid_at` isn't a column — it's a property derived from the first **succeeded** `PayoutAttempt` that has a `paid_at` (`models/payout.py`). A manual payout never goes through a processor, so it has no attempt and `paid_at` stays `None`.

Meanwhile `Payout.status` becomes `succeeded` via the DB trigger, so `trigger_invoice_generation`'s gate (`status == succeeded`) passes and the merchant can request an invoice — which then hits the unconditional `assert payout.paid_at is not None` and crashes. Because the assert is uncaught, Dramatiq retries indefinitely.

## Fix

- Only assert `paid_at is not None` when `payout.processor != PayoutAccountType.manual`.
- Omit the "Paid at" heading item from the rendered invoice when `paid_at` is absent (`InvoiceHeadingItem.value` is `str | datetime`, so passing `None` would fail Pydantic validation).

## Test

Added `TestCreatePayoutInvoice::test_manual_payout_without_paid_at`: builds a real manual payout (no attempt → `paid_at is None`) and asserts invoice generation succeeds and the "Paid at" heading is omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

