### PR TITLE
Hide license key rotation after checkout

### DIFF
--- a/clients/apps/web/src/components/Benefit/BenefitGrant.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitGrant.tsx
@@ -31,6 +31,7 @@ interface BenefitGrantProps {
   api: Client
   benefitGrant: schemas['CustomerBenefitGrant']
   locale?: AcceptedLocale
+  allowLicenseKeyRotation?: boolean
 }
 
 const benefitTypeTranslationKeys = {
@@ -502,6 +503,7 @@ export const BenefitGrant = ({
   api,
   benefitGrant,
   locale = DEFAULT_LOCALE,
+  allowLicenseKeyRotation = true,
 }: BenefitGrantProps) => {
   const t = useTranslations(locale)
   const { benefit } = benefitGrant
@@ -541,6 +543,7 @@ export const BenefitGrant = ({
             benefitGrant as schemas['CustomerBenefitGrantLicenseKeys']
           }
           locale={locale}
+          allowRotation={allowLicenseKeyRotation}
         />
       )}
       {benefit.type === 'github_repository' && (

--- a/clients/apps/web/src/components/Benefit/LicenseKeys/LicenseKeyBenefitGrant.test.tsx
+++ b/clients/apps/web/src/components/Benefit/LicenseKeys/LicenseKeyBenefitGrant.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LicenseKeyBenefitGrant } from './LicenseKeyBenefitGrant'
+
+vi.mock('@/hooks/queries/customerPortal', () => ({
+  useCustomerLicenseKey: () => ({
+    data: {
+      id: 'license-key-id',
+      key: 'polar_license_key',
+      status: 'granted',
+    },
+    isLoading: false,
+  }),
+  useCustomerLicenseKeyRotate: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/Modal/ConfirmModal', () => ({
+  ConfirmModal: () => null,
+}))
+
+vi.mock('@/components/Toast/use-toast', () => ({
+  toast: vi.fn(),
+}))
+
+vi.mock('@polar-sh/i18n', () => ({
+  DEFAULT_LOCALE: 'en',
+  useTranslations: () => (key: string) => key,
+}))
+
+vi.mock('@polar-sh/orbit', () => ({
+  Button: ({ children }: { children: ReactNode }) => (
+    <button>{children}</button>
+  ),
+}))
+
+vi.mock('@polar-sh/ui/components/atoms/CopyToClipboardInput', () => ({
+  default: () => null,
+}))
+
+vi.mock('./LicenseKeyActivations', () => ({
+  LicenseKeyActivations: () => null,
+}))
+
+vi.mock('./LicenseKeyDetails', () => ({
+  LicenseKeyDetails: () => null,
+}))
+
+const benefitGrant = {
+  properties: {
+    license_key_id: 'license-key-id',
+  },
+}
+
+afterEach(cleanup)
+
+describe('LicenseKeyBenefitGrant', () => {
+  it('shows rotation by default', () => {
+    render(
+      <LicenseKeyBenefitGrant
+        api={{} as never}
+        benefitGrant={benefitGrant as never}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Rotate' })).toBeTruthy()
+  })
+
+  it('hides rotation when disabled by the checkout flow', () => {
+    render(
+      <LicenseKeyBenefitGrant
+        api={{} as never}
+        benefitGrant={benefitGrant as never}
+        allowRotation={false}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: 'Rotate' })).toBeNull()
+  })
+})

--- a/clients/apps/web/src/components/Benefit/LicenseKeys/LicenseKeyBenefitGrant.tsx
+++ b/clients/apps/web/src/components/Benefit/LicenseKeys/LicenseKeyBenefitGrant.tsx
@@ -23,10 +23,12 @@ const LicenseKey = ({
   api,
   licenseKey,
   locale = DEFAULT_LOCALE,
+  allowRotation,
 }: {
   api: Client
   licenseKey: schemas['LicenseKeyWithActivations']
   locale?: AcceptedLocale
+  allowRotation: boolean
 }) => {
   const t = useTranslations(locale)
   const [showRotateConfirm, setShowRotateConfirm] = useState(false)
@@ -74,7 +76,7 @@ const LicenseKey = ({
         }}
       />
       <LicenseKeyDetails licenseKey={licenseKey} locale={locale} />
-      {canRotate ? (
+      {allowRotation && canRotate ? (
         <Button
           variant="secondary"
           onClick={() => setShowRotateConfirm(true)}
@@ -105,10 +107,12 @@ export const LicenseKeyBenefitGrant = ({
   api,
   benefitGrant,
   locale = DEFAULT_LOCALE,
+  allowRotation = true,
 }: {
   api: Client
   benefitGrant: schemas['CustomerBenefitGrantLicenseKeys']
   locale?: AcceptedLocale
+  allowRotation?: boolean
 }) => {
   const t = useTranslations(locale)
   const { data: licenseKey, isLoading } = useCustomerLicenseKey(
@@ -126,7 +130,12 @@ export const LicenseKeyBenefitGrant = ({
 
   return (
     <div className="flex w-full flex-col gap-y-6">
-      <LicenseKey api={api} licenseKey={licenseKey} locale={locale} />
+      <LicenseKey
+        api={api}
+        licenseKey={licenseKey}
+        locale={locale}
+        allowRotation={allowRotation}
+      />
     </div>
   )
 }

--- a/clients/apps/web/src/components/Checkout/CheckoutBenefits.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutBenefits.tsx
@@ -66,6 +66,7 @@ const CheckoutBenefits = ({
               api={api}
               benefitGrant={benefitGrant}
               locale={locale}
+              allowLicenseKeyRotation={false}
             />
           </ListItem>
         ))}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Related Issue**: #13977

Removes the license key rotation action from the post-checkout benefit display while preserving self-service rotation in the customer portal.

## What

- Add an explicit license-key rotation capability flag to shared benefit grant components.
- Disable rotation from `CheckoutBenefits`.
- Cover both enabled and disabled rendering with component tests.

## Why

The post-checkout flow reuses the customer portal benefit component, unintentionally allowing a newly purchased license key to be rotated immediately from the confirmation page.

## How

Rotation remains enabled by default for existing customer portal consumers. The checkout flow opts out explicitly, so the shared component omits the Rotate button there.

## Verification

- `pnpm --filter web exec vitest run src/components/Benefit/LicenseKeys/LicenseKeyBenefitGrant.test.tsx`
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- Completed a local free one-time MeltedSQL checkout through API + worker: checkout `succeeded`, order `paid`, two benefit grants and one license key persisted.
- Reloaded the real confirmation UI, verified the license key and Copy action render, and verified Rotate is absent.

[checkout_license_key_without_rotate.mp4](https://cursor.com/agents/bc-cfaefcc7-b5b6-41a2-b7ef-a4bf69d66831/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcheckout_license_key_without_rotate.mp4)

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass
- [x] No unrelated changes or drive-by fixes are included

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfaefcc7-b5b6-41a2-b7ef-a4bf69d66831?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfaefcc7-b5b6-41a2-b7ef-a4bf69d66831&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

