### PR TITLE
fix(merchant-migration): serialize subscription creation

### DIFF
--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -324,6 +324,11 @@ class SubscriptionCutover:
             if reason is not None:
                 return _skip(reason)
 
+        if await self.subscription_repository.exists_live_by_customer_and_product(
+            customer.id, product.id
+        ):
+            return _skip(_CUSTOMER_ALREADY_SUBSCRIBED.message)
+
         payment_method = await link_payment_method(
             self.session, customer, source_method=source.payment_method
         )
@@ -359,6 +364,8 @@ class SubscriptionCutover:
         )
         if customer is None or customer.is_deleted:
             return _skip(_CUSTOMER_DELETED)
+        # Re-check under the lock: another cutover may have created one while
+        # this worker resolved the payment method.
         if await self.subscription_repository.exists_live_by_customer_and_product(
             customer.id, product.id
         ):

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -324,18 +324,6 @@ class SubscriptionCutover:
             if reason is not None:
                 return _skip(reason)
 
-        try:
-            canonical_product = deserialize(
-                product_record.type, product_record.canonical
-            )
-        except KeyError, TypeError, ValueError:
-            return _skip(_NOT_IMPORTED)
-        if not isinstance(canonical_product, CanonicalProduct):
-            return _skip(_NOT_IMPORTED)
-        price = find_imported_price(product, canonical_product, staged)
-        if price is None:
-            return _skip(_NOT_IMPORTED)
-
         customer = await self.customer_repository.get_by_id(
             customer.id, include_deleted=True, for_update=True
         )
@@ -360,6 +348,18 @@ class SubscriptionCutover:
                 return _fail(_STRANDED)
         elif payment_method is None or payment_method.type != "card":
             return _skip(_NO_CARD)
+
+        try:
+            canonical_product = deserialize(
+                product_record.type, product_record.canonical
+            )
+        except KeyError, TypeError, ValueError:
+            return _skip(_NOT_IMPORTED)
+        if not isinstance(canonical_product, CanonicalProduct):
+            return _skip(_NOT_IMPORTED)
+        price = find_imported_price(product, canonical_product, staged)
+        if price is None:
+            return _skip(_NOT_IMPORTED)
 
         if already_stopped and self._period_is_lapsed(source, product):
             return _fail(_LAPSED)

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -324,6 +324,23 @@ class SubscriptionCutover:
             if reason is not None:
                 return _skip(reason)
 
+        try:
+            canonical_product = deserialize(
+                product_record.type, product_record.canonical
+            )
+        except KeyError, TypeError, ValueError:
+            return _skip(_NOT_IMPORTED)
+        if not isinstance(canonical_product, CanonicalProduct):
+            return _skip(_NOT_IMPORTED)
+        price = find_imported_price(product, canonical_product, staged)
+        if price is None:
+            return _skip(_NOT_IMPORTED)
+
+        customer = await self.customer_repository.get_by_id(
+            customer.id, include_deleted=True, for_update=True
+        )
+        if customer is None or customer.is_deleted:
+            return _skip(_CUSTOMER_DELETED)
         if await self.subscription_repository.exists_live_by_customer_and_product(
             customer.id, product.id
         ):
@@ -343,18 +360,6 @@ class SubscriptionCutover:
                 return _fail(_STRANDED)
         elif payment_method is None or payment_method.type != "card":
             return _skip(_NO_CARD)
-
-        try:
-            canonical_product = deserialize(
-                product_record.type, product_record.canonical
-            )
-        except KeyError, TypeError, ValueError:
-            return _skip(_NOT_IMPORTED)
-        if not isinstance(canonical_product, CanonicalProduct):
-            return _skip(_NOT_IMPORTED)
-        price = find_imported_price(product, canonical_product, staged)
-        if price is None:
-            return _skip(_NOT_IMPORTED)
 
         if already_stopped and self._period_is_lapsed(source, product):
             return _fail(_LAPSED)

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -324,16 +324,6 @@ class SubscriptionCutover:
             if reason is not None:
                 return _skip(reason)
 
-        customer = await self.customer_repository.get_by_id(
-            customer.id, include_deleted=True, for_update=True
-        )
-        if customer is None or customer.is_deleted:
-            return _skip(_CUSTOMER_DELETED)
-        if await self.subscription_repository.exists_live_by_customer_and_product(
-            customer.id, product.id
-        ):
-            return _skip(_CUSTOMER_ALREADY_SUBSCRIBED.message)
-
         payment_method = await link_payment_method(
             self.session, customer, source_method=source.payment_method
         )
@@ -363,6 +353,16 @@ class SubscriptionCutover:
 
         if already_stopped and self._period_is_lapsed(source, product):
             return _fail(_LAPSED)
+
+        customer = await self.customer_repository.get_by_id(
+            customer.id, include_deleted=True, for_update=True
+        )
+        if customer is None or customer.is_deleted:
+            return _skip(_CUSTOMER_DELETED)
+        if await self.subscription_repository.exists_live_by_customer_and_product(
+            customer.id, product.id
+        ):
+            return _skip(_CUSTOMER_ALREADY_SUBSCRIBED.message)
 
         subscription = await create_imported_subscription(
             self.session, staged, product, price, customer

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -262,6 +262,7 @@ class TestRun:
         migration: MerchantMigration,
         organization: Organization,
         pending_record: MerchantMigrationRecord,
+        imported_customer: Customer,
     ) -> None:
         second = MerchantMigrationRecord(
             merchant_migration=migration,
@@ -275,10 +276,14 @@ class TestRun:
         copied_cards(mocker, build_stripe_payment_method(customer="cus_1"))
         adapter = _source()
         cutover = SubscriptionCutover(session, migration, adapter)
+        get_customer = mocker.spy(cutover.customer_repository, "get_by_id")
 
         first = await cutover.run(pending_record)
         later = await cutover.run(second)
 
+        get_customer.assert_any_call(
+            imported_customer.id, include_deleted=True, for_update=True
+        )
         assert first.status == MerchantMigrationCutoverStatus.moved
         assert later.status == MerchantMigrationCutoverStatus.skipped
         assert "already has a live subscription" in (later.message or "")

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -254,6 +254,37 @@ class TestRun:
         _assert_left_alone(adapter, pending_record)
         assert pending_record.status == MerchantMigrationRecordStatus.pending
 
+    async def test_second_source_subscription_for_same_product_stays_on_source(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        organization: Organization,
+        pending_record: MerchantMigrationRecord,
+    ) -> None:
+        second = MerchantMigrationRecord(
+            merchant_migration=migration,
+            organization=organization,
+            type=MerchantMigrationRecordType.subscription,
+            status=MerchantMigrationRecordStatus.pending,
+            source_id="sub_2",
+            canonical=serialize(canonical_subscription(source_id="sub_2")),
+        )
+        await save_fixture(second)
+        copied_cards(mocker, build_stripe_payment_method(customer="cus_1"))
+        adapter = _source()
+        cutover = SubscriptionCutover(session, migration, adapter)
+
+        first = await cutover.run(pending_record)
+        later = await cutover.run(second)
+
+        assert first.status == MerchantMigrationCutoverStatus.moved
+        assert later.status == MerchantMigrationCutoverStatus.skipped
+        assert "already has a live subscription" in (later.message or "")
+        assert second.target_id is None
+        assert adapter.stopped == ["sub_1"]
+
     async def test_moves_and_stops_the_source(
         self,
         mocker: MockerFixture,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lock and re-check the customer immediately before creating a live subscription during cutover.

## Test plan

- 37 targeted tests pass, including explicit lock acquisition coverage
- Ruff and mypy pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed28e7c1-5cbf-42fb-9fb0-6c16dada0d52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed28e7c1-5cbf-42fb-9fb0-6c16dada0d52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

