### PR TITLE
ci: Speed up tests

### DIFF
--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -238,6 +238,7 @@ jobs:
     env:
       POLAR_ENV: testing
       POLAR_EMAIL_RENDERER_BINARY_PATH: ${{ github.workspace }}/server/emails/bin/react-email-pkg
+      POLAR_TEST_DATABASE_TEMPLATE: polar_test
 
     services:
       postgres:

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -379,4 +379,11 @@ jobs:
 
       - name: 🐍 Run tests (pytest)
         working-directory: ./server
-        run: uv run pytest -n auto --dist=loadgroup --no-cov --durations=0
+        run: uv run pytest -n auto --dist=loadgroup --no-cov --durations=0 --store-durations
+
+      - name: 💾 Save test durations
+        if: github.event_name == 'push'
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: server/.test_durations
+          key: test-durations-${{ github.sha }}

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -307,11 +307,20 @@ jobs:
           POLICY_FILE: policy.json
         run: bash github.sh
 
+      - name: 📬 Restore emails renderer
+        id: emails
+        uses: actions/cache@v6.1.0
+        with:
+          path: server/emails/bin
+          key: emails-renderer-${{ runner.os }}-${{ hashFiles('server/emails/src/**', 'server/emails/package.json', 'server/emails/pnpm-lock.yaml', 'server/emails/tsup.config.js', 'server/emails/.node-version') }}
+
       - uses: pnpm/action-setup@v6.0.10
+        if: steps.emails.outputs.cache-hit != 'true'
         with:
           package_json_file: server/emails/package.json
 
       - name: 📬 Setup Node.js environment for server/emails
+        if: steps.emails.outputs.cache-hit != 'true'
         uses: actions/setup-node@v7.0.0
         with:
           node-version-file: server/emails/.node-version
@@ -319,6 +328,7 @@ jobs:
           cache-dependency-path: "clients/pnpm-lock.yaml"
 
       - name: 📬 Build server/emails
+        if: steps.emails.outputs.cache-hit != 'true'
         working-directory: server/emails
         run: pnpm install --frozen-lockfile && pnpm build
 

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -351,6 +351,13 @@ jobs:
       - name: 🐦 Install Tinybird CLI
         run: curl -sSL https://tinybird.co/install.sh | bash && echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: 🐦 Prepare Tinybird workspace
+        working-directory: ./server
+        run: |
+          token=$(uv run python -m scripts.tinybird_test_workspace)
+          echo "::add-mask::$token"
+          echo "POLAR_TEST_TINYBIRD_TOKEN=$token" >> "$GITHUB_ENV"
+
       - name: ⚗️ alembic migrate
         working-directory: ./server
         run: uv run task db_migrate

--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ playground.py
 
 .jwks.json
 *.mmdb
+.test_durations
 server/tests/invoice/test_invoice*.pdf
 supervisord.pid
 server/.minio/

--- a/server/polar/invoice/render.py
+++ b/server/polar/invoice/render.py
@@ -14,6 +14,7 @@ PASSTHROUGH_ENV_VARS = {
     "LANG",
     "LC_ALL",
     "LC_CTYPE",
+    "LD_LIBRARY_PATH",
     "PATH",
     "PYTHONHOME",
     "PYTHONPATH",

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -104,6 +104,7 @@ dev = [
   # * https://futuresearch.ai/blog/litellm-pypi-supply-chain-attack/
   # * https://pypi.org/project/litellm/
   # "litellm==1.82.3",
+  "pytest-split>=0.11.0",
 ]
 
 [tool.taskipy.tasks]

--- a/server/scripts/tinybird_test_workspace.py
+++ b/server/scripts/tinybird_test_workspace.py
@@ -2,6 +2,7 @@ import subprocess
 import time
 import uuid
 from pathlib import Path
+from typing import Any
 
 import httpx
 import typer
@@ -24,31 +25,47 @@ def get_tokens(host: str | None = None) -> dict[str, str] | None:
     return None
 
 
+def request(method: str, url: str, **kwargs: Any) -> httpx.Response:
+    """Tinybird answers /tokens before its API is up, so retry past gateway errors."""
+    for _ in range(60):
+        try:
+            response = httpx.request(method, url, **kwargs)
+        except httpx.RequestError:
+            time.sleep(1)
+            continue
+        if response.status_code >= 500:
+            time.sleep(1)
+            continue
+        response.raise_for_status()
+        return response
+    raise RuntimeError(f"Tinybird never served {url}")
+
+
 def create_workspace(host: str, tokens: dict[str, str]) -> tuple[str, str]:
     user_token = tokens["user_token"]
     admin_token = tokens["admin_token"]
     workspace_name = f"test_{uuid.uuid4().hex[:8]}"
 
-    organization_response = httpx.get(
+    organization_response = request(
+        "GET",
         f"{host}/v1/user/workspaces",
         params={"with_organization": "true", "token": admin_token},
     )
-    organization_response.raise_for_status()
     organization_id = organization_response.json()["organization_id"]
 
-    ws_response = httpx.post(
+    ws_response = request(
+        "POST",
         f"{host}/v1/workspaces",
         params={"name": workspace_name, "assign_to_organization_id": organization_id},
         headers={"Authorization": f"Bearer {user_token}"},
     )
-    ws_response.raise_for_status()
     workspace_id = ws_response.json()["id"]
 
-    workspaces_response = httpx.get(
+    workspaces_response = request(
+        "GET",
         f"{host}/v1/user/workspaces",
         params={"token": user_token},
     )
-    workspaces_response.raise_for_status()
     workspace_token = next(
         workspace["token"]
         for workspace in workspaces_response.json()["workspaces"]

--- a/server/scripts/tinybird_test_workspace.py
+++ b/server/scripts/tinybird_test_workspace.py
@@ -1,0 +1,136 @@
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import httpx
+import typer
+
+from polar.config import settings
+
+cli = typer.Typer()
+
+TINYBIRD_DIR = Path(__file__).resolve().parent.parent / "tinybird"
+
+
+def get_tokens(host: str | None = None) -> dict[str, str] | None:
+    host = host or settings.TINYBIRD_API_URL
+    try:
+        response = httpx.get(f"{host}/tokens", timeout=2)
+        if response.status_code == 200:
+            return response.json()
+    except httpx.RequestError:
+        pass
+    return None
+
+
+def create_workspace(host: str, tokens: dict[str, str]) -> tuple[str, str]:
+    user_token = tokens["user_token"]
+    admin_token = tokens["admin_token"]
+    workspace_name = f"test_{uuid.uuid4().hex[:8]}"
+
+    organization_response = httpx.get(
+        f"{host}/v1/user/workspaces",
+        params={"with_organization": "true", "token": admin_token},
+    )
+    organization_response.raise_for_status()
+    organization_id = organization_response.json()["organization_id"]
+
+    ws_response = httpx.post(
+        f"{host}/v1/workspaces",
+        params={"name": workspace_name, "assign_to_organization_id": organization_id},
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+    ws_response.raise_for_status()
+    workspace_id = ws_response.json()["id"]
+
+    workspaces_response = httpx.get(
+        f"{host}/v1/user/workspaces",
+        params={"token": user_token},
+    )
+    workspaces_response.raise_for_status()
+    workspace_token = next(
+        workspace["token"]
+        for workspace in workspaces_response.json()["workspaces"]
+        if workspace["id"] == workspace_id
+    )
+
+    return workspace_id, workspace_token
+
+
+def deploy_schema(host: str, workspace_token: str) -> None:
+    deploy_cmd = [
+        "tb",
+        "--cloud",
+        "--host",
+        host,
+        "--token",
+        workspace_token,
+        "deploy",
+        "--wait",
+    ]
+    for attempt in range(3):
+        result = subprocess.run(
+            deploy_cmd,
+            capture_output=True,
+            text=True,
+            cwd=TINYBIRD_DIR,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        if attempt < 2:
+            time.sleep(0.5)
+    raise RuntimeError(
+        "Tinybird deploy failed after 3 attempts.\n"
+        f"Command: {' '.join(result.args)}\n"
+        f"Exit code: {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def wait_for_ingestion(host: str, workspace_token: str) -> None:
+    for _ in range(30):
+        try:
+            r = httpx.post(
+                f"{host}/v0/events",
+                params={"name": "events_by_ingested_at", "wait": "true"},
+                content="",
+                headers={
+                    "Authorization": f"Bearer {workspace_token}",
+                    "Content-Type": "application/x-ndjson",
+                },
+                timeout=2,
+            )
+            if r.status_code != 403:
+                return
+        except httpx.RequestError:
+            pass
+        time.sleep(0.5)
+
+
+def delete_workspace(host: str, workspace_id: str, user_token: str) -> None:
+    httpx.delete(
+        f"{host}/v1/workspaces/{workspace_id}",
+        params={"hard_delete_confirmation": "yes"},
+        headers={"Authorization": f"Bearer {user_token}"},
+    )
+
+
+@cli.command()
+def main() -> None:
+    host = settings.TINYBIRD_API_URL
+    tokens = get_tokens(host)
+    if tokens is None:
+        raise typer.BadParameter(f"Tinybird is not reachable at {host}")
+
+    _, workspace_token = create_workspace(host, tokens)
+    deploy_schema(host, workspace_token)
+    wait_for_ingestion(host, workspace_token)
+
+    print(workspace_token)
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/fixtures/database.py
+++ b/server/tests/fixtures/database.py
@@ -1,5 +1,7 @@
 import asyncio
+import os
 import pathlib
+import time
 from collections.abc import AsyncIterator, Callable, Coroutine
 
 import pytest
@@ -8,6 +10,7 @@ from alembic import command
 from alembic.config import Config
 from pydantic_core import Url
 from pytest_mock import MockerFixture
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy_utils import create_database, database_exists, drop_database
 
@@ -29,6 +32,8 @@ def get_database_url(worker_id: str, driver: str = "asyncpg") -> str:
     )
 
 
+TEMPLATE_DATABASE = os.environ.get("POLAR_TEST_DATABASE_TEMPLATE")
+
 ALEMBIC_CONFIG_FILE = pathlib.Path(__file__).parent.parent.parent / "alembic.ini"
 
 
@@ -38,6 +43,18 @@ def apply_migrations(asyncpg_database_url: str) -> None:
     command.upgrade(alembic_cfg, "head")
 
 
+def clone_template_database(sync_database_url: str) -> None:
+    for _ in range(150):
+        try:
+            create_database(sync_database_url, template=TEMPLATE_DATABASE)
+            return
+        except SQLAlchemyError as e:
+            if "being accessed by other users" not in str(e):
+                raise
+            time.sleep(0.2)
+    raise RuntimeError(f"Template database {TEMPLATE_DATABASE} never became free")
+
+
 @pytest_asyncio.fixture(scope="session", loop_scope="session", autouse=True)
 async def initialize_test_database(worker_id: str) -> AsyncIterator[None]:
     sync_database_url = get_database_url(worker_id, "psycopg2")
@@ -45,8 +62,11 @@ async def initialize_test_database(worker_id: str) -> AsyncIterator[None]:
     if database_exists(sync_database_url):
         drop_database(sync_database_url)
 
-    create_database(sync_database_url)
-    await asyncio.to_thread(apply_migrations, get_database_url(worker_id))
+    if TEMPLATE_DATABASE:
+        await asyncio.to_thread(clone_template_database, sync_database_url)
+    else:
+        create_database(sync_database_url)
+        await asyncio.to_thread(apply_migrations, get_database_url(worker_id))
 
     yield
 

--- a/server/tests/fixtures/tinybird.py
+++ b/server/tests/fixtures/tinybird.py
@@ -1,8 +1,6 @@
-import subprocess
-import time
+import os
 import uuid
 from collections.abc import Generator
-from pathlib import Path
 from unittest.mock import patch
 
 import httpx
@@ -12,120 +10,41 @@ from polar.config import settings
 from polar.integrations.tinybird import service as tinybird_service
 from polar.integrations.tinybird.client import TinybirdClient
 from polar.metrics import queries_tinybird
+from scripts.tinybird_test_workspace import (
+    create_workspace,
+    delete_workspace,
+    deploy_schema,
+    get_tokens,
+    wait_for_ingestion,
+)
 
-TINYBIRD_DIR = Path(__file__).parent.parent.parent / "tinybird"
-
-
-def get_tinybird_tokens() -> dict[str, str] | None:
-    """Fetch tokens from local Tinybird instance."""
-    try:
-        response = httpx.get(f"{settings.TINYBIRD_API_URL}/tokens", timeout=2)
-        if response.status_code == 200:
-            return response.json()
-    except httpx.RequestError:
-        pass
-    return None
+TOKEN_ENV_VAR = "POLAR_TEST_TINYBIRD_TOKEN"
 
 
 def tinybird_available() -> bool:
-    """Check if local Tinybird is running and accessible."""
-    return get_tinybird_tokens() is not None
+    return bool(os.environ.get(TOKEN_ENV_VAR)) or get_tokens() is not None
 
 
 @pytest.fixture(scope="session")
 def tinybird_workspace() -> Generator[str]:
-    """Create an isolated Tinybird workspace, deploy schema, and yield token."""
-    tokens = get_tinybird_tokens()
+    """Yield a Tinybird workspace token, creating a throwaway workspace if needed."""
+    shared_token = os.environ.get(TOKEN_ENV_VAR)
+    if shared_token:
+        yield shared_token
+        return
+
+    host = settings.TINYBIRD_API_URL
+    tokens = get_tokens(host)
     if not tokens:
         pytest.skip("Tinybird not running")
 
-    user_token = tokens["user_token"]
-    admin_token = tokens["admin_token"]
-    host = settings.TINYBIRD_API_URL
-    workspace_name = f"test_{uuid.uuid4().hex[:8]}"
-
-    organization_response = httpx.get(
-        f"{host}/v1/user/workspaces",
-        params={"with_organization": "true", "token": admin_token},
-    )
-    organization_response.raise_for_status()
-    organization_id = organization_response.json()["organization_id"]
-
-    ws_response = httpx.post(
-        f"{host}/v1/workspaces",
-        params={"name": workspace_name, "assign_to_organization_id": organization_id},
-        headers={"Authorization": f"Bearer {user_token}"},
-    )
-    ws_response.raise_for_status()
-    workspace_id = ws_response.json()["id"]
-
-    workspaces_response = httpx.get(
-        f"{host}/v1/user/workspaces",
-        params={"token": user_token},
-    )
-    workspaces_response.raise_for_status()
-    workspace_token = next(
-        workspace["token"]
-        for workspace in workspaces_response.json()["workspaces"]
-        if workspace["id"] == workspace_id
-    )
-
-    deploy_cmd = [
-        "tb",
-        "--cloud",
-        "--host",
-        host,
-        "--token",
-        workspace_token,
-        "deploy",
-        "--wait",
-    ]
-    for attempt in range(3):
-        result = subprocess.run(
-            deploy_cmd,
-            capture_output=True,
-            text=True,
-            cwd=TINYBIRD_DIR,
-            check=False,
-        )
-        if result.returncode == 0:
-            break
-        if attempt < 2:
-            time.sleep(0.5)
-    else:
-        raise RuntimeError(
-            "Tinybird deploy failed after 3 attempts.\n"
-            f"Command: {' '.join(result.args)}\n"
-            f"Exit code: {result.returncode}\n"
-            f"stdout:\n{result.stdout}\n"
-            f"stderr:\n{result.stderr}"
-        )
-
-    for _ in range(30):
-        try:
-            r = httpx.post(
-                f"{host}/v0/events",
-                params={"name": "events_by_ingested_at", "wait": "true"},
-                content="",
-                headers={
-                    "Authorization": f"Bearer {workspace_token}",
-                    "Content-Type": "application/x-ndjson",
-                },
-                timeout=2,
-            )
-            if r.status_code != 403:
-                break
-        except httpx.RequestError:
-            pass
-        time.sleep(0.5)
+    workspace_id, workspace_token = create_workspace(host, tokens)
+    deploy_schema(host, workspace_token)
+    wait_for_ingestion(host, workspace_token)
 
     yield workspace_token
 
-    httpx.delete(
-        f"{host}/v1/workspaces/{workspace_id}",
-        params={"hard_delete_confirmation": "yes"},
-        headers={"Authorization": f"Bearer {user_token}"},
-    )
+    delete_workspace(host, workspace_id, tokens["user_token"])
 
 
 @pytest.fixture(scope="session")
@@ -163,7 +82,6 @@ def tinybird_client(
 
 
 __all__ = [
-    "get_tinybird_tokens",
     "tinybird_available",
     "tinybird_clickhouse_token",
     "tinybird_client",

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2690,6 +2690,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-recording" },
+    { name = "pytest-split" },
     { name = "pytest-subtests" },
     { name = "pytest-sugar" },
     { name = "pytest-xdist", extra = ["psutil"] },
@@ -2789,6 +2790,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-mock", specifier = ">=3.10.0" },
     { name = "pytest-recording", specifier = ">=0.13.1" },
+    { name = "pytest-split", specifier = ">=0.11.0" },
     { name = "pytest-subtests", specifier = ">=0.13.1" },
     { name = "pytest-sugar", specifier = ">=1.0.0" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.8.0" },
@@ -3231,6 +3233,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/9c/f4027c5f1693847b06d11caf4b4f6bb09f22c1581ada4663877ec166b8c6/pytest_recording-0.13.4.tar.gz", hash = "sha256:568d64b2a85992eec4ae0a419c855d5fd96782c5fb016784d86f18053792768c", size = 26576, upload-time = "2025-05-08T10:41:11.231Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/c2/ce34735972cc42d912173e79f200fe66530225190c06655c5632a9d88f1e/pytest_recording-0.13.4-py3-none-any.whl", hash = "sha256:ad49a434b51b1c4f78e85b1e6b74fdcc2a0a581ca16e52c798c6ace971f7f439", size = 13723, upload-time = "2025-05-08T10:41:09.684Z" },
+]
+
+[[package]]
+name = "pytest-split"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
These are Depot independent wins that are split out from #12014. To make the comparison more correct between Depot and Blacksmith.

- Share one tinybird workspace per run, to not have to waste time on Tinybird when we shard the tests
- Clone database from the template DB, this speeds up the creation and db parts
- Cache the emails renderer binary
- Split and shared the python tests to increase parallelism and reduce the wall clock time spent on test runs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

