### PR TITLE
invariant: Speed up slow subquery

### DIFF
--- a/server/polar/observability/invariants/rules/payout_transactions_amount_invariant.py
+++ b/server/polar/observability/invariants/rules/payout_transactions_amount_invariant.py
@@ -48,18 +48,28 @@ class PayoutTransactionsAmountInvariant(Invariant):
     AGE_LIMIT = timedelta(days=30)
 
     async def check(self) -> None:
+        # Reversals are created after their payout, so AGE_LIMIT covers them too
+        reversed_payout_ids = (
+            (
+                await self.session.execute(
+                    select(Transaction.payout_id).where(
+                        Transaction.created_at > (func.now() - self.AGE_LIMIT),
+                        Transaction.type == TransactionType.payout_reversal,
+                        Transaction.payout_id.isnot(None),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
         # Recent payout transactions without reversal (same payout_id)
         recent_payouts = (
             select(Transaction.id, Transaction.amount)
             .where(
                 Transaction.created_at > (func.now() - self.AGE_LIMIT),
                 Transaction.type == TransactionType.payout,
-                ~Transaction.payout_id.in_(
-                    select(Transaction.payout_id).where(
-                        Transaction.type == TransactionType.payout_reversal,
-                        Transaction.payout_id.isnot(None),
-                    )
-                ),
+                Transaction.payout_id.not_in(reversed_payout_ids),
             )
             .cte("recent_payouts")
         )


### PR DESCRIPTION
Postgres doesn't plan NOT IN queries as an anti-join, which makes us do a plan against the ful transactions table.

This splits the query up into two parts, one that fetches reversal payout IDs, and then one that does an IN query of those IDs.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

