### PR TITLE
Exclude canceled payouts from withdraw modal cooldown

### DIFF
--- a/clients/apps/web/src/components/Payouts/WithdrawModal.tsx
+++ b/clients/apps/web/src/components/Payouts/WithdrawModal.tsx
@@ -14,6 +14,14 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { DetailRow } from '../Shared/DetailRow'
 import { toast } from '../Toast/use-toast'
 
+const COOLDOWN_PAYOUT_STATUSES: schemas['PayoutStatus'][] = [
+  'pending',
+  'in_transit',
+  'succeeded',
+  'failed',
+  'held',
+]
+
 interface WithdrawModalProps {
   organization: schemas['Organization']
   account: schemas['Account']
@@ -44,6 +52,7 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
     {
       limit: 1,
       sorting: ['-created_at'],
+      status: COOLDOWN_PAYOUT_STATUSES,
     },
   )
 


### PR DESCRIPTION
The withdraw modal computed the payout interval cooldown from the latest payout regardless of status, while the backend excludes canceled payouts from the check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

