### PR TITLE
Show imported and pending migration subscriptions

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ImportedStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ImportedStep.tsx
@@ -61,7 +61,7 @@ export function ImportedStep({ migrationId }: { migrationId: string }) {
 
         {expanded && (
           <Box id={panelId} flexDirection="column">
-            <ReviewTable migrationId={migrationId} />
+            <ReviewTable migrationId={migrationId} defaultFilter="imported" />
           </Box>
         )}
       </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
@@ -1,6 +1,22 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { ReviewStatusTabs } from './ReviewStatusTabs'
+
+vi.mock('@polar-sh/orbit', () => ({
+  SegmentedControl: ({
+    options,
+    onChange,
+  }: {
+    options: { value: string; label: ReactNode }[]
+    onChange: (value: string) => void
+  }) =>
+    options.map((option) => (
+      <button key={option.value} onClick={() => onChange(option.value)}>
+        {option.label}
+      </button>
+    )),
+}))
 
 describe('ReviewStatusTabs', () => {
   it('shows imported and pending subscriptions as separate filters', () => {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ReviewStatusTabs } from './ReviewStatusTabs'
+
+describe('ReviewStatusTabs', () => {
+  it('shows imported and pending subscriptions as separate filters', () => {
+    const onChange = vi.fn()
+
+    render(
+      <ReviewStatusTabs
+        value="all"
+        counts={{
+          all: 58,
+          imported: 27,
+          pending: 31,
+          attention: 0,
+          skipped: 0,
+        }}
+        onChange={onChange}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'All rows 58' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Imported 27' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Pending 31' }))
+    expect(onChange).toHaveBeenCalledWith('pending')
+  })
+})

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.tsx
@@ -1,6 +1,11 @@
 import { SegmentedControl } from '@polar-sh/orbit'
 
-export type ReviewFilter = 'attention' | 'skipped' | 'all'
+export type ReviewFilter =
+  | 'all'
+  | 'imported'
+  | 'pending'
+  | 'attention'
+  | 'skipped'
 
 export type ReviewFilterCounts = Record<ReviewFilter, number>
 
@@ -8,14 +13,18 @@ const numberFormat = new Intl.NumberFormat('en-US')
 
 const OPTIONS: { value: ReviewFilter; label: string }[] = [
   { value: 'all', label: 'All rows' },
+  { value: 'imported', label: 'Imported' },
+  { value: 'pending', label: 'Pending' },
   { value: 'attention', label: 'Needs attention' },
   { value: 'skipped', label: "Won't import" },
 ]
 
 export const EMPTY_MESSAGES: Record<ReviewFilter, string> = {
+  all: 'No subscriptions to show.',
+  imported: 'No subscriptions have been imported.',
+  pending: 'No subscriptions are pending.',
   attention: 'Nothing needs attention.',
   skipped: 'Nothing is staying on Stripe.',
-  all: 'No records to show.',
 }
 
 interface Props {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -30,6 +30,8 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
     entity: 'subscriptions',
     page,
     limit: pageSize,
+    ...(filter === 'imported' ? { importStatus: 'imported' as const } : {}),
+    ...(filter === 'pending' ? { importStatus: 'pending' as const } : {}),
     ...(filter === 'attention' ? { reasonLevel: 'action_required' } : {}),
     ...(filter === 'skipped' ? { status: 'skipped' as const } : {}),
   })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -20,8 +20,14 @@ import {
 import { ReviewFilter } from './ReviewStatusTabs'
 import { ReviewTableView } from './ReviewTableView'
 
-export function ReviewTable({ migrationId }: { migrationId: string }) {
-  const [filter, setFilter] = useState<ReviewFilter>('all')
+export function ReviewTable({
+  migrationId,
+  defaultFilter = 'all',
+}: {
+  migrationId: string
+  defaultFilter?: ReviewFilter
+}) {
+  const [filter, setFilter] = useState<ReviewFilter>(defaultFilter)
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(20)
   const [selection, setSelection] = useState<SelectionState>(initialSelection)

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -73,13 +73,14 @@ export function ReviewTableView({
   const selectableTotal = counts.subscriptions.selectable
 
   const importCount = selectedCount(selection, selectableTotal)
-  const importLabel = importing
-    ? 'Importing…'
+  const prepareLabel = importing
+    ? 'Preparing…'
     : importCount > 0
-      ? `Import ${numberFormat.format(importCount)} ${
+      ? `Prepare ${numberFormat.format(importCount)} ${
           importCount === 1 ? 'subscription' : 'subscriptions'
         }`
-      : 'Import subscriptions'
+      : 'Prepare subscriptions'
+  const canPrepare = filter === 'all' || filter === 'pending'
   const hasCatalog = rowTotal > 0
   const [openRow, setOpenRow] = useState<ReviewRow | null>(null)
 
@@ -169,7 +170,7 @@ export function ReviewTableView({
       {importError && (
         <Alert
           variant="danger"
-          title="We couldn't import the catalog"
+          title="We couldn't prepare these subscriptions"
           description={importError}
         />
       )}
@@ -206,18 +207,20 @@ export function ReviewTableView({
                 {rerunning ? 'Refreshing…' : 'Refresh from Stripe'}
               </Button>
             )}
-            <Button
-              size="sm"
-              onClick={onImport}
-              disabled={importing || importCount <= 0}
-            >
-              {importLabel}
-            </Button>
+            {canPrepare ? (
+              <Button
+                size="sm"
+                onClick={onImport}
+                disabled={importing || importCount <= 0}
+              >
+                {prepareLabel}
+              </Button>
+            ) : null}
           </Box>
         </Box>
 
         <Text variant="caption" color="muted">
-          Importing a subscription brings its customer and product to Polar.
+          Preparing a subscription brings its customer and product to Polar.
           Polar starts billing only when you switch.
         </Text>
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -186,9 +186,11 @@ export function ReviewTableView({
             <ReviewStatusTabs
               value={filter}
               counts={{
+                all: rowTotal,
+                imported: counts.subscriptions.imported,
+                pending: counts.subscriptions.pending,
                 attention: attentionCount,
                 skipped: skippedTotal,
-                all: rowTotal,
               }}
               onChange={onFilterChange}
             />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/recordSummary.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/recordSummary.ts
@@ -14,6 +14,8 @@ const empty = (entity: CountEntity): EntityCount => ({
   importable: 0,
   skipped: 0,
   imported: 0,
+  pending: 0,
+  action_required: 0,
   selectable: 0,
 })
 
@@ -37,7 +39,7 @@ export const useRecordSummary = (id: string) => {
         customers: counts.customers.imported,
       },
       selectableTotal: counts.subscriptions.selectable,
-      attentionCount: query.data?.action_required ?? 0,
+      attentionCount: counts.subscriptions.action_required,
     }
   }, [query.data])
 

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -24476,6 +24476,16 @@ export interface components {
        */
       imported: number
       /**
+       * Pending
+       * @description How many are waiting to be imported into Polar.
+       */
+      pending: number
+      /**
+       * Action Required
+       * @description How many require merchant action before they can be imported.
+       */
+      action_required: number
+      /**
        * Selectable
        * @description How many subscriptions an import would still prepare: importable by the pre-check, pending in the ledger, and not already backed by an imported customer and product. Zero for other entities.
        */

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -161,6 +161,10 @@ class MerchantMigrationRecordSummaryEntity(PrecheckEntitySummary):
     """The pre-check's per-entity counts, plus where the ledger has got to."""
 
     imported: int = Field(description="How many are already in Polar.")
+    pending: int = Field(description="How many are waiting to be imported into Polar.")
+    action_required: int = Field(
+        description="How many require merchant action before they can be imported."
+    )
     selectable: int = Field(
         description="How many subscriptions an import would still prepare: "
         "importable by the pre-check, pending in the ledger, and not already backed "

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -273,7 +273,14 @@ def _summarize_entities(
 ) -> list[MerchantMigrationRecordSummaryEntity]:
     """Tally every entity in one pass over the classified rows."""
     tallies = {
-        entity: {"total": 0, "importable": 0, "imported": 0, "selectable": 0}
+        entity: {
+            "total": 0,
+            "importable": 0,
+            "imported": 0,
+            "pending": 0,
+            "action_required": 0,
+            "selectable": 0,
+        }
         for entity in entities
     }
     for item in items:
@@ -283,6 +290,10 @@ def _summarize_entities(
         tally["total"] += 1
         if item.import_status == MerchantMigrationRecordStatus.imported:
             tally["imported"] += 1
+        if item.import_status == MerchantMigrationRecordStatus.pending:
+            tally["pending"] += 1
+        if item.reason_level == PrecheckReasonLevel.action_required:
+            tally["action_required"] += 1
         if item.status != PrecheckRecordStatus.importable:
             continue
         tally["importable"] += 1
@@ -300,6 +311,8 @@ def _summarize_entities(
             importable=tally["importable"],
             skipped=tally["total"] - tally["importable"],
             imported=tally["imported"],
+            pending=tally["pending"],
+            action_required=tally["action_required"],
             selectable=tally["selectable"],
         )
         for entity, tally in tallies.items()

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1519,11 +1519,14 @@ class TestSummarizeRecords:
         assert products.importable == 1
         assert products.skipped == 1
         assert products.imported == 1
+        assert products.pending == 1
+        assert products.action_required == 0
         assert products.selectable == 0
 
         customers = by_entity[PrecheckEntity.customers]
         assert customers.total == 1
         assert customers.imported == 1
+        assert customers.pending == 0
         assert customers.selectable == 0
 
         items, count = await service.list_records(
@@ -1536,6 +1539,7 @@ class TestSummarizeRecords:
             pagination=PaginationParams(page=1, limit=100),
         )
         assert summary.action_required == count
+        assert sum(entity.action_required for entity in summary.entities) == count
 
     @pytest.mark.auth
     async def test_summary_counts_what_is_still_selectable(
@@ -1556,8 +1560,11 @@ class TestSummarizeRecords:
         by_entity = {entry.entity: entry for entry in summary.entities}
         products = by_entity[PrecheckEntity.products]
         assert products.imported == 0
+        assert products.pending == 2
         assert products.selectable == 0
-        assert by_entity[PrecheckEntity.subscriptions].selectable == 1
+        subscriptions = by_entity[PrecheckEntity.subscriptions]
+        assert subscriptions.pending == 1
+        assert subscriptions.selectable == 1
 
 
 def _canonical_subscription(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Related Issue**: #<!-- issue number -->

Makes imported and pending subscriptions visible in the migration records view, opening on Imported and allowing additional pending subscriptions to be prepared.

## What

- Adds Imported and Pending record filters.
- Opens the post-import Records panel on Imported.
- Shows a Prepare subscriptions action on All rows and Pending only.
- Keeps All rows as the default for the pre-import review step, where nothing is imported yet.
- Reports subscription-specific pending and needs-attention counts.

## Why

Merchants need to review subscriptions already imported into Polar alongside subscriptions still waiting to be created. Additional pending subscriptions should be preparable without implying that Polar starts billing them immediately.

## How

Adds per-entity pending and action-required summary fields, regenerates the TypeScript API client, and wires those values into the subscription filter tabs. `ReviewTable` takes a `defaultFilter`, which the imported-records panel sets to `imported`. The existing import mutation is presented as Prepare subscriptions and only appears in contexts containing pending records.

## Walkthrough

Imported has no preparation action. Switching to Pending reveals the pending records and the preparation action; the pointer highlights the action without triggering it.

[prepare_subscription_action_highlighted.mp4](https://cursor.com/agents/bc-604cd60d-152b-445c-bdef-0bc3400a5920/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprepare_subscription_action_highlighted.mp4)

## Verification

- `POLAR_ENV=testing uv run python -m pytest tests/merchant_migration/test_service.py::TestSummarizeRecords`
- `pnpm exec vitest run "src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx"`
- `pnpm typecheck` (`clients/apps/web`)
- `pnpm exec eslint "src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx"`
- `pnpm exec oxfmt --check "src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx"`
- `uv run task lint && uv run task lint_types` (`server`)
- `pnpm lint && pnpm typecheck` (`clients/packages/client`)

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-604cd60d-152b-445c-bdef-0bc3400a5920?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-604cd60d-152b-445c-bdef-0bc3400a5920&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

