### PR TITLE
fix(merchant-migration): accept copied chargeable methods

### DIFF
--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -50,6 +50,17 @@ class CanonicalPaymentMethodType(StrEnum):
             CanonicalPaymentMethodType.other,
         }
 
+    @classmethod
+    def is_chargeable_type(cls, type: str) -> bool:
+        try:
+            return not cls(type).requires_reentry
+        except ValueError:
+            return False
+
+    @classmethod
+    def chargeable_values(cls) -> tuple[str, ...]:
+        return tuple(member.value for member in cls if not member.requires_reentry)
+
 
 @dataclass
 class CanonicalPaymentMethod:

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -6,6 +6,7 @@ stays there.
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import TypeIs
 from uuid import UUID
 
 import stripe as stripe_lib
@@ -35,6 +36,7 @@ from polar.subscription.service import subscription as subscription_service
 
 from .adapters import SourceAdapter
 from .canonical import (
+    CanonicalPaymentMethodType,
     CanonicalProduct,
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
@@ -81,8 +83,8 @@ _PLAN_CHANGED = (
     "subscription no longer matches. Re-run the import for this customer."
 )
 _NO_CARD = (
-    "No copied card has landed on Polar for this customer yet. They need to "
-    "enter their billing details again, or the copy has to pick them up."
+    "No copied payment method has landed on Polar for this customer yet. They "
+    "need to enter their billing details again, or the copy has to pick them up."
 )
 _NOT_PAUSED = "It isn't paused in Polar any more, so it was left alone."
 _STRANDED = (
@@ -133,6 +135,12 @@ def _skip(reason: str) -> CutoverOutcome:
 
 def _fail(reason: str) -> CutoverOutcome:
     return CutoverOutcome(MerchantMigrationCutoverStatus.failed, reason)
+
+
+def _is_chargeable(payment_method: PaymentMethod | None) -> TypeIs[PaymentMethod]:
+    return payment_method is not None and CanonicalPaymentMethodType.is_chargeable_type(
+        payment_method.type
+    )
 
 
 class SubscriptionCutover:
@@ -220,7 +228,7 @@ class SubscriptionCutover:
         if already_stopped:
             # An unproven card beats no biller at all: a failed first renewal
             # goes to dunning, which is recoverable.
-            if payment_method is None or payment_method.type != "card":
+            if not _is_chargeable(payment_method):
                 log.error(
                     "merchant_migration.cutover.stranded",
                     migration_id=self.migration.id,
@@ -230,7 +238,7 @@ class SubscriptionCutover:
                 return _fail(_STRANDED)
             if subscription.is_period_lapsed(self._period_end(source, subscription)):
                 return _fail(_LAPSED)
-        elif payment_method is None or payment_method.type != "card":
+        elif not _is_chargeable(payment_method):
             return _skip(_NO_CARD)
 
         # Locked only now: the portal takes this same row lock, and everything
@@ -333,7 +341,7 @@ class SubscriptionCutover:
             self.session, customer, source_method=source.payment_method
         )
         if already_stopped:
-            if payment_method is None or payment_method.type != "card":
+            if not _is_chargeable(payment_method):
                 log.error(
                     "merchant_migration.cutover.stranded",
                     migration_id=self.migration.id,
@@ -341,7 +349,7 @@ class SubscriptionCutover:
                     source_id=record.source_id,
                 )
                 return _fail(_STRANDED)
-        elif payment_method is None or payment_method.type != "card":
+        elif not _is_chargeable(payment_method):
             return _skip(_NO_CARD)
 
         try:

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -28,7 +28,7 @@ from polar.models.merchant_migration_record import (
     MerchantMigrationRecordType,
 )
 
-from .canonical import CanonicalRecord, serialize
+from .canonical import CanonicalPaymentMethodType, CanonicalRecord, serialize
 
 type RecordCounts = dict[
     tuple[UUID, MerchantMigrationRecordType, MerchantMigrationRecordStatus], int
@@ -459,7 +459,7 @@ class MerchantMigrationRecordRepository(
         return {status: count for status, count in result.all()}
 
     async def payment_method_coverage(self, migration_id: UUID) -> set[UUID]:
-        """Switchable subscription record ids whose Polar customer has a card."""
+        """Switchable records whose Polar customer has a chargeable method."""
         CustomerRecord = aliased(MerchantMigrationRecord)
         statement = (
             self._switchable_subscriptions_statement(migration_id)
@@ -490,7 +490,9 @@ class MerchantMigrationRecordRepository(
                 and_(
                     PaymentMethod.customer_id == Customer.id,
                     PaymentMethod.deleted_at.is_(None),
-                    PaymentMethod.type == "card",
+                    PaymentMethod.type.in_(
+                        CanonicalPaymentMethodType.chargeable_values()
+                    ),
                 ),
             )
             .with_only_columns(MerchantMigrationRecord.id)

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -769,7 +769,7 @@ class TestSkips:
         assert "can't renew subscriptions" in (outcome.message or "")
         _assert_left_alone(adapter, pending_record)
 
-    async def test_no_card_landed_on_polar(
+    async def test_no_payment_method_landed_on_polar(
         self,
         mocker: MockerFixture,
         cutover: RunCutover,
@@ -781,7 +781,7 @@ class TestSkips:
         outcome = await cutover(adapter)
 
         assert outcome.status == MerchantMigrationCutoverStatus.skipped
-        assert "No copied card" in (outcome.message or "")
+        assert "No copied payment method" in (outcome.message or "")
         _assert_left_alone(adapter, pending_record)
 
     async def test_customer_deleted_on_polar(

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -230,24 +230,6 @@ class TestRun:
         assert subscription.payment_method_id is not None
         assert subscription.user_metadata["stripe_subscription_id"] == "sub_1"
 
-    async def test_creates_and_activates_with_copied_bank_debit(
-        self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        cutover: RunCutover,
-        pending_record: MerchantMigrationRecord,
-    ) -> None:
-        copied_cards(
-            mocker,
-            build_stripe_payment_method(type="us_bank_account", customer="cus_1"),
-        )
-
-        outcome = await cutover(_source())
-
-        assert outcome.status == MerchantMigrationCutoverStatus.moved
-        subscription = await _created(session, pending_record)
-        assert subscription.payment_method_id is not None
-
     async def test_duplicate_pending_subscription_stays_on_source(
         self,
         session: AsyncSession,
@@ -291,6 +273,24 @@ class TestRun:
         assert subscription.status == SubscriptionStatus.active
         assert subscription.paused_at is None
         assert subscription.current_period_end == renewal
+        assert subscription.payment_method_id is not None
+
+    async def test_creates_and_activates_with_copied_bank_debit(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        cutover: RunCutover,
+        pending_record: MerchantMigrationRecord,
+    ) -> None:
+        copied_cards(
+            mocker,
+            build_stripe_payment_method(type="us_bank_account", customer="cus_1"),
+        )
+
+        outcome = await cutover(_source())
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        subscription = await _created(session, pending_record)
         assert subscription.payment_method_id is not None
 
     async def test_finishes_a_paused_polar_subscription_from_a_crashed_cutover(

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -230,6 +230,24 @@ class TestRun:
         assert subscription.payment_method_id is not None
         assert subscription.user_metadata["stripe_subscription_id"] == "sub_1"
 
+    async def test_creates_and_activates_with_copied_bank_debit(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        cutover: RunCutover,
+        pending_record: MerchantMigrationRecord,
+    ) -> None:
+        copied_cards(
+            mocker,
+            build_stripe_payment_method(type="us_bank_account", customer="cus_1"),
+        )
+
+        outcome = await cutover(_source())
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        subscription = await _created(session, pending_record)
+        assert subscription.payment_method_id is not None
+
     async def test_duplicate_pending_subscription_stays_on_source(
         self,
         session: AsyncSession,

--- a/server/tests/merchant_migration/test_repository.py
+++ b/server/tests/merchant_migration/test_repository.py
@@ -350,5 +350,10 @@ class TestSwitchableSubscriptions:
 
         assert [record.id for record in records] == [ready.id]
         assert await repository.payment_method_coverage(migration.id) == set()
-        await create_payment_method(save_fixture, customer, processor_id="pm_ready")
+        await create_payment_method(
+            save_fixture,
+            customer,
+            processor_id="pm_ready",
+            type="us_bank_account",
+        )
         assert await repository.payment_method_coverage(migration.id) == {ready.id}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Allow cutover to use copied card, US bank account, and SEPA debit payment methods.

## Test plan

- 47 targeted tests pass
- Ruff and mypy pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed28e7c1-5cbf-42fb-9fb0-6c16dada0d52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed28e7c1-5cbf-42fb-9fb0-6c16dada0d52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

