### PR TITLE
test(server): parametrize repeated path-template and slug cases

### DIFF
--- a/server/tests/observability/observability/test_utils.py
+++ b/server/tests/observability/observability/test_utils.py
@@ -1,5 +1,8 @@
 from unittest.mock import MagicMock
 
+import pytest
+from starlette.types import Scope
+
 from polar.observability.http_metrics import (
     METRICS_EXCLUDED_APPS,
     exclude_app_from_metrics,
@@ -8,12 +11,22 @@ from polar.observability.utils import get_path_template
 
 
 class TestGetPathTemplate:
-    def test_middleware_denies_healthz(self) -> None:
-        """Test that middleware denies /healthz."""
-
-        scope = {"path": "/healthz", "type": "http"}
-        result = get_path_template(scope)
-        assert result is None
+    @pytest.mark.parametrize(
+        "scope",
+        [
+            pytest.param({"path": "/healthz", "type": "http"}, id="healthz"),
+            pytest.param({"path": "/healthz/deep", "type": "http"}, id="denied_prefix"),
+            pytest.param({"path": "/readyz", "type": "http"}, id="readyz"),
+            pytest.param(
+                {"path": "/.well-known/jwks.json", "type": "http"}, id="well_known"
+            ),
+            pytest.param({"path": "/v1/unknown", "type": "http"}, id="unknown_route"),
+            pytest.param({"path": "", "type": "http"}, id="empty_path"),
+            pytest.param({"type": "http"}, id="missing_path"),
+        ],
+    )
+    def test_no_metrics(self, scope: Scope) -> None:
+        assert get_path_template(scope) is None
 
     def test_middleware_uses_route_path(self) -> None:
         """Test that middleware uses route.path when available."""
@@ -44,52 +57,6 @@ class TestGetPathTemplate:
 
         result = get_path_template(scope)
         # Should return None to skip metrics (prevents cardinality explosion)
-        assert result is None
-
-    def test_middleware_prefix_deny(self) -> None:
-        """Test that paths starting with denied prefixes are blocked."""
-
-        scope = {"path": "/healthz/deep", "type": "http"}
-        result = get_path_template(scope)
-        assert result is None  # Should be denied
-
-    def test_middleware_denies_readyz(self) -> None:
-        """Test that middleware denies /readyz."""
-
-        scope = {"path": "/readyz", "type": "http"}
-        result = get_path_template(scope)
-        assert result is None
-
-    def test_middleware_denies_well_known(self) -> None:
-        """Test that middleware denies /.well-known paths."""
-
-        scope = {"path": "/.well-known/jwks.json", "type": "http"}
-        result = get_path_template(scope)
-        assert result is None
-
-    def test_middleware_empty_path(self) -> None:
-        """Test middleware with empty path."""
-
-        scope = {"path": "", "type": "http"}
-        result = get_path_template(scope)
-        # No route matched, returns None to skip metrics
-        assert result is None
-
-    def test_middleware_missing_path(self) -> None:
-        """Test middleware when path is missing from scope."""
-
-        scope = {"type": "http"}  # No path key
-        result = get_path_template(scope)
-        # No route matched, returns None to skip metrics
-        assert result is None
-
-    def test_middleware_unknown_route_returns_none(self) -> None:
-        """Test that unknown routes return None (no metrics exported)."""
-
-        # Simulate an unknown route - no route object in scope
-        scope = {"path": "/v1/unknown", "type": "http"}
-        result = get_path_template(scope)
-        # Should return None to prevent cardinality explosion
         assert result is None
 
     def test_middleware_excludes_app(self) -> None:

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -1628,15 +1628,6 @@ class TestCheckSlugAvailability:
         assert response.status_code == 401
 
     @pytest.mark.auth
-    async def test_available(self, client: AsyncClient) -> None:
-        response = await client.post(
-            "/v1/organizations/check-slug", json={"slug": "brand-new-slug"}
-        )
-
-        assert response.status_code == 200
-        assert response.json() == {"available": True}
-
-    @pytest.mark.auth
     async def test_taken(self, client: AsyncClient, organization: Organization) -> None:
         response = await client.post(
             "/v1/organizations/check-slug", json={"slug": organization.slug}
@@ -1646,49 +1637,26 @@ class TestCheckSlugAvailability:
         assert response.json() == {"available": False}
 
     @pytest.mark.auth
-    async def test_too_short(self, client: AsyncClient) -> None:
+    @pytest.mark.parametrize(
+        ("slug", "available"),
+        [
+            pytest.param("brand-new-slug", True, id="available"),
+            pytest.param("ab", False, id="too_short"),
+            pytest.param("a" * 65, False, id="too_long"),
+            pytest.param("Invalid Slug!", False, id="invalid_format"),
+            pytest.param("dashboard", False, id="reserved"),
+            pytest.param("porn-shop", False, id="blocked_word"),
+        ],
+    )
+    async def test_slug_availability(
+        self, client: AsyncClient, slug: str, available: bool
+    ) -> None:
         response = await client.post(
-            "/v1/organizations/check-slug", json={"slug": "ab"}
+            "/v1/organizations/check-slug", json={"slug": slug}
         )
 
         assert response.status_code == 200
-        assert response.json() == {"available": False}
-
-    @pytest.mark.auth
-    async def test_too_long(self, client: AsyncClient) -> None:
-        response = await client.post(
-            "/v1/organizations/check-slug", json={"slug": "a" * 65}
-        )
-
-        assert response.status_code == 200
-        assert response.json() == {"available": False}
-
-    @pytest.mark.auth
-    async def test_invalid_format(self, client: AsyncClient) -> None:
-        response = await client.post(
-            "/v1/organizations/check-slug", json={"slug": "Invalid Slug!"}
-        )
-
-        assert response.status_code == 200
-        assert response.json() == {"available": False}
-
-    @pytest.mark.auth
-    async def test_reserved(self, client: AsyncClient) -> None:
-        response = await client.post(
-            "/v1/organizations/check-slug", json={"slug": "dashboard"}
-        )
-
-        assert response.status_code == 200
-        assert response.json() == {"available": False}
-
-    @pytest.mark.auth
-    async def test_blocked_word(self, client: AsyncClient) -> None:
-        response = await client.post(
-            "/v1/organizations/check-slug", json={"slug": "porn-shop"}
-        )
-
-        assert response.status_code == 200
-        assert response.json() == {"available": False}
+        assert response.json() == {"available": available}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

My super optimization 

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors repeated path-template and slug availability test cases into parametrized tests to reduce duplication and improve readability.

<sup>Written for commit 88c1d604c71fab8ee410642354df86cd14d0f9ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/14005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

