### PR TITLE
Don't require identity verification for ownership transfer in sandbox

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/team_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/team_section.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 from fastapi import Request
 from tagflow import classes, tag, text
 
+from polar.config import settings
 from polar.models import Organization
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
@@ -125,6 +126,7 @@ class TeamSection:
                                             member_is_verified = (
                                                 member.user.identity_verification_status
                                                 == IdentityVerificationStatus.verified
+                                                or settings.is_sandbox()
                                             )
                                             if (
                                                 not member_is_owner
@@ -172,12 +174,13 @@ class TeamSection:
                                 "of the organization"
                             )
 
-                    with tag.li(classes="flex items-start gap-2"):
-                        with tag.span(classes="text-base-content/60"):
-                            text(
-                                "• The new owner must have completed Stripe "
-                                "identity verification"
-                            )
+                    if not settings.is_sandbox():
+                        with tag.li(classes="flex items-start gap-2"):
+                            with tag.span(classes="text-base-content/60"):
+                                text(
+                                    "• The new owner must have completed Stripe "
+                                    "identity verification"
+                                )
 
                     with tag.li(classes="flex items-start gap-2"):
                         with tag.span(classes="text-base-content/60"):

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -6,6 +6,7 @@ from sqlalchemy import Select, func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
+from polar.config import settings
 from polar.exceptions import PolarError
 from polar.integrations.polar.service import billing_member_role
 from polar.integrations.polar.service import polar_self as polar_self_service
@@ -250,7 +251,8 @@ class UserOrganizationService:
         promote `new_owner_user_id` to `owner`.
 
         Fires the `IdentityVerificationStatus.verified` gate on the new
-        owner, since payouts route through whoever holds `owner`.
+        owner, since payouts route through whoever holds `owner`. The gate
+        is skipped in the sandbox environment.
         """
         new_owner_user_org = await self.get_by_user_and_org(
             session, new_owner_user_id, organization_id
@@ -264,7 +266,8 @@ class UserOrganizationService:
             raise AlreadyOwner(new_owner_user_id, organization_id)
 
         if (
-            new_owner_user.identity_verification_status
+            not settings.is_sandbox()
+            and new_owner_user.identity_verification_status
             != IdentityVerificationStatus.verified
         ):
             raise NewOwnerNotVerified(

--- a/server/tests/user_organization/test_service.py
+++ b/server/tests/user_organization/test_service.py
@@ -810,6 +810,39 @@ class TestTransferOwnership:
                 organization_id=organization.id,
             )
 
+    async def test_allows_unverified_user_in_sandbox(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: Any,
+        organization: Organization,
+        user_second: User,
+    ) -> None:
+        mocker.patch(
+            "polar.user_organization.service.settings.is_sandbox",
+            return_value=True,
+        )
+        await save_fixture(
+            UserOrganization(
+                user_id=user_second.id,
+                organization_id=organization.id,
+                role=OrganizationRole.member,
+            )
+        )
+        # user_second left at the default unverified status
+
+        await user_organization_service.transfer_ownership(
+            session,
+            new_owner_user_id=user_second.id,
+            organization_id=organization.id,
+        )
+
+        new = await user_organization_service.get_by_user_and_org(
+            session, user_second.id, organization.id
+        )
+        assert new is not None
+        assert new.role == OrganizationRole.owner
+
     async def test_rejects_non_member(
         self,
         session: Any,


### PR DESCRIPTION
This removes the identity verification checks usually required to transfer organization ownership to another team member when in sandbox environment.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)