### PR TITLE
Cut over to only read encrypted OauthAccount access and refresh tokens

### DIFF
--- a/server/polar/models/user.py
+++ b/server/polar/models/user.py
@@ -113,19 +113,19 @@ class OAuthAccount(RecordModel):
     def should_refresh_access_token(self, unless_ttl_gt: int = 60 * 30) -> bool:
         return bool(
             self.expires_at
-            and self.refresh_token
+            and self.refresh_token_encrypted
             and self.expires_at <= time.time() + unless_ttl_gt
         )
 
     async def get_access_token(self) -> str:
-        if self.access_token_encrypted is not None:
-            return await self.access_token_encrypted.decrypt(id=str(self.id))
-        return self.access_token
+        if self.access_token_encrypted is None:
+            raise ValueError("access_token_encrypted is required")
+        return await self.access_token_encrypted.decrypt(id=str(self.id))
 
     async def get_refresh_token(self) -> str | None:
-        if self.refresh_token_encrypted is not None:
-            return await self.refresh_token_encrypted.decrypt(id=str(self.id))
-        return self.refresh_token
+        if self.refresh_token_encrypted is None:
+            return None
+        return await self.refresh_token_encrypted.decrypt(id=str(self.id))
 
     async def to_dataclass(self, scope: list[str]) -> OAuth2EnrollmentDataclass:
         return OAuth2EnrollmentDataclass(

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -236,12 +236,12 @@ async def create_oauth_account(
 ) -> OAuthAccount:
     oauth_account = OAuthAccount(
         platform=platform,
-        access_token="xxyyzz",
         account_id="xxyyzz",
         account_email="foo@bar.com",
         account_username=rstr("gh_username"),
         user=user,
     )
+    await oauth_account.set_tokens(access_token="xxyyzz", refresh_token=None)
     await save_fixture(oauth_account)
     return oauth_account
 
@@ -252,12 +252,12 @@ async def create_user_github_oauth(
 ) -> OAuthAccount:
     oauth_account = OAuthAccount(
         platform=OAuthPlatform.github,
-        access_token="xxyyzz",
         account_id="xxyyzz",
         account_email="foo@bar.com",
         account_username=rstr("gh_username"),
         user=user,
     )
+    await oauth_account.set_tokens(access_token="xxyyzz", refresh_token=None)
     await save_fixture(oauth_account)
     return oauth_account
 

--- a/server/tests/models/test_oauth_account.py
+++ b/server/tests/models/test_oauth_account.py
@@ -104,7 +104,7 @@ class TestEncryptClassmethods:
 
 @pytest.mark.asyncio
 class TestGetTokens:
-    async def test_prefers_encrypted(self, user: User) -> None:
+    async def test_decrypts_encrypted(self, user: User) -> None:
         oauth_account = await _build(user)
         await oauth_account.set_tokens(
             access_token="the-access-token", refresh_token="the-refresh-token"
@@ -113,20 +113,19 @@ class TestGetTokens:
         assert await oauth_account.get_access_token() == "the-access-token"
         assert await oauth_account.get_refresh_token() == "the-refresh-token"
 
-    async def test_falls_back_to_plain(self, user: User) -> None:
+    async def test_access_token_requires_encrypted(self, user: User) -> None:
         oauth_account = await _build(user)
         oauth_account.id = OAuthAccount.generate_id()
         oauth_account.access_token = "the-access-token"
-        oauth_account.refresh_token = "the-refresh-token"
 
-        assert await oauth_account.get_access_token() == "the-access-token"
-        assert await oauth_account.get_refresh_token() == "the-refresh-token"
+        with pytest.raises(ValueError, match="access_token_encrypted is required"):
+            await oauth_account.get_access_token()
 
     async def test_refresh_token_none_without_encrypted(self, user: User) -> None:
         oauth_account = await _build(user)
         oauth_account.id = OAuthAccount.generate_id()
         oauth_account.access_token = "the-access-token"
-        oauth_account.refresh_token = None
+        oauth_account.refresh_token = "the-refresh-token"
 
         assert await oauth_account.get_refresh_token() is None
 


### PR DESCRIPTION
## Summary

Switch to only reading _encrypted_ `OauthAccount` access and refresh tokens.

## What

Stop falling back to unencrypted `OauthAccount` access and refresh tokens, they're all backfilled.

## Why

Next step in the [Secrets Encryption migration plan](https://github.com/polarsource/polar/blob/main/handbook/engineering/design-documents/secrets-encryption.mdx#appendix-c-migration-plan). Existing access and refresh tokens have already been backfilled.

## How

-

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

