### PR TITLE
Send benefit_grant.updated webhook when a license key is rotated or updated

### DIFF
--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -10,6 +10,7 @@ from polar.auth.models import AuthSubject, Customer, Member
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.benefit.grant.repository import BenefitGrantRepository
+from polar.benefit.repository import BenefitRepository
 from polar.benefit.strategies.license_keys.properties import (
     BenefitLicenseKeysProperties,
 )
@@ -25,7 +26,9 @@ from polar.models import (
     User,
 )
 from polar.models.license_key import LicenseKeyStatus
+from polar.models.webhook_endpoint import WebhookEventType
 from polar.postgres import AsyncReadSession, AsyncSession
+from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job
 
 from .repository import LicenseKeyRepository
@@ -184,9 +187,7 @@ class LicenseKeyService:
         await session.flush()
 
         if update_dict:
-            grant = await self._get_grant(session, license_key)
-            if grant is not None:
-                enqueue_job("benefit.update", benefit_grant_id=grant.id)
+            await self._send_benefit_updated_webhook(session, license_key)
 
         return license_key
 
@@ -219,8 +220,7 @@ class LicenseKeyService:
             session.add(grant)
         await session.flush()
 
-        if grant is not None:
-            enqueue_job("benefit.update", benefit_grant_id=grant.id)
+        await self._send_benefit_updated_webhook(session, license_key)
 
         log.info(
             "license_key.rotate",
@@ -231,6 +231,20 @@ class LicenseKeyService:
             previous_key_suffix=old_key[-6:],
         )
         return license_key
+
+    async def _send_benefit_updated_webhook(
+        self, session: AsyncSession, license_key: LicenseKey
+    ) -> None:
+        benefit_repository = BenefitRepository.from_session(session)
+        benefit = await benefit_repository.get_by_id(
+            license_key.benefit_id, options=benefit_repository.get_eager_options()
+        )
+        if benefit is None:
+            return
+
+        await webhook_service.send(
+            session, benefit.organization, WebhookEventType.benefit_updated, benefit
+        )
 
     async def _get_grant(
         self, session: AsyncSession, license_key: LicenseKey

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -10,7 +10,7 @@ from polar.auth.models import AuthSubject, Customer, Member
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.benefit.grant.repository import BenefitGrantRepository
-from polar.benefit.repository import BenefitRepository
+from polar.benefit.strategies import BenefitGrantProperties
 from polar.benefit.strategies.license_keys.properties import (
     BenefitLicenseKeysProperties,
 )
@@ -187,7 +187,9 @@ class LicenseKeyService:
         await session.flush()
 
         if update_dict:
-            await self._send_benefit_updated_webhook(session, license_key)
+            grant = await self._get_grant(session, license_key)
+            if grant is not None:
+                await self._send_grant_updated_webhook(session, grant, grant.properties)
 
         return license_key
 
@@ -212,15 +214,19 @@ class LicenseKeyService:
         old_key = license_key.key
         license_key.key = LicenseKeyCreate.generate_key(prefix=prefix)
         session.add(license_key)
+        await session.flush()
+
         if grant is not None:
+            previous_grant_properties = grant.properties
             grant.properties = {
                 **grant.properties,
                 "display_key": license_key.display_key,
             }
             session.add(grant)
-        await session.flush()
-
-        await self._send_benefit_updated_webhook(session, license_key)
+            await session.flush()
+            await self._send_grant_updated_webhook(
+                session, grant, previous_grant_properties
+            )
 
         log.info(
             "license_key.rotate",
@@ -232,19 +238,25 @@ class LicenseKeyService:
         )
         return license_key
 
-    async def _send_benefit_updated_webhook(
-        self, session: AsyncSession, license_key: LicenseKey
+    async def _send_grant_updated_webhook(
+        self,
+        session: AsyncSession,
+        grant: BenefitGrant,
+        previous_grant_properties: BenefitGrantProperties,
     ) -> None:
-        benefit_repository = BenefitRepository.from_session(session)
-        benefit = await benefit_repository.get_by_id(
-            license_key.benefit_id, options=benefit_repository.get_eager_options()
+        grant_repository = BenefitGrantRepository.from_session(session)
+        loaded = await grant_repository.get_by_id(
+            grant.id, options=grant_repository.get_eager_options()
         )
-        if benefit is None:
-            return
-
+        assert loaded is not None
+        loaded.previous_properties = previous_grant_properties
         await webhook_service.send(
-            session, benefit.organization, WebhookEventType.benefit_updated, benefit
+            session,
+            loaded.benefit.organization,
+            WebhookEventType.benefit_grant_updated,
+            loaded,
         )
+        enqueue_job("customer.state_changed", loaded.customer_id)
 
     async def _get_grant(
         self, session: AsyncSession, license_key: LicenseKey

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -18,6 +18,7 @@ from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.utils import utc_now
 from polar.models import (
     Benefit,
+    BenefitGrant,
     LicenseKey,
     LicenseKeyActivation,
     Organization,
@@ -181,6 +182,12 @@ class LicenseKeyService:
 
         session.add(license_key)
         await session.flush()
+
+        if update_dict:
+            grant = await self._get_grant(session, license_key)
+            if grant is not None:
+                enqueue_job("benefit.update", benefit_grant_id=grant.id)
+
         return license_key
 
     async def rotate(
@@ -199,13 +206,7 @@ class LicenseKeyService:
         prefix = cast(BenefitLicenseKeysProperties, license_key.benefit.properties).get(
             "prefix"
         )
-        grant_repository = BenefitGrantRepository.from_session(session)
-        grant = await grant_repository.get_by_property_and_organization(
-            license_key.organization_id,
-            "license_key_id",
-            str(license_key.id),
-            benefit_id=license_key.benefit_id,
-        )
+        grant = await self._get_grant(session, license_key)
 
         old_key = license_key.key
         license_key.key = LicenseKeyCreate.generate_key(prefix=prefix)
@@ -218,6 +219,9 @@ class LicenseKeyService:
             session.add(grant)
         await session.flush()
 
+        if grant is not None:
+            enqueue_job("benefit.update", benefit_grant_id=grant.id)
+
         log.info(
             "license_key.rotate",
             license_key_id=license_key.id,
@@ -228,19 +232,24 @@ class LicenseKeyService:
         )
         return license_key
 
+    async def _get_grant(
+        self, session: AsyncSession, license_key: LicenseKey
+    ) -> BenefitGrant | None:
+        grant_repository = BenefitGrantRepository.from_session(session)
+        return await grant_repository.get_by_property_and_organization(
+            license_key.organization_id,
+            "license_key_id",
+            str(license_key.id),
+            benefit_id=license_key.benefit_id,
+        )
+
     async def _enqueue_grant_lifecycle(
         self,
         session: AsyncSession,
         license_key: LicenseKey,
         status: LicenseKeyStatus,
     ) -> None:
-        grant_repository = BenefitGrantRepository.from_session(session)
-        grant = await grant_repository.get_by_property_and_organization(
-            license_key.organization_id,
-            "license_key_id",
-            str(license_key.id),
-            benefit_id=license_key.benefit_id,
-        )
+        grant = await self._get_grant(session, license_key)
         if grant is None:
             return
 

--- a/server/tests/license_key/test_service.py
+++ b/server/tests/license_key/test_service.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import cast
+from unittest.mock import call
 from uuid import UUID
 
 import pytest
@@ -285,9 +286,10 @@ class TestUpdate:
         )
 
         assert license_key.status == status
-        enqueue_job_mock.assert_called_once_with(
-            "license_key.sync_benefit_grant", license_key_id=license_key.id
-        )
+        assert enqueue_job_mock.call_args_list == [
+            call("license_key.sync_benefit_grant", license_key_id=license_key.id),
+            call("benefit.update", benefit_grant_id=grant.id),
+        ]
 
     async def test_revoked_status_enqueues_sync(
         self,
@@ -300,7 +302,7 @@ class TestUpdate:
         customer: Customer,
     ) -> None:
         enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
-        license_key, _ = await _license_key_and_grant(
+        license_key, grant = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
 
@@ -311,11 +313,12 @@ class TestUpdate:
         )
 
         assert license_key.status == LicenseKeyStatus.revoked
-        enqueue_job_mock.assert_called_once_with(
-            "license_key.sync_benefit_grant", license_key_id=license_key.id
-        )
+        assert enqueue_job_mock.call_args_list == [
+            call("license_key.sync_benefit_grant", license_key_id=license_key.id),
+            call("benefit.update", benefit_grant_id=grant.id),
+        ]
 
-    async def test_status_already_matching_grant_does_not_enqueue(
+    async def test_status_already_matching_grant_skips_sync(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
@@ -326,7 +329,7 @@ class TestUpdate:
         customer: Customer,
     ) -> None:
         enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
-        license_key, _ = await _license_key_and_grant(
+        license_key, grant = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
 
@@ -337,9 +340,11 @@ class TestUpdate:
         )
 
         assert license_key.status == LicenseKeyStatus.disabled
-        enqueue_job_mock.assert_not_called()
+        enqueue_job_mock.assert_called_once_with(
+            "benefit.update", benefit_grant_id=grant.id
+        )
 
-    async def test_update_without_status_does_not_enqueue(
+    async def test_update_without_status_enqueues_benefit_update(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
@@ -350,7 +355,7 @@ class TestUpdate:
         customer: Customer,
     ) -> None:
         enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
-        license_key, _ = await _license_key_and_grant(
+        license_key, grant = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
 
@@ -361,13 +366,16 @@ class TestUpdate:
         )
 
         assert license_key.limit_activations == 5
-        enqueue_job_mock.assert_not_called()
+        enqueue_job_mock.assert_called_once_with(
+            "benefit.update", benefit_grant_id=grant.id
+        )
 
 
 @pytest.mark.asyncio
 class TestRotate:
     async def test_rotates_key_and_updates_grant_display_key(
         self,
+        mocker: MockerFixture,
         session: AsyncSession,
         redis: Redis,
         save_fixture: SaveFixture,
@@ -375,6 +383,7 @@ class TestRotate:
         product: Product,
         customer: Customer,
     ) -> None:
+        enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
         license_key, grant = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
@@ -406,6 +415,10 @@ class TestRotate:
         properties = cast(BenefitGrantLicenseKeysProperties, grant.properties)
         assert properties["display_key"] == rotated.display_key
         assert properties["license_key_id"] == str(rotated.id)
+
+        enqueue_job_mock.assert_called_once_with(
+            "benefit.update", benefit_grant_id=grant.id
+        )
 
     async def test_revoked_raises_bad_request(
         self,

--- a/server/tests/license_key/test_service.py
+++ b/server/tests/license_key/test_service.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import cast
+from unittest.mock import call
 from uuid import UUID
 
 import pytest
@@ -289,12 +290,15 @@ class TestUpdate:
         )
 
         assert license_key.status == status
-        enqueue_job_mock.assert_called_once_with(
-            "license_key.sync_benefit_grant", license_key_id=license_key.id
-        )
+        assert enqueue_job_mock.call_args_list == [
+            call("license_key.sync_benefit_grant", license_key_id=license_key.id),
+            call("customer.state_changed", grant.customer_id),
+        ]
         webhook_send_mock.assert_called_once()
-        assert webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_updated
-        assert webhook_send_mock.call_args[0][3].id == license_key.benefit_id
+        assert (
+            webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_grant_updated
+        )
+        assert webhook_send_mock.call_args[0][3].id == grant.id
 
     async def test_revoked_status_enqueues_sync(
         self,
@@ -310,7 +314,7 @@ class TestUpdate:
         webhook_send_mock = mocker.patch(
             "polar.license_key.service.webhook_service.send"
         )
-        license_key, _ = await _license_key_and_grant(
+        license_key, grant = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
 
@@ -321,11 +325,15 @@ class TestUpdate:
         )
 
         assert license_key.status == LicenseKeyStatus.revoked
-        enqueue_job_mock.assert_called_once_with(
-            "license_key.sync_benefit_grant", license_key_id=license_key.id
-        )
+        assert enqueue_job_mock.call_args_list == [
+            call("license_key.sync_benefit_grant", license_key_id=license_key.id),
+            call("customer.state_changed", grant.customer_id),
+        ]
         webhook_send_mock.assert_called_once()
-        assert webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_updated
+        assert (
+            webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_grant_updated
+        )
+        assert webhook_send_mock.call_args[0][3].id == grant.id
 
     async def test_status_already_matching_grant_skips_sync(
         self,
@@ -341,7 +349,7 @@ class TestUpdate:
         webhook_send_mock = mocker.patch(
             "polar.license_key.service.webhook_service.send"
         )
-        license_key, _ = await _license_key_and_grant(
+        license_key, grant = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
 
@@ -352,9 +360,14 @@ class TestUpdate:
         )
 
         assert license_key.status == LicenseKeyStatus.disabled
-        enqueue_job_mock.assert_not_called()
+        enqueue_job_mock.assert_called_once_with(
+            "customer.state_changed", grant.customer_id
+        )
         webhook_send_mock.assert_called_once()
-        assert webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_updated
+        assert (
+            webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_grant_updated
+        )
+        assert webhook_send_mock.call_args[0][3].id == grant.id
 
     async def test_update_without_status_sends_webhook(
         self,
@@ -370,7 +383,7 @@ class TestUpdate:
         webhook_send_mock = mocker.patch(
             "polar.license_key.service.webhook_service.send"
         )
-        license_key, _ = await _license_key_and_grant(
+        license_key, grant = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
 
@@ -381,10 +394,14 @@ class TestUpdate:
         )
 
         assert license_key.limit_activations == 5
-        enqueue_job_mock.assert_not_called()
+        enqueue_job_mock.assert_called_once_with(
+            "customer.state_changed", grant.customer_id
+        )
         webhook_send_mock.assert_called_once()
-        assert webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_updated
-        assert webhook_send_mock.call_args[0][3].id == license_key.benefit_id
+        assert (
+            webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_grant_updated
+        )
+        assert webhook_send_mock.call_args[0][3].id == grant.id
 
 
 @pytest.mark.asyncio
@@ -399,6 +416,7 @@ class TestRotate:
         product: Product,
         customer: Customer,
     ) -> None:
+        enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
         webhook_send_mock = mocker.patch(
             "polar.license_key.service.webhook_service.send"
         )
@@ -435,8 +453,15 @@ class TestRotate:
         assert properties["license_key_id"] == str(rotated.id)
 
         webhook_send_mock.assert_called_once()
-        assert webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_updated
-        assert webhook_send_mock.call_args[0][3].id == license_key.benefit_id
+        assert (
+            webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_grant_updated
+        )
+        sent_grant = webhook_send_mock.call_args[0][3]
+        assert sent_grant.id == grant.id
+        assert sent_grant.previous_properties["display_key"] == old_display_key
+        enqueue_job_mock.assert_called_once_with(
+            "customer.state_changed", grant.customer_id
+        )
 
     async def test_revoked_raises_bad_request(
         self,

--- a/server/tests/license_key/test_service.py
+++ b/server/tests/license_key/test_service.py
@@ -1,6 +1,5 @@
 import asyncio
 from typing import cast
-from unittest.mock import call
 from uuid import UUID
 
 import pytest
@@ -40,6 +39,7 @@ from polar.models import (
     User,
 )
 from polar.models.license_key import LicenseKeyStatus
+from polar.models.webhook_endpoint import WebhookEventType
 from polar.postgres import AsyncSession
 from polar.redis import Redis
 from tests.fixtures.database import SaveFixture, get_database_url, save_fixture_factory
@@ -272,6 +272,9 @@ class TestUpdate:
         customer: Customer,
     ) -> None:
         enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
+        webhook_send_mock = mocker.patch(
+            "polar.license_key.service.webhook_service.send"
+        )
         license_key, grant = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
@@ -286,10 +289,12 @@ class TestUpdate:
         )
 
         assert license_key.status == status
-        assert enqueue_job_mock.call_args_list == [
-            call("license_key.sync_benefit_grant", license_key_id=license_key.id),
-            call("benefit.update", benefit_grant_id=grant.id),
-        ]
+        enqueue_job_mock.assert_called_once_with(
+            "license_key.sync_benefit_grant", license_key_id=license_key.id
+        )
+        webhook_send_mock.assert_called_once()
+        assert webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_updated
+        assert webhook_send_mock.call_args[0][3].id == license_key.benefit_id
 
     async def test_revoked_status_enqueues_sync(
         self,
@@ -302,7 +307,10 @@ class TestUpdate:
         customer: Customer,
     ) -> None:
         enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
-        license_key, grant = await _license_key_and_grant(
+        webhook_send_mock = mocker.patch(
+            "polar.license_key.service.webhook_service.send"
+        )
+        license_key, _ = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
 
@@ -313,10 +321,11 @@ class TestUpdate:
         )
 
         assert license_key.status == LicenseKeyStatus.revoked
-        assert enqueue_job_mock.call_args_list == [
-            call("license_key.sync_benefit_grant", license_key_id=license_key.id),
-            call("benefit.update", benefit_grant_id=grant.id),
-        ]
+        enqueue_job_mock.assert_called_once_with(
+            "license_key.sync_benefit_grant", license_key_id=license_key.id
+        )
+        webhook_send_mock.assert_called_once()
+        assert webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_updated
 
     async def test_status_already_matching_grant_skips_sync(
         self,
@@ -329,7 +338,10 @@ class TestUpdate:
         customer: Customer,
     ) -> None:
         enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
-        license_key, grant = await _license_key_and_grant(
+        webhook_send_mock = mocker.patch(
+            "polar.license_key.service.webhook_service.send"
+        )
+        license_key, _ = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
 
@@ -340,11 +352,11 @@ class TestUpdate:
         )
 
         assert license_key.status == LicenseKeyStatus.disabled
-        enqueue_job_mock.assert_called_once_with(
-            "benefit.update", benefit_grant_id=grant.id
-        )
+        enqueue_job_mock.assert_not_called()
+        webhook_send_mock.assert_called_once()
+        assert webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_updated
 
-    async def test_update_without_status_enqueues_benefit_update(
+    async def test_update_without_status_sends_webhook(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
@@ -355,7 +367,10 @@ class TestUpdate:
         customer: Customer,
     ) -> None:
         enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
-        license_key, grant = await _license_key_and_grant(
+        webhook_send_mock = mocker.patch(
+            "polar.license_key.service.webhook_service.send"
+        )
+        license_key, _ = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
 
@@ -366,9 +381,10 @@ class TestUpdate:
         )
 
         assert license_key.limit_activations == 5
-        enqueue_job_mock.assert_called_once_with(
-            "benefit.update", benefit_grant_id=grant.id
-        )
+        enqueue_job_mock.assert_not_called()
+        webhook_send_mock.assert_called_once()
+        assert webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_updated
+        assert webhook_send_mock.call_args[0][3].id == license_key.benefit_id
 
 
 @pytest.mark.asyncio
@@ -383,7 +399,9 @@ class TestRotate:
         product: Product,
         customer: Customer,
     ) -> None:
-        enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
+        webhook_send_mock = mocker.patch(
+            "polar.license_key.service.webhook_service.send"
+        )
         license_key, grant = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
@@ -416,9 +434,9 @@ class TestRotate:
         assert properties["display_key"] == rotated.display_key
         assert properties["license_key_id"] == str(rotated.id)
 
-        enqueue_job_mock.assert_called_once_with(
-            "benefit.update", benefit_grant_id=grant.id
-        )
+        webhook_send_mock.assert_called_once()
+        assert webhook_send_mock.call_args[0][2] == WebhookEventType.benefit_updated
+        assert webhook_send_mock.call_args[0][3].id == license_key.benefit_id
 
     async def test_revoked_raises_bad_request(
         self,


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

Rotating or updating a license key now sends the `benefit_grant.updated` webhook for the key's benefit grant, so merchant integrations are notified of the change.

## What

- `LicenseKeyService.rotate` and `LicenseKeyService.update` now send `WebhookEventType.benefit_grant_updated` (via a shared `_send_grant_updated_webhook` helper) after the change is flushed, and enqueue `customer.state_changed` — mirroring `BenefitGrantService._send_webhook`. On rotation, the payload's `previous_properties` carries the old `display_key`.
- Extracted the repeated benefit-grant lookup into a `_get_grant` helper, shared by `update`, `rotate`, and `_enqueue_grant_lifecycle`.
- Updated the service tests accordingly (both dashboard and customer-portal rotate endpoints go through the same service methods).

## Why

Previously, rotating a key updated the grant's `display_key` property directly but never notified anyone: no webhook fired, so merchant integrations kept working off the old key. Likewise, updating a key's limits/expiry didn't emit anything.

## How

Earlier revisions of this PR first enqueued `benefit.update` — rejected because that task re-runs the license-keys strategy `grant(update=True)`, which resets per-key overrides (`expires_at`, `limit_activations`, `limit_usage`) from the benefit's configured properties — and then sent `benefit.updated`, which carries the benefit definition rather than pointing at the affected customer's grant. The final approach sends `benefit_grant.updated` directly: the grant is reloaded with `BenefitGrantRepository.get_eager_options()` (customer, benefit → organization, member) so serialization works under `lazy="raise"`, `previous_properties` is set for the payload diff, and `customer.state_changed` keeps the customer state webhook in sync — the same sequence `BenefitGrantService._send_webhook` uses. Nothing touches the key or grant beyond what rotation already did, so per-key overrides survive.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXM55Y42X6hbbPPTKYEJ5g