### PR TITLE
subscription/test: Freeze time for noop_within_one_period

### DIFF
--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -2971,6 +2971,7 @@ class TestCheckMeterCycleLag:
         with pytest.raises(SubscriptionMeterCycleLag):
             subscription_service.check_meter_cycle_lag(subscription)
 
+    @freeze_time("2024-01-15 12:00:00")
     async def test_noop_within_one_period(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
anchor day = 1 (today’s date)
period ended Aug 30 (now minus 2 days)
next period end = Aug 30 + 1 month = Sep 30 -> snapped to anchor day 1 -> Sep 1, a few microseconds before 'now'


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

