### PR TITLE
Fix payout invoice generation crash-loop for manual payouts

### DIFF
--- a/server/polar/invoice/service.py
+++ b/server/polar/invoice/service.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 
 from polar.config import settings
+from polar.enums import PayoutAccountType
 from polar.exceptions import PolarError
 from polar.integrations.aws.s3 import S3Service
 from polar.kit.utils import utc_now
@@ -113,7 +114,14 @@ class InvoiceService:
         # Sanity check to make sure the amounts add up correctly
         assert payout.fees_amount == abs(current_payout_fees_amount)
         assert payout.amount == gross_amount + payout_fees_amount + payment_fees_amount
-        assert payout.paid_at is not None
+
+        # Manual payouts have no succeeded attempt, so `paid_at` is always None.
+        # Fall back to the payout's creation date in that case.
+        if payout.processor == PayoutAccountType.manual:
+            paid_at = payout.created_at
+        else:
+            assert payout.paid_at is not None
+            paid_at = payout.paid_at
 
         items = [
             InvoiceItem(
@@ -168,7 +176,7 @@ class InvoiceService:
                 "Payouts (reverse invoices) are therefore without taxes."
             ),
             extra_heading_items=[
-                InvoiceHeadingItem(label="Paid at", value=payout.paid_at),
+                InvoiceHeadingItem(label="Paid at", value=paid_at),
                 InvoiceHeadingItem(
                     label="Payout Method", value=payout.processor.get_display_name()
                 ),


### PR DESCRIPTION
## Problem

The `payout.invoice` task was crash-looping on a single manual payout (`d738a37d-…`) — 52 retries since Aug 24, every one an `AssertionError` on `assert payout.paid_at is not None`.

**Root cause:** `Payout.paid_at` is a property derived from a succeeded `PayoutAttempt`. Manual payouts have no attempt, so `paid_at` is always `None`. The DB trigger still flips status to `succeeded`, so invoice generation gets triggered — and then asserts and retries forever.

## Fix

In `polar/invoice/service.py`, fall back to `payout.created_at` for manual payouts instead of asserting on `paid_at`:

```python
if payout.processor == PayoutAccountType.manual:
    paid_at = payout.created_at
else:
    assert payout.paid_at is not None
    paid_at = payout.paid_at
```

The assert is kept for Stripe payouts, where `paid_at` genuinely should always be set — dropping that invariant would hide real bugs. The computed `paid_at` is used for the invoice's "Paid at" heading item.

Once shipped, the stuck payout will generate its invoice on the next retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

