### PR TITLE
fix(merchant-migration): count subscription attention only

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -24444,7 +24444,7 @@ export interface components {
       entities: components['schemas']['MerchantMigrationRecordSummaryEntity'][]
       /**
        * Action Required
-       * @description How many records the pre-check flagged for the merchant to fix, across entities. Classification only, so a flagged record that has since been imported still counts.
+       * @description How many subscription records the pre-check flagged for the merchant to fix. Classification only, so a flagged record that has since been imported still counts.
        */
       action_required: number
     }

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -176,9 +176,9 @@ class MerchantMigrationRecordSummary(Schema):
     )
     action_required: int = Field(
         description=(
-            "How many records the pre-check flagged for the merchant to fix, "
-            "across entities. Classification only, so a flagged record that has "
-            "since been imported still counts."
+            "How many subscription records the pre-check flagged for the merchant "
+            "to fix. Classification only, so a flagged record that has since been "
+            "imported still counts."
         )
     )
 

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -1225,7 +1225,8 @@ class MerchantMigrationService:
             action_required=sum(
                 1
                 for item in items
-                if item.reason_level == PrecheckReasonLevel.action_required
+                if item.entity == PrecheckEntity.subscriptions
+                and item.reason_level == PrecheckReasonLevel.action_required
             ),
         )
 

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1530,12 +1530,58 @@ class TestSummarizeRecords:
             session,
             auth_subject,
             migration.id,
-            entity=None,
+            entity=PrecheckEntity.subscriptions,
             status=None,
             reason_level=PrecheckReasonLevel.action_required,
             pagination=PaginationParams(page=1, limit=100),
         )
         assert summary.action_required == count
+
+    @pytest.mark.auth
+    async def test_attention_count_ignores_customer_flags(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker,
+            session,
+            save_fixture,
+            auth_subject,
+            organization,
+            records=[
+                *_catalog(),
+                CanonicalCustomer(
+                    source_id="cus_1",
+                    email="alice@example.com",
+                    name="Alice",
+                    country=None,
+                ),
+                CanonicalSubscription(
+                    source_id="sub_1",
+                    customer_source_id="cus_1",
+                    price_source_id="price_1",
+                    status=CanonicalSubscriptionStatus.active,
+                    collection_method=CanonicalCollectionMethod.charge_automatically,
+                    current_period_start=None,
+                    current_period_end=None,
+                    trialing=False,
+                    paused_collection=False,
+                    line_item_count=1,
+                    quantity=1,
+                    payment_method=None,
+                    currency="usd",
+                ),
+            ],
+        )
+
+        summary = await service.summarize_records(session, auth_subject, migration.id)
+
+        assert summary.action_required == 0
 
     @pytest.mark.auth
     async def test_summary_counts_what_is_still_selectable(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Show only the number of subscriptions in the migration nav

## Test plan

- 58 targeted tests pass
- Ruff and mypy pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed28e7c1-5cbf-42fb-9fb0-6c16dada0d52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed28e7c1-5cbf-42fb-9fb0-6c16dada0d52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

