### PR TITLE
fix(merchant-migration): reuse imported dependencies

### DIFF
--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -284,10 +284,10 @@ class SubscriptionCutover:
             return _skip(_NOT_IMPORTED)
 
         customer_record = await self.record_repository.get_imported_customer_dependency(
-            self.migration.id, staged.customer_source_id
+            self.migration.organization_id, staged.customer_source_id
         )
         product_record = await self.record_repository.get_imported_product_dependency(
-            self.migration.id, staged.price_source_id
+            self.migration.organization_id, staged.price_source_id
         )
         if (
             customer_record is None

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -167,6 +167,15 @@ class CatalogImporter:
 
     async def run(self) -> MerchantMigrationImportReport:
         records = await self.record_repository.list_by_migration(self.migration.id)
+        imported_dependencies = (
+            await self.record_repository.list_imported_catalog_dependencies(
+                self.organization.id
+            )
+        )
+        by_identity = {(record.type, record.source_id): record for record in records}
+        for record in imported_dependencies:
+            by_identity.setdefault((record.type, record.source_id), record)
+        catalog = list(by_identity.values())
         product_records = self._records_of(records, MerchantMigrationRecordType.product)
         customer_records = self._records_of(
             records, MerchantMigrationRecordType.customer
@@ -177,7 +186,9 @@ class CatalogImporter:
 
         product_source_ids, customer_source_ids = (
             self._selected_subscription_dependencies(
-                subscription_records, product_records, customer_records
+                subscription_records,
+                self._records_of(catalog, MerchantMigrationRecordType.product),
+                self._records_of(catalog, MerchantMigrationRecordType.customer),
             )
         )
 

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -172,9 +172,12 @@ class CatalogImporter:
                 self.organization.id
             )
         )
-        by_identity = {(record.type, record.source_id): record for record in records}
-        for record in imported_dependencies:
-            by_identity.setdefault((record.type, record.source_id), record)
+        by_identity = {
+            (record.type, record.source_id): record for record in imported_dependencies
+        }
+        by_identity.update(
+            {(record.type, record.source_id): record for record in records}
+        )
         catalog = list(by_identity.values())
         product_records = self._records_of(records, MerchantMigrationRecordType.product)
         customer_records = self._records_of(

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -286,10 +286,10 @@ class MerchantMigrationRecordRepository(
         return await self.get_all(statement)
 
     async def get_imported_customer_dependency(
-        self, migration_id: UUID, customer_source_id: str
+        self, organization_id: UUID, customer_source_id: str
     ) -> MerchantMigrationRecord | None:
         statement = self.get_base_statement().where(
-            MerchantMigrationRecord.merchant_migration_id == migration_id,
+            MerchantMigrationRecord.organization_id == organization_id,
             MerchantMigrationRecord.type == MerchantMigrationRecordType.customer,
             MerchantMigrationRecord.status == MerchantMigrationRecordStatus.imported,
             MerchantMigrationRecord.target_id.is_not(None),
@@ -298,10 +298,10 @@ class MerchantMigrationRecordRepository(
         return await self.get_one_or_none(statement)
 
     async def get_imported_product_dependency(
-        self, migration_id: UUID, price_source_id: str
+        self, organization_id: UUID, price_source_id: str
     ) -> MerchantMigrationRecord | None:
         statement = self.get_base_statement().where(
-            MerchantMigrationRecord.merchant_migration_id == migration_id,
+            MerchantMigrationRecord.organization_id == organization_id,
             MerchantMigrationRecord.type == MerchantMigrationRecordType.product,
             MerchantMigrationRecord.status == MerchantMigrationRecordStatus.imported,
             MerchantMigrationRecord.target_id.is_not(None),
@@ -312,6 +312,22 @@ class MerchantMigrationRecordRepository(
             ),
         )
         return await self.get_one_or_none(statement)
+
+    async def list_imported_catalog_dependencies(
+        self, organization_id: UUID
+    ) -> Sequence[MerchantMigrationRecord]:
+        statement = self.get_base_statement().where(
+            MerchantMigrationRecord.organization_id == organization_id,
+            MerchantMigrationRecord.type.in_(
+                (
+                    MerchantMigrationRecordType.customer,
+                    MerchantMigrationRecordType.product,
+                )
+            ),
+            MerchantMigrationRecord.status == MerchantMigrationRecordStatus.imported,
+            MerchantMigrationRecord.target_id.is_not(None),
+        )
+        return await self.get_all(statement)
 
     def _switchable_subscriptions_statement(
         self, migration_id: UUID
@@ -325,8 +341,8 @@ class MerchantMigrationRecordRepository(
         pending_ready = and_(
             MerchantMigrationRecord.status == MerchantMigrationRecordStatus.pending,
             exists().where(
-                CustomerRecord.merchant_migration_id
-                == MerchantMigrationRecord.merchant_migration_id,
+                CustomerRecord.organization_id
+                == MerchantMigrationRecord.organization_id,
                 CustomerRecord.type == MerchantMigrationRecordType.customer,
                 CustomerRecord.status == MerchantMigrationRecordStatus.imported,
                 CustomerRecord.target_id.is_not(None),
@@ -335,8 +351,8 @@ class MerchantMigrationRecordRepository(
                 CustomerRecord.deleted_at.is_(None),
             ),
             exists().where(
-                ProductRecord.merchant_migration_id
-                == MerchantMigrationRecord.merchant_migration_id,
+                ProductRecord.organization_id
+                == MerchantMigrationRecord.organization_id,
                 ProductRecord.type == MerchantMigrationRecordType.product,
                 ProductRecord.status == MerchantMigrationRecordStatus.imported,
                 ProductRecord.target_id.is_not(None),
@@ -466,8 +482,8 @@ class MerchantMigrationRecordRepository(
             .join(
                 CustomerRecord,
                 and_(
-                    CustomerRecord.merchant_migration_id
-                    == MerchantMigrationRecord.merchant_migration_id,
+                    CustomerRecord.organization_id
+                    == MerchantMigrationRecord.organization_id,
                     CustomerRecord.type == MerchantMigrationRecordType.customer,
                     CustomerRecord.status == MerchantMigrationRecordStatus.imported,
                     CustomerRecord.target_id.is_not(None),

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -1216,7 +1216,7 @@ class MerchantMigrationService:
         for entity_type in entities:
             classified_from = records
             if entity_type == PrecheckEntity.subscriptions:
-                classified_from = [*records, *extra_canonicals]
+                classified_from = [*extra_canonicals, *records]
             entity_items = classify_records(
                 classified_from,
                 entity_type,

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -1190,7 +1190,10 @@ class MerchantMigrationService:
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         staged = await record_repository.list_by_migration(migration.id)
         extra_dependencies: Sequence[MerchantMigrationRecord] = ()
-        if PrecheckEntity.subscriptions in entities:
+        if (
+            PrecheckEntity.subscriptions in entities
+            or PrecheckEntity.customers in entities
+        ):
             extra_dependencies = (
                 await record_repository.list_imported_catalog_dependencies(
                     migration.organization_id
@@ -1215,7 +1218,10 @@ class MerchantMigrationService:
         items: list[MerchantMigrationRecordItem] = []
         for entity_type in entities:
             classified_from = records
-            if entity_type == PrecheckEntity.subscriptions:
+            if entity_type in {
+                PrecheckEntity.customers,
+                PrecheckEntity.subscriptions,
+            }:
                 classified_from = [*extra_canonicals, *records]
             entity_items = classify_records(
                 classified_from,
@@ -1223,6 +1229,17 @@ class MerchantMigrationService:
                 organization.default_presentment_currency,
                 existing_product_names,
             )
+            if entity_type == PrecheckEntity.customers:
+                staged_customer_source_ids = {
+                    record.source_id
+                    for record in staged
+                    if record.type == MerchantMigrationRecordType.customer
+                }
+                entity_items = [
+                    item
+                    for item in entity_items
+                    if item.source_id in staged_customer_source_ids
+                ]
             self._attach_record_ids(
                 entity_items, staged, entity_type, extra_dependencies
             )

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -668,7 +668,7 @@ class MerchantMigrationService:
             if staged is None:
                 continue
             customer_record = await record_repository.get_imported_customer_dependency(
-                migration.id, staged.customer_source_id
+                migration.organization_id, staged.customer_source_id
             )
             if customer_record is None or customer_record.target_id is None:
                 continue
@@ -1189,7 +1189,22 @@ class MerchantMigrationService:
 
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         staged = await record_repository.list_by_migration(migration.id)
+        extra_dependencies: Sequence[MerchantMigrationRecord] = ()
+        if PrecheckEntity.subscriptions in entities:
+            extra_dependencies = (
+                await record_repository.list_imported_catalog_dependencies(
+                    migration.organization_id
+                )
+            )
         records = [deserialize(record.type, record.canonical) for record in staged]
+        staged_identities = {
+            (staged_record.type, staged_record.source_id) for staged_record in staged
+        }
+        extra_canonicals = [
+            deserialize(record.type, record.canonical)
+            for record in extra_dependencies
+            if (record.type, record.source_id) not in staged_identities
+        ]
         # Only product classification consults it.
         existing_product_names: set[str] = set()
         if PrecheckEntity.products in entities:
@@ -1199,13 +1214,18 @@ class MerchantMigrationService:
 
         items: list[MerchantMigrationRecordItem] = []
         for entity_type in entities:
+            classified_from = records
+            if entity_type == PrecheckEntity.subscriptions:
+                classified_from = [*records, *extra_canonicals]
             entity_items = classify_records(
-                records,
+                classified_from,
                 entity_type,
                 organization.default_presentment_currency,
                 existing_product_names,
             )
-            self._attach_record_ids(entity_items, staged, entity_type)
+            self._attach_record_ids(
+                entity_items, staged, entity_type, extra_dependencies
+            )
             items.extend(entity_items)
         return items
 
@@ -1234,6 +1254,7 @@ class MerchantMigrationService:
         items: Sequence[MerchantMigrationRecordItem],
         staged: Sequence[MerchantMigrationRecord],
         entity: PrecheckEntity,
+        extra_dependencies: Sequence[MerchantMigrationRecord] = (),
     ) -> None:
         """Give each item its ledger record id. The 1:1 entities
         (products/customers/subscriptions) map to their staged records in order —
@@ -1249,14 +1270,15 @@ class MerchantMigrationService:
         imported_customer_source_ids: set[str] = set()
         imported_product_price_source_ids: set[str] = set()
         if entity == PrecheckEntity.subscriptions:
+            imported_rows = [*staged, *extra_dependencies]
             imported_customer_source_ids = {
                 record.source_id
-                for record in staged
+                for record in imported_rows
                 if record.type == MerchantMigrationRecordType.customer
                 and record.status == MerchantMigrationRecordStatus.imported
                 and record.target_id is not None
             }
-            for product_record in staged:
+            for product_record in imported_rows:
                 if (
                     product_record.type != MerchantMigrationRecordType.product
                     or product_record.status != MerchantMigrationRecordStatus.imported

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -230,6 +230,71 @@ class TestRun:
         assert subscription.payment_method_id is not None
         assert subscription.user_metadata["stripe_subscription_id"] == "sub_1"
 
+    async def test_creates_from_dependencies_imported_on_earlier_migration(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        imported_customer: Customer,
+        product: Product,
+    ) -> None:
+        earlier = await build_connected_migration(save_fixture, organization)
+        current = await build_connected_migration(save_fixture, organization)
+        await save_fixture(
+            MerchantMigrationRecord(
+                merchant_migration=earlier,
+                organization=organization,
+                type=MerchantMigrationRecordType.customer,
+                status=MerchantMigrationRecordStatus.imported,
+                source_id="cus_1",
+                target_id=imported_customer.id,
+                canonical={},
+            )
+        )
+        await save_fixture(
+            MerchantMigrationRecord(
+                merchant_migration=earlier,
+                organization=organization,
+                type=MerchantMigrationRecordType.product,
+                status=MerchantMigrationRecordStatus.imported,
+                source_id="prod_1:month:1",
+                target_id=product.id,
+                canonical=serialize(
+                    CanonicalProduct(
+                        source_id="prod_1:month:1",
+                        product_source_id="prod_1",
+                        name="Product",
+                        recurring_interval="month",
+                        recurring_interval_count=1,
+                        prices=[
+                            CanonicalPrice(
+                                source_id="price_1",
+                                currency="usd",
+                                amount=1000,
+                                pricing_scheme=CanonicalPricingScheme.fixed,
+                            )
+                        ],
+                    )
+                ),
+            )
+        )
+        pending = MerchantMigrationRecord(
+            merchant_migration=current,
+            organization=organization,
+            type=MerchantMigrationRecordType.subscription,
+            status=MerchantMigrationRecordStatus.pending,
+            source_id="sub_1",
+            canonical=serialize(canonical_subscription()),
+        )
+        await save_fixture(pending)
+        copied_cards(mocker, build_stripe_payment_method(customer="cus_1"))
+
+        outcome = await SubscriptionCutover(session, current, _source()).run(pending)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert pending.target_id is not None
+
     async def test_duplicate_pending_subscription_stays_on_source(
         self,
         session: AsyncSession,

--- a/server/tests/merchant_migration/test_repository.py
+++ b/server/tests/merchant_migration/test_repository.py
@@ -352,3 +352,81 @@ class TestSwitchableSubscriptions:
         assert await repository.payment_method_coverage(migration.id) == set()
         await create_payment_method(save_fixture, customer, processor_id="pm_ready")
         assert await repository.payment_method_coverage(migration.id) == {ready.id}
+
+    async def test_pending_subscription_sees_dependencies_from_earlier_migration(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        earlier = await _create_migration(save_fixture, organization)
+        current = await _create_migration(save_fixture, organization)
+        customer = await create_customer(
+            save_fixture, organization=organization, email="reused@example.com"
+        )
+        await save_fixture(
+            MerchantMigrationRecord(
+                merchant_migration=earlier,
+                organization=organization,
+                type=MerchantMigrationRecordType.customer,
+                status=MerchantMigrationRecordStatus.imported,
+                source_id="cus_ready",
+                target_id=customer.id,
+                canonical={},
+            )
+        )
+        await save_fixture(
+            MerchantMigrationRecord(
+                merchant_migration=earlier,
+                organization=organization,
+                type=MerchantMigrationRecordType.product,
+                status=MerchantMigrationRecordStatus.imported,
+                source_id="prod_1:month:1",
+                target_id=product.id,
+                canonical=serialize(
+                    CanonicalProduct(
+                        source_id="prod_1:month:1",
+                        product_source_id="prod_1",
+                        name="Product",
+                        recurring_interval="month",
+                        recurring_interval_count=1,
+                        prices=[
+                            CanonicalPrice(
+                                source_id="price_ready",
+                                currency="usd",
+                                amount=1000,
+                                pricing_scheme=CanonicalPricingScheme.fixed,
+                            )
+                        ],
+                    )
+                ),
+            )
+        )
+        pending = MerchantMigrationRecord(
+            merchant_migration=current,
+            organization=organization,
+            type=MerchantMigrationRecordType.subscription,
+            status=MerchantMigrationRecordStatus.pending,
+            source_id="sub_ready",
+            canonical=serialize(
+                canonical_subscription(
+                    source_id="sub_ready",
+                    customer_source_id="cus_ready",
+                    price_source_id="price_ready",
+                )
+            ),
+        )
+        await save_fixture(pending)
+        repository = MerchantMigrationRecordRepository.from_session(session)
+
+        records = await repository.list_imported_subscriptions(
+            current.id, offset=0, limit=10
+        )
+
+        assert [record.id for record in records] == [pending.id]
+        found = await repository.get_imported_customer_dependency(
+            organization.id, "cus_ready"
+        )
+        assert found is not None
+        assert found.merchant_migration_id == earlier.id

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -629,6 +629,72 @@ class TestListRecords:
         assert prod_1 is not None
         assert prod_1.id in {item.record_id for item in items}
 
+    @pytest.mark.auth
+    async def test_imported_customer_wins_duplicate_email_classification(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker,
+            session,
+            save_fixture,
+            auth_subject,
+            organization,
+            records=[
+                *_catalog(),
+                CanonicalCustomer(
+                    source_id="cus_current",
+                    email="shared@example.com",
+                    name="Current",
+                    country="US",
+                ),
+                canonical_subscription(
+                    customer_source_id="cus_reused",
+                    price_source_id="price_1",
+                ),
+            ],
+        )
+        earlier = await build_connected_migration(save_fixture, organization)
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="shared@example.com",
+        )
+        await save_fixture(
+            MerchantMigrationRecord(
+                merchant_migration=earlier,
+                organization=organization,
+                type=MerchantMigrationRecordType.customer,
+                status=MerchantMigrationRecordStatus.imported,
+                source_id="cus_reused",
+                target_id=customer.id,
+                canonical=serialize(
+                    CanonicalCustomer(
+                        source_id="cus_reused",
+                        email="shared@example.com",
+                        name="Reused",
+                        country="US",
+                    )
+                ),
+            )
+        )
+
+        items, _ = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.subscriptions,
+            status=None,
+            pagination=PaginationParams(page=1, limit=20),
+        )
+
+        assert items[0].status == PrecheckRecordStatus.importable
+
 
 def _importable_catalog() -> list[CanonicalRecord]:
     """An importable recurring product, a one-time product that's skipped, and

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -694,6 +694,18 @@ class TestListRecords:
         )
 
         assert items[0].status == PrecheckRecordStatus.importable
+        customer_items, _ = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.customers,
+            status=None,
+            pagination=PaginationParams(page=1, limit=20),
+        )
+        assert len(customer_items) == 1
+        assert customer_items[0].source_id == "cus_current"
+        assert customer_items[0].status == PrecheckRecordStatus.skipped
+        assert customer_items[0].reason_code == "duplicate_customer_email"
 
 
 def _importable_catalog() -> list[CanonicalRecord]:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reuse imported customers and products from earlier migrations in the same organization.

## Test plan

- 106 targeted tests pass, including same-email customer collision coverage
- Ruff and mypy pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed28e7c1-5cbf-42fb-9fb0-6c16dada0d52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed28e7c1-5cbf-42fb-9fb0-6c16dada0d52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

