### PR TITLE
fix(checkout-link): stop concurrent archives from emptying links

### DIFF
--- a/server/polar/checkout_link/repository.py
+++ b/server/polar/checkout_link/repository.py
@@ -145,6 +145,9 @@ class CheckoutLinkRepository(
                     )
                 )
             )
+            # Ordered to avoid deadlocks between concurrent archives
+            .order_by(CheckoutLink.id)
+            .with_for_update(of=CheckoutLink)
             .options(selectinload(CheckoutLink.checkout_link_products))
         )
         checkout_links = await self.get_all(statement)

--- a/server/scripts/soft_delete_empty_checkout_links.py
+++ b/server/scripts/soft_delete_empty_checkout_links.py
@@ -1,0 +1,111 @@
+"""
+Soft delete checkout links that have no product.
+
+A checkout link with no product cannot create a checkout session, and reading
+one fails response validation, so the merchant's whole checkout links page
+returns 500. Soft deleting is what archiving a link's last product does, and it
+restores the page.
+
+The lock in `CheckoutLinkRepository.archive_product` keeps new ones from
+appearing, so this is a one-shot repair.
+
+Usage:
+    cd server
+
+    # Dry-run (default) — count the affected links:
+    uv run python -m scripts.soft_delete_empty_checkout_links
+
+    # Execute the repair (batched):
+    uv run python -m scripts.soft_delete_empty_checkout_links --execute
+"""
+
+import structlog
+import typer
+from rich.console import Console
+from sqlalchemy import Select, Update, and_, func, select, update
+
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.models import CheckoutLink, CheckoutLinkProduct
+from polar.postgres import create_async_engine
+from scripts.helper import (
+    configure_script_console_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
+
+cli = typer.Typer()
+console = Console()
+log = structlog.get_logger()
+
+configure_script_console_logging()
+
+_has_no_product = and_(
+    CheckoutLink.deleted_at.is_(None),
+    ~select(1).where(CheckoutLinkProduct.checkout_link_id == CheckoutLink.id).exists(),
+)
+
+
+def empty_count_statement() -> Select[tuple[int]]:
+    return select(func.count()).select_from(CheckoutLink).where(_has_no_product)
+
+
+def soft_delete_statement() -> Update:
+    subquery = (
+        select(CheckoutLink.id)
+        .where(_has_no_product)
+        .order_by(CheckoutLink.id)
+        .limit(limit_bindparam())
+        .scalar_subquery()
+    )
+    return (
+        update(CheckoutLink)
+        .where(CheckoutLink.id.in_(subquery))
+        .values(deleted_at=func.now())
+    )
+
+
+@cli.command()
+@typer_async
+async def soft_delete_empty_checkout_links(
+    execute: bool = typer.Option(
+        False, help="Actually run the repair (default: dry-run)"
+    ),
+    batch_size: int = typer.Option(
+        5000, min=1, help="Number of rows to process per batch"
+    ),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+
+    try:
+        async with sessionmaker() as session:
+            result = await session.execute(empty_count_statement())
+            total = result.scalar_one()
+
+        console.print(f"[bold]{total}[/bold] checkout link(s) with no product.")
+
+        if total == 0:
+            console.print("[green]Every live checkout link has a product.")
+            return
+
+        if not execute:
+            console.print("[yellow]Dry-run — use --execute to soft delete them.")
+            return
+
+        console.rule("[bold]Executing repair")
+        rows_updated = await run_batched_update(
+            soft_delete_statement(),
+            batch_size=batch_size,
+            sleep_seconds=sleep_seconds,
+        )
+        log.info("soft_delete_empty_checkout_links.complete", rowcount=rows_updated)
+        console.print(f"[green]Soft deleted {rows_updated} checkout link(s).")
+
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/checkout_link/test_repository.py
+++ b/server/tests/checkout_link/test_repository.py
@@ -1,11 +1,31 @@
+import asyncio
+import uuid
+
 import pytest
+from sqlalchemy import delete
 from sqlalchemy.orm import selectinload
 
 from polar.checkout_link.repository import CheckoutLinkRepository
-from polar.models import CheckoutLink, Product
+from polar.config import settings
+from polar.kit.db.postgres import (
+    AsyncSessionMaker,
+    create_async_engine,
+    create_async_sessionmaker,
+)
+from polar.models import Account, CheckoutLink, Organization, Product, User
 from polar.postgres import AsyncSession
-from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_checkout_link
+from tests.fixtures.database import (
+    SaveFixture,
+    get_database_url,
+    save_fixture_factory,
+)
+from tests.fixtures.random_objects import (
+    create_account,
+    create_checkout_link,
+    create_organization,
+    create_product,
+    create_user,
+)
 
 
 @pytest.mark.asyncio
@@ -59,3 +79,83 @@ class TestArchiveProduct:
         assert updated_checkout_link is not None
         assert updated_checkout_link.deleted_at is None
         assert len(updated_checkout_link.checkout_link_products) == 1
+
+
+async def _attempt_archive_product(
+    sessionmaker: AsyncSessionMaker,
+    product_id: uuid.UUID,
+    barrier: asyncio.Barrier,
+) -> None:
+    async with sessionmaker() as session:
+        await barrier.wait()
+        repository = CheckoutLinkRepository.from_session(session)
+        await repository.archive_product(product_id)
+        await session.commit()
+
+
+@pytest.mark.asyncio
+class TestArchiveProductConcurrency:
+    async def test_concurrent_archive_of_every_product_soft_deletes_the_link(
+        self, worker_id: str
+    ) -> None:
+        engine = create_async_engine(
+            dsn=get_database_url(worker_id),
+            application_name=f"test_{worker_id}_checkout_link_archive_concurrency",
+            pool_size=8,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+
+        async with sessionmaker() as setup_session:
+            save_fixture = save_fixture_factory(setup_session)
+            user = await create_user(save_fixture)
+            account = await create_account(save_fixture, user)
+            organization = await create_organization(save_fixture, account)
+            products = [
+                await create_product(
+                    save_fixture,
+                    organization=organization,
+                    recurring_interval=None,
+                    name=f"Product {index}",
+                )
+                for index in range(3)
+            ]
+            checkout_link = await create_checkout_link(save_fixture, products=products)
+            await setup_session.commit()
+
+        try:
+            barrier = asyncio.Barrier(len(products))
+            await asyncio.gather(
+                *(
+                    _attempt_archive_product(sessionmaker, product.id, barrier)
+                    for product in products
+                )
+            )
+
+            async with sessionmaker() as session:
+                repository = CheckoutLinkRepository.from_session(session)
+                updated_checkout_link = await repository.get_by_id(
+                    checkout_link.id,
+                    include_deleted=True,
+                    options=(selectinload(CheckoutLink.checkout_link_products),),
+                )
+                assert updated_checkout_link is not None
+                assert updated_checkout_link.checkout_link_products == []
+                assert updated_checkout_link.deleted_at is not None
+        finally:
+            async with sessionmaker() as cleanup_session:
+                await cleanup_session.execute(
+                    delete(CheckoutLink).where(CheckoutLink.id == checkout_link.id)
+                )
+                await cleanup_session.execute(
+                    delete(Product).where(Product.organization_id == organization.id)
+                )
+                await cleanup_session.execute(
+                    delete(Organization).where(Organization.id == organization.id)
+                )
+                await cleanup_session.execute(
+                    delete(Account).where(Account.id == account.id)
+                )
+                await cleanup_session.execute(delete(User).where(User.id == user.id))
+                await cleanup_session.commit()
+            await engine.dispose()


### PR DESCRIPTION
## Summary

Concurrent archives of different products on the same checkout link each read the others as still present, so none soft deletes the link. Both DELETEs land and the link survives with no product; every read 500s and the merchant's checkout links page breaks.

Sentry: SERVER-4YR.

red green fix + `scripts/soft_delete_empty_checkout_links.py` to repair the rows already there.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

