### PR TITLE
test(server): exercise the real discount analysis in tests

### DIFF
--- a/server/tests/scripts/test_transfer_products_between_organizations.py
+++ b/server/tests/scripts/test_transfer_products_between_organizations.py
@@ -16,9 +16,11 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_account,
     create_benefit,
+    create_checkout,
     create_checkout_link,
     create_customer,
     create_discount,
+    create_discount_redemption,
     create_event,
     create_order,
     create_organization,
@@ -656,21 +658,34 @@ class TestProductTransferService:
             code="STAY5",
         )
 
+        # `_analyze_discounts` categorizes by redemption, not by the
+        # discount's product association.
+        checkout_transfer = await create_checkout(
+            save_fixture, products=[product_transfer], product=product_transfer
+        )
+        checkout_stay = await create_checkout(
+            save_fixture, products=[product_stay], product=product_stay
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount_direct, checkout=checkout_transfer
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount_split, checkout=checkout_transfer
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount_split, checkout=checkout_stay
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount_stay, checkout=checkout_stay
+        )
+
         service = ProductTransferService(source_org.id, target_org.id)
         service.products = [product_transfer]
 
-        # Manually set up the discount analysis (simulating what analyze_affected_data does)
-        service.discounts_to_transfer = [discount_direct]
-        service.discounts_to_split = [discount_split]
-        # discount_stay should not be in either list (stays with source org)
+        await service._analyze_discounts(session)
 
-        # Verify categorization
-        assert len(service.discounts_to_transfer) == 1
-        assert discount_direct in service.discounts_to_transfer
-        assert len(service.discounts_to_split) == 1
-        assert discount_split in service.discounts_to_split
-        assert discount_stay not in service.discounts_to_transfer
-        assert discount_stay not in service.discounts_to_split
+        assert service.discounts_to_transfer == [discount_direct]
+        assert service.discounts_to_split == [discount_split]
 
     async def test_validate_transfer_success(
         self,


### PR DESCRIPTION
## Summary

Instead of assigning service.discounts_to_transfer and service.discounts_to_split by hand

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

