### PR TITLE
Revoke benefits and cancel subscription on chargeback prevention

### DIFF
--- a/docs/features/refunds.mdx
+++ b/docs/features/refunds.mdx
@@ -9,7 +9,7 @@ No matter what refund policy you offer to customers, Polar makes it easy to issu
 <Note>
 **Polar can issue refunds on your behalf**
 
-Polar reserves the right to issue refunds within 60 days of purchase, at its own discretion, in order to prevent chargebacks. We integrate with credit card networks to receive early chargeback signals before a dispute is officially filed, and for lower-value transactions we'll automatically refund the order — and cancel any related subscription — on your behalf to head off the chargeback.
+Polar reserves the right to issue refunds within 60 days of purchase, at its own discretion, in order to prevent chargebacks. We integrate with credit card networks to receive early chargeback signals before a dispute is officially filed, and for lower-value transactions we'll automatically refund the order on your behalf to head off the chargeback — cancelling any related subscription and revoking the customer's benefits at the same time.
 
 This applies even if you have a "no refunds" policy: keeping chargebacks low protects your account, so Polar may still refund proactively. See [Chargeback Management](/merchant-of-record/account-reviews#chargeback-management) for the wider context.
 </Note>

--- a/docs/merchant-of-record/account-reviews.mdx
+++ b/docs/merchant-of-record/account-reviews.mdx
@@ -56,7 +56,7 @@ If your rate climbs toward our threshold, we'll reach out first to collaborate o
 We don't take any of these actions lightly and always try to resolve issues with you first.
 
 <Note>
-  We integrate with credit card networks to receive early chargeback signals before they're officially filed. Below a certain transaction value, we automatically refund and cancel any related subscription to reduce chargebacks proactively. If we issue a proactive refund, we'll notify you by email. Keep in mind that while a refund reverses the payment, it may not revoke benefits the customer has already received or accessed, such as downloaded files or forked repositories.
+  We integrate with credit card networks to receive early chargeback signals before they're officially filed. Below a certain transaction value, we automatically refund the order, cancel any related subscription, and revoke the customer's benefits to reduce chargebacks proactively. If we issue a proactive refund, we'll notify you by email. Keep in mind that benefits the customer has already consumed — such as downloaded files or forked repositories — can't be taken back.
 </Note>
 
 ### Policy Violations

--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -94,6 +94,7 @@ class DisputeRepository(
         currency: str,
         *,
         options: Options = (),
+        for_update: bool = False,
     ) -> Dispute | None:
         statement = (
             self.get_base_statement()
@@ -108,6 +109,8 @@ class DisputeRepository(
             .order_by(Dispute.created_at.asc())
             .limit(1)
         )
+        if for_update:
+            statement = statement.with_for_update(of=Dispute)
         return await self.get_one_or_none(statement)
 
     async def get_by_alert_processor_id(
@@ -116,6 +119,7 @@ class DisputeRepository(
         processor_id: str,
         *,
         options: Options = (),
+        for_update: bool = False,
     ) -> Dispute | None:
         statement = (
             self.get_base_statement()
@@ -125,6 +129,8 @@ class DisputeRepository(
             )
             .options(*options)
         )
+        if for_update:
+            statement = statement.with_for_update(of=Dispute)
         return await self.get_one_or_none(statement)
 
     def get_statement_by_org_ids(

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -438,9 +438,14 @@ class DisputeService:
         dispute.dispute_alert_processor = DisputeAlertProcessor.chargeback_stop
         dispute.dispute_alert_processor_id = alert["id"]
 
-        # We refunded the transaction before the dispute could be escalated
-        if alert["transaction_refund_outcome"] == "REFUNDED":
+        # We refunded the transaction before the dispute could be escalated:
+        # the customer got their money back, so their access goes too.
+        if (
+            alert["transaction_refund_outcome"] == "REFUNDED"
+            and dispute.status != DisputeStatus.prevented
+        ):
             dispute.status = DisputeStatus.prevented
+            await self._revoke(session, dispute)
 
         return await repository.update(dispute)
 

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -399,11 +399,13 @@ class DisputeService:
         assert latest_charge is not None
         charge_id = get_expandable_id(latest_charge)
 
-        # First try to find by alert processor ID
+        # First try to find by alert processor ID. Locked so concurrent alert
+        # deliveries can't both see a non-prevented dispute and revoke twice.
         dispute = await repository.get_by_alert_processor_id(
             DisputeAlertProcessor.chargeback_stop,
             alert["id"],
             options=repository.get_eager_options(),
+            for_update=True,
         )
         # Then try to find by matching payment info, in case Stripe already pinged us about the dispute
         if dispute is None:
@@ -413,6 +415,7 @@ class DisputeService:
                 alert["transaction_amount_in_cents"],
                 alert["transaction_currency_code"].lower(),
                 options=repository.get_eager_options(),
+                for_update=True,
             )
 
         if dispute is None:

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -343,6 +343,7 @@ class RefundService:
 
             refund.dispute = dispute
             refund.reason = RefundReason.dispute_prevention
+            refund.revoke_benefits = True
 
         refund = await repository.create(refund, flush=True)
 

--- a/server/tests/dispute/test_service.py
+++ b/server/tests/dispute/test_service.py
@@ -1236,7 +1236,7 @@ class TestUpsertFromChargebackStop:
         assert dispute.order == order
         assert dispute.payment == payment
 
-    async def test_refunded_revokes_subscription(
+    async def test_prevented_cancels_subscription(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -1281,7 +1281,7 @@ class TestUpsertFromChargebackStop:
         assert dispute.status == DisputeStatus.prevented
         assert subscription.status == "canceled"
 
-    async def test_refunded_revokes_order_benefits(
+    async def test_prevented_revokes_benefits(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,

--- a/server/tests/dispute/test_service.py
+++ b/server/tests/dispute/test_service.py
@@ -1236,6 +1236,145 @@ class TestUpsertFromChargebackStop:
         assert dispute.order == order
         assert dispute.payment == payment
 
+    async def test_refunded_revokes_subscription(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        mocker: MockerFixture,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+            subscription=subscription,
+            subtotal_amount=1000,
+            tax_amount=200,
+        )
+        charge_id = "STRIPE_CHARGE_ID"
+        payment_intent_id = "STRIPE_PAYMENT_INTENT_ID"
+        await create_payment(
+            save_fixture, organization, amount=1200, order=order, processor_id=charge_id
+        )
+        payment_intent = build_stripe_payment_intent(
+            id=payment_intent_id, latest_charge=charge_id
+        )
+        mocker.patch(
+            "polar.dispute.service.stripe_service.get_payment_intent",
+            return_value=payment_intent,
+        )
+
+        alert = build_chargeback_stop_alert(
+            integration_transaction_id=payment_intent_id,
+            transaction_refund_outcome="REFUNDED",
+            transaction_amount_in_cents=1200,
+            transaction_currency_code="USD",
+        )
+
+        dispute = await dispute_service.upsert_from_chargeback_stop(session, alert)
+
+        assert dispute.status == DisputeStatus.prevented
+        assert subscription.status == "canceled"
+
+    async def test_refunded_revokes_order_benefits(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        product_one_time: Product,
+        benefit_grant_service_mock: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            product=product_one_time,
+            subtotal_amount=1000,
+            tax_amount=200,
+        )
+        charge_id = "STRIPE_CHARGE_ID"
+        payment_intent_id = "STRIPE_PAYMENT_INTENT_ID"
+        await create_payment(
+            save_fixture, organization, amount=1200, order=order, processor_id=charge_id
+        )
+        payment_intent = build_stripe_payment_intent(
+            id=payment_intent_id, latest_charge=charge_id
+        )
+        mocker.patch(
+            "polar.dispute.service.stripe_service.get_payment_intent",
+            return_value=payment_intent,
+        )
+
+        alert = build_chargeback_stop_alert(
+            integration_transaction_id=payment_intent_id,
+            transaction_refund_outcome="REFUNDED",
+            transaction_amount_in_cents=1200,
+            transaction_currency_code="USD",
+        )
+
+        dispute = await dispute_service.upsert_from_chargeback_stop(session, alert)
+
+        assert dispute.status == DisputeStatus.prevented
+        benefit_grant_service_mock.enqueue_benefits_grants.assert_awaited_once_with(
+            session,
+            task="revoke",
+            customer=customer,
+            product=product_one_time,
+            order=order,
+        )
+
+    async def test_already_prevented_does_not_revoke_again(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        mocker: MockerFixture,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        payment_intent_id = "STRIPE_PAYMENT_INTENT_ID"
+        payment = await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        await create_dispute(
+            save_fixture,
+            order,
+            payment,
+            status=DisputeStatus.prevented,
+            alert_processor=DisputeAlertProcessor.chargeback_stop,
+            alert_processor_id="CHARGEBACK_STOP_ALERT_ID",
+        )
+        payment_intent = build_stripe_payment_intent(
+            id=payment_intent_id, latest_charge=charge_id
+        )
+        mocker.patch(
+            "polar.dispute.service.stripe_service.get_payment_intent",
+            return_value=payment_intent,
+        )
+        revoke_mock = mocker.patch.object(
+            dispute_service, "_revoke", new_callable=AsyncMock
+        )
+
+        alert = build_chargeback_stop_alert(
+            id="CHARGEBACK_STOP_ALERT_ID",
+            integration_transaction_id=payment_intent_id,
+            transaction_refund_outcome="REFUNDED",
+        )
+
+        updated_dispute = await dispute_service.upsert_from_chargeback_stop(
+            session, alert
+        )
+
+        assert updated_dispute.status == DisputeStatus.prevented
+        revoke_mock.assert_not_awaited()
+
     async def test_update_existing_dispute(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/refund/test_service.py
+++ b/server/tests/refund/test_service.py
@@ -635,6 +635,7 @@ class TestCreate(StripeRefund):
 
         assert refund.reason == RefundReason.dispute_prevention
         assert refund.dispute_id == dispute.id
+        assert refund.revoke_benefits is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Chargebacks are considered hostile customer behavior, and very clearly communicate "I do not want this purchase and don't charge me again", so we should honor that.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

