### PR TITLE
fix: populate grant.member for direct purchases during member model Phase 1

### DIFF
--- a/docs/guides/migrate-seat-based-to-member-model.mdx
+++ b/docs/guides/migrate-seat-based-to-member-model.mdx
@@ -282,7 +282,12 @@ if (event.type === 'benefit_grant.created') {
 
   // For a seat-based grant the member is the seat holder.
   // For a direct purchase it is the buyer's own member.
-  await grantAccess(grant.member.id, grant.member.email);
+  // In Phase 1 it can still be null, so keep the customer fallback.
+  if (grant.member) {
+    await grantAccess(grant.member.id, grant.member.email);
+  } else {
+    await grantAccess(grant.customer_id);
+  }
 }
 ```
 

--- a/docs/guides/migrate-seat-based-to-member-model.mdx
+++ b/docs/guides/migrate-seat-based-to-member-model.mdx
@@ -280,14 +280,9 @@ if (event.type === 'customer_seat.claimed') {
 if (event.type === 'benefit_grant.created') {
   const grant = event.data;
 
-  if (grant.member) {
-    // Seat-based grant: the member is the seat holder.
-    // Direct purchase: the member is the buyer's owner member.
-    await grantAccess(grant.member.id, grant.member.email);
-  } else {
-    // No member (for example, a product without seat-based pricing).
-    await grantAccess(grant.customer_id);
-  }
+  // For a seat-based grant the member is the seat holder.
+  // For a direct purchase it is the buyer's own member.
+  await grantAccess(grant.member.id, grant.member.email);
 }
 ```
 

--- a/docs/guides/migrate-seat-based-to-member-model.mdx
+++ b/docs/guides/migrate-seat-based-to-member-model.mdx
@@ -26,6 +26,8 @@ The migration happens in **two phases** so you can update your integration befor
 
 In this phase, Polar creates `Member` records for all your existing seat holders and populates `member_id` on seats and benefit grants. **Nothing breaks** because `customer_id` on seats still points to the seat holder, and no customers are deleted.
 
+This applies to new records too, not just the initial backfill. While your organization is in Phase 1, every seat you assign and every benefit grant that is created already carries its `member`, so what you read stays consistent as you migrate.
+
 This gives you time to start reading the new `member` and `member_id` fields and update your code before the breaking change.
 
 ### Phase 2: Member model enabled (breaking)
@@ -279,10 +281,11 @@ if (event.type === 'benefit_grant.created') {
   const grant = event.data;
 
   if (grant.member) {
-    // Seat-based grant: member is the end user
+    // Seat-based grant: the member is the seat holder.
+    // Direct purchase: the member is the buyer's owner member.
     await grantAccess(grant.member.id, grant.member.email);
   } else {
-    // Direct purchase: customer is the end user
+    // No member (for example, a product without seat-based pricing).
     await grantAccess(grant.customer_id);
   }
 }

--- a/docs/guides/migrate-seat-based-to-member-model.mdx
+++ b/docs/guides/migrate-seat-based-to-member-model.mdx
@@ -26,7 +26,7 @@ The migration happens in **two phases** so you can update your integration befor
 
 In this phase, Polar creates `Member` records for all your existing seat holders and populates `member_id` on seats and benefit grants. **Nothing breaks** because `customer_id` on seats still points to the seat holder, and no customers are deleted.
 
-This applies to new records too, not just the initial backfill. While your organization is in Phase 1, every seat you assign and every benefit grant that is created already carries its `member`, so what you read stays consistent as you migrate.
+This applies to new records too, not just the initial backfill.
 
 This gives you time to start reading the new `member` and `member_id` fields and update your code before the breaking change.
 

--- a/server/polar/benefit/grant/scope.py
+++ b/server/polar/benefit/grant/scope.py
@@ -4,7 +4,7 @@ import structlog
 from sqlalchemy.orm import joinedload
 
 from polar.customer.repository import CustomerRepository
-from polar.exceptions import PolarError
+from polar.exceptions import PolarError, PolarRequestValidationError
 from polar.logging import Logger
 from polar.member.repository import MemberRepository
 from polar.member.service import member_service
@@ -138,11 +138,21 @@ async def resolve_member(
         # Phase 1 of the member model migration: link direct-purchase grants to
         # the owner member so `grant.member` is already populated before the
         # flag flips. Without this, every grant created during Phase 1 lands
-        # with member_id NULL and has to be backfilled later. Best effort: the
-        # member model isn't active yet, so a failure must not block the grant.
-        return await _resolve_or_create_owner_member(
-            session, customer_id, organization, include_deleted=include_deleted
-        )
+        # with member_id NULL and has to be backfilled later.
+        try:
+            return await _resolve_or_create_owner_member(
+                session, customer_id, organization, include_deleted=include_deleted
+            )
+        except PolarRequestValidationError:
+            # The member model isn't active yet, so linking is best effort: a
+            # customer we can't build an owner member for (no email, for
+            # instance) still gets its grant, with a null member as before.
+            log.warning(
+                "Could not link benefit grant to an owner member",
+                customer_id=str(customer_id),
+                organization_id=str(organization.id),
+            )
+            return None
 
     if member_id is not None:
         member = await member_repository.get_by_id(member_id)

--- a/server/polar/benefit/grant/scope.py
+++ b/server/polar/benefit/grant/scope.py
@@ -137,25 +137,19 @@ async def resolve_member(
                 session
             ).list_active_seat_member_ids(customer_id)
             if seat_member_ids:
-                # A seat holder's grant belongs to the member on their seat, not
-                # to their own owner member. With more than one seat the right
-                # member needs the grant's scope, so leave it for the backfill
-                # rather than guessing.
+                # The member is the one on the holder's seat. Several seats need
+                # the grant's scope to tell apart, so leave those to the backfill.
                 if len(seat_member_ids) == 1 and seat_member_ids[0] is not None:
                     return await member_repository.get_by_id(seat_member_ids[0])
                 return None
-        # Phase 1 of the member model migration: link direct-purchase grants to
-        # the owner member so `grant.member` is already populated before the
-        # flag flips. Without this, every grant created during Phase 1 lands
-        # with member_id NULL and has to be backfilled later.
+        # Populate the member before the flag flips, so grants don't pile up
+        # needing a backfill. Best effort: a customer we can't build an owner
+        # member for still gets its grant.
         try:
             return await _resolve_or_create_owner_member(
                 session, customer_id, organization, include_deleted=include_deleted
             )
         except PolarRequestValidationError:
-            # The member model isn't active yet, so linking is best effort: a
-            # customer we can't build an owner member for (no email, for
-            # instance) still gets its grant, with a null member as before.
             log.warning(
                 "Could not link benefit grant to an owner member",
                 customer_id=str(customer_id),

--- a/server/polar/benefit/grant/scope.py
+++ b/server/polar/benefit/grant/scope.py
@@ -136,13 +136,17 @@ async def resolve_member(
             return member  # may be None if member was deleted
         if is_seat_based:
             # The seat's member sits under the buyer, not the holder.
-            seat_member_id = await CustomerSeatRepository.from_session(
+            seat_member_ids = await CustomerSeatRepository.from_session(
                 session
-            ).get_active_seat_member_id(
+            ).list_active_seat_member_ids(
                 customer_id, subscription_id=subscription_id, order_id=order_id
             )
-            if seat_member_id is not None:
-                return await member_repository.get_by_id(seat_member_id)
+            if seat_member_ids:
+                if len(seat_member_ids) == 1 and seat_member_ids[0] is not None:
+                    return await member_repository.get_by_id(seat_member_ids[0])
+                # Leave the grant for the backfill rather than linking it to the
+                # seat holder's own owner member.
+                return None
         # Link now, so grants don't pile up for the backfill.
         try:
             return await _resolve_or_create_owner_member(

--- a/server/polar/benefit/grant/scope.py
+++ b/server/polar/benefit/grant/scope.py
@@ -95,8 +95,7 @@ async def _resolve_or_create_owner_member(
 ) -> Member | None:
     """Return the customer's owner member, creating it if it doesn't exist yet.
 
-    Returns None when the customer is gone, or when `create_owner_member` opts
-    out because neither the member model nor seat-based pricing is enabled.
+    Returns None when the customer no longer exists.
     """
     member_repository = MemberRepository.from_session(session)
     member = await member_repository.get_owner_by_customer_id(

--- a/server/polar/benefit/grant/scope.py
+++ b/server/polar/benefit/grant/scope.py
@@ -120,6 +120,8 @@ async def resolve_member(
     member_id: UUID | None,
     is_seat_based: bool,
     *,
+    subscription_id: UUID | None = None,
+    order_id: UUID | None = None,
     include_deleted: bool = False,
 ) -> Member | None:
     member_model_enabled = organization.feature_settings.get(
@@ -133,15 +135,15 @@ async def resolve_member(
             member = await member_repository.get_by_id(member_id)
             return member  # may be None if member was deleted
         if is_seat_based:
-            seat_member_ids = await CustomerSeatRepository.from_session(
+            # A seat holder's grant belongs to the member on their seat, which
+            # lives under the buyer rather than under the holder.
+            seat_member_id = await CustomerSeatRepository.from_session(
                 session
-            ).list_active_seat_member_ids(customer_id)
-            if seat_member_ids:
-                # The member is the one on the holder's seat. Several seats need
-                # the grant's scope to tell apart, so leave those to the backfill.
-                if len(seat_member_ids) == 1 and seat_member_ids[0] is not None:
-                    return await member_repository.get_by_id(seat_member_ids[0])
-                return None
+            ).get_active_seat_member_id(
+                customer_id, subscription_id=subscription_id, order_id=order_id
+            )
+            if seat_member_id is not None:
+                return await member_repository.get_by_id(seat_member_id)
         # Populate the member before the flag flips, so grants don't pile up
         # needing a backfill. Best effort: a customer we can't build an owner
         # member for still gets its grant.

--- a/server/polar/benefit/grant/scope.py
+++ b/server/polar/benefit/grant/scope.py
@@ -135,8 +135,7 @@ async def resolve_member(
             member = await member_repository.get_by_id(member_id)
             return member  # may be None if member was deleted
         if is_seat_based:
-            # A seat holder's grant belongs to the member on their seat, which
-            # lives under the buyer rather than under the holder.
+            # The seat's member sits under the buyer, not the holder.
             seat_member_id = await CustomerSeatRepository.from_session(
                 session
             ).get_active_seat_member_id(
@@ -144,14 +143,13 @@ async def resolve_member(
             )
             if seat_member_id is not None:
                 return await member_repository.get_by_id(seat_member_id)
-        # Populate the member before the flag flips, so grants don't pile up
-        # needing a backfill. Best effort: a customer we can't build an owner
-        # member for still gets its grant.
+        # Link now, so grants don't pile up for the backfill.
         try:
             return await _resolve_or_create_owner_member(
                 session, customer_id, organization, include_deleted=include_deleted
             )
         except PolarRequestValidationError:
+            # No email to build an owner member from. Grant it unlinked.
             log.warning(
                 "Could not link benefit grant to an owner member",
                 customer_id=str(customer_id),

--- a/server/polar/benefit/grant/scope.py
+++ b/server/polar/benefit/grant/scope.py
@@ -4,6 +4,7 @@ import structlog
 from sqlalchemy.orm import joinedload
 
 from polar.customer.repository import CustomerRepository
+from polar.customer_seat.repository import CustomerSeatRepository
 from polar.exceptions import PolarError, PolarRequestValidationError
 from polar.logging import Logger
 from polar.member.repository import MemberRepository
@@ -131,8 +132,12 @@ async def resolve_member(
         if member_id is not None:
             member = await member_repository.get_by_id(member_id)
             return member  # may be None if member was deleted
-        if is_seat_based:
-            # Seat grants carry an explicit member_id, resolved from the seat.
+        if is_seat_based and await CustomerSeatRepository.from_session(
+            session
+        ).has_non_revoked_seat(customer_id):
+            # This customer holds a seat, so the grant belongs to the member on
+            # that seat. The seat flow passes it explicitly; leave it unset
+            # rather than guessing, so the backfill can still resolve it.
             return None
         # Phase 1 of the member model migration: link direct-purchase grants to
         # the owner member so `grant.member` is already populated before the

--- a/server/polar/benefit/grant/scope.py
+++ b/server/polar/benefit/grant/scope.py
@@ -86,6 +86,33 @@ def scope_to_args(scope: BenefitGrantScope) -> BenefitGrantScopeArgs:
     return args
 
 
+async def _resolve_or_create_owner_member(
+    session: AsyncSession,
+    customer_id: UUID,
+    organization: Organization,
+    *,
+    include_deleted: bool = False,
+) -> Member | None:
+    """Return the customer's owner member, creating it if it doesn't exist yet.
+
+    Returns None when the customer is gone, or when `create_owner_member` opts
+    out because neither the member model nor seat-based pricing is enabled.
+    """
+    member_repository = MemberRepository.from_session(session)
+    member = await member_repository.get_owner_by_customer_id(
+        customer_id, include_deleted=include_deleted
+    )
+    if member is not None:
+        return member
+
+    customer_repository = CustomerRepository.from_session(session)
+    customer = await customer_repository.get_by_id(customer_id)
+    if customer is None:
+        return None
+
+    return await member_service.create_owner_member(session, customer, organization)
+
+
 async def resolve_member(
     session: AsyncSession,
     customer_id: UUID,
@@ -105,7 +132,17 @@ async def resolve_member(
         if member_id is not None:
             member = await member_repository.get_by_id(member_id)
             return member  # may be None if member was deleted
-        return None
+        if is_seat_based:
+            # Seat grants carry an explicit member_id, resolved from the seat.
+            return None
+        # Phase 1 of the member model migration: link direct-purchase grants to
+        # the owner member so `grant.member` is already populated before the
+        # flag flips. Without this, every grant created during Phase 1 lands
+        # with member_id NULL and has to be backfilled later. Best effort: the
+        # member model isn't active yet, so a failure must not block the grant.
+        return await _resolve_or_create_owner_member(
+            session, customer_id, organization, include_deleted=include_deleted
+        )
 
     if member_id is not None:
         member = await member_repository.get_by_id(member_id)
@@ -122,23 +159,15 @@ async def resolve_member(
     if is_seat_based:
         raise MemberIdRequired()
 
-    member = await member_repository.get_owner_by_customer_id(
-        customer_id, include_deleted=include_deleted
+    member = await _resolve_or_create_owner_member(
+        session, customer_id, organization, include_deleted=include_deleted
     )
     if member is None:
-        # Auto-create owner member (graceful fallback during migration)
-        customer_repository = CustomerRepository.from_session(session)
-        customer = await customer_repository.get_by_id(customer_id)
-        if customer is not None:
-            member = await member_service.create_owner_member(
-                session, customer, organization
-            )
-        if member is None:
-            log.error(
-                "Owner member not found for benefit grant",
-                customer_id=str(customer_id),
-                organization_id=str(organization.id),
-            )
-            raise CustomerDoesntHaveOwnerMember(customer_id)
+        log.error(
+            "Owner member not found for benefit grant",
+            customer_id=str(customer_id),
+            organization_id=str(organization.id),
+        )
+        raise CustomerDoesntHaveOwnerMember(customer_id)
 
     return member

--- a/server/polar/benefit/grant/scope.py
+++ b/server/polar/benefit/grant/scope.py
@@ -132,13 +132,18 @@ async def resolve_member(
         if member_id is not None:
             member = await member_repository.get_by_id(member_id)
             return member  # may be None if member was deleted
-        if is_seat_based and await CustomerSeatRepository.from_session(
-            session
-        ).has_non_revoked_seat(customer_id):
-            # This customer holds a seat, so the grant belongs to the member on
-            # that seat. The seat flow passes it explicitly; leave it unset
-            # rather than guessing, so the backfill can still resolve it.
-            return None
+        if is_seat_based:
+            seat_member_ids = await CustomerSeatRepository.from_session(
+                session
+            ).list_active_seat_member_ids(customer_id)
+            if seat_member_ids:
+                # A seat holder's grant belongs to the member on their seat, not
+                # to their own owner member. With more than one seat the right
+                # member needs the grant's scope, so leave it for the backfill
+                # rather than guessing.
+                if len(seat_member_ids) == 1 and seat_member_ids[0] is not None:
+                    return await member_repository.get_by_id(seat_member_ids[0])
+                return None
         # Phase 1 of the member model migration: link direct-purchase grants to
         # the owner member so `grant.member` is already populated before the
         # flag flips. Without this, every grant created during Phase 1 lands

--- a/server/polar/benefit/tasks.py
+++ b/server/polar/benefit/tasks.py
@@ -137,10 +137,12 @@ async def benefit_grant(
 
         resolved_scope = await resolve_scope(session, scope)
 
+        subscription = resolved_scope.get("subscription")
+        order = resolved_scope.get("order")
         product = None
-        if subscription := resolved_scope.get("subscription"):
+        if subscription is not None:
             product = subscription.product
-        elif order := resolved_scope.get("order"):
+        elif order is not None:
             product = order.product
         is_seat_based = product.has_seat_based_price if product else False
 
@@ -150,6 +152,8 @@ async def benefit_grant(
             organization=benefit.organization,
             member_id=member_id,
             is_seat_based=is_seat_based,
+            subscription_id=subscription.id if subscription else None,
+            order_id=order.id if order else None,
         )
 
         try:
@@ -208,10 +212,12 @@ async def benefit_revoke(
 
         resolved_scope = await resolve_scope(session, scope)
 
+        subscription = resolved_scope.get("subscription")
+        order = resolved_scope.get("order")
         product = None
-        if subscription := resolved_scope.get("subscription"):
+        if subscription is not None:
             product = subscription.product
-        elif order := resolved_scope.get("order"):
+        elif order is not None:
             product = order.product
         is_seat_based = product.has_seat_based_price if product else False
 
@@ -221,6 +227,8 @@ async def benefit_revoke(
             organization=benefit.organization,
             member_id=member_id,
             is_seat_based=is_seat_based,
+            subscription_id=subscription.id if subscription else None,
+            order_id=order.id if order else None,
             include_deleted=True,
         )
 

--- a/server/polar/customer_seat/repository.py
+++ b/server/polar/customer_seat/repository.py
@@ -213,10 +213,9 @@ class CustomerSeatRepository(RepositoryBase[CustomerSeat]):
         subscription_id: UUID | None = None,
         order_id: UUID | None = None,
     ) -> UUID | None:
-        """Member on the customer's seat for a given subscription or order.
+        """Member on the customer's seat for this subscription or order.
 
-        Scoping by the container is what tells two seats held by the same
-        customer apart.
+        The container is what tells a customer's seats apart.
         """
         if subscription_id is None and order_id is None:
             return None

--- a/server/polar/customer_seat/repository.py
+++ b/server/polar/customer_seat/repository.py
@@ -206,18 +206,24 @@ class CustomerSeatRepository(RepositoryBase[CustomerSeat]):
         )
         return await self.get_all(statement)
 
-    async def has_non_revoked_seat(self, customer_id: UUID) -> bool:
-        """Whether the customer currently holds a pending or claimed seat."""
+    async def list_active_seat_member_ids(
+        self, customer_id: UUID, *, limit: int = 2
+    ) -> Sequence[UUID | None]:
+        """Member ids on the customer's pending or claimed seats.
+
+        Empty when the customer holds no seat. Callers that need an unambiguous
+        answer should ask for two and treat anything else as ambiguous.
+        """
         statement = (
-            select(CustomerSeat.id)
+            select(CustomerSeat.member_id)
             .where(
                 CustomerSeat.customer_id == customer_id,
                 CustomerSeat.status != SeatStatus.revoked,
             )
-            .limit(1)
+            .limit(limit)
         )
         result = await self.session.execute(statement)
-        return result.scalar_one_or_none() is not None
+        return result.scalars().all()
 
     async def list_active_by_member_id(
         self, member_id: UUID, *, options: Options = ()

--- a/server/polar/customer_seat/repository.py
+++ b/server/polar/customer_seat/repository.py
@@ -206,23 +206,24 @@ class CustomerSeatRepository(RepositoryBase[CustomerSeat]):
         )
         return await self.get_all(statement)
 
-    async def get_active_seat_member_id(
+    async def list_active_seat_member_ids(
         self,
         customer_id: UUID,
         *,
         subscription_id: UUID | None = None,
         order_id: UUID | None = None,
-    ) -> UUID | None:
-        """Member on the customer's seat for this subscription or order.
+    ) -> Sequence[UUID | None]:
+        """Members on the customer's active seats for this subscription or order.
 
-        The container is what tells a customer's seats apart.
+        The container is what tells a customer's seats apart. An entry is None
+        when the seat has no member yet. More than one entry means the seat
+        can't be told apart from another one.
         """
         if subscription_id is None and order_id is None:
-            return None
+            return []
 
         statement = select(CustomerSeat.member_id).where(
             CustomerSeat.customer_id == customer_id,
-            CustomerSeat.member_id.is_not(None),
             CustomerSeat.status != SeatStatus.revoked,
         )
         if subscription_id is not None:
@@ -230,8 +231,8 @@ class CustomerSeatRepository(RepositoryBase[CustomerSeat]):
         else:
             statement = statement.where(CustomerSeat.order_id == order_id)
 
-        result = await self.session.execute(statement.limit(1))
-        return result.scalar_one_or_none()
+        result = await self.session.execute(statement.distinct().limit(2))
+        return result.scalars().all()
 
     async def list_active_by_member_id(
         self, member_id: UUID, *, options: Options = ()

--- a/server/polar/customer_seat/repository.py
+++ b/server/polar/customer_seat/repository.py
@@ -206,6 +206,19 @@ class CustomerSeatRepository(RepositoryBase[CustomerSeat]):
         )
         return await self.get_all(statement)
 
+    async def has_non_revoked_seat(self, customer_id: UUID) -> bool:
+        """Whether the customer currently holds a pending or claimed seat."""
+        statement = (
+            select(CustomerSeat.id)
+            .where(
+                CustomerSeat.customer_id == customer_id,
+                CustomerSeat.status != SeatStatus.revoked,
+            )
+            .limit(1)
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none() is not None
+
     async def list_active_by_member_id(
         self, member_id: UUID, *, options: Options = ()
     ) -> Sequence[CustomerSeat]:

--- a/server/polar/customer_seat/repository.py
+++ b/server/polar/customer_seat/repository.py
@@ -206,24 +206,33 @@ class CustomerSeatRepository(RepositoryBase[CustomerSeat]):
         )
         return await self.get_all(statement)
 
-    async def list_active_seat_member_ids(
-        self, customer_id: UUID, *, limit: int = 2
-    ) -> Sequence[UUID | None]:
-        """Member ids on the customer's pending or claimed seats.
+    async def get_active_seat_member_id(
+        self,
+        customer_id: UUID,
+        *,
+        subscription_id: UUID | None = None,
+        order_id: UUID | None = None,
+    ) -> UUID | None:
+        """Member on the customer's seat for a given subscription or order.
 
-        Empty when the customer holds no seat. Callers that need an unambiguous
-        answer should ask for two and treat anything else as ambiguous.
+        Scoping by the container is what tells two seats held by the same
+        customer apart.
         """
-        statement = (
-            select(CustomerSeat.member_id)
-            .where(
-                CustomerSeat.customer_id == customer_id,
-                CustomerSeat.status != SeatStatus.revoked,
-            )
-            .limit(limit)
+        if subscription_id is None and order_id is None:
+            return None
+
+        statement = select(CustomerSeat.member_id).where(
+            CustomerSeat.customer_id == customer_id,
+            CustomerSeat.member_id.is_not(None),
+            CustomerSeat.status != SeatStatus.revoked,
         )
-        result = await self.session.execute(statement)
-        return result.scalars().all()
+        if subscription_id is not None:
+            statement = statement.where(CustomerSeat.subscription_id == subscription_id)
+        else:
+            statement = statement.where(CustomerSeat.order_id == order_id)
+
+        result = await self.session.execute(statement.limit(1))
+        return result.scalar_one_or_none()
 
     async def list_active_by_member_id(
         self, member_id: UUID, *, options: Options = ()

--- a/server/tests/benefit/grant/test_scope.py
+++ b/server/tests/benefit/grant/test_scope.py
@@ -96,6 +96,102 @@ class TestResolveMember:
 
         assert result is None
 
+    async def test_phase_1_links_direct_purchase_to_owner_member(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+    ) -> None:
+        """Phase 1: seat-based org, flag off, direct purchase resolves the owner member.
+
+        Keeps `grant.member` populated before the member model is enabled, so the
+        backlog of member_id NULL grants doesn't grow between prepare and flip.
+        """
+        organization = await create_organization(
+            save_fixture,
+            account,
+            feature_settings={
+                "member_model_enabled": False,
+                "seat_based_pricing_enabled": True,
+            },
+        )
+        customer = await create_customer(save_fixture, organization=organization)
+
+        result = await resolve_member(
+            session,
+            customer_id=customer.id,
+            organization=organization,
+            member_id=None,
+            is_seat_based=False,
+        )
+
+        assert result is not None
+        assert result.customer_id == customer.id
+        assert result.role == MemberRole.owner
+
+    async def test_phase_1_seat_based_without_member_id_returns_none(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+    ) -> None:
+        """Phase 1: seat grants carry an explicit member_id, so nothing is resolved."""
+        organization = await create_organization(
+            save_fixture,
+            account,
+            feature_settings={
+                "member_model_enabled": False,
+                "seat_based_pricing_enabled": True,
+            },
+        )
+        customer = await create_customer(save_fixture, organization=organization)
+
+        result = await resolve_member(
+            session,
+            customer_id=customer.id,
+            organization=organization,
+            member_id=None,
+            is_seat_based=True,
+        )
+
+        assert result is None
+
+    async def test_phase_1_reuses_existing_owner_member(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+    ) -> None:
+        """Phase 1 resolution reuses the existing owner instead of creating a second one."""
+        organization = await create_organization(
+            save_fixture,
+            account,
+            feature_settings={
+                "member_model_enabled": False,
+                "seat_based_pricing_enabled": True,
+            },
+        )
+        customer = await create_customer(save_fixture, organization=organization)
+        owner = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email=customer.email,
+            name="Owner",
+            role=MemberRole.owner,
+        )
+        await save_fixture(owner)
+
+        result = await resolve_member(
+            session,
+            customer_id=customer.id,
+            organization=organization,
+            member_id=None,
+            is_seat_based=False,
+        )
+
+        assert result is not None
+        assert result.id == owner.id
+
     async def test_explicit_member_id_returns_member(
         self,
         session: AsyncSession,

--- a/server/tests/benefit/grant/test_scope.py
+++ b/server/tests/benefit/grant/test_scope.py
@@ -9,6 +9,7 @@ from polar.benefit.grant.scope import (
     resolve_member,
 )
 from polar.enums import SubscriptionRecurringInterval
+from polar.member.repository import MemberRepository
 from polar.models import Account, Member
 from polar.models.customer_seat import SeatStatus
 from polar.models.member import MemberRole
@@ -198,6 +199,59 @@ class TestResolveMember:
         assert result is not None
         assert result.id == seat_member.id
         assert result.customer_id == buyer.id
+
+    async def test_phase_1_unlinked_seat_returns_none(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+    ) -> None:
+        """Phase 1: a seat with no member yet leaves the grant unlinked.
+
+        Creating an owner member under the holder would attach the wrong
+        identity and hide the grant from the backfill.
+        """
+        organization = await create_organization(
+            save_fixture,
+            account,
+            feature_settings={
+                "member_model_enabled": False,
+                "seat_based_pricing_enabled": True,
+            },
+        )
+        buyer = await create_customer(
+            save_fixture, organization=organization, email="buyer@example.com"
+        )
+        holder = await create_customer(
+            save_fixture, organization=organization, email="holder@example.com"
+        )
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+        subscription = await create_subscription(
+            save_fixture, product=product, customer=buyer
+        )
+        await create_customer_seat(
+            save_fixture,
+            subscription=subscription,
+            customer=holder,
+            status=SeatStatus.claimed,
+        )
+
+        result = await resolve_member(
+            session,
+            customer_id=holder.id,
+            organization=organization,
+            member_id=None,
+            is_seat_based=True,
+            subscription_id=subscription.id,
+        )
+
+        assert result is None
+        member_repository = MemberRepository.from_session(session)
+        assert await member_repository.get_owner_by_customer_id(holder.id) is None
 
     async def test_phase_1_two_seats_resolve_by_scope(
         self,

--- a/server/tests/benefit/grant/test_scope.py
+++ b/server/tests/benefit/grant/test_scope.py
@@ -129,6 +129,40 @@ class TestResolveMember:
         assert result.customer_id == customer.id
         assert result.role == MemberRole.owner
 
+    async def test_phase_1_customer_without_email_returns_none(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+    ) -> None:
+        """Phase 1 linking is best effort: an email-less customer still gets its grant.
+
+        `create_owner_member` can't build an owner member without an email, and
+        the member model isn't active yet, so the grant is created with a null
+        member instead of failing.
+        """
+        organization = await create_organization(
+            save_fixture,
+            account,
+            feature_settings={
+                "member_model_enabled": False,
+                "seat_based_pricing_enabled": True,
+            },
+        )
+        customer = await create_customer(save_fixture, organization=organization)
+        customer.email = None
+        await save_fixture(customer)
+
+        result = await resolve_member(
+            session,
+            customer_id=customer.id,
+            organization=organization,
+            member_id=None,
+            is_seat_based=False,
+        )
+
+        assert result is None
+
     async def test_phase_1_seat_based_without_member_id_returns_none(
         self,
         session: AsyncSession,

--- a/server/tests/benefit/grant/test_scope.py
+++ b/server/tests/benefit/grant/test_scope.py
@@ -8,11 +8,19 @@ from polar.benefit.grant.scope import (
     MemberNotFound,
     resolve_member,
 )
+from polar.enums import SubscriptionRecurringInterval
 from polar.models import Account, Member
+from polar.models.customer_seat import SeatStatus
 from polar.models.member import MemberRole
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_customer, create_organization
+from tests.fixtures.random_objects import (
+    create_customer,
+    create_customer_seat,
+    create_organization,
+    create_product,
+    create_subscription,
+)
 
 
 @pytest.mark.asyncio
@@ -129,6 +137,57 @@ class TestResolveMember:
         assert result.customer_id == customer.id
         assert result.role == MemberRole.owner
 
+    async def test_phase_1_seat_holder_is_left_for_the_backfill(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+    ) -> None:
+        """Phase 1: a seat holder's grant belongs to the member on their seat.
+
+        The seat flow passes that member explicitly, so resolution is skipped
+        rather than guessing the holder's own owner member, which would hide the
+        row from the backfill.
+        """
+        organization = await create_organization(
+            save_fixture,
+            account,
+            feature_settings={
+                "member_model_enabled": False,
+                "seat_based_pricing_enabled": True,
+            },
+        )
+        buyer = await create_customer(
+            save_fixture, organization=organization, email="buyer@example.com"
+        )
+        holder = await create_customer(
+            save_fixture, organization=organization, email="holder@example.com"
+        )
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+        subscription = await create_subscription(
+            save_fixture, product=product, customer=buyer
+        )
+        await create_customer_seat(
+            save_fixture,
+            subscription=subscription,
+            customer=holder,
+            status=SeatStatus.claimed,
+        )
+
+        result = await resolve_member(
+            session,
+            customer_id=holder.id,
+            organization=organization,
+            member_id=None,
+            is_seat_based=True,
+        )
+
+        assert result is None
+
     async def test_phase_1_customer_without_email_returns_none(
         self,
         session: AsyncSession,
@@ -163,13 +222,17 @@ class TestResolveMember:
 
         assert result is None
 
-    async def test_phase_1_seat_based_without_member_id_returns_none(
+    async def test_phase_1_seat_product_buyer_resolves_owner_member(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
         account: Account,
     ) -> None:
-        """Phase 1: seat grants carry an explicit member_id, so nothing is resolved."""
+        """Phase 1: buying a seat-based product without holding a seat links the buyer.
+
+        The grant belongs to the buyer, so it resolves their owner member rather
+        than being left unlinked for the backfill to pick up later.
+        """
         organization = await create_organization(
             save_fixture,
             account,
@@ -188,7 +251,9 @@ class TestResolveMember:
             is_seat_based=True,
         )
 
-        assert result is None
+        assert result is not None
+        assert result.customer_id == customer.id
+        assert result.role == MemberRole.owner
 
     async def test_phase_1_reuses_existing_owner_member(
         self,

--- a/server/tests/benefit/grant/test_scope.py
+++ b/server/tests/benefit/grant/test_scope.py
@@ -192,11 +192,77 @@ class TestResolveMember:
             organization=organization,
             member_id=None,
             is_seat_based=True,
+            subscription_id=subscription.id,
         )
 
         assert result is not None
         assert result.id == seat_member.id
         assert result.customer_id == buyer.id
+
+    async def test_phase_1_two_seats_resolve_by_scope(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+    ) -> None:
+        """A holder with two seats resolves the member for the grant's own scope."""
+        organization = await create_organization(
+            save_fixture,
+            account,
+            feature_settings={
+                "member_model_enabled": False,
+                "seat_based_pricing_enabled": True,
+            },
+        )
+        holder = await create_customer(
+            save_fixture, organization=organization, email="holder@example.com"
+        )
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+
+        members = []
+        subscriptions = []
+        for index in range(2):
+            buyer = await create_customer(
+                save_fixture,
+                organization=organization,
+                email=f"buyer{index}@example.com",
+            )
+            member = Member(
+                customer_id=buyer.id,
+                organization_id=organization.id,
+                email=holder.email,
+                name="Seat holder",
+                role=MemberRole.member,
+            )
+            await save_fixture(member)
+            subscription = await create_subscription(
+                save_fixture, product=product, customer=buyer
+            )
+            await create_customer_seat(
+                save_fixture,
+                subscription=subscription,
+                customer=holder,
+                status=SeatStatus.claimed,
+                member_id=member.id,
+            )
+            members.append(member)
+            subscriptions.append(subscription)
+
+        for member, subscription in zip(members, subscriptions, strict=True):
+            result = await resolve_member(
+                session,
+                customer_id=holder.id,
+                organization=organization,
+                member_id=None,
+                is_seat_based=True,
+                subscription_id=subscription.id,
+            )
+            assert result is not None
+            assert result.id == member.id
 
     async def test_phase_1_customer_without_email_returns_none(
         self,

--- a/server/tests/benefit/grant/test_scope.py
+++ b/server/tests/benefit/grant/test_scope.py
@@ -137,17 +137,16 @@ class TestResolveMember:
         assert result.customer_id == customer.id
         assert result.role == MemberRole.owner
 
-    async def test_phase_1_seat_holder_is_left_for_the_backfill(
+    async def test_phase_1_seat_holder_resolves_the_seat_member(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
         account: Account,
     ) -> None:
-        """Phase 1: a seat holder's grant belongs to the member on their seat.
+        """Phase 1: a seat holder's grant resolves the member on their seat.
 
-        The seat flow passes that member explicitly, so resolution is skipped
-        rather than guessing the holder's own owner member, which would hide the
-        row from the backfill.
+        That member lives under the buyer, not under the holder's own customer,
+        so resolving the holder's owner member would attach the wrong identity.
         """
         organization = await create_organization(
             save_fixture,
@@ -163,6 +162,14 @@ class TestResolveMember:
         holder = await create_customer(
             save_fixture, organization=organization, email="holder@example.com"
         )
+        seat_member = Member(
+            customer_id=buyer.id,
+            organization_id=organization.id,
+            email=holder.email,
+            name="Seat holder",
+            role=MemberRole.member,
+        )
+        await save_fixture(seat_member)
         product = await create_product(
             save_fixture,
             organization=organization,
@@ -176,6 +183,7 @@ class TestResolveMember:
             subscription=subscription,
             customer=holder,
             status=SeatStatus.claimed,
+            member_id=seat_member.id,
         )
 
         result = await resolve_member(
@@ -186,7 +194,9 @@ class TestResolveMember:
             is_seat_based=True,
         )
 
-        assert result is None
+        assert result is not None
+        assert result.id == seat_member.id
+        assert result.customer_id == buyer.id
 
     async def test_phase_1_customer_without_email_returns_none(
         self,


### PR DESCRIPTION
## Summary

Doing the  status check to the new members model, I noticed that the benefit grants don't write member_id on all cases. We have the backfill mechanism, but this was intended to backfill member_id only once. During new checkouts we need to fill member_id so Phase 1 it's always kept on sync. 

Merchant migration guide: https://polar.sh/docs/guides/migrate-seat-based-to-member-model#phase-1-preparation-non-breaking

## What

- `resolve_member` now creates the owner member  for non-seat-based grants.
- update the guide to make sure this is explicit

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


