### PR TITLE
clients(checkout): tiered metered pricing display

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutPricing.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricing.test.tsx
@@ -5,6 +5,7 @@ import {
   createCheckout,
   createCustomPrice,
   createFreePrice,
+  createMeteredPrice,
 } from '../test-utils/makeCheckout'
 import CheckoutPricing from './CheckoutPricing'
 
@@ -119,6 +120,33 @@ describe('CheckoutPricing', () => {
       render(<CheckoutPricing checkout={checkout} locale="en" />)
 
       expect(screen.getByTestId('headline-price')).toHaveTextContent('$0')
+    })
+  })
+
+  describe('tiered metered price', () => {
+    it('shows the first tier alongside the zero upfront total', () => {
+      const meteredPrice = createMeteredPrice({
+        unit_amount: null,
+        tiers: {
+          type: 'volume',
+          tiers: [
+            { bound: 1000, unit_amount: '5' },
+            { bound: null, unit_amount: '1' },
+          ],
+        },
+      })
+      const checkout = createCheckout({
+        amount: 0,
+        net_amount: 0,
+        total_amount: 0,
+        product_price: meteredPrice,
+      })
+
+      render(<CheckoutPricing checkout={checkout} locale="en" />)
+
+      expect(screen.getByTestId('headline-price')).toHaveTextContent('$0')
+      expect(screen.getByText(/metered usage/i)).toBeInTheDocument()
+      expect(screen.getByText(/up to 1,000/i)).toBeInTheDocument()
     })
   })
 })

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
@@ -633,6 +633,36 @@ describe('CheckoutPricingBreakdown', () => {
       expect(screen.getByTestId('detail-row-API Calls')).toBeInTheDocument()
     })
 
+    it('shows the selected tiered price as metered usage', () => {
+      const meteredPrice = createMeteredPrice({
+        id: 'price_metered_1',
+        unit_amount: null,
+        tiers: {
+          type: 'graduated',
+          tiers: [
+            { bound: 1000, unit_amount: '5' },
+            { bound: null, unit_amount: '1' },
+          ],
+        },
+      })
+      const checkout = createCheckout({
+        amount: 0,
+        net_amount: 0,
+        total_amount: 0,
+        product_price: meteredPrice,
+      })
+
+      render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
+
+      expect(screen.getByText(/^metered usage$/i)).toBeInTheDocument()
+      const row = screen.getByTestId('detail-row-API Calls')
+      expect(row).toHaveTextContent('Graduated pricing')
+      expect(row).toHaveTextContent('up to 1,000')
+      expect(row).toHaveTextContent('$0.05 / unit')
+      expect(row).toHaveTextContent('Over 1,000')
+      expect(row).toHaveTextContent('$0.01 / unit')
+    })
+
     it('strikes through the original rate when a percentage discount is active', () => {
       const meteredPrice = createMeteredPrice({
         id: 'price_metered_1',

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
@@ -655,12 +655,12 @@ describe('CheckoutPricingBreakdown', () => {
       render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
 
       expect(screen.getByText(/^metered usage$/i)).toBeInTheDocument()
-      const row = screen.getByTestId('detail-row-API Calls')
-      expect(row).toHaveTextContent('Graduated pricing')
-      expect(row).toHaveTextContent('up to 1,000')
-      expect(row).toHaveTextContent('$0.05 / unit')
-      expect(row).toHaveTextContent('Over 1,000')
-      expect(row).toHaveTextContent('$0.01 / unit')
+      expect(screen.getByTestId('detail-row-API Calls')).toBeInTheDocument()
+      expect(screen.getByText('Up to 1,000')).toBeInTheDocument()
+      expect(screen.getByText('Over 1,000')).toBeInTheDocument()
+      expect(screen.getAllByText('/ unit')).toHaveLength(2)
+      expect(screen.getByText('$0.05')).toBeInTheDocument()
+      expect(screen.getByText('$0.01')).toBeInTheDocument()
     })
 
     it('strikes through the original rate when a percentage discount is active', () => {

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -299,7 +299,6 @@ const CheckoutPricingBreakdown = ({
                     price={meteredPrice}
                     locale={locale}
                     discount={checkout.discount}
-                    showTierLadder
                   />
                 </div>
               )

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -18,7 +18,7 @@ import {
 } from '../guards'
 import { getSeatRows } from '../utils/seats'
 import { getDiscountDisplay } from '../utils/discount'
-import { getMeteredPrices } from '../utils/product'
+import { getMeteredPrices, isMeteredPrice } from '../utils/product'
 import { unreachable } from '../utils/unreachable'
 import AmountLabel from './AmountLabel'
 import DetailRow from './DetailRow'
@@ -278,7 +278,12 @@ const CheckoutPricingBreakdown = ({
           </DetailRow>
           {meteredPrices.length > 0 && (
             <DetailRow
-              title={t('checkout.pricing.additionalMeteredUsage')}
+              title={t(
+                hasProductCheckout(checkout) &&
+                  isMeteredPrice(checkout.product_price)
+                  ? 'checkout.pricing.meteredUsage'
+                  : 'checkout.pricing.additionalMeteredUsage',
+              )}
               className="dark:border-polar-700 mt-2 border-t border-gray-200 pt-4"
             />
           )}
@@ -292,6 +297,7 @@ const CheckoutPricingBreakdown = ({
                 price={meteredPrice}
                 locale={locale}
                 discount={checkout.discount}
+                showTierLadder
               />
             </DetailRow>
           ))}

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -287,20 +287,37 @@ const CheckoutPricingBreakdown = ({
               className="dark:border-polar-700 mt-2 border-t border-gray-200 pt-4"
             />
           )}
-          {meteredPrices.map((meteredPrice) => (
-            <DetailRow
-              title={meteredPrice.meter.name}
-              key={meteredPrice.id}
-              emphasis
-            >
-              <MeteredPriceLabel
-                price={meteredPrice}
-                locale={locale}
-                discount={checkout.discount}
-                showTierLadder
-              />
-            </DetailRow>
-          ))}
+          {meteredPrices.map((meteredPrice) => {
+            if (meteredPrice.tiers !== null) {
+              return (
+                <div
+                  key={meteredPrice.id}
+                  className="flex flex-col gap-y-2"
+                >
+                  <DetailRow title={meteredPrice.meter.name} emphasis />
+                  <MeteredPriceLabel
+                    price={meteredPrice}
+                    locale={locale}
+                    discount={checkout.discount}
+                    showTierLadder
+                  />
+                </div>
+              )
+            }
+            return (
+              <DetailRow
+                title={meteredPrice.meter.name}
+                key={meteredPrice.id}
+                emphasis
+              >
+                <MeteredPriceLabel
+                  price={meteredPrice}
+                  locale={locale}
+                  discount={checkout.discount}
+                />
+              </DetailRow>
+            )
+          })}
         </>
       ) : (
         <span>{t('checkout.pricing.free')}</span>

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
@@ -318,6 +318,39 @@ describe('MeteredPriceLabel', () => {
       expect(container.textContent).toContain('up to 1,000')
     })
 
+    it('localizes the tier bound', () => {
+      const price = tieredPrice('graduated', [
+        { bound: 1000, unit_amount: '5' },
+        { bound: null, unit_amount: '1' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="sv" />,
+      )
+
+      expect(container.textContent).toContain('upp till')
+    })
+
+    it('shows the complete tier ladder when requested', () => {
+      const price = tieredPrice('volume', [
+        { bound: 1000, unit_amount: '5' },
+        { bound: 5000, unit_amount: '2' },
+        { bound: null, unit_amount: '1' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" showTierLadder />,
+      )
+
+      expect(container.textContent).toContain('Volume pricing')
+      expect(container.textContent).toContain('up to 1,000')
+      expect(container.textContent).toContain('Over 1,000, up to 5,000')
+      expect(container.textContent).toContain('Over 5,000')
+      expect(container.textContent).toContain('$0.05')
+      expect(container.textContent).toContain('$0.02')
+      expect(container.textContent).toContain('$0.01')
+    })
+
     it('omits the bound when the only tier is unbounded', () => {
       const price = tieredPrice('graduated', [
         { bound: null, unit_amount: '5' },

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
@@ -256,4 +256,116 @@ describe('MeteredPriceLabel', () => {
       expect(container.querySelector('.line-through')).toBeNull()
     })
   })
+  describe('tiered prices', () => {
+    const tieredPrice = (
+      tierType: 'graduated' | 'volume',
+      tiers: { bound: number | null; unit_amount: string }[],
+      meter?: Partial<schemas['ProductPriceMeteredUnit']['meter']>,
+    ) =>
+      createMeteredPrice({
+        unit_amount: null,
+        tiers: { type: tierType, tiers },
+        ...(meter
+          ? {
+              meter: {
+                ...createMeteredPrice().meter,
+                ...meter,
+              },
+            }
+          : {}),
+      })
+
+    it('renders the first tier rate and the bound it applies up to', () => {
+      const price = tieredPrice('graduated', [
+        { bound: 1000, unit_amount: '5' },
+        { bound: null, unit_amount: '1' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$0.05')
+      expect(container.textContent).toContain('/ unit')
+      expect(container.textContent).toContain('up to 1,000')
+    })
+
+    it('anchors volume prices to the first tier too, not the cheapest', () => {
+      const price = tieredPrice('volume', [
+        { bound: 1000, unit_amount: '5' },
+        { bound: null, unit_amount: '0.1' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$0.05')
+      expect(container.textContent).not.toContain('$0.001')
+    })
+
+    it('reads the tiers even when they arrive unsorted', () => {
+      const price = tieredPrice('graduated', [
+        { bound: null, unit_amount: '1' },
+        { bound: 1000, unit_amount: '5' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$0.05')
+      expect(container.textContent).toContain('up to 1,000')
+    })
+
+    it('omits the bound when the only tier is unbounded', () => {
+      const price = tieredPrice('graduated', [
+        { bound: null, unit_amount: '5' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$0.05')
+      expect(container.textContent).not.toContain('up to')
+    })
+
+    it('scales the rate to the meter unit but leaves the bound in base units', () => {
+      const price = tieredPrice(
+        'graduated',
+        [
+          { bound: 5_000_000, unit_amount: '0.001' },
+          { bound: null, unit_amount: '0.0005' },
+        ],
+        { unit: 'token' },
+      )
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$10.00')
+      expect(container.textContent).toContain('/ 1M tokens')
+      expect(container.textContent).toContain('up to 5,000,000')
+    })
+
+    it('discounts the first tier rate', () => {
+      const price = tieredPrice('graduated', [
+        { bound: 1000, unit_amount: '1000' },
+        { bound: null, unit_amount: '100' },
+      ])
+
+      render(
+        <MeteredPriceLabel
+          price={price}
+          locale="en"
+          discount={percentageDiscount(5000)}
+        />,
+      )
+
+      expect(screen.getByText('$10.00')).toHaveClass('line-through')
+      expect(screen.getByText('$5.00')).toBeInTheDocument()
+    })
+  })
 })

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
@@ -342,8 +342,7 @@ describe('MeteredPriceLabel', () => {
         <MeteredPriceLabel price={price} locale="en" showTierLadder />,
       )
 
-      expect(container.textContent).toContain('Volume pricing')
-      expect(container.textContent).toContain('up to 1,000')
+      expect(container.textContent).toContain('Up to 1,000')
       expect(container.textContent).toContain('Over 1,000, up to 5,000')
       expect(container.textContent).toContain('Over 5,000')
       expect(container.textContent).toContain('$0.05')

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
@@ -275,63 +275,7 @@ describe('MeteredPriceLabel', () => {
           : {}),
       })
 
-    it('renders the first tier rate and the bound it applies up to', () => {
-      const price = tieredPrice('graduated', [
-        { bound: 1000, unit_amount: '5' },
-        { bound: null, unit_amount: '1' },
-      ])
-
-      const { container } = render(
-        <MeteredPriceLabel price={price} locale="en" />,
-      )
-
-      expect(container.textContent).toContain('$0.05')
-      expect(container.textContent).toContain('/ unit')
-      expect(container.textContent).toContain('up to 1,000')
-    })
-
-    it('anchors volume prices to the first tier too, not the cheapest', () => {
-      const price = tieredPrice('volume', [
-        { bound: 1000, unit_amount: '5' },
-        { bound: null, unit_amount: '0.1' },
-      ])
-
-      const { container } = render(
-        <MeteredPriceLabel price={price} locale="en" />,
-      )
-
-      expect(container.textContent).toContain('$0.05')
-      expect(container.textContent).not.toContain('$0.001')
-    })
-
-    it('reads the tiers even when they arrive unsorted', () => {
-      const price = tieredPrice('graduated', [
-        { bound: null, unit_amount: '1' },
-        { bound: 1000, unit_amount: '5' },
-      ])
-
-      const { container } = render(
-        <MeteredPriceLabel price={price} locale="en" />,
-      )
-
-      expect(container.textContent).toContain('$0.05')
-      expect(container.textContent).toContain('up to 1,000')
-    })
-
-    it('localizes the tier bound', () => {
-      const price = tieredPrice('graduated', [
-        { bound: 1000, unit_amount: '5' },
-        { bound: null, unit_amount: '1' },
-      ])
-
-      const { container } = render(
-        <MeteredPriceLabel price={price} locale="sv" />,
-      )
-
-      expect(container.textContent).toContain('upp till')
-    })
-
-    it('shows the complete tier ladder when requested', () => {
+    it('renders every tier as a range with its own rate', () => {
       const price = tieredPrice('volume', [
         { bound: 1000, unit_amount: '5' },
         { bound: 5000, unit_amount: '2' },
@@ -339,7 +283,7 @@ describe('MeteredPriceLabel', () => {
       ])
 
       const { container } = render(
-        <MeteredPriceLabel price={price} locale="en" showTierLadder />,
+        <MeteredPriceLabel price={price} locale="en" />,
       )
 
       expect(container.textContent).toContain('Up to 1,000')
@@ -350,7 +294,37 @@ describe('MeteredPriceLabel', () => {
       expect(container.textContent).toContain('$0.01')
     })
 
-    it('omits the bound when the only tier is unbounded', () => {
+    it('sorts the tiers even when they arrive unsorted', () => {
+      const price = tieredPrice('graduated', [
+        { bound: null, unit_amount: '1' },
+        { bound: 1000, unit_amount: '5' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      const upToIndex = container.textContent!.indexOf('Up to 1,000')
+      const overIndex = container.textContent!.indexOf('Over 1,000')
+      expect(upToIndex).toBeGreaterThanOrEqual(0)
+      expect(overIndex).toBeGreaterThan(upToIndex)
+    })
+
+    it('localizes the tier ranges', () => {
+      const price = tieredPrice('graduated', [
+        { bound: 1000, unit_amount: '5' },
+        { bound: 5000, unit_amount: '2' },
+        { bound: null, unit_amount: '1' },
+      ])
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="sv" />,
+      )
+
+      expect(container.textContent).toContain('upp till')
+    })
+
+    it('renders a single unbounded tier as "All usage"', () => {
       const price = tieredPrice('graduated', [
         { bound: null, unit_amount: '5' },
       ])
@@ -359,11 +333,11 @@ describe('MeteredPriceLabel', () => {
         <MeteredPriceLabel price={price} locale="en" />,
       )
 
+      expect(container.textContent).toContain('All usage')
       expect(container.textContent).toContain('$0.05')
-      expect(container.textContent).not.toContain('up to')
     })
 
-    it('scales the rate to the meter unit but leaves the bound in base units', () => {
+    it('scales the rate to the meter unit but leaves the bounds in base units', () => {
       const price = tieredPrice(
         'graduated',
         [
@@ -379,10 +353,10 @@ describe('MeteredPriceLabel', () => {
 
       expect(container.textContent).toContain('$10.00')
       expect(container.textContent).toContain('/ 1M tokens')
-      expect(container.textContent).toContain('up to 5,000,000')
+      expect(container.textContent).toContain('Up to 5,000,000')
     })
 
-    it('discounts the first tier rate', () => {
+    it('discounts every tier rate', () => {
       const price = tieredPrice('graduated', [
         { bound: 1000, unit_amount: '1000' },
         { bound: null, unit_amount: '100' },
@@ -398,6 +372,8 @@ describe('MeteredPriceLabel', () => {
 
       expect(screen.getByText('$10.00')).toHaveClass('line-through')
       expect(screen.getByText('$5.00')).toBeInTheDocument()
+      expect(screen.getByText('$1.00')).toHaveClass('line-through')
+      expect(screen.getByText('$0.50')).toBeInTheDocument()
     })
   })
 })

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -29,7 +29,7 @@ const getSortedTiers = (
     return []
   }
 
-  return price.tiers.tiers.toSorted(
+  return [...price.tiers.tiers].sort(
     (a, b) =>
       Number(a.bound === null) - Number(b.bound === null) ||
       (a.bound ?? 0) - (b.bound ?? 0),

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -1,6 +1,10 @@
 import type { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
-import { DEFAULT_LOCALE, type AcceptedLocale } from '@polar-sh/i18n'
+import {
+  DEFAULT_LOCALE,
+  useTranslations,
+  type AcceptedLocale,
+} from '@polar-sh/i18n'
 import { getMeterUnitFormat } from '@polar-sh/ui/lib/meterUnit'
 import { cn } from '@polar-sh/ui/lib/utils'
 
@@ -10,11 +14,35 @@ interface MeteredPriceLabelProps {
   discount?: schemas['CheckoutPublic']['discount']
 }
 
+type MeteredTier = NonNullable<
+  schemas['ProductPriceMeteredUnit']['tiers']
+>['tiers'][number]
+
+const mutedTextClass =
+  'dark:text-polar-400 text-[max(12px,0.5em)] text-gray-500'
+
+const getFirstTier = (
+  price: schemas['ProductPriceMeteredUnit'],
+): MeteredTier | null => {
+  if (price.tiers == null) {
+    return null
+  }
+  return (
+    price.tiers.tiers.toSorted(
+      (a, b) =>
+        Number(a.bound === null) - Number(b.bound === null) ||
+        (a.bound ?? 0) - (b.bound ?? 0),
+    )[0] ?? null
+  )
+}
+
 const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
   price,
   locale = DEFAULT_LOCALE,
   discount,
 }) => {
+  const t = useTranslations(locale)
+
   if (price.unit_amount == null) return null
 
   const { scale, label } = getMeterUnitFormat(price.meter.unit ?? 'scalar', {
@@ -23,7 +51,12 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
   })
 
   const format = formatCurrency('subcent', locale)
-  const baseAmount = Number.parseFloat(price.unit_amount) * scale
+  const firstTier = getFirstTier(price)
+  const bound = firstTier?.bound ?? null
+  const rate = Number.parseFloat(
+    firstTier?.unit_amount ?? price.unit_amount ?? '0',
+  )
+  const baseAmount = rate * scale
   const discountedAmount =
     discount && 'basis_points' in discount
       ? baseAmount * (1 - discount.basis_points / 10000)
@@ -43,12 +76,20 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
       )}
       <span
         className={cn(
-          'dark:text-polar-400 text-[max(12px,0.5em)] text-gray-500',
+          mutedTextClass,
           price.meter.unit === 'custom' ? 'lowercase' : '',
         )}
       >
         / {label}
       </span>
+      {bound !== null && (
+        <span className={mutedTextClass}>
+          ·{' '}
+          {t('checkout.pricing.upTo', {
+            units: new Intl.NumberFormat(locale).format(bound),
+          })}
+        </span>
+      )}
     </div>
   )
 }

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -12,6 +12,7 @@ interface MeteredPriceLabelProps {
   price: schemas['ProductPriceMeteredUnit']
   locale?: AcceptedLocale
   discount?: schemas['CheckoutPublic']['discount']
+  showTierLadder?: boolean
 }
 
 type MeteredTier = NonNullable<
@@ -21,18 +22,62 @@ type MeteredTier = NonNullable<
 const mutedTextClass =
   'dark:text-polar-400 text-[max(12px,0.5em)] text-gray-500'
 
-const getFirstTier = (
+const getSortedTiers = (
   price: schemas['ProductPriceMeteredUnit'],
-): MeteredTier | null => {
+): MeteredTier[] => {
   if (price.tiers == null) {
-    return null
+    return []
   }
+
+  return price.tiers.tiers.toSorted(
+    (a, b) =>
+      Number(a.bound === null) - Number(b.bound === null) ||
+      (a.bound ?? 0) - (b.bound ?? 0),
+  )
+}
+
+interface MeteredRateProps {
+  unitAmount: string
+  scale: number
+  label: string
+  currency: string
+  locale: AcceptedLocale
+  discount?: schemas['CheckoutPublic']['discount']
+  lowercaseLabel: boolean
+}
+
+const MeteredRate = ({
+  unitAmount,
+  scale,
+  label,
+  currency,
+  locale,
+  discount,
+  lowercaseLabel,
+}: MeteredRateProps) => {
+  const format = formatCurrency('subcent', locale)
+  const baseAmount = Number.parseFloat(unitAmount) * scale
+  const discountedAmount =
+    discount && 'basis_points' in discount
+      ? baseAmount * (1 - discount.basis_points / 10000)
+      : null
+
   return (
-    price.tiers.tiers.toSorted(
-      (a, b) =>
-        Number(a.bound === null) - Number(b.bound === null) ||
-        (a.bound ?? 0) - (b.bound ?? 0),
-    )[0] ?? null
+    <span className="flex flex-row items-baseline gap-x-1">
+      {discountedAmount !== null ? (
+        <>
+          <span className="dark:text-polar-500 text-gray-400 line-through">
+            {format(baseAmount, currency)}
+          </span>
+          <span>{format(discountedAmount, currency)}</span>
+        </>
+      ) : (
+        format(baseAmount, currency)
+      )}
+      <span className={cn(mutedTextClass, lowercaseLabel ? 'lowercase' : '')}>
+        / {label}
+      </span>
+    </span>
   )
 }
 
@@ -40,57 +85,90 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
   price,
   locale = DEFAULT_LOCALE,
   discount,
+  showTierLadder = false,
 }) => {
   const t = useTranslations(locale)
-
-  if (price.unit_amount == null) return null
+  const tiers = getSortedTiers(price)
+  const firstTier = tiers[0] ?? null
+  const unitAmount = firstTier?.unit_amount ?? price.unit_amount
+  if (unitAmount === null) return null
 
   const { scale, label } = getMeterUnitFormat(price.meter.unit ?? 'scalar', {
     customLabel: price.meter.custom_label,
     customMultiplier: price.meter.custom_multiplier,
   })
 
-  const format = formatCurrency('subcent', locale)
-  const firstTier = getFirstTier(price)
+  const lowercaseLabel = price.meter.unit === 'custom'
+  const numberFormat = new Intl.NumberFormat(locale)
+
+  if (showTierLadder && price.tiers !== null) {
+    return (
+      <span className="flex flex-col gap-y-1.5">
+        <span className={`${mutedTextClass} text-right`}>
+          {t(`checkout.pricing.tieredPricing.${price.tiers.type}`)}
+        </span>
+        {tiers.map((tier, index) => {
+          const previousBound = index > 0 ? tiers[index - 1].bound : null
+          const range =
+            index === 0
+              ? tier.bound === null
+                ? t('checkout.pricing.tieredPricing.allUsage')
+                : t('checkout.pricing.upTo', {
+                    units: numberFormat.format(tier.bound),
+                  })
+              : tier.bound === null
+                ? t('checkout.pricing.tieredPricing.over', {
+                    units: numberFormat.format(previousBound ?? 0),
+                  })
+                : t('checkout.pricing.tieredPricing.overUpTo', {
+                    lowerBound: numberFormat.format(previousBound ?? 0),
+                    upperBound: numberFormat.format(tier.bound),
+                  })
+
+          return (
+            <span
+              key={tier.bound ?? 'unbounded'}
+              className="flex flex-row items-baseline justify-between gap-x-6"
+            >
+              <span className={mutedTextClass}>{range}</span>
+              <MeteredRate
+                unitAmount={tier.unit_amount}
+                scale={scale}
+                label={label}
+                currency={price.price_currency}
+                locale={locale}
+                discount={discount}
+                lowercaseLabel={lowercaseLabel}
+              />
+            </span>
+          )
+        })}
+      </span>
+    )
+  }
+
   const bound = firstTier?.bound ?? null
-  const rate = Number.parseFloat(
-    firstTier?.unit_amount ?? price.unit_amount ?? '0',
-  )
-  const baseAmount = rate * scale
-  const discountedAmount =
-    discount && 'basis_points' in discount
-      ? baseAmount * (1 - discount.basis_points / 10000)
-      : null
 
   return (
-    <div className="flex flex-row items-baseline gap-x-1">
-      {discountedAmount !== null ? (
-        <>
-          <span className="dark:text-polar-500 text-gray-400 line-through">
-            {format(baseAmount, price.price_currency)}
-          </span>
-          <span>{format(discountedAmount, price.price_currency)}</span>
-        </>
-      ) : (
-        format(baseAmount, price.price_currency)
-      )}
-      <span
-        className={cn(
-          mutedTextClass,
-          price.meter.unit === 'custom' ? 'lowercase' : '',
-        )}
-      >
-        / {label}
-      </span>
+    <span className="flex flex-row items-baseline gap-x-1">
+      <MeteredRate
+        unitAmount={unitAmount}
+        scale={scale}
+        label={label}
+        currency={price.price_currency}
+        locale={locale}
+        discount={discount}
+        lowercaseLabel={lowercaseLabel}
+      />
       {bound !== null && (
         <span className={mutedTextClass}>
           ·{' '}
           {t('checkout.pricing.upTo', {
-            units: new Intl.NumberFormat(locale).format(bound),
+            units: numberFormat.format(bound),
           })}
         </span>
       )}
-    </div>
+    </span>
   )
 }
 

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -12,7 +12,6 @@ interface MeteredPriceLabelProps {
   price: schemas['ProductPriceMeteredUnit']
   locale?: AcceptedLocale
   discount?: schemas['CheckoutPublic']['discount']
-  showTierLadder?: boolean
 }
 
 type MeteredTier = NonNullable<
@@ -85,13 +84,9 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
   price,
   locale = DEFAULT_LOCALE,
   discount,
-  showTierLadder = false,
 }) => {
   const t = useTranslations(locale)
   const tiers = getSortedTiers(price)
-  const firstTier = tiers[0] ?? null
-  const unitAmount = firstTier?.unit_amount ?? price.unit_amount
-  if (unitAmount === null) return null
 
   const { scale, label } = getMeterUnitFormat(price.meter.unit ?? 'scalar', {
     customLabel: price.meter.custom_label,
@@ -101,7 +96,7 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
   const lowercaseLabel = price.meter.unit === 'custom'
   const numberFormat = new Intl.NumberFormat(locale)
 
-  if (showTierLadder && price.tiers !== null) {
+  if (price.tiers !== null) {
     return (
       <span className="flex w-full flex-col gap-y-1.5">
         {tiers.map((tier, index) => {
@@ -144,12 +139,12 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
     )
   }
 
-  const bound = firstTier?.bound ?? null
+  if (price.unit_amount === null) return null
 
   return (
     <span className="flex flex-row items-baseline gap-x-1">
       <MeteredRate
-        unitAmount={unitAmount}
+        unitAmount={price.unit_amount}
         scale={scale}
         label={label}
         currency={price.price_currency}
@@ -157,14 +152,6 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
         discount={discount}
         lowercaseLabel={lowercaseLabel}
       />
-      {bound !== null && (
-        <span className={mutedTextClass}>
-          ·{' '}
-          {t('checkout.pricing.upTo', {
-            units: numberFormat.format(bound),
-          })}
-        </span>
-      )}
     </span>
   )
 }

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -103,20 +103,17 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
 
   if (showTierLadder && price.tiers !== null) {
     return (
-      <span className="flex flex-col gap-y-1.5">
-        <span className={`${mutedTextClass} text-right`}>
-          {t(`checkout.pricing.tieredPricing.${price.tiers.type}`)}
-        </span>
+      <span className="flex w-full flex-col gap-y-1.5">
         {tiers.map((tier, index) => {
           const previousBound = index > 0 ? tiers[index - 1].bound : null
           const range =
             index === 0
-              ? tier.bound === null
+              ? tier.bound == null
                 ? t('checkout.pricing.tieredPricing.allUsage')
-                : t('checkout.pricing.upTo', {
+                : t('checkout.pricing.tieredPricing.upTo', {
                     units: numberFormat.format(tier.bound),
                   })
-              : tier.bound === null
+              : tier.bound == null
                 ? t('checkout.pricing.tieredPricing.over', {
                     units: numberFormat.format(previousBound ?? 0),
                   })

--- a/clients/packages/checkout/src/components/MeteredPricesDisplay.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredPricesDisplay.test.tsx
@@ -65,8 +65,18 @@ describe('MeteredPricesDisplay', () => {
       expect(container.textContent).toContain('$0.0005')
     })
 
-    it('filters out the currently selected price', () => {
-      const meteredPrice = createMeteredPrice({ id: 'price_metered_only' })
+    it('shows a selected tiered metered price', () => {
+      const meteredPrice = createMeteredPrice({
+        id: 'price_metered_only',
+        unit_amount: null,
+        tiers: {
+          type: 'graduated',
+          tiers: [
+            { bound: 1000, unit_amount: '5' },
+            { bound: null, unit_amount: '1' },
+          ],
+        },
+      })
 
       const checkout = createCheckout({
         product_price: meteredPrice,
@@ -79,7 +89,10 @@ describe('MeteredPricesDisplay', () => {
         <MeteredPricesDisplay checkout={checkout} locale="en" />,
       )
 
-      expect(container.innerHTML).toBe('')
+      expect(container.textContent).toContain('Metered usage')
+      expect(container.textContent).toContain('API Calls')
+      expect(container.textContent).toContain('$0.05')
+      expect(container.textContent).toContain('up to 1,000')
     })
 
     it('shows multiple metered prices', () => {

--- a/clients/packages/checkout/src/components/MeteredPricesDisplay.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredPricesDisplay.test.tsx
@@ -92,7 +92,7 @@ describe('MeteredPricesDisplay', () => {
       expect(container.textContent).toContain('Metered usage')
       expect(container.textContent).toContain('API Calls')
       expect(container.textContent).toContain('$0.05')
-      expect(container.textContent).toContain('up to 1,000')
+      expect(container.textContent).toContain('Up to 1,000')
     })
 
     it('shows multiple metered prices', () => {

--- a/clients/packages/checkout/src/components/MeteredPricesDisplay.tsx
+++ b/clients/packages/checkout/src/components/MeteredPricesDisplay.tsx
@@ -5,9 +5,8 @@ import {
   useTranslations,
   type AcceptedLocale,
 } from '@polar-sh/i18n'
-import { useMemo } from 'react'
 import { ProductCheckoutPublic } from '../guards'
-import { getMeteredPrices } from '../utils/product'
+import { getMeteredPrices, isMeteredPrice } from '../utils/product'
 import ProductPriceLabel from './ProductPriceLabel'
 
 const GaugeIcon = ({ className }: { className?: string }) => {
@@ -42,14 +41,8 @@ const MeteredPricesDisplay = ({
   const t = useTranslations(locale)
   const { product, prices, product_price, currency } = checkout
 
-  // Get the metered prices, minus the currently selected one, in case there are only metered prices
-  const meteredPrices = useMemo(
-    () =>
-      getMeteredPrices(prices[product.id], currency).filter(
-        (p) => p.id !== product_price.id,
-      ),
-    [prices, product, product_price, currency],
-  )
+  const meteredPrices = getMeteredPrices(prices[product.id], currency)
+  const selectedPriceIsMetered = isMeteredPrice(product_price)
 
   if (meteredPrices.length === 0) {
     return null
@@ -58,7 +51,9 @@ const MeteredPricesDisplay = ({
   return (
     <div className="text-sm">
       <h2 className="mb-2 text-base font-medium">
-        + {t('checkout.pricing.additionalMeteredUsage')}
+        {selectedPriceIsMetered
+          ? t('checkout.pricing.meteredUsage')
+          : `+ ${t('checkout.pricing.additionalMeteredUsage')}`}
       </h2>
       {meteredPrices.map((price) => (
         <div

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -179,7 +179,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -361,7 +367,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -543,7 +555,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -725,7 +743,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -907,7 +931,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1081,7 +1111,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1255,7 +1291,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1429,7 +1471,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1603,7 +1651,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1777,7 +1831,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1951,7 +2011,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "tr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2125,7 +2191,13 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   },
   "pl": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2299,6 +2371,12 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}"
+    "checkout.pricing.upTo": "up to {units}",
+    "checkout.pricing.meteredUsage": "Metered usage",
+    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
+    "checkout.pricing.tieredPricing.volume": "Volume pricing",
+    "checkout.pricing.tieredPricing.allUsage": "All usage",
+    "checkout.pricing.tieredPricing.over": "Over {units}",
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
   }
 }

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -178,7 +178,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -359,7 +360,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -540,7 +542,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -721,7 +724,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -902,7 +906,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1075,7 +1080,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1248,7 +1254,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1421,7 +1428,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1594,7 +1602,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1767,7 +1776,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1940,7 +1950,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "tr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2113,7 +2124,8 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   },
   "pl": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2286,6 +2298,7 @@
     "intervals.short.year.=1": "yr",
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
-    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    "checkout.pricing.upTo": "up to {units}"
   }
 }

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -179,13 +179,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -367,13 +365,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -555,13 +551,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -743,13 +737,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -931,13 +923,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1111,13 +1101,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1291,13 +1279,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1471,13 +1457,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1651,13 +1635,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1831,13 +1813,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2011,13 +1991,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "tr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2191,13 +2169,11 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   },
   "pl": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2371,12 +2347,10 @@
     "intervals.short.year.other": "# yr",
     "checkout.trialUnavailable.title": "No free trial for this purchase",
     "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
-    "checkout.pricing.upTo": "up to {units}",
     "checkout.pricing.meteredUsage": "Metered usage",
-    "checkout.pricing.tieredPricing.graduated": "Graduated pricing",
-    "checkout.pricing.tieredPricing.volume": "Volume pricing",
     "checkout.pricing.tieredPricing.allUsage": "All usage",
     "checkout.pricing.tieredPricing.over": "Over {units}",
-    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}"
+    "checkout.pricing.tieredPricing.overUpTo": "Over {lowerBound}, up to {upperBound}",
+    "checkout.pricing.tieredPricing.upTo": "Up to {units}"
   }
 }

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -94,14 +94,12 @@ export default {
       },
       inclTax: 'MwSt. (inklusive)',
       basePrice: 'Grundpreis',
-      upTo: 'bis zu {units}',
       meteredUsage: 'Nutzungsabhängige Abrechnung',
       tieredPricing: {
-        graduated: 'Staffelpreise',
-        volume: 'Mengenpreise',
         allUsage: 'Gesamte Nutzung',
         over: 'Über {units}',
         overUpTo: 'Über {lowerBound}, bis {upperBound}',
+        upTo: 'Bis zu {units}',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'MwSt. (inklusive)',
       basePrice: 'Grundpreis',
+      upTo: 'bis zu {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -95,6 +95,14 @@ export default {
       inclTax: 'MwSt. (inklusive)',
       basePrice: 'Grundpreis',
       upTo: 'bis zu {units}',
+      meteredUsage: 'Nutzungsabhängige Abrechnung',
+      tieredPricing: {
+        graduated: 'Staffelpreise',
+        volume: 'Mengenpreise',
+        allUsage: 'Gesamte Nutzung',
+        over: 'Über {units}',
+        overUpTo: 'Über {lowerBound}, bis {upperBound}',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -101,11 +101,6 @@ export default {
         over: 'Over {units}',
         overUpTo: 'Over {lowerBound}, up to {upperBound}',
       },
-      upTo: {
-        value: 'up to {units}',
-        _llmContext:
-          'Suffix after a metered price rate on checkout, marking the usage bound that rate applies up to. {units} is an already-formatted number of metered units, e.g. "1,000". Displayed as: "$0.05 / unit \u00b7 up to 1,000".',
-      },
       perSeat: 'per seat',
       basePrice: {
         value: 'Base price',

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -96,9 +96,8 @@ export default {
       additionalMeteredUsage: 'Additional metered usage',
       meteredUsage: 'Metered usage',
       tieredPricing: {
-        graduated: 'Graduated pricing',
-        volume: 'Volume pricing',
         allUsage: 'All usage',
+        upTo: 'Up to {units}',
         over: 'Over {units}',
         overUpTo: 'Over {lowerBound}, up to {upperBound}',
       },

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -94,6 +94,14 @@ export default {
         },
       },
       additionalMeteredUsage: 'Additional metered usage',
+      meteredUsage: 'Metered usage',
+      tieredPricing: {
+        graduated: 'Graduated pricing',
+        volume: 'Volume pricing',
+        allUsage: 'All usage',
+        over: 'Over {units}',
+        overUpTo: 'Over {lowerBound}, up to {upperBound}',
+      },
       upTo: {
         value: 'up to {units}',
         _llmContext:

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -94,6 +94,11 @@ export default {
         },
       },
       additionalMeteredUsage: 'Additional metered usage',
+      upTo: {
+        value: 'up to {units}',
+        _llmContext:
+          'Suffix after a metered price rate on checkout, marking the usage bound that rate applies up to. {units} is an already-formatted number of metered units, e.g. "1,000". Displayed as: "$0.05 / unit \u00b7 up to 1,000".',
+      },
       perSeat: 'per seat',
       basePrice: {
         value: 'Base price',

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'Impuestos (incluidos)',
       basePrice: 'Precio base',
+      upTo: 'hasta {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -94,14 +94,12 @@ export default {
       },
       inclTax: 'Impuestos (incluidos)',
       basePrice: 'Precio base',
-      upTo: 'hasta {units}',
       meteredUsage: 'Uso medido',
       tieredPricing: {
-        graduated: 'Tarifas escalonadas',
-        volume: 'Tarifas por volumen',
         allUsage: 'Todo el uso',
         over: 'Más de {units}',
         overUpTo: 'Más de {lowerBound}, hasta {upperBound}',
+        upTo: 'Hasta {units}',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -95,6 +95,14 @@ export default {
       inclTax: 'Impuestos (incluidos)',
       basePrice: 'Precio base',
       upTo: 'hasta {units}',
+      meteredUsage: 'Uso medido',
+      tieredPricing: {
+        graduated: 'Tarifas escalonadas',
+        volume: 'Tarifas por volumen',
+        allUsage: 'Todo el uso',
+        over: 'Más de {units}',
+        overUpTo: 'Más de {lowerBound}, hasta {upperBound}',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -95,6 +95,14 @@ export default {
       inclTax: 'TVA (incluse)',
       basePrice: 'Prix de base',
       upTo: 'jusqu’à {units}',
+      meteredUsage: "Utilisation facturée à l'usage",
+      tieredPricing: {
+        graduated: 'Tarification dégressive',
+        volume: 'Tarification par volume',
+        allUsage: "Toute l'utilisation",
+        over: 'Au-delà de {units}',
+        overUpTo: "Au-delà de {lowerBound}, jusqu'à {upperBound}",
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -94,14 +94,12 @@ export default {
       },
       inclTax: 'TVA (incluse)',
       basePrice: 'Prix de base',
-      upTo: 'jusqu’à {units}',
       meteredUsage: "Utilisation facturée à l'usage",
       tieredPricing: {
-        graduated: 'Tarification dégressive',
-        volume: 'Tarification par volume',
         allUsage: "Toute l'utilisation",
         over: 'Au-delà de {units}',
         overUpTo: "Au-delà de {lowerBound}, jusqu'à {upperBound}",
+        upTo: 'Jusqu’à {units}',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'TVA (incluse)',
       basePrice: 'Prix de base',
+      upTo: 'jusqu’à {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -94,14 +94,12 @@ export default {
       },
       inclTax: 'ÁFA (tartalmazza)',
       basePrice: 'Alapár',
-      upTo: '{units}-ig',
       meteredUsage: 'Mért használat',
       tieredPricing: {
-        graduated: 'Fokozatos díjszabás',
-        volume: 'Mennyiségi díjszabás',
         allUsage: 'Minden használat',
         over: '{units} felett',
         overUpTo: '{lowerBound} felett, {upperBound}-ig',
+        upTo: 'Akár {units} darab',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'ÁFA (tartalmazza)',
       basePrice: 'Alapár',
+      upTo: '{units}-ig',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -95,6 +95,14 @@ export default {
       inclTax: 'ÁFA (tartalmazza)',
       basePrice: 'Alapár',
       upTo: '{units}-ig',
+      meteredUsage: 'Mért használat',
+      tieredPricing: {
+        graduated: 'Fokozatos díjszabás',
+        volume: 'Mennyiségi díjszabás',
+        allUsage: 'Minden használat',
+        over: '{units} felett',
+        overUpTo: '{lowerBound} felett, {upperBound}-ig',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'IVA (inclusa)',
       basePrice: 'Prezzo base',
+      upTo: 'fino a {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -95,6 +95,14 @@ export default {
       inclTax: 'IVA (inclusa)',
       basePrice: 'Prezzo base',
       upTo: 'fino a {units}',
+      meteredUsage: 'Utilizzo a consumo',
+      tieredPricing: {
+        graduated: 'Prezzi a scaglioni',
+        volume: 'Prezzi a volume',
+        allUsage: "Tutto l'utilizzo",
+        over: 'Oltre {units}',
+        overUpTo: 'Oltre {lowerBound}, fino a {upperBound}',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -94,14 +94,12 @@ export default {
       },
       inclTax: 'IVA (inclusa)',
       basePrice: 'Prezzo base',
-      upTo: 'fino a {units}',
       meteredUsage: 'Utilizzo a consumo',
       tieredPricing: {
-        graduated: 'Prezzi a scaglioni',
-        volume: 'Prezzi a volume',
         allUsage: "Tutto l'utilizzo",
         over: 'Oltre {units}',
         overUpTo: 'Oltre {lowerBound}, fino a {upperBound}',
+        upTo: 'Fino a {units}',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -95,6 +95,14 @@ export default {
       },
       basePrice: '基本料金',
       upTo: '{units}まで',
+      meteredUsage: '従量課金',
+      tieredPricing: {
+        graduated: '段階課金',
+        volume: '数量割引',
+        allUsage: '全使用量',
+        over: '{units}超',
+        overUpTo: '{lowerBound}超、{upperBound}以下',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -94,6 +94,7 @@ export default {
         until: '{date}まで',
       },
       basePrice: '基本料金',
+      upTo: '{units}まで',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -94,14 +94,12 @@ export default {
         until: '{date}まで',
       },
       basePrice: '基本料金',
-      upTo: '{units}まで',
       meteredUsage: '従量課金',
       tieredPricing: {
-        graduated: '段階課金',
-        volume: '数量割引',
         allUsage: '全使用量',
         over: '{units}超',
         overUpTo: '{lowerBound}超、{upperBound}以下',
+        upTo: '{units}まで',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -94,14 +94,12 @@ export default {
       },
       inclTax: '부가세 (포함)',
       basePrice: '기본 가격',
-      upTo: '최대 {units}',
       meteredUsage: '사용량 기반 과금',
       tieredPricing: {
-        graduated: '누진 요금',
-        volume: '수량별 요금',
         allUsage: '전체 사용량',
         over: '{units} 초과',
         overUpTo: '{lowerBound} 초과, {upperBound} 이하',
+        upTo: '최대 {units}',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -95,6 +95,14 @@ export default {
       inclTax: '부가세 (포함)',
       basePrice: '기본 가격',
       upTo: '최대 {units}',
+      meteredUsage: '사용량 기반 과금',
+      tieredPricing: {
+        graduated: '누진 요금',
+        volume: '수량별 요금',
+        allUsage: '전체 사용량',
+        over: '{units} 초과',
+        overUpTo: '{lowerBound} 초과, {upperBound} 이하',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: '부가세 (포함)',
       basePrice: '기본 가격',
+      upTo: '최대 {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -94,14 +94,12 @@ export default {
       },
       inclTax: 'Btw (inbegrepen)',
       basePrice: 'Basisprijs',
-      upTo: 'tot {units}',
       meteredUsage: 'Verbruik op basis van gebruik',
       tieredPricing: {
-        graduated: 'Gedifferentieerde prijs',
-        volume: 'Volumekorting',
         allUsage: 'Alle verbruik',
         over: 'Boven {units}',
         overUpTo: 'Boven {lowerBound}, tot {upperBound}',
+        upTo: 'Tot {units}',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'Btw (inbegrepen)',
       basePrice: 'Basisprijs',
+      upTo: 'tot {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -95,6 +95,14 @@ export default {
       inclTax: 'Btw (inbegrepen)',
       basePrice: 'Basisprijs',
       upTo: 'tot {units}',
+      meteredUsage: 'Verbruik op basis van gebruik',
+      tieredPricing: {
+        graduated: 'Gedifferentieerde prijs',
+        volume: 'Volumekorting',
+        allUsage: 'Alle verbruik',
+        over: 'Boven {units}',
+        overUpTo: 'Boven {lowerBound}, tot {upperBound}',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pl.ts
+++ b/clients/packages/i18n/src/locales/pl.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'Podatki (w cenie)',
       basePrice: 'Cena bazowa',
+      upTo: 'do {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pl.ts
+++ b/clients/packages/i18n/src/locales/pl.ts
@@ -95,6 +95,14 @@ export default {
       inclTax: 'Podatki (w cenie)',
       basePrice: 'Cena bazowa',
       upTo: 'do {units}',
+      meteredUsage: 'Rozliczanie według zużycia',
+      tieredPricing: {
+        graduated: 'Cennik progresywny',
+        volume: 'Cennik wolumenowy',
+        allUsage: 'Całe zużycie',
+        over: 'Powyżej {units}',
+        overUpTo: 'Powyżej {lowerBound}, do {upperBound}',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pl.ts
+++ b/clients/packages/i18n/src/locales/pl.ts
@@ -94,14 +94,12 @@ export default {
       },
       inclTax: 'Podatki (w cenie)',
       basePrice: 'Cena bazowa',
-      upTo: 'do {units}',
       meteredUsage: 'Rozliczanie według zużycia',
       tieredPricing: {
-        graduated: 'Cennik progresywny',
-        volume: 'Cennik wolumenowy',
         allUsage: 'Całe zużycie',
         over: 'Powyżej {units}',
         overUpTo: 'Powyżej {lowerBound}, do {upperBound}',
+        upTo: 'Do {units}',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -95,6 +95,14 @@ export default {
       inclTax: 'IVA (incluído)',
       basePrice: 'Preço base',
       upTo: 'até {units}',
+      meteredUsage: 'Utilização medida',
+      tieredPricing: {
+        graduated: 'Preços graduais',
+        volume: 'Preços por volume',
+        allUsage: 'Toda a utilização',
+        over: 'Acima de {units}',
+        overUpTo: 'Acima de {lowerBound}, até {upperBound}',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -94,14 +94,12 @@ export default {
       },
       inclTax: 'IVA (incluído)',
       basePrice: 'Preço base',
-      upTo: 'até {units}',
       meteredUsage: 'Utilização medida',
       tieredPricing: {
-        graduated: 'Preços graduais',
-        volume: 'Preços por volume',
         allUsage: 'Toda a utilização',
         over: 'Acima de {units}',
         overUpTo: 'Acima de {lowerBound}, até {upperBound}',
+        upTo: 'Até {units}',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'IVA (incluído)',
       basePrice: 'Preço base',
+      upTo: 'até {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -95,6 +95,14 @@ export default {
       inclTax: 'Impostos (inclusos)',
       basePrice: 'Preço base',
       upTo: 'até {units}',
+      meteredUsage: 'Uso medido',
+      tieredPricing: {
+        graduated: 'Preço escalonado',
+        volume: 'Preço por volume',
+        allUsage: 'Todo o uso',
+        over: 'Acima de {units}',
+        overUpTo: 'Acima de {lowerBound}, até {upperBound}',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -94,14 +94,12 @@ export default {
       },
       inclTax: 'Impostos (inclusos)',
       basePrice: 'Preço base',
-      upTo: 'até {units}',
       meteredUsage: 'Uso medido',
       tieredPricing: {
-        graduated: 'Preço escalonado',
-        volume: 'Preço por volume',
         allUsage: 'Todo o uso',
         over: 'Acima de {units}',
         overUpTo: 'Acima de {lowerBound}, até {upperBound}',
+        upTo: 'Até {units}',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'Impostos (inclusos)',
       basePrice: 'Preço base',
+      upTo: 'até {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -95,6 +95,14 @@ export default {
       inclTax: 'Moms (ingår)',
       basePrice: 'Grundavgift',
       upTo: 'upp till {units}',
+      meteredUsage: 'Debitering efter användning',
+      tieredPricing: {
+        graduated: 'Stegvis prissättning',
+        volume: 'Volymprissättning',
+        allUsage: 'All användning',
+        over: 'Över {units}',
+        overUpTo: 'Över {lowerBound}, upp till {upperBound}',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -94,14 +94,12 @@ export default {
       },
       inclTax: 'Moms (ingår)',
       basePrice: 'Grundavgift',
-      upTo: 'upp till {units}',
       meteredUsage: 'Debitering efter användning',
       tieredPricing: {
-        graduated: 'Stegvis prissättning',
-        volume: 'Volymprissättning',
         allUsage: 'All användning',
         over: 'Över {units}',
         overUpTo: 'Över {lowerBound}, upp till {upperBound}',
+        upTo: 'Upp till {units}',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -94,6 +94,7 @@ export default {
       },
       inclTax: 'Moms (ingår)',
       basePrice: 'Grundavgift',
+      upTo: 'upp till {units}',
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/tr.ts
+++ b/clients/packages/i18n/src/locales/tr.ts
@@ -94,14 +94,12 @@ export default {
         updateFailed: 'Koltuklar güncellenemedi',
       },
       basePrice: 'Temel fiyat',
-      upTo: "{units}'e kadar",
       meteredUsage: 'Kullanıma göre ücretlendirme',
       tieredPricing: {
-        graduated: 'Kademeli fiyatlandırma',
-        volume: 'Hacim bazlı fiyatlandırma',
         allUsage: 'Tüm kullanım',
         over: '{units} üzeri',
         overUpTo: '{lowerBound} üzeri, {upperBound} kadar',
+        upTo: '{units} adede kadar',
       },
     },
     trial: {

--- a/clients/packages/i18n/src/locales/tr.ts
+++ b/clients/packages/i18n/src/locales/tr.ts
@@ -94,6 +94,7 @@ export default {
         updateFailed: 'Koltuklar güncellenemedi',
       },
       basePrice: 'Temel fiyat',
+      upTo: "{units}'e kadar",
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/tr.ts
+++ b/clients/packages/i18n/src/locales/tr.ts
@@ -95,6 +95,14 @@ export default {
       },
       basePrice: 'Temel fiyat',
       upTo: "{units}'e kadar",
+      meteredUsage: 'Kullanıma göre ücretlendirme',
+      tieredPricing: {
+        graduated: 'Kademeli fiyatlandırma',
+        volume: 'Hacim bazlı fiyatlandırma',
+        allUsage: 'Tüm kullanım',
+        over: '{units} üzeri',
+        overUpTo: '{lowerBound} üzeri, {upperBound} kadar',
+      },
     },
     trial: {
       hero: {


### PR DESCRIPTION
Adds checkout UI for metered Tiers. Including some unit tests and translations.

Not 100% happy with tiered style under the Additional Information and need some input on it. Maybe have it as uncollapse? All is behind a feature flag so this could be v1 and continued iterated on since trying to handover this.

| Screenshot |
|---|
| <img width="647" height="656" alt="Screenshot 2026-08-31 at 07 06 33" src="https://github.com/user-attachments/assets/8b52cceb-ab90-42cc-a46f-41af8db80205" /> |

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

