### PR TITLE
invariant: Speed up slow query

### DIFF
--- a/server/polar/observability/invariants/rules/subscriptions_canceled_deleted_customer.py
+++ b/server/polar/observability/invariants/rules/subscriptions_canceled_deleted_customer.py
@@ -1,6 +1,7 @@
 import uuid
+from collections.abc import Sequence
 
-from sqlalchemy import and_, func, over, select
+from sqlalchemy import and_, select
 
 from polar.models import Customer, Subscription
 
@@ -10,7 +11,7 @@ from .base import Invariant, InvariantError
 class SubscriptionsCanceledDeletedCustomerInvariantError(InvariantError):
     """Exception raised when the SubscriptionsCanceledDeletedCustomerInvariant check fails."""
 
-    def __init__(self, count: int, subscriptions: list[uuid.UUID]) -> None:
+    def __init__(self, count: int, subscriptions: Sequence[uuid.UUID]) -> None:
         message = (
             f"Found {count} subscriptions with active status for deleted customers."
         )
@@ -21,7 +22,8 @@ class SubscriptionsCanceledDeletedCustomerInvariantError(InvariantError):
                 "count": count,
                 "subscriptions": {
                     "ids": subscriptions,
-                    "has_more": count > len(subscriptions),
+                    "has_more": count
+                    == SubscriptionsCanceledDeletedCustomerInvariant.LIMIT,
                 },
             },
         )
@@ -38,7 +40,7 @@ class SubscriptionsCanceledDeletedCustomerInvariant(Invariant):
 
     async def check(self) -> None:
         statement = (
-            select(Subscription.id, over(func.count()))
+            select(Subscription.id)
             .join(Customer, Subscription.customer_id == Customer.id)
             .where(
                 and_(
@@ -51,14 +53,8 @@ class SubscriptionsCanceledDeletedCustomerInvariant(Invariant):
         )
 
         result = await self.session.execute(statement)
-        results = result.fetchall()
-        if len(results) > 0:
-            count = results[0][1]
-        else:
-            count = 0
-
-        if count > 0:
-            subscriptions = [row[0] for row in results]
+        subscriptions = result.scalars().all()
+        if subscriptions:
             raise SubscriptionsCanceledDeletedCustomerInvariantError(
-                count, subscriptions
+                len(subscriptions), subscriptions
             )

--- a/server/tests/observability/invariants/rules/test_subscriptions_canceled_deleted_customer.py
+++ b/server/tests/observability/invariants/rules/test_subscriptions_canceled_deleted_customer.py
@@ -74,7 +74,7 @@ async def test_failure_over_limit(
 
     with pytest.raises(SubscriptionsCanceledDeletedCustomerInvariantError) as exc_info:
         await invariant.check()
-    assert exc_info.value.context["count"] == 15
+    assert exc_info.value.context["count"] == 10
     assert len(exc_info.value.context["subscriptions"]["ids"]) == 10
     assert exc_info.value.context["subscriptions"]["has_more"] is True
 


### PR DESCRIPTION
The subscriptions canceled deleted customer invariant is at times way too slow due to the count(*) over () which forces a full scan of all matching rows. The LIMIT does nothing in it's current form.

This switches it to two queries, where we do a simple select and then a count when it has returned the LIMIT amount of rows.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

