### PR TITLE
Prevent reusing Stripe accounts for merchant migrations

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -33541,6 +33541,17 @@ export interface components {
        */
       users: components['schemas']['SlackWorkspaceUser'][]
     }
+    /** SourceAccountAlreadyMigrated */
+    SourceAccountAlreadyMigrated: {
+      /**
+       * Error
+       * @example SourceAccountAlreadyMigrated
+       * @constant
+       */
+      error: 'SourceAccountAlreadyMigrated'
+      /** Detail */
+      detail: string
+    }
     /** SourceAccountNotMigratable */
     SourceAccountNotMigratable: {
       /**
@@ -54361,6 +54372,15 @@ export interface operations {
           'application/json':
             | components['schemas']['NotPermitted']
             | components['schemas']['MerchantMigrationNotEnabled']
+        }
+      }
+      /** @description The Stripe account is already used by another migration. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SourceAccountAlreadyMigrated']
         }
       }
       /** @description Validation Error */

--- a/server/polar/kit/db/locking.py
+++ b/server/polar/kit/db/locking.py
@@ -7,7 +7,7 @@ from polar.kit.db.postgres import AsyncReadSession, AsyncSession
 
 
 async def pg_advisory_xact_lock(
-    session: AsyncSession | AsyncReadSession, namespace: str, key: uuid.UUID
+    session: AsyncSession | AsyncReadSession, namespace: str, key: str | uuid.UUID
 ) -> None:
     """
     Acquire a transaction-level exclusive advisory lock.

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -52,6 +52,7 @@ from .service import (
     MerchantMigrationNotEnabled,
     MerchantMigrationNotFound,
     MissingStripeScopes,
+    SourceAccountAlreadyMigrated,
     SourceAccountNotMigratable,
     SourceKeyModeMismatch,
     SourceNotConnected,
@@ -109,6 +110,10 @@ async def list(
             "description": "Not allowed to manage this organization, or "
             "migrations aren't enabled for it.",
             "model": NotPermitted.schema() | MerchantMigrationNotEnabled.schema(),
+        },
+        409: {
+            "description": "The Stripe account is already used by another migration.",
+            "model": SourceAccountAlreadyMigrated.schema(),
         },
         502: {
             "description": "Couldn't reach Stripe to validate the key.",

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -57,6 +57,8 @@ class MerchantMigrationRepository(
     async def get_by_stripe_account_id(
         self, stripe_account_id: str
     ) -> MerchantMigration | None:
+        # Deleting our record cannot undo a Stripe PAN copy, so the source
+        # account remains reserved after soft deletion.
         statement = self.get_base_statement(include_deleted=True).where(
             MerchantMigration.source_platform == MerchantMigrationSourcePlatform.stripe,
             MerchantMigration.source_credentials["stripe_user_id"].astext

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -54,17 +54,20 @@ class MerchantMigrationRepository(
             self.session, "merchant_migration.stripe_account", stripe_account_id
         )
 
-    async def get_by_stripe_account_id(
-        self, stripe_account_id: str
-    ) -> MerchantMigration | None:
+    async def stripe_account_id_exists(self, stripe_account_id: str) -> bool:
         # Deleting our record cannot undo a Stripe PAN copy, so the source
         # account remains reserved after soft deletion.
-        statement = self.get_base_statement(include_deleted=True).where(
-            MerchantMigration.source_platform == MerchantMigrationSourcePlatform.stripe,
-            MerchantMigration.source_credentials["stripe_user_id"].astext
-            == stripe_account_id,
+        statement = select(
+            self.get_base_statement(include_deleted=True)
+            .where(
+                MerchantMigration.source_platform
+                == MerchantMigrationSourcePlatform.stripe,
+                MerchantMigration.source_credentials["stripe_user_id"].astext
+                == stripe_account_id,
+            )
+            .exists()
         )
-        return await self.get_one_or_none(statement)
+        return bool(await self.session.scalar(statement))
 
     def get_readable_statement(
         self, auth_subject: AuthSubject[User | Organization]

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -58,8 +58,7 @@ class MerchantMigrationRepository(
         self, stripe_account_id: str
     ) -> MerchantMigration | None:
         statement = self.get_base_statement(include_deleted=True).where(
-            MerchantMigration.source_platform
-            == MerchantMigrationSourcePlatform.stripe,
+            MerchantMigration.source_platform == MerchantMigrationSourcePlatform.stripe,
             MerchantMigration.source_credentials["stripe_user_id"].astext
             == stripe_account_id,
         )

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import joinedload
 from polar.auth.models import AuthSubject, Organization, User, is_organization, is_user
 from polar.authz.repository import select_accessible_org_ids
 from polar.config import settings
+from polar.kit.db.locking import pg_advisory_xact_lock
 from polar.kit.repository import (
     RepositoryBase,
     RepositorySoftDeletionIDMixin,
@@ -49,10 +50,9 @@ class MerchantMigrationRepository(
     model = MerchantMigration
 
     async def lock_stripe_account(self, stripe_account_id: str) -> None:
-        statement = select(
-            func.pg_advisory_xact_lock(func.hashtextextended(stripe_account_id, 0))
+        await pg_advisory_xact_lock(
+            self.session, "merchant_migration.stripe_account", stripe_account_id
         )
-        await self.session.execute(statement)
 
     async def get_by_stripe_account_id(
         self, stripe_account_id: str

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -19,6 +19,7 @@ from polar.models import (
     PaymentMethod,
     Subscription,
 )
+from polar.models.merchant_migration import MerchantMigrationSourcePlatform
 from polar.models.merchant_migration_operation import (
     MerchantMigrationOperationSelection,
 )
@@ -46,6 +47,23 @@ class MerchantMigrationRepository(
     RepositoryBase[MerchantMigration],
 ):
     model = MerchantMigration
+
+    async def lock_stripe_account(self, stripe_account_id: str) -> None:
+        statement = select(
+            func.pg_advisory_xact_lock(func.hashtextextended(stripe_account_id, 0))
+        )
+        await self.session.execute(statement)
+
+    async def get_by_stripe_account_id(
+        self, stripe_account_id: str
+    ) -> MerchantMigration | None:
+        statement = self.get_base_statement(include_deleted=True).where(
+            MerchantMigration.source_platform
+            == MerchantMigrationSourcePlatform.stripe,
+            MerchantMigration.source_credentials["stripe_user_id"].astext
+            == stripe_account_id,
+        )
+        return await self.get_one_or_none(statement)
 
     def get_readable_statement(
         self, auth_subject: AuthSubject[User | Organization]

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -407,10 +407,7 @@ class MerchantMigrationService:
         repository = MerchantMigrationRepository.from_session(session)
         if stripe_account_id is not None:
             await repository.lock_stripe_account(stripe_account_id)
-            if (
-                await repository.get_by_stripe_account_id(stripe_account_id)
-                is not None
-            ):
+            if await repository.get_by_stripe_account_id(stripe_account_id) is not None:
                 raise SourceAccountAlreadyMigrated()
         return await repository.create(migration, flush=True)
 

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -405,10 +405,11 @@ class MerchantMigrationService:
             )
         )
         repository = MerchantMigrationRepository.from_session(session)
-        if stripe_account_id is not None:
-            await repository.lock_stripe_account(stripe_account_id)
-            if await repository.get_by_stripe_account_id(stripe_account_id) is not None:
-                raise SourceAccountAlreadyMigrated()
+        if stripe_account_id is None:
+            raise SourceVerificationUnavailable()
+        await repository.lock_stripe_account(stripe_account_id)
+        if await repository.stripe_account_id_exists(stripe_account_id):
+            raise SourceAccountAlreadyMigrated()
         return await repository.create(migration, flush=True)
 
     async def run_precheck(

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -186,6 +186,14 @@ class SourceVerificationUnavailable(MerchantMigrationError):
         )
 
 
+class SourceAccountAlreadyMigrated(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "This Stripe account is already used by another merchant migration.",
+            409,
+        )
+
+
 class CatalogImportNotReady(MerchantMigrationError):
     def __init__(self) -> None:
         super().__init__(
@@ -390,12 +398,20 @@ class MerchantMigrationService:
             source_platform=create_schema.source_platform,
             step=MerchantMigrationStep.source_setup,
         )
+        stripe_account_id = await adapter.get_account_id()
         migration.source_credentials = dict(
             await self._build_stripe_credentials(
-                migration, create_schema.api_key, adapter
+                migration, create_schema.api_key, stripe_account_id
             )
         )
         repository = MerchantMigrationRepository.from_session(session)
+        if stripe_account_id is not None:
+            await repository.lock_stripe_account(stripe_account_id)
+            if (
+                await repository.get_by_stripe_account_id(stripe_account_id)
+                is not None
+            ):
+                raise SourceAccountAlreadyMigrated()
         return await repository.create(migration, flush=True)
 
     async def run_precheck(
@@ -1293,7 +1309,7 @@ class MerchantMigrationService:
         self,
         migration: MerchantMigration,
         api_key: str,
-        adapter: StripeAdapter,
+        stripe_account_id: str | None,
     ) -> StripeSourceCredentials:
         encrypted = await EncryptedString.encrypt(
             api_key,
@@ -1301,7 +1317,7 @@ class MerchantMigrationService:
         )
         return StripeSourceCredentials(
             api_key_encrypted=encrypted.encrypted_value,
-            stripe_user_id=await adapter.get_account_id(),
+            stripe_user_id=stripe_account_id,
             livemode=_is_live_key(api_key),
         )
 

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -215,6 +215,27 @@ class TestCreate:
         assert stored is not None
         assert stored.source_credentials["api_key_encrypted"].startswith("v1.")
 
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_reused_stripe_account_returns_409(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        await _enable_feature(save_fixture, organization)
+        await build_connected_migration(save_fixture, organization_second)
+        _mock_stripe_adapter(mocker)
+
+        response = await client.post(
+            "/v1/merchant-migrations/", json=_body(organization)
+        )
+
+        assert response.status_code == 409
+        assert "already used by another merchant migration" in response.text
+
 
 @pytest.mark.asyncio
 class TestGet:

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -203,9 +203,7 @@ class TestCreate:
         user_organization: UserOrganization,
     ) -> None:
         await _enable_feature(save_fixture, organization)
-        existing = await build_connected_migration(
-            save_fixture, organization_second
-        )
+        existing = await build_connected_migration(save_fixture, organization_second)
         mocker.patch(
             "polar.merchant_migration.service.StripeAdapter",
             return_value=_FakeAdapter(account_id="acct_test"),

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -55,6 +55,7 @@ from polar.merchant_migration.service import (
     CutoverNotStarted,
     InvalidSourceCredentials,
     MissingStripeScopes,
+    SourceAccountAlreadyMigrated,
     SourceAccountNotMigratable,
     SourceKeyModeMismatch,
     SourceNotConnected,
@@ -189,6 +190,33 @@ class TestCreate:
         assert credentials["livemode"] is False
         assert credentials["api_key_encrypted"].startswith("v1.")
         assert await service._decrypt_stripe_api_key(migration) == "rk_test_123"
+
+    @pytest.mark.auth
+    async def test_rejects_stripe_account_used_by_another_migration(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _enable_feature(save_fixture, organization)
+        existing = await build_connected_migration(
+            save_fixture, organization_second
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(account_id="acct_test"),
+        )
+
+        with pytest.raises(SourceAccountAlreadyMigrated):
+            await service.create(session, auth_subject, _create_schema(organization))
+
+        await assert_no_migrations(session, organization)
+        repository = MerchantMigrationRepository.from_session(session)
+        assert await repository.get_by_id(existing.id) is not None
 
     @pytest.mark.auth
     async def test_missing_scopes_raises_and_persists_nothing(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -203,7 +203,10 @@ class TestCreate:
         user_organization: UserOrganization,
     ) -> None:
         await _enable_feature(save_fixture, organization)
-        existing = await build_connected_migration(save_fixture, organization_second)
+        existing = [
+            await build_connected_migration(save_fixture, organization_second),
+            await build_connected_migration(save_fixture, organization_second),
+        ]
         mocker.patch(
             "polar.merchant_migration.service.StripeAdapter",
             return_value=_FakeAdapter(account_id="acct_test"),
@@ -214,7 +217,29 @@ class TestCreate:
 
         await assert_no_migrations(session, organization)
         repository = MerchantMigrationRepository.from_session(session)
-        assert await repository.get_by_id(existing.id) is not None
+        for migration in existing:
+            assert await repository.get_by_id(migration.id) is not None
+
+    @pytest.mark.auth
+    async def test_rejects_source_without_stripe_account_id(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _enable_feature(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(account_id=None),
+        )
+
+        with pytest.raises(SourceVerificationUnavailable):
+            await service.create(session, auth_subject, _create_schema(organization))
+
+        await assert_no_migrations(session, organization)
 
     @pytest.mark.auth
     async def test_missing_scopes_raises_and_persists_nothing(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Related Issue**: N/A

Prevent a Stripe source account from being used by more than one merchant migration.

## What

- Reject duplicate Stripe source accounts with a `409 Conflict`
- Serialize concurrent creation attempts with a transaction-scoped advisory lock
- Check existing migrations across organizations, including soft-deleted rows
- Regenerate the internal OpenAPI client for the new error response
- Add service and endpoint coverage

## Why

Stripe PAN copy is a one-to-one account operation. Allowing the same source account in multiple migrations can enable abuse and create conflicting migration state. Soft deletion does not release the account because deleting Polar's record cannot undo a Stripe PAN copy.

## How

The migration creation flow reads the verified Stripe account ID, locks that ID for the current transaction, and checks persisted migration credentials before inserting the new migration.

## Verification

- `TestCreate` service and endpoint suites: 17 passed
- Focused duplicate-account tests: 2 passed
- `uv run task lint`: passed
- `uv run task lint_types`: passed
- Generated client lint and typecheck: passed

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1893743f-d60a-4a2b-bc2f-a9ec1c9ee593?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1893743f-d60a-4a2b-bc2f-a9ec1c9ee593&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

