### PR TITLE
Speed up backoffice organization list and detail views

### DIFF
--- a/server/migrations/versions/2026-08-28-1435_add_partial_index_on_organizations_.py
+++ b/server/migrations/versions/2026-08-28-1435_add_partial_index_on_organizations_.py
@@ -1,0 +1,50 @@
+"""add partial index on organizations status for backoffice list
+
+Revision ID: b58196b41f41
+Revises: a83cf131398d
+Create Date: 2026-08-28 14:35:09.753552
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "b58196b41f41"
+down_revision = "a83cf131398d"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX_NAME = "ix_organizations_status_priority"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Drop any INVALID leftover from an interrupted concurrent build first.
+        op.drop_index(
+            INDEX_NAME,
+            table_name="organizations",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.create_index(
+            INDEX_NAME,
+            "organizations",
+            [sa.text("status DESC"), sa.text("status_updated_at ASC NULLS FIRST")],
+            unique=False,
+            postgresql_where=sa.text("deleted_at IS NULL"),
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX_NAME,
+            table_name="organizations",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/server/migrations/versions/2026-08-28-1435_add_partial_index_on_organizations_.py
+++ b/server/migrations/versions/2026-08-28-1435_add_partial_index_on_organizations_.py
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "b58196b41f41"
-down_revision = "a83cf131398d"
+down_revision = "0b0f090a35df"
 branch_labels: tuple[str] | None = None
 depends_on: tuple[str] | None = None
 

--- a/server/polar/backoffice/organizations_v2/analytics.py
+++ b/server/polar/backoffice/organizations_v2/analytics.py
@@ -6,7 +6,6 @@ from sqlalchemy import func, select
 from polar.models import (
     Benefit,
     CheckoutLink,
-    Customer,
     Dispute,
     Order,
     Organization,
@@ -78,14 +77,13 @@ class PaymentAnalyticsService:
                 func.coalesce(-func.sum(Transaction.amount), 0),
             )
             .join(Order, Refund.order_id == Order.id)
-            .join(Customer, Order.customer_id == Customer.id)
             .outerjoin(
                 Transaction,
                 onclause=(Transaction.refund_id == Refund.id)
                 & (Transaction.type == TransactionType.refund),
             )
             .where(
-                Customer.organization_id == organization_id,
+                Order.organization_id == organization_id,
                 Refund.status == RefundStatus.succeeded,
             )
         )

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -384,7 +384,7 @@ async def count_test_sales(
     )
 
     test_sales_filter = (
-        Customer.organization_id == organization_id,
+        Order.organization_id == organization_id,
         func.lower(Customer.email).in_(team_member_emails_subquery),
         Order.net_amount > 0,
     )

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
     CheckConstraint,
     ColumnElement,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -29,6 +30,7 @@ from sqlalchemy import (
     Uuid,
     and_,
     or_,
+    text,
 )
 from sqlalchemy.dialects.postgresql import CITEXT, JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -516,6 +518,16 @@ class Organization(RateLimitGroupMixin, RecordModel):
         UniqueConstraint("slug"),
         CheckConstraint(
             "next_review_threshold >= 0", name="next_review_threshold_positive"
+        ),
+        # Serves the backoffice list default (status/priority) ordering: the
+        # column directions match `ORDER BY status DESC, status_updated_at ASC
+        # NULLS FIRST` so the planner walks the index and stops at the page
+        # limit instead of seq-scanning and sorting the whole table.
+        Index(
+            "ix_organizations_status_priority",
+            text("status DESC"),
+            text("status_updated_at ASC NULLS FIRST"),
+            postgresql_where=text("deleted_at IS NULL"),
         ),
     )
 

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -347,7 +347,7 @@ class OrganizationRepository(
             select(func.count(Order.id))
             .join(Customer, Order.customer_id == Customer.id)
             .where(
-                Customer.organization_id == organization_id,
+                Order.organization_id == organization_id,
                 ~Customer.is_deleted,
                 Order.total_amount > 0,
             )
@@ -370,7 +370,7 @@ class OrganizationRepository(
             .join(Customer, Subscription.customer_id == Customer.id)
             .outerjoin(Discount, Subscription.discount_id == Discount.id)
             .where(
-                Customer.organization_id == organization_id,
+                Subscription.organization_id == organization_id,
                 ~Customer.is_deleted,
                 Subscription.status.in_(SubscriptionStatus.active_statuses()),
                 ~(

--- a/server/polar/search/service.py
+++ b/server/polar/search/service.py
@@ -223,7 +223,7 @@ class SearchService:
             .join(Customer, Order.customer_id == Customer.id)
             .join(Product, Order.product_id == Product.id)
             .where(
-                Customer.organization_id.in_(organization_subquery),
+                Order.organization_id.in_(organization_subquery),
                 ~Order.is_deleted,
             )
         )
@@ -273,7 +273,7 @@ class SearchService:
             .join(Customer, Subscription.customer_id == Customer.id)
             .join(Product, Subscription.product_id == Product.id)
             .where(
-                Customer.organization_id.in_(organization_subquery),
+                Subscription.organization_id.in_(organization_subquery),
                 ~Subscription.is_deleted,
             )
         )


### PR DESCRIPTION
## Problem

The backoffice organization pages load in 6–38s. Confirmed in Logfire (production, last 24h):

- **Detail view** (`/organizations/{id}`): up to **38s**, frequently hitting the 30s statement timeout and returning a **500**.
- **List view** (`/organizations/`): **6–18s**, ~14s of it in a single query.

## Detail view

`PaymentAnalyticsService.get_refund_stats` filtered on `customers.organization_id`, which is two joins away from `refunds` (`refunds → orders → customers`). Postgres can't narrow by org up front, so the plan does a **Seq Scan over the entire `refunds` table** and nested-loops each into orders → 30s timeout.

Fix: `orders` has a direct, indexed `organization_id`. Filter `Order.organization_id` and drop the `customers` join. One join away, via an index.

## List view

The default status/priority ordering (`ORDER BY status DESC, status_updated_at ASC NULLS FIRST`) had **no supporting index** — no index on `status` or `status_updated_at` existed. Every load seq-scanned the whole `organizations` table  and sorted all wide rows in memory before applying `LIMIT`.

Fix: partial composite index on `(status DESC, status_updated_at ASC NULLS FIRST) WHERE deleted_at IS NULL`, built `CONCURRENTLY`. Column directions match the `ORDER BY` exactly so the planner can walk the index and stop at the page limit with no sort. The leading `status` column also serves any status-only filter.

## Deploy safety

- Additive index built `CONCURRENTLY` (no write lock), in its own migration (can't run in a transaction). Safe alongside running code.
- Detail-view change is query-only.
- Migration verified locally: upgrade + downgrade/re-upgrade cycle clean.