### PR TITLE
Add manual payout paid action in backoffice

### DIFF
--- a/server/polar/backoffice/payouts/endpoints.py
+++ b/server/polar/backoffice/payouts/endpoints.py
@@ -23,7 +23,7 @@ from polar.models import (
 from polar.models.payout import PayoutStatus
 from polar.models.payout_attempt import PayoutAttemptStatus
 from polar.payout.repository import PayoutRepository
-from polar.payout.service import NoSyncableAttempt
+from polar.payout.service import NoSyncableAttempt, PayoutNotManual, PayoutNotPending
 from polar.payout.service import payout as payout_service
 from polar.payout.sorting import ListSorting, PayoutSortProperty
 from polar.postgres import AsyncSession, get_db_session
@@ -364,6 +364,18 @@ async def get(
 
                     with tag.div(classes="flex justify-end gap-2"):
                         if (
+                            payout.processor == PayoutAccountType.manual
+                            and payout.status == PayoutStatus.pending
+                        ):
+                            with tag.button(
+                                classes="btn btn-success",
+                                hx_get=str(
+                                    request.url_for("payouts:mark_paid", id=payout.id)
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Mark as Paid")
+                        if (
                             payout.latest_attempt is not None
                             and payout.latest_attempt.processor_id is not None
                         ):
@@ -533,6 +545,57 @@ async def retry(
                         variant="primary",
                     ):
                         text("Retry")
+
+
+@router.api_route("/{id}/mark-paid", name="payouts:mark_paid", methods=["GET", "POST"])
+async def mark_paid(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    repository = PayoutRepository.from_session(session)
+    if request.method == "POST":
+        payout = await repository.get_by_id(id, for_update=True)
+    else:
+        payout = await repository.get_by_id(id)
+
+    if payout is None:
+        raise HTTPException(status_code=404)
+
+    if request.method == "POST":
+        await payout_service.mark_manual_as_paid(session, payout)
+        await add_toast(
+            request, f"Payout {payout.id} marked as paid", variant="success"
+        )
+
+        with tag.div(hx_redirect=str(request.url_for("payouts:get", id=payout.id))):
+            pass
+        return
+
+    if payout.processor != PayoutAccountType.manual:
+        raise PayoutNotManual(payout)
+    if payout.status != PayoutStatus.pending:
+        raise PayoutNotPending(payout)
+
+    with modal(f"Mark Payout {payout.id} as Paid", open=True):
+        with tag.div(classes="flex flex-col gap-4"):
+            with tag.p():
+                text(f"Are you sure payout {payout.id} has been paid?")
+
+            with tag.p():
+                text("This will create a successful manual payout attempt.")
+
+            with tag.div(classes="modal-action"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Go back")
+                with button(
+                    type="button",
+                    variant="primary",
+                    hx_post=str(request.url_for("payouts:mark_paid", id=payout.id)),
+                    hx_target="#modal",
+                ):
+                    text("Mark as Paid")
 
 
 @router.api_route("/{id}/cancel", name="payouts:cancel", methods=["GET", "POST"])

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -234,6 +234,20 @@ class PayoutHeld(PayoutError):
         super().__init__(message, 400)
 
 
+class PayoutNotManual(PayoutError):
+    def __init__(self, payout: Payout) -> None:
+        self.payout = payout
+        message = f"Payout {payout.id} is not a manual payout."
+        super().__init__(message, 400)
+
+
+class PayoutNotPending(PayoutError):
+    def __init__(self, payout: Payout) -> None:
+        self.payout = payout
+        message = f"Payout {payout.id} is not pending."
+        super().__init__(message, 409)
+
+
 class PayoutNotCancelable(PayoutError):
     def __init__(self, payout: Payout) -> None:
         self.payout = payout
@@ -740,6 +754,27 @@ class PayoutService:
         return await attempt_repository.update(
             attempt,
             update_dict={"processor_id": stripe_payout.id},
+        )
+
+    async def mark_manual_as_paid(
+        self, session: AsyncSession, payout: Payout
+    ) -> PayoutAttempt:
+        if payout.processor != PayoutAccountType.manual:
+            raise PayoutNotManual(payout)
+        if payout.status != PayoutStatus.pending:
+            raise PayoutNotPending(payout)
+
+        attempt_repository = PayoutAttemptRepository.from_session(session)
+        return await attempt_repository.create(
+            PayoutAttempt(
+                payout=payout,
+                processor=PayoutAccountType.manual,
+                status=PayoutAttemptStatus.succeeded,
+                amount=payout.account_amount,
+                currency=payout.account_currency,
+                paid_at=utc_now(),
+            ),
+            flush=True,
         )
 
     async def cancel(self, session: AsyncSession, payout: Payout) -> Payout:

--- a/server/tests/backoffice/payouts/test_endpoints.py
+++ b/server/tests/backoffice/payouts/test_endpoints.py
@@ -7,10 +7,14 @@ import pytest_asyncio
 
 from polar.backoffice import app as backoffice_app
 from polar.backoffice.dependencies import get_admin
-from polar.models import User
+from polar.enums import PayoutAccountType
+from polar.models import Account, Organization, User
 from polar.models.payout import PayoutStatus
+from polar.models.payout_attempt import PayoutAttemptStatus
 from polar.models.user_session import UserSession
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_payout, create_payout_account
 
 
 @pytest_asyncio.fixture
@@ -47,3 +51,91 @@ class TestList:
             r'<option(?=[^>]*value="pending")(?=[^>]*selected)[^>]*>\s*Pending\s*</option>',
             response.text,
         )
+
+
+@pytest.mark.asyncio
+class TestMarkPaid:
+    async def test_button_and_confirmation(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.manual
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.pending,
+            attempts=[],
+        )
+
+        response = await backoffice_client.get(f"/payouts/{payout.id}")
+
+        assert response.status_code == 200
+        assert "Mark as Paid" in response.text
+
+        response = await backoffice_client.get(f"/payouts/{payout.id}/mark-paid")
+
+        assert response.status_code == 200
+        assert "This will create a successful manual payout attempt." in response.text
+
+    async def test_post_creates_succeeded_attempt(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.manual
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.pending,
+            attempts=[],
+        )
+
+        response = await backoffice_client.post(f"/payouts/{payout.id}/mark-paid")
+
+        assert response.status_code == 200
+        assert f"/payouts/{payout.id}" in response.text
+
+        await session.refresh(payout, attribute_names=["status", "attempts"])
+        assert payout.status == PayoutStatus.succeeded
+        assert len(payout.attempts) == 1
+        attempt = payout.attempts[0]
+        assert attempt.status == PayoutAttemptStatus.succeeded
+        assert attempt.paid_at is not None
+
+    async def test_stripe_payout_has_no_button(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.pending,
+            attempts=[],
+        )
+
+        response = await backoffice_client.get(f"/payouts/{payout.id}")
+
+        assert response.status_code == 200
+        assert "Mark as Paid" not in response.text

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -18,6 +18,7 @@ from polar.locker import Locker
 from polar.models import Account, Organization, Payout, Transaction, User
 from polar.models.organization import OrganizationStatus, PayoutAccountNotReady
 from polar.models.payout import PayoutStatus
+from polar.models.payout_attempt import PayoutAttemptStatus
 from polar.models.transaction import Processor, TransactionType
 from polar.payout.repository import PayoutRepository
 from polar.payout.schemas import PayoutGenerateInvoice
@@ -30,6 +31,8 @@ from polar.payout.service import (
     PayoutHeld,
     PayoutIntervalLimitReached,
     PayoutNotCancelable,
+    PayoutNotManual,
+    PayoutNotPending,
     PayoutNotSucceeded,
 )
 from polar.payout.service import payout as payout_service
@@ -698,6 +701,86 @@ class TestTriggerStripePayout:
 
         stripe_service_mock.retrieve_balance.assert_not_called()
         stripe_service_mock.create_payout.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestMarkManualAsPaid:
+    async def test_valid(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.manual
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            account_amount=900,
+            account_currency="eur",
+            status=PayoutStatus.pending,
+            attempts=[],
+        )
+
+        attempt = await payout_service.mark_manual_as_paid(session, payout)
+
+        assert attempt.payout == payout
+        assert attempt.processor == PayoutAccountType.manual
+        assert attempt.status == PayoutAttemptStatus.succeeded
+        assert attempt.amount == 900
+        assert attempt.currency == "eur"
+        assert attempt.paid_at is not None
+
+        await session.refresh(payout, attribute_names=["status"])
+        assert payout.status == PayoutStatus.succeeded
+        assert payout.paid_at == attempt.paid_at
+
+    async def test_stripe_payout_raises(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.pending,
+            attempts=[],
+        )
+
+        with pytest.raises(PayoutNotManual):
+            await payout_service.mark_manual_as_paid(session, payout)
+
+    async def test_succeeded_payout_raises(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.manual
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.succeeded,
+        )
+
+        with pytest.raises(PayoutNotPending):
+            await payout_service.mark_manual_as_paid(session, payout)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a backoffice action to mark pending manual payouts as paid
- create a succeeded `PayoutAttempt` with the correct amount, currency, and payment timestamp
- rely on the existing payout-attempt status trigger so `Payout.status` and `Payout.paid_at` stay consistent
- cover the service transition and backoffice action with tests

## Testing

- `uv run pytest tests/payout/test_service.py tests/backoffice/payouts/test_endpoints.py -q`
- `uv run task lint_check`
- `uv run mypy polar/payout/service.py polar/backoffice/payouts/endpoints.py tests/payout/test_service.py tests/backoffice/payouts/test_endpoints.py`

Fixes #13975

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

