### PR TITLE
test(server): remove duplicate tests

### DIFF
--- a/server/tests/benefit/grant/test_scope.py
+++ b/server/tests/benefit/grant/test_scope.py
@@ -19,28 +19,6 @@ from tests.fixtures.random_objects import create_customer, create_organization
 class TestResolveMember:
     """Tests for resolve_member() function in scope.py"""
 
-    async def test_feature_flag_disabled_returns_none(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        account: Account,
-    ) -> None:
-        """When member_model_enabled is False, should return None regardless of inputs."""
-        organization = await create_organization(
-            save_fixture, account, feature_settings={"member_model_enabled": False}
-        )
-        customer = await create_customer(save_fixture, organization=organization)
-
-        result = await resolve_member(
-            session,
-            customer_id=customer.id,
-            organization=organization,
-            member_id=None,
-            is_seat_based=False,
-        )
-
-        assert result is None
-
     async def test_feature_flag_disabled_uses_explicit_member_id(
         self,
         session: AsyncSession,

--- a/server/tests/checkout_link/test_endpoints.py
+++ b/server/tests/checkout_link/test_endpoints.py
@@ -140,17 +140,6 @@ class TestCreateCheckoutLink:
 
         assert response.status_code == 403
 
-    @pytest.mark.auth(AuthSubjectFixture(scopes=set()))
-    async def test_missing_scope_with_price(
-        self, client: AsyncClient, product: Product
-    ) -> None:
-        response = await client.post(
-            "/v1/checkout-links/",
-            json={"payment_processor": "stripe", "products": [str(product.id)]},
-        )
-
-        assert response.status_code == 403
-
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.checkout_links_write}))
     async def test_valid(
         self, client: AsyncClient, product: Product, user_organization: UserOrganization

--- a/server/tests/customer_seat/test_endpoints.py
+++ b/server/tests/customer_seat/test_endpoints.py
@@ -887,46 +887,8 @@ class TestOrderBasedSeats:
 
 
 @pytest.mark.asyncio
-class TestCustomerSeatsAuthentication:
-    async def test_list_seats_anonymous_rejected(
-        self,
-        client: AsyncClient,
-        subscription_with_seats: Subscription,
-    ) -> None:
-        response = await client.get(
-            "/v1/customer-seats",
-            params={"subscription_id": str(subscription_with_seats.id)},
-        )
-
-        assert response.status_code == 401
-
-    async def test_assign_seat_anonymous_rejected(
-        self,
-        client: AsyncClient,
-        subscription_with_seats: Subscription,
-    ) -> None:
-        response = await client.post(
-            "/v1/customer-seats",
-            json={
-                "subscription_id": str(subscription_with_seats.id),
-                "email": "test@example.com",
-            },
-        )
-
-        assert response.status_code == 401
-
-    async def test_revoke_seat_anonymous_rejected(
-        self,
-        client: AsyncClient,
-        customer_seat_claimed: CustomerSeat,
-    ) -> None:
-        response = await client.delete(
-            f"/v1/customer-seats/{customer_seat_claimed.id}",
-        )
-
-        assert response.status_code == 401
-
-    async def test_resend_invitation_anonymous_rejected(
+class TestResendInvitation:
+    async def test_anonymous(
         self,
         client: AsyncClient,
         customer_seat_pending: CustomerSeat,


### PR DESCRIPTION
## Summary

Five tests that assert exactly what another test in the same file already asserts.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

