### PR TITLE
Reapply "sqs: Re-enqueue instead of retry"

### DIFF
--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -132,6 +132,7 @@ def compute_retry_backoff(
 
 class RetryAction(enum.Enum):
     DEAD_LETTER = "dead_letter"
+    RE_ENQUEUE = "re_enqueue"
     SCHEDULE = "schedule"
     SET_VISIBILITY = "set_visibility"
 
@@ -143,15 +144,19 @@ def plan_retry(
     *,
     scheduler_available: bool,
 ) -> tuple[RetryAction, int]:
-    """Decide how to redeliver a failed task and the delay (seconds) to apply."""
-    if receive_count - 1 >= get_actor_max_retries(actor_name):
+    """Pick where a failed task waits out its backoff, and for how many seconds."""
+    retries_used = receive_count - 1
+    if retries_used >= get_actor_max_retries(actor_name):
         return RetryAction.DEAD_LETTER, 0
+
     backoff_seconds = compute_retry_backoff(actor_name, receive_count, exception)
-    if backoff_seconds > _sqs.MAX_VISIBILITY_TIMEOUT_SECONDS and scheduler_available:
-        return RetryAction.SCHEDULE, backoff_seconds
-    return RetryAction.SET_VISIBILITY, min(
-        backoff_seconds, _sqs.MAX_VISIBILITY_TIMEOUT_SECONDS
-    )
+    if backoff_seconds <= _sqs.MAX_DELAY_SECONDS:
+        return RetryAction.RE_ENQUEUE, backoff_seconds
+    if not scheduler_available:
+        return RetryAction.SET_VISIBILITY, min(
+            backoff_seconds, _sqs.MAX_VISIBILITY_TIMEOUT_SECONDS
+        )
+    return RetryAction.SCHEDULE, backoff_seconds
 
 
 @contextlib.contextmanager

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -228,6 +228,19 @@ def set_message_visibility(
     )
 
 
+def send_delayed_message(
+    client: "SQSClient", queue_arn: str, body: str, delay_seconds: int
+) -> None:
+    """Re-enqueue a retry so its backoff waits outside the visible queue."""
+    queue_name = queue_arn.rsplit(":", 1)[-1]
+    queue_url = get_queue_url(client, queue_name)
+    client.send_message(
+        QueueUrl=queue_url,
+        MessageBody=body,
+        DelaySeconds=min(delay_seconds, MAX_DELAY_SECONDS),
+    )
+
+
 def build_retry_schedule_name(queue_arn: str, message_id: str, attempt: int) -> str:
     """Deterministic per logical handoff so a crash + SQS redelivery is idempotent."""
     digest = hashlib.sha256(f"{queue_arn}:{message_id}:{attempt}".encode()).hexdigest()
@@ -242,7 +255,7 @@ def schedule_delayed_message(
     delay_seconds: int,
     schedule_name: str,
 ) -> None:
-    """Redeliver to SQS after a delay longer than SQS visibility allows (>12h)."""
+    """Redeliver to SQS after a delay longer than SQS's own delay cap allows."""
     fire_at = datetime.now(UTC) + timedelta(seconds=delay_seconds)
     try:
         client.create_schedule(
@@ -332,6 +345,7 @@ def send_jobs_sync(jobs: list[Job]) -> None:
 
 
 __all__ = [
+    "MAX_DELAY_SECONDS",
     "MAX_JOB_PAYLOAD_BYTES",
     "MAX_VISIBILITY_TIMEOUT_SECONDS",
     "Job",
@@ -347,6 +361,7 @@ __all__ = [
     "parse_envelope",
     "resolve_queue_url",
     "schedule_delayed_message",
+    "send_delayed_message",
     "send_jobs",
     "send_jobs_sync",
     "send_to_dlq",

--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -20,6 +20,7 @@ from ._sqs import (
     get_consumer_sqs_client,
     parse_envelope,
     schedule_delayed_message,
+    send_delayed_message,
     send_to_dlq,
     set_message_visibility,
 )
@@ -117,23 +118,37 @@ def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> bo
             )
             return False
 
+        retry_body = build_envelope(
+            envelope.actor,
+            tuple(envelope.args),
+            envelope.kwargs,
+            envelope.correlation_id,
+            receive_count + 1,
+            envelope.message_timestamp,
+            message_id=envelope.message_id,
+            debounce_key=envelope.debounce_key,
+            message_options=envelope.message_options,
+        )
+
+        if action is RetryAction.RE_ENQUEUE:
+            send_delayed_message(
+                consumer_sqs_client, queue_arn, retry_body, delay_seconds
+            )
+            log.info(
+                "polar.worker.sqs_retry_reenqueued",
+                actor=envelope.actor,
+                receive_count=receive_count,
+                backoff_seconds=delay_seconds,
+            )
+            return False
+
         if action is RetryAction.SCHEDULE:
             assert scheduler_role_arn is not None
             schedule_delayed_message(
                 consumer_scheduler_client,
                 queue_arn,
                 scheduler_role_arn,
-                build_envelope(
-                    envelope.actor,
-                    tuple(envelope.args),
-                    envelope.kwargs,
-                    envelope.correlation_id,
-                    receive_count + 1,
-                    envelope.message_timestamp,
-                    message_id=envelope.message_id,
-                    debounce_key=envelope.debounce_key,
-                    message_options=envelope.message_options,
-                ),
+                retry_body,
                 delay_seconds,
                 build_retry_schedule_name(
                     queue_arn, record["messageId"], envelope.attempt

--- a/server/tests/worker/test_backoff.py
+++ b/server/tests/worker/test_backoff.py
@@ -168,10 +168,22 @@ class TestPlanRetry:
         action, _ = plan_retry("dummy", max_retries, None, scheduler_available=True)
         assert action is not RetryAction.DEAD_LETTER
 
-    def test_sets_visibility_for_short_backoff(self) -> None:
+    def test_re_enqueues_for_short_backoff(self) -> None:
         action, delay = plan_retry("dummy", 1, None, scheduler_available=True)
+        assert action is RetryAction.RE_ENQUEUE
+        assert delay <= _sqs.MAX_DELAY_SECONDS
+
+    def test_schedules_when_backoff_exceeds_delay_cap(self) -> None:
+        long_delay = Retry(delay=2 * _sqs.MAX_DELAY_SECONDS * 1000)
+        action, delay = plan_retry("dummy", 1, long_delay, scheduler_available=True)
+        assert action is RetryAction.SCHEDULE
+        assert delay == 2 * _sqs.MAX_DELAY_SECONDS
+
+    def test_falls_back_to_visibility_without_scheduler(self) -> None:
+        long_delay = Retry(delay=2 * _sqs.MAX_DELAY_SECONDS * 1000)
+        action, delay = plan_retry("dummy", 1, long_delay, scheduler_available=False)
         assert action is RetryAction.SET_VISIBILITY
-        assert delay <= _sqs.MAX_VISIBILITY_TIMEOUT_SECONDS
+        assert delay == 2 * _sqs.MAX_DELAY_SECONDS
 
     def test_schedules_when_backoff_exceeds_visibility(self) -> None:
         long_delay = Retry(delay=2 * _sqs.MAX_VISIBILITY_TIMEOUT_SECONDS * 1000)
@@ -184,6 +196,41 @@ class TestPlanRetry:
         action, delay = plan_retry("dummy", 1, long_delay, scheduler_available=False)
         assert action is RetryAction.SET_VISIBILITY
         assert delay == _sqs.MAX_VISIBILITY_TIMEOUT_SECONDS
+
+
+class TestSendDelayedMessage:
+    def test_re_enqueues_with_delay(self, mocker: MockerFixture) -> None:
+        client = mocker.MagicMock()
+        client.get_queue_url.return_value = {"QueueUrl": "https://sqs/queue"}
+        _sqs._queue_url_cache.clear()
+
+        _sqs.send_delayed_message(
+            client,
+            "arn:aws:sqs:us-east-2:123456789012:polar-sandbox-tasks-dummy",
+            '{"actor":"dummy"}',
+            60,
+        )
+
+        client.get_queue_url.assert_called_once_with(
+            QueueName="polar-sandbox-tasks-dummy"
+        )
+        client.send_message.assert_called_once_with(
+            QueueUrl="https://sqs/queue",
+            MessageBody='{"actor":"dummy"}',
+            DelaySeconds=60,
+        )
+
+    def test_caps_delay_at_sqs_limit(self, mocker: MockerFixture) -> None:
+        client = mocker.MagicMock()
+        client.get_queue_url.return_value = {"QueueUrl": "https://sqs/queue"}
+        _sqs._queue_url_cache.clear()
+
+        _sqs.send_delayed_message(client, "arn:q", "{}", _sqs.MAX_DELAY_SECONDS * 2)
+
+        assert (
+            client.send_message.call_args.kwargs["DelaySeconds"]
+            == _sqs.MAX_DELAY_SECONDS
+        )
 
 
 class TestBuildRetryScheduleName:


### PR DESCRIPTION
Reverts polarsource/polar#14019

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

