### PR TITLE
feat(portal): require approval for reset proration on same-interval

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
@@ -10,7 +10,6 @@ import { formatTrialEnd, useTrialChangeOutcome } from '@/utils/trial-change'
 import { Client, schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import { List, ListItem } from '@polar-sh/orbit'
-import { Checkbox } from '@polar-sh/orbit'
 import { useRouter } from 'next/navigation'
 import { useCallback, useMemo, useState } from 'react'
 import { resolveBenefitIcon } from '../Benefit/utils'
@@ -152,21 +151,21 @@ const CustomerChangePlanModal = ({
         selectedProduct.recurring_interval === 'month' ? 'monthly' : 'yearly'
 
       if (nextInvoiceType === 'charge') {
-        return `I'll be charged immediately for the new ${newPeriod} plan.`
+        return `You'll be charged immediately for the new ${newPeriod} plan.`
       } else {
-        return `My previous payment will appear as a credit on my next invoice.`
+        return `Your previous payment will appear as a credit on your next invoice.`
       }
     }
 
     switch (prorationBehavior) {
       case 'invoice':
-        return "I'll be charged immediately, with a proration for the current period."
+        return "You'll be charged immediately, with a proration for the current period."
       case 'prorate':
         return 'Your next invoice will include the new plan plus the proration for the current period.'
       case 'next_period':
         return 'The new plan will be applied on your next billing cycle.'
       case 'reset':
-        return "I'll be charged the full amount for the new plan immediately, and my billing period restarts today."
+        return "You'll be charged the full amount for the new plan immediately, and your billing period restarts today."
     }
   }, [
     selectedProduct,
@@ -176,32 +175,17 @@ const CustomerChangePlanModal = ({
     trialOutcome,
   ])
 
-  const willIssueInvoice =
-    trialOutcome?.kind === 'ends' ||
-    willTriggerImmediateCycle ||
-    (!isTrialing &&
-      (prorationBehavior === 'invoice' || prorationBehavior === 'reset'))
-  const [approveImmediateInvoice, setApproveImmediateInvoice] = useState(false)
-
   const canChangePlan = useMemo(() => {
     if (!selectedProduct) return false
     const isSamePlan = selectedProduct?.id === subscription.product_id
     if (isSamePlan) return false
-
-    if (willIssueInvoice && !approveImmediateInvoice) return false
 
     const selectedPlanIsFree = selectedProduct?.prices.some(isFreePrice)
 
     if (selectedPlanIsFree) return true
 
     return hasPaymentMethod
-  }, [
-    hasPaymentMethod,
-    selectedProduct,
-    subscription,
-    willIssueInvoice,
-    approveImmediateInvoice,
-  ])
+  }, [hasPaymentMethod, selectedProduct, subscription])
 
   const updateSubscription = useCustomerUpdateSubscription(api)
   const onConfirm = useCallback(async () => {
@@ -321,22 +305,9 @@ const CustomerChangePlanModal = ({
             </div>
           )}
           {invoicingMessage && (
-            <label className="flex flex-row items-start gap-x-2">
-              {willIssueInvoice && (
-                <div>
-                  <Checkbox
-                    checked={approveImmediateInvoice}
-                    onCheckedChange={(checked) =>
-                      setApproveImmediateInvoice(checked === true)
-                    }
-                  />
-                </div>
-              )}
-
-              <span className="dark:text-polar-500 text-sm text-pretty text-gray-500">
-                {invoicingMessage}
-              </span>
-            </label>
+            <span className="dark:text-polar-500 text-sm text-pretty text-gray-500">
+              {invoicingMessage}
+            </span>
           )}
         </div>
         {needToAddPaymentMethod && (

--- a/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
@@ -135,7 +135,7 @@ const CustomerChangePlanModal = ({
     return [willTrigger, chargeOrCredit]
   }, [selectedProduct, prorationBehavior, subscription, isTrialing])
 
-  const invoicingMessage = useMemo(() => {
+  const invoicingMessage = useMemo((): string | null => {
     if (!selectedProduct) return null
 
     if (trialOutcome?.kind === 'continues') {

--- a/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
@@ -160,11 +160,13 @@ const CustomerChangePlanModal = ({
 
     switch (prorationBehavior) {
       case 'invoice':
-        return "I'll be charged immediately with a proration for the current month."
+        return "I'll be charged immediately, with a proration for the current period."
       case 'prorate':
-        return 'Your next invoice will include the new plan plus the proration for the current month.'
+        return 'Your next invoice will include the new plan plus the proration for the current period.'
       case 'next_period':
         return 'The new plan will be applied on your next billing cycle.'
+      case 'reset':
+        return "I'll be charged the full amount for the new plan immediately, and my billing period restarts today."
     }
   }, [
     selectedProduct,
@@ -177,7 +179,8 @@ const CustomerChangePlanModal = ({
   const willIssueInvoice =
     trialOutcome?.kind === 'ends' ||
     willTriggerImmediateCycle ||
-    prorationBehavior === 'invoice'
+    prorationBehavior === 'invoice' ||
+    prorationBehavior === 'reset'
   const [approveImmediateInvoice, setApproveImmediateInvoice] = useState(false)
 
   const canChangePlan = useMemo(() => {

--- a/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerChangePlanModal.tsx
@@ -179,8 +179,8 @@ const CustomerChangePlanModal = ({
   const willIssueInvoice =
     trialOutcome?.kind === 'ends' ||
     willTriggerImmediateCycle ||
-    prorationBehavior === 'invoice' ||
-    prorationBehavior === 'reset'
+    (!isTrialing &&
+      (prorationBehavior === 'invoice' || prorationBehavior === 'reset'))
   const [approveImmediateInvoice, setApproveImmediateInvoice] = useState(false)
 
   const canChangePlan = useMemo(() => {

--- a/clients/apps/web/src/components/CustomerPortal/CustomerSeatQuantityManager.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerSeatQuantityManager.tsx
@@ -47,11 +47,13 @@ export const CustomerSeatQuantityManager = ({
     if (!prorationBehavior) return null
     switch (prorationBehavior) {
       case 'invoice':
-        return "I'll be charged immediately with a proration for the current month."
+        return "You'll be charged immediately, with a proration for the current period."
       case 'prorate':
-        return 'Your next invoice will include the updated seats plus the proration for the current month.'
+        return 'Your next invoice will include the updated seats plus the proration for the current period.'
       case 'next_period':
         return 'The seat update will be applied on your next billing cycle.'
+      case 'reset':
+        return "You'll be charged the full new amount immediately, and your billing period restarts today."
     }
   }, [prorationBehavior])
 

--- a/clients/apps/web/src/components/CustomerPortal/CustomerSeatQuantityManager.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerSeatQuantityManager.tsx
@@ -43,7 +43,7 @@ export const CustomerSeatQuantityManager = ({
   const canDecrease = seats !== undefined && seats > assignedSeats
   const hasChanges = seats !== totalSeats
 
-  const invoicingMessage = useMemo(() => {
+  const invoicingMessage = useMemo((): string | null => {
     if (!prorationBehavior) return null
     switch (prorationBehavior) {
       case 'invoice':


### PR DESCRIPTION
## Summary

`reset` proration always charges immediately, but the modal only treated it as immediate when the interval changed. A same-interval plan change rendered no message, and therefore no approval checkbox.

Adds the missing reset case to both portal components, and drops 'month' from the proration copy, which is wrong on yearly subscriptions.

Driven by work on unit based pricing.

❓ ~why does plan change require a confirm checkbox while seat change has no consent mechanism at all~❓

ℹ️ Discussed with @pieterbeulque , checkbox removed

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

