### PR TITLE
feat(customer-portal): let customers update subscription units

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
@@ -30,6 +30,7 @@ import CustomerCancellationModal from './CustomerCancellationModal'
 import CustomerPauseSubscriptionModal from './CustomerPauseSubscriptionModal'
 import { SubscriptionStatusLabel } from '../Subscriptions/utils'
 import { CustomerPortalGrants } from './CustomerPortalGrants'
+import { CustomerUnitQuantityManager } from './CustomerUnitQuantityManager'
 import { SeatManagementTable } from './SeatManagementTable'
 
 const CustomerPortalSubscription = ({
@@ -91,6 +92,11 @@ const CustomerPortalSubscription = ({
   // Seats management
   const hasSeatBasedPricing = subscription.prices.some(
     (price) => price.amount_type === 'seat_based',
+  )
+
+  const unitPrice = subscription.prices.find(
+    (price): price is schemas['ProductPriceUnitBased'] =>
+      price.amount_type === 'unit_based',
   )
 
   // Check customer portal settings for seat management visibility
@@ -269,6 +275,12 @@ const CustomerPortalSubscription = ({
                 value={`${subscription.seats} -> ${pendingUpdate.seats}`}
               />
             )}
+            {pendingUpdate.units !== null && (
+              <DetailRow
+                label="Units"
+                value={`${subscription.units} -> ${pendingUpdate.units}`}
+              />
+            )}
             <DetailRow
               label="Update in effect from"
               value={
@@ -340,6 +352,21 @@ const CustomerPortalSubscription = ({
             subscription.product.organization.proration_behavior
           }
         />
+      )}
+
+      {unitPrice && canManageBilling && !isCancelled && (
+        <div className="flex flex-col gap-y-2">
+          <h3 className="text-lg">Units</h3>
+          <CustomerUnitQuantityManager
+            api={api}
+            subscription={subscription}
+            unitPrice={unitPrice}
+            prorationBehavior={
+              subscription.product.organization.proration_behavior
+            }
+            onUpdate={() => router.refresh()}
+          />
+        </div>
       )}
 
       <CustomerPortalGrants api={api} subscriptionId={subscription.id} />

--- a/clients/apps/web/src/components/CustomerPortal/CustomerUnitQuantityManager.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerUnitQuantityManager.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import { useCustomerUpdateSubscription } from '@/hooks/queries/customerPortal'
+import { setValidationErrors } from '@/utils/api/errors'
+import { getUnitLabels } from '@/utils/product'
+import { Client, isValidationError, schemas } from '@polar-sh/client'
+import { Button, Input } from '@polar-sh/orbit'
+import { MinusIcon, PlusIcon } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { toast } from '../Toast/use-toast'
+
+interface CustomerUnitQuantityManagerProps {
+  api: Client
+  subscription: schemas['CustomerSubscription']
+  unitPrice: schemas['ProductPriceUnitBased']
+  prorationBehavior?: schemas['CustomerOrganization']['proration_behavior']
+  onUpdate?: () => void
+}
+
+const getUnitBounds = (
+  unitPrice: schemas['ProductPriceUnitBased'],
+): { min: number; max: number | null } => {
+  const min = Math.max(1, unitPrice.minimum_units ?? 0)
+  if (unitPrice.maximum_units != null) {
+    return { min, max: unitPrice.maximum_units }
+  }
+  const lastBound = unitPrice.tiers.tiers.at(-1)?.bound ?? null
+  return { min, max: lastBound }
+}
+
+export const CustomerUnitQuantityManager = ({
+  api,
+  subscription,
+  unitPrice,
+  prorationBehavior,
+  onUpdate,
+}: CustomerUnitQuantityManagerProps) => {
+  const updateSubscription = useCustomerUpdateSubscription(api)
+
+  const currentUnits = subscription.units ?? 1
+  const { min, max } = useMemo(() => getUnitBounds(unitPrice), [unitPrice])
+  const { unitLabel, unitLabelPlural } = getUnitLabels(unitPrice)
+
+  const { handleSubmit, watch, setValue, setError } = useForm<{
+    units: number
+  }>({
+    values: {
+      units: currentUnits,
+    },
+  })
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const units = watch('units')
+  const canDecrease = units > min
+  const canIncrease = max == null || units < max
+  const hasChanges = units !== currentUnits
+
+  const [draft, setDraft] = useState(String(currentUnits))
+
+  const setUnits = (value: number) => {
+    setValue('units', value, { shouldValidate: true })
+    setDraft(String(value))
+  }
+
+  const invoicingMessage = useMemo(() => {
+    if (!prorationBehavior) return null
+    switch (prorationBehavior) {
+      case 'invoice':
+        return "I'll be charged immediately with a proration for the current month."
+      case 'prorate':
+        return 'Your next invoice will include the updated units plus the proration for the current month.'
+      case 'next_period':
+        return 'The unit update will be applied on your next billing cycle.'
+    }
+  }, [prorationBehavior])
+
+  const onSubmit = useCallback(
+    async (data: { units: number }) => {
+      try {
+        const result = await updateSubscription.mutateAsync({
+          id: subscription.id,
+          body: {
+            units: data.units,
+          },
+        })
+
+        if (result.error) {
+          const errorMessage =
+            typeof result.error.detail === 'string'
+              ? result.error.detail
+              : 'Failed to update units'
+          toast({
+            title: 'Error updating units',
+            description: errorMessage,
+            variant: 'error',
+          })
+        } else {
+          const noun = data.units === 1 ? unitLabel : unitLabelPlural
+          const description = `Subscription now has ${data.units} ${noun}.`
+          toast({
+            title: 'Units updated',
+            description,
+          })
+          onUpdate?.()
+        }
+      } catch (error) {
+        if (isValidationError(error)) {
+          setValidationErrors(error, setError)
+        } else {
+          toast({
+            title: 'Error updating units',
+            description:
+              error instanceof Error
+                ? error.message
+                : 'An unexpected error occurred',
+            variant: 'error',
+          })
+        }
+      }
+    },
+    [
+      updateSubscription,
+      subscription.id,
+      unitLabel,
+      unitLabelPlural,
+      onUpdate,
+      setError,
+    ],
+  )
+
+  const handleIncrement = () => {
+    if (canIncrease) {
+      setUnits(units + 1)
+    }
+  }
+
+  const handleDecrement = () => {
+    if (canDecrease) {
+      setUnits(units - 1)
+    }
+  }
+
+  const clampUnits = (value: number): number => {
+    const floored = Math.max(min, Math.floor(value))
+    return max != null ? Math.min(max, floored) : floored
+  }
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = event.target.value
+    if (!/^\d*$/.test(raw)) {
+      return
+    }
+    setDraft(raw)
+    if (raw !== '') {
+      setValue('units', Number.parseInt(raw, 10), { shouldValidate: true })
+    }
+  }
+
+  const handleInputBlur = () => {
+    const parsed = draft === '' ? min : Number.parseInt(draft, 10)
+    setUnits(clampUnits(parsed))
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="rounded-2xl border p-4">
+      <div className="flex flex-col gap-2 text-sm">
+        <div className="flex items-center justify-between">
+          <div>
+            <span className="font-medium">
+              {units === 1
+                ? unitLabel.charAt(0).toUpperCase() + unitLabel.slice(1)
+                : unitLabelPlural.charAt(0).toUpperCase() +
+                  unitLabelPlural.slice(1)}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              type="button"
+              variant="secondary"
+              size="icon"
+              onClick={handleDecrement}
+              disabled={!canDecrease || updateSubscription.isPending}
+            >
+              <MinusIcon className="h-4 w-4" />
+            </Button>
+
+            <Input
+              type="text"
+              inputMode="numeric"
+              value={draft}
+              onChange={handleInputChange}
+              onBlur={handleInputBlur}
+              disabled={updateSubscription.isPending}
+              className="w-20 text-center font-medium"
+            />
+
+            <Button
+              type="button"
+              variant="secondary"
+              size="icon"
+              onClick={handleIncrement}
+              disabled={!canIncrease || updateSubscription.isPending}
+            >
+              <PlusIcon className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {hasChanges && (
+        <div className="mt-4 flex flex-col gap-3">
+          {invoicingMessage && (
+            <span className="dark:text-polar-500 text-sm text-gray-500">
+              {invoicingMessage}
+            </span>
+          )}
+          <div className="flex flex-row-reverse gap-3">
+            <Button
+              loading={updateSubscription.isPending}
+              onClick={handleSubmit(onSubmit)}
+              className="w-full"
+            >
+              Update units
+            </Button>
+          </div>
+        </div>
+      )}
+    </form>
+  )
+}

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -19577,6 +19577,7 @@ export interface components {
     CustomerSubscriptionChangePreview:
       | components['schemas']['CustomerSubscriptionChangePreviewProduct']
       | components['schemas']['CustomerSubscriptionChangePreviewSeats']
+      | components['schemas']['CustomerSubscriptionChangePreviewUnits']
     /** CustomerSubscriptionChangePreviewProduct */
     CustomerSubscriptionChangePreviewProduct: {
       /**
@@ -19593,6 +19594,14 @@ export interface components {
        * @description Preview a change of the subscription to this number of seats.
        */
       seats: number
+    }
+    /** CustomerSubscriptionChangePreviewUnits */
+    CustomerSubscriptionChangePreviewUnits: {
+      /**
+       * Units
+       * @description Preview a change of the subscription to this number of units.
+       */
+      units: number
     }
     /** CustomerSubscriptionMeter */
     CustomerSubscriptionMeter: {
@@ -19808,6 +19817,7 @@ export interface components {
     CustomerSubscriptionUpdate:
       | components['schemas']['CustomerSubscriptionUpdateProduct']
       | components['schemas']['CustomerSubscriptionUpdateSeats']
+      | components['schemas']['CustomerSubscriptionUpdateUnits']
       | components['schemas']['CustomerSubscriptionCancel']
       | components['schemas']['CustomerSubscriptionPause']
       | components['schemas']['CustomerSubscriptionResume']
@@ -19836,6 +19846,14 @@ export interface components {
        * @description Update the number of seats for this subscription.
        */
       seats: number
+    }
+    /** CustomerSubscriptionUpdateUnits */
+    CustomerSubscriptionUpdateUnits: {
+      /**
+       * Units
+       * @description Update the number of units for this subscription.
+       */
+      units: number
     }
     /**
      * CustomerTeam
@@ -37055,6 +37073,17 @@ export interface components {
       /** Detail */
       detail: string
     }
+    /** UpdateSubscriptionUnitsNotAllowed */
+    UpdateSubscriptionUnitsNotAllowed: {
+      /**
+       * Error
+       * @example UpdateSubscriptionUnitsNotAllowed
+       * @constant
+       */
+      error: 'UpdateSubscriptionUnitsNotAllowed'
+      /** Detail */
+      detail: string
+    }
     /**
      * UserDeletionBlockedReason
      * @description Reasons why a user account cannot be immediately deleted.
@@ -53679,6 +53708,8 @@ export interface operations {
           'application/json':
             | components['schemas']['AlreadyCanceledSubscription']
             | components['schemas']['PauseResumeNotAllowed']
+            | components['schemas']['UpdateSubscriptionSeatsNotAllowed']
+            | components['schemas']['UpdateSubscriptionUnitsNotAllowed']
         }
       }
       /** @description Customer subscription was not found. */
@@ -53827,6 +53858,7 @@ export interface operations {
             | components['schemas']['AlreadyCanceledSubscription']
             | components['schemas']['UpdateSubscriptionPlanNotAllowed']
             | components['schemas']['UpdateSubscriptionSeatsNotAllowed']
+            | components['schemas']['UpdateSubscriptionUnitsNotAllowed']
         }
       }
       /** @description Customer subscription was not found. */

--- a/server/polar/customer_portal/endpoints/subscription.py
+++ b/server/polar/customer_portal/endpoints/subscription.py
@@ -36,6 +36,7 @@ from ..service.subscription import (
     RevokeNotAllowed,
     UpdateSubscriptionPlanNotAllowed,
     UpdateSubscriptionSeatsNotAllowed,
+    UpdateSubscriptionUnitsNotAllowed,
 )
 from ..service.subscription import (
     customer_subscription as customer_subscription_service,
@@ -185,7 +186,8 @@ async def get_cancel_preview(
             "description": "Previewing this change is not allowed.",
             "model": AlreadyCanceledSubscription.schema()
             | UpdateSubscriptionPlanNotAllowed.schema()
-            | UpdateSubscriptionSeatsNotAllowed.schema(),
+            | UpdateSubscriptionSeatsNotAllowed.schema()
+            | UpdateSubscriptionUnitsNotAllowed.schema(),
         },
         404: SubscriptionNotFound,
     },
@@ -228,7 +230,9 @@ async def preview_change(
                 "or pausing/resuming is not enabled for the organization."
             ),
             "model": AlreadyCanceledSubscription.schema()
-            | PauseResumeNotAllowed.schema(),
+            | PauseResumeNotAllowed.schema()
+            | UpdateSubscriptionSeatsNotAllowed.schema()
+            | UpdateSubscriptionUnitsNotAllowed.schema(),
         },
         404: SubscriptionNotFound,
         409: {

--- a/server/polar/customer_portal/schemas/subscription.py
+++ b/server/polar/customer_portal/schemas/subscription.py
@@ -102,6 +102,15 @@ class CustomerSubscriptionUpdateSeats(Schema):
     )
 
 
+class CustomerSubscriptionUpdateUnits(Schema):
+    model_config = ConfigDict(extra="forbid")
+
+    units: Int32 = Field(
+        description="Update the number of units for this subscription.",
+        ge=1,
+    )
+
+
 class CustomerSubscriptionChangePreviewProduct(Schema):
     model_config = ConfigDict(extra="forbid")
 
@@ -119,8 +128,19 @@ class CustomerSubscriptionChangePreviewSeats(Schema):
     )
 
 
+class CustomerSubscriptionChangePreviewUnits(Schema):
+    model_config = ConfigDict(extra="forbid")
+
+    units: Int32 = Field(
+        description="Preview a change of the subscription to this number of units.",
+        ge=1,
+    )
+
+
 CustomerSubscriptionChangePreview = Annotated[
-    CustomerSubscriptionChangePreviewProduct | CustomerSubscriptionChangePreviewSeats,
+    CustomerSubscriptionChangePreviewProduct
+    | CustomerSubscriptionChangePreviewSeats
+    | CustomerSubscriptionChangePreviewUnits,
     SetSchemaReference("CustomerSubscriptionChangePreview"),
 ]
 
@@ -213,6 +233,7 @@ class CustomerSubscriptionUpdateClear(Schema):
 CustomerSubscriptionUpdate = Annotated[
     CustomerSubscriptionUpdateProduct
     | CustomerSubscriptionUpdateSeats
+    | CustomerSubscriptionUpdateUnits
     | CustomerSubscriptionCancel
     | CustomerSubscriptionPause
     | CustomerSubscriptionResume

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -31,12 +31,14 @@ from polar.subscription.service import subscription as subscription_service
 from ..schemas.subscription import (
     CustomerSubscriptionChangePreview,
     CustomerSubscriptionChangePreviewSeats,
+    CustomerSubscriptionChangePreviewUnits,
     CustomerSubscriptionPause,
     CustomerSubscriptionResume,
     CustomerSubscriptionUpdate,
     CustomerSubscriptionUpdateClear,
     CustomerSubscriptionUpdateProduct,
     CustomerSubscriptionUpdateSeats,
+    CustomerSubscriptionUpdateUnits,
 )
 from ..utils import get_customer_id
 
@@ -52,6 +54,11 @@ class UpdateSubscriptionPlanNotAllowed(CustomerSubscriptionError):
 class UpdateSubscriptionSeatsNotAllowed(CustomerSubscriptionError):
     def __init__(self) -> None:
         super().__init__("Updating subscription seats is not allowed.", 403)
+
+
+class UpdateSubscriptionUnitsNotAllowed(CustomerSubscriptionError):
+    def __init__(self) -> None:
+        super().__init__("Updating subscription units is not allowed.", 403)
 
 
 class PauseResumeNotAllowed(CustomerSubscriptionError):
@@ -206,6 +213,20 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
                     seats=updates.seats,
                 )
 
+        if isinstance(updates, CustomerSubscriptionUpdateUnits):
+            if not organization.is_unit_based_pricing_enabled:
+                raise UpdateSubscriptionUnitsNotAllowed()
+
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                return await subscription_service.update_units(
+                    session,
+                    ctx,
+                    subscription,
+                    units=updates.units,
+                )
+
         if isinstance(updates, CustomerSubscriptionUpdateClear):
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
@@ -265,6 +286,15 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
                 session,
                 subscription,
                 seats=change.seats,
+            )
+
+        if isinstance(change, CustomerSubscriptionChangePreviewUnits):
+            if not organization.is_unit_based_pricing_enabled:
+                raise UpdateSubscriptionUnitsNotAllowed()
+            return await subscription_service.calculate_change_preview(
+                session,
+                subscription,
+                units=change.units,
             )
 
         if not organization.customer_portal_subscription_update_plan:

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -720,6 +720,10 @@ class Organization(RateLimitGroupMixin, RecordModel):
         return self.feature_settings.get("compass_enabled", False)
 
     @property
+    def is_unit_based_pricing_enabled(self) -> bool:
+        return self.feature_settings.get("unit_based_pricing_enabled", False)
+
+    @property
     def is_merchant_migration_enabled(self) -> bool:
         return self.feature_settings.get("merchant_migration_enabled", False)
 

--- a/server/tests/customer_portal/service/test_subscription.py
+++ b/server/tests/customer_portal/service/test_subscription.py
@@ -11,12 +11,14 @@ from polar.customer_portal.schemas.subscription import (
     CustomerSubscriptionUpdateClear,
     CustomerSubscriptionUpdateProduct,
     CustomerSubscriptionUpdateSeats,
+    CustomerSubscriptionUpdateUnits,
 )
 from polar.customer_portal.service.subscription import (
     PauseResumeNotAllowed,
     PaymentMethodRequired,
     UpdateSubscriptionPlanNotAllowed,
     UpdateSubscriptionSeatsNotAllowed,
+    UpdateSubscriptionUnitsNotAllowed,
 )
 from polar.customer_portal.service.subscription import (
     customer_subscription as customer_subscription_service,
@@ -41,7 +43,9 @@ from tests.fixtures.random_objects import (
     create_active_subscription,
     create_payment_method,
     create_product,
+    create_product_unit_based,
     create_subscription,
+    create_subscription_with_units,
 )
 
 
@@ -347,6 +351,30 @@ class TestUpdate:
         assert (
             updated_subscription.recurring_interval == product_second.recurring_interval
         )
+
+
+@pytest.mark.asyncio
+class TestUpdateUnits:
+    async def test_update_not_allowed_without_feature_flag(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        product = await create_product_unit_based(
+            save_fixture, organization=organization, price_per_unit=1000
+        )
+        subscription = await create_subscription_with_units(
+            save_fixture, product=product, customer=customer, units=3
+        )
+
+        with pytest.raises(UpdateSubscriptionUnitsNotAllowed):
+            await customer_subscription_service.update(
+                session,
+                subscription,
+                updates=CustomerSubscriptionUpdateUnits(units=5),
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The customers who has made a subscription with Unit Based pricing needs a way to manage their bought units. This PR adds customer portal increment / decrement controls for unit based pricing. Gated behind feature flag. 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

