### PR TITLE
fix: repoint sole payable subscription when customer sets default payment method

### DIFF
--- a/server/polar/customer_portal/service/customer.py
+++ b/server/polar/customer_portal/service/customer.py
@@ -17,6 +17,7 @@ from polar.order.service import order as order_service
 from polar.payment_method.repository import PaymentMethodRepository
 from polar.payment_method.service import payment_method as payment_method_service
 from polar.postgres import AsyncSession
+from polar.subscription.service import subscription as subscription_service
 from polar.tax.tax_id import (
     IncompatibleTaxIDFormat,
     InvalidTaxID,
@@ -227,6 +228,9 @@ class CustomerService:
             )
 
         if new_default_payment_method is not None:
+            await subscription_service.update_payment_method_from_new_default(
+                session, customer, new_default_payment_method
+            )
             await order_service.schedule_retry_for_past_due_orders(
                 session, customer, new_default_payment_method
             )
@@ -425,6 +429,9 @@ class CustomerService:
             repository = CustomerRepository.from_session(session)
             customer = await repository.update(
                 customer, update_dict={"default_payment_method": payment_method}
+            )
+            await subscription_service.update_payment_method_from_new_default(
+                session, customer, payment_method
             )
             await order_service.schedule_retry_for_past_due_orders(
                 session, customer, payment_method

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -111,6 +111,20 @@ class SubscriptionRepository(
         )
         return await self.get_all(statement)
 
+    async def list_payable_by_customer(
+        self, customer_id: UUID, *, options: Options = ()
+    ) -> Sequence[Subscription]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Subscription.customer_id == customer_id,
+                Subscription.requires_payment_method,
+                Subscription.ended_at.is_(None),
+            )
+            .options(*options)
+        )
+        return await self.get_all(statement)
+
     async def list_requiring_payment_method(
         self, payment_method_id: UUID, *, options: Options = ()
     ) -> Sequence[Subscription]:

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -4200,6 +4200,25 @@ class SubscriptionService:
         repository = SubscriptionRepository.from_session(session)
         return await repository.update(subscription)
 
+    async def update_payment_method_from_new_default(
+        self,
+        session: AsyncSession,
+        customer: Customer,
+        payment_method: PaymentMethod,
+    ) -> None:
+        """
+        Point the customer's only payable subscription at their new default
+        payment method. With several payable subscriptions, each may
+        deliberately be billed by a different method, so the pins are left
+        untouched.
+        """
+        repository = SubscriptionRepository.from_session(session)
+        subscriptions = await repository.list_payable_by_customer(customer.id)
+        if len(subscriptions) == 1:
+            subscription = subscriptions[0]
+            subscription.payment_method = payment_method
+            await repository.update(subscription)
+
     async def _create_subscription_update_order(
         self, session: AsyncSession, subscription: Subscription
     ) -> Order:

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -7284,6 +7284,65 @@ class TestUpdatePaymentMethodFromRetry:
 
 
 @pytest.mark.asyncio
+class TestUpdatePaymentMethodFromNewDefault:
+    async def test_single_payable_subscription(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        old_payment_method = await create_payment_method(save_fixture, customer)
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=old_payment_method,
+        )
+        canceled_subscription = await create_canceled_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        new_payment_method = await create_payment_method(save_fixture, customer)
+
+        await subscription_service.update_payment_method_from_new_default(
+            session, customer, new_payment_method
+        )
+
+        assert subscription.payment_method == new_payment_method
+        assert canceled_subscription.payment_method_id is None
+
+    async def test_multiple_payable_subscriptions(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        first_payment_method = await create_payment_method(save_fixture, customer)
+        second_payment_method = await create_payment_method(save_fixture, customer)
+        first_subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=first_payment_method,
+        )
+        second_subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=second_payment_method,
+        )
+        new_payment_method = await create_payment_method(save_fixture, customer)
+
+        await subscription_service.update_payment_method_from_new_default(
+            session, customer, new_payment_method
+        )
+
+        assert first_subscription.payment_method_id == first_payment_method.id
+        assert second_subscription.payment_method_id == second_payment_method.id
+
+
+@pytest.mark.asyncio
 class TestUpdateSeats:
     async def test_seat_increase_same_tier(
         self,


### PR DESCRIPTION
We pin the payment method used during checkout to the subscription, which I assume is helpful only when multiple subscriptions are allowed.

This means that even if customers add a new default payment method in the customer portal, we're still charging the subscription to the payment method used during checkout.

I don't believe that's the customer's expected behavior.

I chose to respect the multiple subscriptions behavior by only updating subscriptions when there is exactly one subscription for the customer, but if we want, we can simplify this and update the payment method on all subscriptions (which would effectively almost always be a single subscription) when a new default is set. 