### PR TITLE
Fix broken webhook event links to use versioned API reference paths

### DIFF
--- a/docs/integrate/webhooks/events.mdx
+++ b/docs/integrate/webhooks/events.mdx
@@ -12,21 +12,21 @@ description: "Our webhook events and in which context they are useful"
   <Card
     title="checkout.created"
     icon="link"
-    href="/api-reference/checkout_created"
+    href="/api-reference/current/checkout_created"
     horizontal
   ></Card>
 
   <Card
     title="checkout.updated"
     icon="link"
-    href="/api-reference/checkout_updated"
+    href="/api-reference/current/checkout_updated"
     horizontal
   ></Card>
 
   <Card
     title="checkout.expired"
     icon="link"
-    href="/api-reference/checkout_expired"
+    href="/api-reference/current/checkout_expired"
     horizontal
   >
     Fired when a checkout link has expired without being completed.
@@ -39,7 +39,7 @@ description: "Our webhook events and in which context they are useful"
   <Card
     title="customer.created"
     icon="link"
-    href="/api-reference/customer_created"
+    href="/api-reference/current/customer_created"
     horizontal
   >
     Fired when a new customer has been created.
@@ -48,7 +48,7 @@ description: "Our webhook events and in which context they are useful"
   <Card
     title="customer.updated"
     icon="link"
-    href="/api-reference/customer_updated"
+    href="/api-reference/current/customer_updated"
     horizontal
   >
     Fired when a customer has been updated.
@@ -57,7 +57,7 @@ description: "Our webhook events and in which context they are useful"
   <Card
     title="customer.deleted"
     icon="link"
-    href="/api-reference/customer_deleted"
+    href="/api-reference/current/customer_deleted"
     horizontal
   >
     Fired when a customer has been deleted.
@@ -66,7 +66,7 @@ description: "Our webhook events and in which context they are useful"
   <Card
     title="customer.state_changed"
     icon="link"
-    href="/api-reference/customer_state_changed"
+    href="/api-reference/current/customer_state_changed"
     horizontal
   >
     Fired when a customer's state has changed. Includes active subscriptions and
@@ -82,7 +82,7 @@ In order to properly implement logic for handling subscriptions, you should look
   <Card
     title="subscription.created"
     icon="link"
-    href="/api-reference/subscription_created"
+    href="/api-reference/current/subscription_created"
     horizontal
   >
     Fired when a new subscription has been created.
@@ -91,21 +91,21 @@ In order to properly implement logic for handling subscriptions, you should look
   <Card
     title="subscription.active"
     icon="link"
-    href="/api-reference/subscription_active"
+    href="/api-reference/current/subscription_active"
     horizontal
   ></Card>
 
   <Card
     title="subscription.uncanceled"
     icon="link"
-    href="/api-reference/subscription_uncanceled"
+    href="/api-reference/current/subscription_uncanceled"
     horizontal
   ></Card>
 
   <Card
     title="subscription.cycled"
     icon="link"
-    href="/api-reference/subscription_cycled"
+    href="/api-reference/current/subscription_cycled"
     horizontal
   >
     Fired when a subscription enters a new billing period, before the renewal order exists and whether or not the payment succeeds.
@@ -114,14 +114,14 @@ In order to properly implement logic for handling subscriptions, you should look
   <Card
     title="subscription.canceled"
     icon="link"
-    href="/api-reference/subscription_canceled"
+    href="/api-reference/current/subscription_canceled"
     horizontal
   ></Card>
 
   <Card
     title="subscription.past_due"
     icon="link"
-    href="/api-reference/subscription_past_due"
+    href="/api-reference/current/subscription_past_due"
     horizontal
   >
     Fired when a subscription payment has failed. The customer can recover by updating their payment method.
@@ -130,7 +130,7 @@ In order to properly implement logic for handling subscriptions, you should look
   <Card
     title="subscription.updated"
     icon="link"
-    href="/api-reference/subscription_updated"
+    href="/api-reference/current/subscription_updated"
     horizontal
   >
     Use this event if you want to handle cancellations, un-cancellations, etc. The
@@ -143,7 +143,7 @@ In order to properly implement logic for handling subscriptions, you should look
   <Card
     title="order.created"
     icon="link"
-    href="/api-reference/order_created"
+    href="/api-reference/current/order_created"
     horizontal
   >
     Carries a `billing_reason` field, which can be `purchase`,
@@ -155,14 +155,14 @@ In order to properly implement logic for handling subscriptions, you should look
   <Card
     title="subscription.revoked"
     icon="link"
-    href="/api-reference/subscription_revoked"
+    href="/api-reference/current/subscription_revoked"
     horizontal
   ></Card>
 
   <Card
     title="subscription.paused"
     icon="link"
-    href="/api-reference/subscription_paused"
+    href="/api-reference/current/subscription_paused"
     horizontal
   >
     Fired when a scheduled pause takes effect at the end of the period. Billing stops and benefits are revoked until the subscription resumes.
@@ -171,7 +171,7 @@ In order to properly implement logic for handling subscriptions, you should look
   <Card
     title="subscription.resumed"
     icon="link"
-    href="/api-reference/subscription_resumed"
+    href="/api-reference/current/subscription_resumed"
     horizontal
   >
     Fired when a paused subscription resumes. A new billing period starts and the customer is charged immediately.
@@ -268,25 +268,25 @@ The subscription data reflects the new period through `current_period_start` and
   <Card
     title="order.created"
     icon="link"
-    href="/api-reference/order_created"
+    href="/api-reference/current/order_created"
     horizontal
   ></Card>
   <Card
     title="order.paid"
     icon="link"
-    href="/api-reference/order_paid"
+    href="/api-reference/current/order_paid"
     horizontal
   ></Card>
   <Card
     title="order.updated"
     icon="link"
-    href="/api-reference/order_updated"
+    href="/api-reference/current/order_updated"
     horizontal
   ></Card>
   <Card
     title="order.refunded"
     icon="link"
-    href="/api-reference/order_refunded"
+    href="/api-reference/current/order_refunded"
     horizontal
   ></Card>
 </Columns>
@@ -297,13 +297,13 @@ The subscription data reflects the new period through `current_period_start` and
   <Card
     title="refund.created"
     icon="link"
-    href="/api-reference/refund_created"
+    href="/api-reference/current/refund_created"
     horizontal
   ></Card>
   <Card
     title="refund.updated"
     icon="link"
-    href="/api-reference/refund_updated"
+    href="/api-reference/current/refund_updated"
     horizontal
   ></Card>
 </Columns>
@@ -314,19 +314,19 @@ The subscription data reflects the new period through `current_period_start` and
   <Card
     title="benefit_grant.created"
     icon="link"
-    href="/api-reference/benefit_grant_created"
+    href="/api-reference/current/benefit_grant_created"
     horizontal
   ></Card>
   <Card
     title="benefit_grant.updated"
     icon="link"
-    href="/api-reference/benefit_grant_updated"
+    href="/api-reference/current/benefit_grant_updated"
     horizontal
   ></Card>
   <Card
     title="benefit_grant.revoked"
     icon="link"
-    href="/api-reference/benefit_grant_revoked"
+    href="/api-reference/current/benefit_grant_revoked"
     horizontal
   ></Card>
 </Columns>
@@ -339,13 +339,13 @@ The subscription data reflects the new period through `current_period_start` and
   <Card
     title="benefit.created"
     icon="link"
-    href="/api-reference/benefit_created"
+    href="/api-reference/current/benefit_created"
     horizontal
   ></Card>
   <Card
     title="benefit.updated"
     icon="link"
-    href="/api-reference/benefit_updated"
+    href="/api-reference/current/benefit_updated"
     horizontal
   ></Card>
 </Columns>
@@ -356,13 +356,13 @@ The subscription data reflects the new period through `current_period_start` and
   <Card
     title="product.created"
     icon="link"
-    href="/api-reference/product_created"
+    href="/api-reference/current/product_created"
     horizontal
   ></Card>
   <Card
     title="product.updated"
     icon="link"
-    href="/api-reference/product_updated"
+    href="/api-reference/current/product_updated"
     horizontal
   ></Card>
 </Columns>
@@ -373,21 +373,21 @@ The subscription data reflects the new period through `current_period_start` and
   <Card
     title="discount.created"
     icon="link"
-    href="/api-reference/discount_created"
+    href="/api-reference/current/discount_created"
     horizontal
   ></Card>
 
   <Card
     title="discount.updated"
     icon="link"
-    href="/api-reference/discount_updated"
+    href="/api-reference/current/discount_updated"
     horizontal
   ></Card>
 
   <Card
     title="discount.deleted"
     icon="link"
-    href="/api-reference/discount_deleted"
+    href="/api-reference/current/discount_deleted"
     horizontal
   ></Card>
 </Columns>
@@ -398,7 +398,7 @@ The subscription data reflects the new period through `current_period_start` and
   <Card
     title="organization.updated"
     icon="link"
-    href="/api-reference/organization_updated"
+    href="/api-reference/current/organization_updated"
     horizontal
   ></Card>
 </Columns>


### PR DESCRIPTION
The event cards on the webhook events page linked to unversioned /api-reference/<event> paths, which no longer exist since the API reference became versioned. Point them at /api-reference/current/<event>, which redirects to the current API version.


Claude-Session: https://claude.ai/code/session_01GUPi2As9EMuxzLDrYXFLzJ


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

