### PR TITLE
Enable centralized AWS root access

### DIFF
--- a/terraform/organization/README.md
+++ b/terraform/organization/README.md
@@ -30,13 +30,18 @@ Application workloads live under the `Workloads` OU:
 - `Test` contains the staging/test environment.
 
 The `Security` OU holds the `identity` account (IAM Identity Center delegated administrator) and
-the `security` account (GuardDuty delegated administrator, managed from `terraform/security`).
+the `security` account (IAM root access and GuardDuty delegated administrator, managed from
+`terraform/security`).
 
 ## Guardrails
 
 - Attach guardrails that apply to every application account to `Workloads`.
 - Attach production-class guardrails to both `Production` and `Sandbox`.
 - Attach test/staging-specific guardrails to `Test`.
+
+The `MemberRootAccess` SCP is attached to the organization root. It denies actions made with
+long-term root credentials in every member account while allowing task-scoped privileged sessions
+created by `sts:AssumeRoot`.
 
 ## Terraform Ownership
 
@@ -58,6 +63,17 @@ test account       -> test workspace
 
 The HCP Terraform workspace variables that point each workspace at its AWS role are managed from
 `terraform/global`.
+
+## Centralized root access
+
+IAM trusted access is enabled for the organization, with both root credential management and
+privileged root sessions enabled. The `security` account is the delegated administrator for these
+features.
+
+Enabling root credential management does not remove existing member account root credentials.
+Audit each member account and remove its credentials through a privileged session scoped by the
+`IAMDeleteRootUserCredentials` AWS managed root-task policy. The management account is not covered
+by centralized root access and must retain its separately secured root credentials.
 
 ## Staff access (IAM Identity Center)
 

--- a/terraform/organization/main.tf
+++ b/terraform/organization/main.tf
@@ -12,6 +12,7 @@ resource "aws_organizations_organization" "current" {
   aws_service_access_principals = [
     "account.amazonaws.com",
     "guardduty.amazonaws.com",
+    "iam.amazonaws.com",
     "malware-protection.guardduty.amazonaws.com",
     "sso.amazonaws.com",
   ]

--- a/terraform/organization/root_access.tf
+++ b/terraform/organization/root_access.tf
@@ -1,0 +1,15 @@
+resource "aws_iam_organizations_features" "root_access" {
+  enabled_features = [
+    "RootCredentialsManagement",
+    "RootSessions",
+  ]
+
+  depends_on = [aws_organizations_organization.current]
+}
+
+resource "aws_organizations_delegated_administrator" "root_access" {
+  account_id        = aws_organizations_account.security.id
+  service_principal = "iam.amazonaws.com"
+
+  depends_on = [aws_iam_organizations_features.root_access]
+}

--- a/terraform/organization/service_control_policies.tf
+++ b/terraform/organization/service_control_policies.tf
@@ -13,10 +13,10 @@ locals {
   )
 
   service_control_policies = {
-    workloads_baseline = {
-      name        = "WorkloadsBaseline"
-      description = "Baseline guardrails for all workload accounts."
-      target_ids  = [aws_organizations_organizational_unit.workloads.id]
+    member_root_access = {
+      name        = "MemberRootAccess"
+      description = "Deny long-term root user actions in member accounts while allowing privileged root sessions."
+      target_ids  = [local.root_id]
       content = {
         Version = "2012-10-17"
         Statement = [
@@ -26,11 +26,25 @@ locals {
             Action   = "*"
             Resource = "*"
             Condition = {
-              StringLike = {
+              ArnLike = {
                 "aws:PrincipalArn" = "arn:aws:iam::*:root"
+              }
+              Null = {
+                "aws:AssumedRoot" = "true"
               }
             }
           },
+        ]
+      }
+    }
+
+    workloads_baseline = {
+      name        = "WorkloadsBaseline"
+      description = "Baseline guardrails for all workload accounts."
+      target_ids  = [aws_organizations_organizational_unit.workloads.id]
+      content = {
+        Version = "2012-10-17"
+        Statement = [
           {
             Sid    = "DenyLeavingOrganization"
             Effect = "Deny"


### PR DESCRIPTION
## Summary

**Related Issue**: https://linear.app/polarsh/issue/ENG-4/centralize-aws-root-access

<!-- Brief description of what this PR does -->

## What

This changes allow the `security` account to request temporary root session (in case of needed emergency operations) through Root access management.

## Why

This allows to remove traditional root accounts with passwords that are vulnerable by nature. This is part of our ISO compliance efforts.

## How

* Enable root sessions features
* Add a policy to deny all actions made by permanent root credentials, but allow temporary "assumed root" sessions

Current root accounts are not deleted. We should do this cautiously after this change is in effect and made sure it works.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

