### PR TITLE
Prevent Orbit from being used in checkout

### DIFF
--- a/clients/packages/checkout/eslint.config.mjs
+++ b/clients/packages/checkout/eslint.config.mjs
@@ -9,6 +9,28 @@ export default [
   {
     rules: {
       'react/prop-types': 'off',
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@polar-sh/orbit', '@polar-sh/orbit/*'],
+              message:
+                'The checkout package must not depend on the Orbit design system — checkout styling is tuned independently for conversion. Use the local components in src/components/ui instead.',
+            },
+            {
+              group: [
+                '@polar-sh/ui/components/atoms/CountryPicker',
+                '@polar-sh/ui/components/atoms/CountryStatePicker',
+                '@polar-sh/ui/components/atoms/MoneyInput',
+                '@polar-sh/ui/components/ui/checkbox',
+              ],
+              message:
+                'This @polar-sh/ui component wraps Orbit components, which are not allowed in the checkout package. Use the local components in src/components/ui instead.',
+            },
+          ],
+        },
+      ],
     },
   },
 ]

--- a/clients/packages/checkout/package.json
+++ b/clients/packages/checkout/package.json
@@ -82,7 +82,8 @@
   "devDependencies": {
     "@polar-sh/eslint-config": "workspace:*",
     "@polar-sh/typescript-config": "workspace:*",
-    "@stylexjs/babel-plugin": "^0.18.2",
+    "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-select": "^2.2.6",
     "@stripe/react-stripe-js": "^5.6.1",
     "@stripe/stripe-js": "^8.11.0",
     "@testing-library/jest-dom": "^6.9.1",
@@ -99,7 +100,6 @@
     "@polar-sh/currency": "workspace:^",
     "@polar-sh/client": "workspace:*",
     "@polar-sh/i18n": "workspace:*",
-    "@polar-sh/orbit": "workspace:*",
     "@polar-sh/ui": "workspace:^",
     "date-fns": "^4.1.0",
     "event-source-plus": "^0.1.15",

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -4,13 +4,13 @@ import type { schemas } from '@polar-sh/client'
 import { enums } from '@polar-sh/client'
 import { useTranslations, type AcceptedLocale } from '@polar-sh/i18n'
 import { MandateText } from './MandateText'
-import { Button } from '@polar-sh/orbit'
-import CountryPicker from '@polar-sh/ui/components/atoms/CountryPicker'
+import { Button } from './ui/Button'
+import CountryPicker from './ui/CountryPicker'
 import CountryStatePicker, {
   COUNTRIES_WITH_FIXED_STATE_OPTIONS,
-} from '@polar-sh/ui/components/atoms/CountryStatePicker'
-import { Input } from '@polar-sh/orbit'
-import { Checkbox } from '@polar-sh/ui/components/ui/checkbox'
+} from './ui/CountryStatePicker'
+import { Input } from './ui/Input'
+import { Checkbox } from './ui/Checkbox'
 import {
   Form,
   FormControl,

--- a/clients/packages/checkout/src/components/CheckoutPWYWForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPWYWForm.tsx
@@ -5,7 +5,7 @@ import {
   useTranslations,
   type AcceptedLocale,
 } from '@polar-sh/i18n'
-import MoneyInput from '@polar-sh/ui/components/atoms/MoneyInput'
+import MoneyInput from './ui/MoneyInput'
 import {
   Form,
   FormField,

--- a/clients/packages/checkout/src/components/CheckoutSeatSelector.tsx
+++ b/clients/packages/checkout/src/components/CheckoutSeatSelector.tsx
@@ -6,7 +6,7 @@ import {
   useTranslations,
   type AcceptedLocale,
 } from '@polar-sh/i18n'
-import { Input } from '@polar-sh/orbit'
+import { Input } from './ui/Input'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { getSeatPrice, type ProductCheckoutPublic } from '../guards'
 import { ErrorResponse } from '../providers/CheckoutProvider'

--- a/clients/packages/checkout/src/components/CustomFieldInput.tsx
+++ b/clients/packages/checkout/src/components/CustomFieldInput.tsx
@@ -1,15 +1,15 @@
 import type { schemas } from '@polar-sh/client'
 
-import { Input } from '@polar-sh/orbit'
+import { Input } from './ui/Input'
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@polar-sh/orbit'
-import { TextArea } from '@polar-sh/orbit'
-import { Checkbox } from '@polar-sh/ui/components/ui/checkbox'
+} from './ui/Select'
+import { TextArea } from './ui/TextArea'
+import { Checkbox } from './ui/Checkbox'
 import {
   FormControl,
   FormDescription,

--- a/clients/packages/checkout/src/components/UnitQuantityControl.tsx
+++ b/clients/packages/checkout/src/components/UnitQuantityControl.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { Button, Input } from '@polar-sh/orbit'
+import { Button } from './ui/Button'
+import { Input } from './ui/Input'
 import { type ChangeEvent, type KeyboardEvent, useState } from 'react'
 import MinusIcon from './icons/MinusIcon'
 import PlusIcon from './icons/PlusIcon'

--- a/clients/packages/checkout/src/components/ui/Button.tsx
+++ b/clients/packages/checkout/src/components/ui/Button.tsx
@@ -1,0 +1,102 @@
+import { cn } from '@polar-sh/ui/lib/utils'
+import type * as React from 'react'
+
+const baseClasses =
+  'gap-2 [&_svg]:pointer-events-none [&_svg]:size-4! [&_svg]:shrink-0 h-10 px-4 py-2 relative inline-flex items-center cursor-pointer font-display font-[550] tracking-[0.01em] select-none justify-center rounded-full text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 whitespace-nowrap'
+
+const variantClasses = {
+  default:
+    'bg-black dark:bg-white dark:text-black text-white hover:opacity-85 transition-opacity duration-100',
+  secondary:
+    'text-black dark:text-white hover:bg-gray-200 dark:bg-polar-700 dark:hover:bg-polar-600 bg-gray-100 border dark:border-white/5 border-black/4',
+  ghost:
+    'bg-transparent hover:bg-gray-200 dark:hover:bg-polar-700 text-black dark:text-white',
+} as const
+
+const sizeClasses = {
+  default: 'h-10 px-5 py-3 text-sm',
+  sm: 'h-8 px-3 py-1.5 text-xs',
+  lg: 'h-12 px-5 py-4 text-sm',
+  icon: 'flex items-center justify-center aspect-square p-2 text-sm',
+} as const
+
+export type ButtonProps = React.ComponentProps<'button'> & {
+  variant?: keyof typeof variantClasses
+  size?: keyof typeof sizeClasses
+  wrapperClassNames?: string
+  loading?: boolean
+}
+
+const Button = ({
+  className,
+  wrapperClassNames,
+  variant = 'default',
+  size = 'default',
+  loading,
+  disabled,
+  children,
+  type = 'button',
+  ...props
+}: ButtonProps) => {
+  return (
+    <button
+      className={cn(
+        baseClasses,
+        variantClasses[variant],
+        sizeClasses[size],
+        className,
+      )}
+      disabled={disabled || loading}
+      type={type}
+      {...props}
+    >
+      {loading ? (
+        <>
+          <div className="absolute inset-0 flex h-full w-full items-center justify-center">
+            <LoadingSpinner disabled={disabled} size={size} />
+          </div>
+          <span className="flex flex-row items-center opacity-0">
+            {children}
+          </span>
+        </>
+      ) : (
+        <div className={cn('flex flex-row items-center', wrapperClassNames)}>
+          {children}
+        </div>
+      )}
+    </button>
+  )
+}
+
+Button.displayName = 'Button'
+
+export { Button }
+
+const LoadingSpinner = ({
+  disabled,
+  size,
+}: {
+  disabled?: boolean
+  size: NonNullable<ButtonProps['size']>
+}) => {
+  const classes = cn(
+    disabled ? 'opacity-40' : '',
+    size === 'lg' ? 'h-4 w-4' : 'h-2 w-2',
+    'animate-spin',
+  )
+
+  return (
+    <div role="status">
+      <svg
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        className={classes}
+      >
+        <path
+          d="M12,4a8,8,0,0,1,7.89,6.7A1.53,1.53,0,0,0,21.38,12h0a1.5,1.5,0,0,0,1.48-1.75,11,11,0,0,0-21.72,0A1.5,1.5,0,0,0,2.62,12h0a1.53,1.53,0,0,0,1.49-1.3A8,8,0,0,1,12,4Z"
+          className="fill-current"
+        ></path>
+      </svg>
+    </div>
+  )
+}

--- a/clients/packages/checkout/src/components/ui/Checkbox.tsx
+++ b/clients/packages/checkout/src/components/ui/Checkbox.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
+import { cn } from '@polar-sh/ui/lib/utils'
+import type * as React from 'react'
+
+export type CheckboxProps = React.ComponentProps<typeof CheckboxPrimitive.Root>
+
+const Checkbox = ({ className, ...props }: CheckboxProps) => (
+  <CheckboxPrimitive.Root
+    className={cn(
+      'ring-offset-background focus-visible:ring-ring peer h-4 w-4 shrink-0 rounded-xs border focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+      'dark:border-polar-600 border-gray-300 data-[state=checked]:border-black data-[state=checked]:bg-black data-[state=checked]:text-white dark:data-[state=checked]:border-white dark:data-[state=checked]:bg-white dark:data-[state=checked]:text-black',
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator className="flex h-full w-full items-center justify-center text-current">
+      <svg
+        className="h-4 w-4"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M20 6 9 17l-5-5" />
+      </svg>
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+)
+
+Checkbox.displayName = 'Checkbox'
+
+export { Checkbox }

--- a/clients/packages/checkout/src/components/ui/CountryPicker.tsx
+++ b/clients/packages/checkout/src/components/ui/CountryPicker.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './Select'
+
+const CountryPicker = ({
+  allowedCountries,
+  locale,
+  value,
+  onChange,
+  autoComplete,
+  disabled,
+  className,
+  itemClassName,
+  contentClassName,
+  placeholder = 'Country',
+}: {
+  allowedCountries: readonly string[]
+  locale?: string
+  value?: string
+  onChange: (value: string) => void
+  autoComplete?: string
+  disabled?: boolean
+  className?: string
+  itemClassName?: string
+  contentClassName?: string
+  placeholder?: string
+}) => {
+  const countryList = useMemo(() => {
+    const displayNames = new Intl.DisplayNames(locale ? [locale] : [], {
+      type: 'region',
+    })
+    return allowedCountries
+      .map((code) => ({
+        code,
+        name: displayNames.of(code) ?? code,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name, locale))
+  }, [allowedCountries, locale])
+
+  return (
+    <Select
+      onValueChange={onChange}
+      value={value}
+      autoComplete={autoComplete}
+      disabled={disabled}
+    >
+      <SelectTrigger className={className}>
+        <SelectValue
+          placeholder={placeholder}
+          // Avoids issues due to browser automatic translation
+          // https://github.com/shadcn-ui/ui/issues/852
+          translate="no"
+        />
+      </SelectTrigger>
+      <SelectContent className={contentClassName} translate="no">
+        {countryList.map(({ code, name }) => (
+          <SelectItem
+            key={code}
+            value={code}
+            textValue={name}
+            className={itemClassName}
+          >
+            {/* Wrap in div to workaround an issue with browser automatic translation
+              https://github.com/shadcn-ui/ui/issues/852 */}
+            <div>{name}</div>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+export default CountryPicker

--- a/clients/packages/checkout/src/components/ui/CountryStatePicker.tsx
+++ b/clients/packages/checkout/src/components/ui/CountryStatePicker.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { Input } from './Input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './Select'
+
+export const FIXED_STATE_OPTIONS: Record<string, Record<string, string>> = {
+  US: {
+    'US-AL': 'Alabama',
+    'US-AK': 'Alaska',
+    'US-AZ': 'Arizona',
+    'US-AR': 'Arkansas',
+    'US-CA': 'California',
+    'US-CO': 'Colorado',
+    'US-CT': 'Connecticut',
+    'US-DE': 'Delaware',
+    'US-FL': 'Florida',
+    'US-GA': 'Georgia',
+    'US-HI': 'Hawaii',
+    'US-ID': 'Idaho',
+    'US-IL': 'Illinois',
+    'US-IN': 'Indiana',
+    'US-IA': 'Iowa',
+    'US-KS': 'Kansas',
+    'US-KY': 'Kentucky',
+    'US-LA': 'Louisiana',
+    'US-ME': 'Maine',
+    'US-MD': 'Maryland',
+    'US-MA': 'Massachusetts',
+    'US-MI': 'Michigan',
+    'US-MN': 'Minnesota',
+    'US-MS': 'Mississippi',
+    'US-MO': 'Missouri',
+    'US-MT': 'Montana',
+    'US-NE': 'Nebraska',
+    'US-NV': 'Nevada',
+    'US-NH': 'New Hampshire',
+    'US-NJ': 'New Jersey',
+    'US-NM': 'New Mexico',
+    'US-NY': 'New York',
+    'US-NC': 'North Carolina',
+    'US-ND': 'North Dakota',
+    'US-OH': 'Ohio',
+    'US-OK': 'Oklahoma',
+    'US-OR': 'Oregon',
+    'US-PA': 'Pennsylvania',
+    'US-RI': 'Rhode Island',
+    'US-SC': 'South Carolina',
+    'US-SD': 'South Dakota',
+    'US-TN': 'Tennessee',
+    'US-TX': 'Texas',
+    'US-UT': 'Utah',
+    'US-VT': 'Vermont',
+    'US-VA': 'Virginia',
+    'US-WA': 'Washington',
+    'US-WV': 'West Virginia',
+    'US-WI': 'Wisconsin',
+    'US-WY': 'Wyoming',
+    'US-DC': 'District of Columbia',
+  },
+  CA: {
+    'CA-AB': 'Alberta',
+    'CA-BC': 'British Columbia',
+    'CA-MB': 'Manitoba',
+    'CA-NB': 'New Brunswick',
+    'CA-NL': 'Newfoundland and Labrador',
+    'CA-NS': 'Nova Scotia',
+    'CA-NT': 'Northwest Territories',
+    'CA-NU': 'Nunavut',
+    'CA-ON': 'Ontario',
+    'CA-PE': 'Prince Edward Island',
+    'CA-QC': 'Quebec',
+    'CA-SK': 'Saskatchewan',
+    'CA-YT': 'Yukon',
+  },
+}
+
+export const COUNTRIES_WITH_FIXED_STATE_OPTIONS =
+  Object.keys(FIXED_STATE_OPTIONS)
+
+const CountryStatePicker = ({
+  className,
+  value,
+  onChange,
+  country,
+  autoComplete,
+  itemClassName,
+  contentClassName,
+  disabled,
+  placeholder = 'State',
+  fallbackPlaceholder = 'State / Province',
+}: {
+  className?: string
+  contentClassName?: string
+  itemClassName?: string
+  value?: string
+  onChange: (value: string) => void
+  country?: string
+  autoComplete?: string
+  disabled?: boolean
+  placeholder?: string
+  fallbackPlaceholder?: string
+}) => {
+  const states = country ? FIXED_STATE_OPTIONS[country] : undefined
+  if (states) {
+    return (
+      <Select
+        onValueChange={onChange}
+        value={value}
+        autoComplete={autoComplete}
+        disabled={disabled}
+      >
+        <SelectTrigger className={className}>
+          <SelectValue
+            placeholder={placeholder}
+            // Avoids issues due to browser automatic translation
+            // https://github.com/shadcn-ui/ui/issues/852
+            translate="no"
+          />
+        </SelectTrigger>
+        <SelectContent className={contentClassName} translate="no">
+          {Object.entries(states).map(([code, name]) => (
+            <SelectItem
+              key={code}
+              value={code}
+              textValue={name}
+              className={itemClassName}
+            >
+              {/* Wrap in div to workaround an issue with browser automatic translation
+                https://github.com/shadcn-ui/ui/issues/852 */}
+              <div>{name}</div>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    )
+  }
+
+  return (
+    <Input
+      type="text"
+      placeholder={fallbackPlaceholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+    />
+  )
+}
+
+export default CountryStatePicker

--- a/clients/packages/checkout/src/components/ui/Input.tsx
+++ b/clients/packages/checkout/src/components/ui/Input.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@polar-sh/ui/lib/utils'
+import type * as React from 'react'
+
+export type InputProps = React.ComponentProps<'input'> & {
+  preSlot?: React.ReactNode
+  postSlot?: React.ReactNode
+}
+
+const Input = ({
+  preSlot,
+  postSlot,
+  className,
+  type,
+  ...props
+}: InputProps) => {
+  return (
+    <div className="relative flex flex-1 flex-row rounded-full">
+      <input
+        type={type}
+        className={cn(
+          'ring-offset-background file:text-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'dark:placeholder:text-polar-500 dark:border-polar-700 dark:bg-polar-800 h-10 rounded-xl border border-gray-200 bg-white px-3 py-2 text-base text-gray-950 shadow-xs outline-none placeholder:text-gray-400 focus:z-10 focus:border-blue-300 focus:ring-[3px] focus:ring-blue-100 focus-visible:ring-blue-100 md:text-sm dark:text-white dark:ring-offset-transparent dark:focus:border-blue-600 dark:focus:ring-blue-700/40',
+          preSlot ? 'pl-10' : '',
+          postSlot ? 'pr-10' : '',
+          className,
+        )}
+        {...props}
+      />
+      {preSlot && (
+        <div className="dark:text-polar-400 pointer-events-none absolute inset-y-0 left-0 z-10 flex items-center pl-3 text-gray-500">
+          {preSlot}
+        </div>
+      )}
+      {postSlot && (
+        <div className="dark:text-polar-400 pointer-events-none absolute inset-y-0 right-0 z-10 flex items-center pr-4 text-gray-500">
+          {postSlot}
+        </div>
+      )}
+    </div>
+  )
+}
+
+Input.displayName = 'Input'
+
+export { Input }

--- a/clients/packages/checkout/src/components/ui/MoneyInput.tsx
+++ b/clients/packages/checkout/src/components/ui/MoneyInput.tsx
@@ -1,0 +1,297 @@
+import { getCurrencyDecimalFactor, isDecimalCurrency } from '@polar-sh/currency'
+import { ChangeEvent, FocusEvent, useCallback, useMemo, useState } from 'react'
+import { cn } from '@polar-sh/ui/lib/utils'
+import { Input } from './Input'
+
+interface Props {
+  name: string
+  placeholder: number
+  currency: string
+  id?: string
+  onChange?: (value: number | null) => void
+  onBlur?: (e: ChangeEvent<HTMLInputElement>) => void
+  onFocus?: (e: FocusEvent<HTMLInputElement>) => void
+  value?: number | null
+  className?: string
+  disabled?: boolean
+  preSlot?: React.ReactNode
+  postSlot?: React.ReactNode
+  step?: number
+}
+
+const MoneyInput = (props: Props) => {
+  const {
+    id,
+    name,
+    value,
+    placeholder,
+    currency,
+    preSlot,
+    postSlot,
+    onChange: _onChange,
+    onBlur: _onBlur,
+    onFocus,
+    disabled,
+    step = 0.1,
+  } = props
+
+  const decimalFactor = useMemo(
+    () => getCurrencyDecimalFactor(currency),
+    [currency],
+  )
+  const isNonDecimalCurrency = !isDecimalCurrency(currency)
+
+  const getInternalValue = useCallback(
+    (value: number | null | undefined): string | undefined => {
+      if (value === undefined || value === null) {
+        return undefined
+      }
+      if (isNonDecimalCurrency) {
+        return value.toString()
+      }
+      return (value / decimalFactor).toFixed(2)
+    },
+    [decimalFactor, isNonDecimalCurrency],
+  )
+
+  const getUnits = useCallback(
+    (value: string): number => {
+      let newAmount = Number.parseFloat(value)
+      if (isNaN(newAmount)) {
+        newAmount = 0
+      }
+      if (isNonDecimalCurrency) {
+        return Math.round(newAmount)
+      }
+      // Round to avoid floating point errors
+      return Math.round(newAmount * decimalFactor)
+    },
+    [decimalFactor, isNonDecimalCurrency],
+  )
+
+  const [previousValue, setPreviousValue] = useState<number | null | undefined>(
+    value,
+  )
+  const [internalValue, setInternalValue] = useState<string | undefined>(
+    getInternalValue(value),
+  )
+
+  if (value !== previousValue) {
+    setPreviousValue(value)
+    setInternalValue(getInternalValue(value))
+  }
+
+  const updateValue = useCallback(
+    (newValue: string) => {
+      if (_onChange) {
+        if (!newValue || newValue.trim() === '') {
+          setPreviousValue(null)
+          _onChange(null)
+        } else {
+          const unitsValue = getUnits(newValue)
+          setPreviousValue(unitsValue)
+          _onChange(unitsValue)
+        }
+      }
+
+      setInternalValue(newValue)
+    },
+    [_onChange, getUnits],
+  )
+
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const input = e.target.value
+
+      // If input is completely empty, allow clearing the field
+      if (input === '') {
+        updateValue('')
+        return
+      }
+
+      // For non-decimal currencies, only allow whole numbers
+      if (isNonDecimalCurrency) {
+        const cleaned = input.replace(/[^0-9]/g, '')
+        updateValue(cleaned)
+        return
+      }
+
+      // Strip everything except numbers, commas, and periods
+      // (people can paste in anything, so the keydown handler is not enough)
+      const cleaned = input.replace(/[^0-9,.]/g, '')
+
+      // By default, parse the full value as a whole number, stripping out decimal separators
+      //
+      // Leave a trailing comma, otherwise people can't type in decimals
+      // (the onBlur handler will strip it if it's dangling on blur)
+      let newValue = cleaned.replace(/[,.](?!$)/g, '').replace(/,$/, '.')
+
+      // However, if we detect a decimal separator, round it to 2 decimal places
+      //
+      // We support period decimal separator (enforced when typing)
+      // but also support comma decimal separators (might be pasted in)
+      const decimalMatch = cleaned.match(/([.,])([0-9]+)$/)
+
+      if (decimalMatch) {
+        const maxDecimalPrecision = 2
+        const decimalPart = decimalMatch[2]
+        const integerPart = cleaned
+          .slice(0, -decimalMatch[0].length)
+          .replace(/[,.]/g, '')
+        const trimmedDecimalPart = decimalPart.slice(0, maxDecimalPrecision)
+
+        const parsedValue = Number.parseFloat(
+          `${integerPart}.${trimmedDecimalPart}`,
+        )
+
+        if (!Number.isNaN(parsedValue)) {
+          const decimalPlaces = Math.min(
+            maxDecimalPrecision,
+            decimalPart.length,
+          )
+          const formatted = parsedValue.toFixed(decimalPlaces)
+
+          // This covers when the user deletes the last integer part and prevents inserting a `0`
+          // in place of the last integer part that would make the caret jump to the end of the input
+          // This way the user can continue typing
+          newValue =
+            integerPart.length > 0
+              ? formatted
+              : formatted.replace(/^0(?=\.)/, '')
+        }
+      }
+
+      updateValue(newValue)
+    },
+    [updateValue, isNonDecimalCurrency],
+  )
+
+  const onBlur = useCallback(
+    (e: FocusEvent<HTMLInputElement>) => {
+      if (internalValue) {
+        let nextValue = internalValue
+
+        if (!isNonDecimalCurrency) {
+          // Add 0 as integer part if value starts with `.`
+          if (nextValue.startsWith('.')) {
+            nextValue = `0${nextValue}`
+          }
+
+          // Strip trailing decimal point
+          if (nextValue.endsWith('.')) {
+            nextValue = nextValue.replace(/\.$/, '')
+          }
+        }
+
+        if (nextValue !== internalValue) {
+          updateValue(nextValue)
+        }
+      }
+
+      if (_onBlur) {
+        _onBlur(e)
+      }
+    },
+    [_onBlur, internalValue, updateValue, isNonDecimalCurrency],
+  )
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // For non-decimal currencies, only allow digits and control keys
+      if (isNonDecimalCurrency) {
+        if (
+          !/[0-9]/.test(e.key) &&
+          !['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'].includes(
+            e.key,
+          ) &&
+          !e.ctrlKey &&
+          !e.metaKey
+        ) {
+          e.preventDefault()
+        }
+        return
+      }
+
+      // Allow only digits, decimal point, and control keys
+      if (
+        !/[0-9.,]/.test(e.key) &&
+        !['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'].includes(
+          e.key,
+        ) &&
+        !e.ctrlKey &&
+        !e.metaKey
+      ) {
+        e.preventDefault()
+      }
+
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        const parsedValue = Number.parseFloat(e.currentTarget.value)
+
+        const newValue = (
+          !Number.isNaN(parsedValue) ? parsedValue + step : step
+        ).toFixed(2)
+
+        updateValue(newValue)
+      }
+
+      if (e.key === 'ArrowDown') {
+        const parsedValue = Number.parseFloat(e.currentTarget.value)
+
+        const newValue = Math.max(
+          0,
+          !Number.isNaN(parsedValue) ? parsedValue - step : -step,
+        ).toFixed(2)
+
+        updateValue(newValue)
+      }
+
+      // Prevent multiple decimal points
+      if (
+        (e.key === '.' || e.key === ',') &&
+        e.currentTarget.value.includes('.')
+      ) {
+        e.preventDefault()
+      }
+    },
+    [step, updateValue, isNonDecimalCurrency],
+  )
+
+  const currencyLabel = (
+    <span className="dark:text-polar-500 text-sm font-medium text-gray-500">
+      {currency.toUpperCase()}
+    </span>
+  )
+
+  const placeholderValue = useMemo(() => {
+    if (!placeholder) return undefined
+    if (isNonDecimalCurrency) {
+      return placeholder.toLocaleString('en-US')
+    }
+    return (placeholder / decimalFactor).toLocaleString('en-US')
+  }, [placeholder, decimalFactor, isNonDecimalCurrency])
+
+  return (
+    <Input
+      type="text"
+      inputMode={isNonDecimalCurrency ? 'numeric' : 'decimal'}
+      id={id}
+      name={name}
+      className={cn(
+        'dark:placeholder:text-polar-500 block w-full px-4 pl-14 text-base placeholder:text-gray-400',
+        props.className ?? '',
+      )}
+      value={internalValue}
+      onChange={onChange}
+      onKeyDown={onKeyDown}
+      placeholder={placeholderValue}
+      preSlot={preSlot ? preSlot : currencyLabel}
+      postSlot={postSlot}
+      onBlur={onBlur}
+      onFocus={onFocus}
+      disabled={disabled}
+    />
+  )
+}
+
+export default MoneyInput

--- a/clients/packages/checkout/src/components/ui/Select.tsx
+++ b/clients/packages/checkout/src/components/ui/Select.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import * as SelectPrimitive from '@radix-ui/react-select'
+import { cn } from '@polar-sh/ui/lib/utils'
+import * as React from 'react'
+
+const ChevronDownIcon = ({ className }: { className?: string }) => (
+  <svg
+    className={className}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="m6 9 6 6 6-6" />
+  </svg>
+)
+
+const ChevronUpIcon = ({ className }: { className?: string }) => (
+  <svg
+    className={className}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="m18 15-6-6-6 6" />
+  </svg>
+)
+
+const CheckIcon = ({ className }: { className?: string }) => (
+  <svg
+    className={className}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M20 6 9 17l-5-5" />
+  </svg>
+)
+
+const Select = SelectPrimitive.Root
+
+const SelectValue = ({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) => (
+  <SelectPrimitive.Value translate="no" {...props} />
+)
+SelectValue.displayName = 'SelectValue'
+
+const SelectTrigger = ({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger>) => (
+  <SelectPrimitive.Trigger
+    className={cn(
+      'ring-offset-background data-placeholder:text-muted-foreground focus:ring-ring flex h-10 w-full items-center justify-between rounded-md border px-3 py-2 md:text-sm focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex cursor-pointer flex-row gap-x-2 rounded-xl border border-gray-200 bg-white px-3 shadow-xs transition-colors hover:border-gray-300 dark:text-white text-black',
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDownIcon className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+)
+SelectTrigger.displayName = 'SelectTrigger'
+
+const SelectContent = ({
+  className,
+  children,
+  position = 'popper',
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      className={cn(
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-md border shadow-md',
+        position === 'popper' &&
+          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        'dark:bg-polar-800 rounded-xl border-none',
+        className,
+      )}
+      position={position}
+      translate="no"
+      {...props}
+    >
+      <SelectPrimitive.ScrollUpButton className="flex cursor-default items-center justify-center py-1">
+        <ChevronUpIcon className="h-4 w-4" />
+      </SelectPrimitive.ScrollUpButton>
+      <SelectPrimitive.Viewport
+        className={cn(
+          'p-1',
+          position === 'popper' &&
+            'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)',
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectPrimitive.ScrollDownButton className="flex cursor-default items-center justify-center py-1">
+        <ChevronDownIcon className="h-4 w-4" />
+      </SelectPrimitive.ScrollDownButton>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+)
+SelectContent.displayName = 'SelectContent'
+
+const SelectItem = ({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) => (
+  <SelectPrimitive.Item
+    className={cn(
+      'focus:bg-accent focus:text-accent-foreground relative flex w-full items-center py-1.5 pr-2 pl-8 text-sm outline-none select-none data-disabled:pointer-events-none data-disabled:opacity-50',
+      className,
+      'cursor-pointer rounded-lg',
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <CheckIcon className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>
+      <div>{children}</div>
+    </SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+)
+SelectItem.displayName = 'SelectItem'
+
+export { Select, SelectContent, SelectItem, SelectTrigger, SelectValue }

--- a/clients/packages/checkout/src/components/ui/TextArea.tsx
+++ b/clients/packages/checkout/src/components/ui/TextArea.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@polar-sh/ui/lib/utils'
+import type * as React from 'react'
+
+export type TextAreaProps = React.ComponentProps<'textarea'>
+
+const TextArea = ({ className, ...props }: TextAreaProps) => {
+  return (
+    <textarea
+      className={cn(
+        'ring-offset-background focus-visible:ring-ring flex min-h-[80px] w-full rounded-md border px-3 py-2 text-base focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'dark:border-polar-700 bg-white shadow-xs dark:bg-polar-800 dark:text-white dark:placeholder:text-polar-500 min-h-[120px] rounded-2xl focus-visible:ring-blue-100 p-4 text-sm border-gray-200 outline-none focus:z-10 focus:border-blue-300 focus:ring-[3px] focus:ring-blue-100 dark:ring-offset-transparent dark:focus:border-blue-600 dark:focus:ring-blue-700/40',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+TextArea.displayName = 'TextArea'
+
+export { TextArea }

--- a/clients/packages/checkout/vitest.config.ts
+++ b/clients/packages/checkout/vitest.config.ts
@@ -1,34 +1,8 @@
 import react from '@vitejs/plugin-react'
-import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 
-// Orbit's `@polar-sh/orbit` entry resolves to raw TS source that calls
-// `stylex.defineVars` at module load. Without the StyleX babel plugin those
-// calls throw ("Styles must be compiled by '@stylexjs/babel-plugin'"), which
-// breaks any test that imports an Orbit component. Mirror apps/web/babel.config.js.
-const orbitRoot = fileURLToPath(new URL('../orbit', import.meta.url))
-
 export default defineConfig({
-  plugins: [
-    react({
-      babel: {
-        plugins: [
-          [
-            '@stylexjs/babel-plugin',
-            {
-              dev: process.env.NODE_ENV !== 'production',
-              runtimeInjection: false,
-              treeshakeCompensation: true,
-              unstable_moduleResolution: {
-                type: 'commonJS',
-                rootDir: orbitRoot,
-              },
-            },
-          ],
-        ],
-      },
-    }),
-  ],
+  plugins: [react()],
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],

--- a/clients/pnpm-lock.yaml
+++ b/clients/pnpm-lock.yaml
@@ -388,7 +388,7 @@ importers:
         version: 16.3.1(@mdx-js/loader@3.1.1(webpack@5.102.1(lightningcss@1.32.0)(postcss@8.5.10)))(@mdx-js/react@3.1.1(@types/react@19.2.13)(react@19.2.5))
       '@next/third-parties':
         specifier: ^16.3.1
-        version: 16.3.1(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 16.3.1(next@16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@polar-sh/checkout':
         specifier: workspace:^
         version: link:../../packages/checkout
@@ -427,7 +427,7 @@ importers:
         version: 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@sentry/nextjs':
         specifier: ^10.49.0
-        version: 10.49.0(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.102.1(lightningcss@1.32.0)(postcss@8.5.10))
+        version: 10.49.0(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.102.1(lightningcss@1.32.0)(postcss@8.5.10))
       '@shikijs/rehype':
         specifier: ^3.23.0
         version: 3.23.0
@@ -478,7 +478,7 @@ importers:
         version: 5.0.4
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 1.7.0(next@16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
@@ -502,13 +502,13 @@ importers:
         version: 5.1.9
       next:
         specifier: ^16.3.1
-        version: 16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       nuqs:
         specifier: ^2.8.9
-        version: 2.8.9(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 2.8.9(next@16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       posthog-js:
         specifier: ^1.369.1
         version: 1.369.1
@@ -676,24 +676,24 @@ importers:
       '@polar-sh/i18n':
         specifier: workspace:*
         version: link:../i18n
-      '@polar-sh/orbit':
-        specifier: workspace:*
-        version: link:../orbit
       '@polar-sh/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
       '@polar-sh/ui':
         specifier: workspace:^
         version: link:../ui
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@stripe/react-stripe-js':
         specifier: ^5.6.1
         version: 5.6.1(@stripe/stripe-js@8.11.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@stripe/stripe-js':
         specifier: ^8.11.0
         version: 8.11.0
-      '@stylexjs/babel-plugin':
-        specifier: ^0.18.2
-        version: 0.18.2
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -13260,7 +13260,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -13320,7 +13320,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.27.1
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -13404,7 +13404,7 @@ snapshots:
 
   '@babel/helper-wrap-function@7.28.3':
     dependencies:
-      '@babel/template': 7.28.6
+      '@babel/template': 7.29.7
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.8
     transitivePeerDependencies:
@@ -13609,7 +13609,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/template': 7.28.6
+      '@babel/template': 7.29.7
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
     dependencies:
@@ -13888,7 +13888,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13900,7 +13900,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/types': 7.29.8
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13918,7 +13918,7 @@ snapshots:
     dependencies:
       '@bacons/xcode': 1.0.0-alpha.27
       '@react-native/normalize-colors': 0.79.7
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       glob: 10.5.0
     transitivePeerDependencies:
       - supports-color
@@ -13926,7 +13926,7 @@ snapshots:
   '@bacons/xcode@1.0.0-alpha.27':
     dependencies:
       '@expo/plist': 0.0.18
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       uuid: 8.3.2
     transitivePeerDependencies:
       - supports-color
@@ -14363,7 +14363,7 @@ snapshots:
   '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -14379,7 +14379,7 @@ snapshots:
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.15.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -14441,7 +14441,7 @@ snapshots:
       ci-info: 3.9.0
       compression: 1.8.1
       connect: 3.7.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       env-editor: 0.4.2
       expo: 54.0.29(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.19)(graphql@16.8.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0)
       expo-server: 1.0.5
@@ -14496,7 +14496,7 @@ snapshots:
       '@expo/plist': 0.4.8
       '@expo/sdk-runtime-versions': 1.0.0
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       getenv: 2.0.0
       glob: 13.0.6
       resolve-from: 5.0.0
@@ -14515,7 +14515,7 @@ snapshots:
       '@expo/plist': 0.5.4
       '@expo/sdk-runtime-versions': 1.0.0
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       getenv: 2.0.0
       glob: 13.0.6
       resolve-from: 5.0.0
@@ -14533,7 +14533,7 @@ snapshots:
       '@expo/plist': 0.2.2
       '@expo/sdk-runtime-versions': 1.0.0
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       getenv: 1.0.0
       glob: 10.5.0
       resolve-from: 5.0.0
@@ -14644,7 +14644,7 @@ snapshots:
   '@expo/env@1.0.7':
     dependencies:
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       dotenv: 16.4.7
       dotenv-expand: 11.0.7
       getenv: 2.0.0
@@ -14654,7 +14654,7 @@ snapshots:
   '@expo/env@2.0.8':
     dependencies:
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       dotenv: 16.4.7
       dotenv-expand: 11.0.7
       getenv: 2.0.0
@@ -14666,7 +14666,7 @@ snapshots:
       '@expo/spawn-async': 1.7.2
       arg: 5.0.2
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       getenv: 2.0.0
       glob: 13.0.6
       ignore: 5.3.2
@@ -14752,7 +14752,7 @@ snapshots:
       '@expo/spawn-async': 1.7.2
       browserslist: 4.28.1
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       dotenv: 16.4.7
       dotenv-expand: 11.0.7
       getenv: 2.0.0
@@ -14880,7 +14880,7 @@ snapshots:
     dependencies:
       '@oclif/core': 2.16.0(@types/node@25.0.2)(typescript@5.9.3)
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       ejs: 3.1.10
       fs-extra: 10.1.0
       http-call: 5.3.0
@@ -14901,7 +14901,7 @@ snapshots:
       '@expo/image-utils': 0.8.8
       '@expo/json-file': 10.0.8
       '@react-native/normalize-colors': 0.81.5
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       expo: 54.0.29(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.19)(graphql@16.8.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0)
       resolve-from: 5.0.0
       semver: 7.8.5
@@ -14917,7 +14917,7 @@ snapshots:
       '@expo/image-utils': 0.6.5
       '@expo/json-file': 9.1.5
       '@react-native/normalize-colors': 0.76.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 9.1.0
       resolve-from: 5.0.0
       semver: 7.8.5
@@ -15785,9 +15785,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.3.1':
     optional: true
 
-  '@next/third-parties@16.3.1(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@next/third-parties@16.3.1(next@16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     dependencies:
-      next: 16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       third-party-capital: 1.0.20
 
@@ -15866,7 +15866,7 @@ snapshots:
     dependencies:
       '@oclif/core': 4.11.9
       ansis: 3.17.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       ejs: 3.1.10
     transitivePeerDependencies:
       - supports-color
@@ -17334,7 +17334,7 @@ snapshots:
   '@react-native/community-cli-plugin@0.81.5(@react-native-community/cli@20.1.2(typescript@5.9.3))':
     dependencies:
       '@react-native/dev-middleware': 0.81.5
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       invariant: 2.2.4
       metro: 0.83.3
       metro-config: 0.83.3
@@ -17356,7 +17356,7 @@ snapshots:
       chrome-launcher: 0.15.2
       chromium-edge-launcher: 0.2.0
       connect: 3.7.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       invariant: 2.2.4
       nullthrows: 1.1.1
       open: 7.4.2
@@ -17808,7 +17808,7 @@ snapshots:
       '@sentry/types': 7.77.0
       '@sentry/utils': 7.77.0
 
-  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.102.1(lightningcss@1.32.0)(postcss@8.5.10))':
+  '@sentry/nextjs@10.49.0(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)(webpack@5.102.1(lightningcss@1.32.0)(postcss@8.5.10))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -17821,7 +17821,7 @@ snapshots:
       '@sentry/react': 10.49.0(react@19.2.5)
       '@sentry/vercel-edge': 10.49.0
       '@sentry/webpack-plugin': 5.2.0(webpack@5.102.1(lightningcss@1.32.0)(postcss@8.5.10))
-      next: 16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       rollup: 4.53.5
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -18545,7 +18545,7 @@ snapshots:
       '@typescript-eslint/types': 8.55.0
       '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.55.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4(jiti@1.21.7)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18557,7 +18557,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18567,7 +18567,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -18576,7 +18576,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -18608,7 +18608,7 @@ snapshots:
       '@typescript-eslint/types': 8.55.0
       '@typescript-eslint/typescript-estree': 8.55.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.55.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4(jiti@1.21.7)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -18620,7 +18620,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/typescript-estree': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/utils': 8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -18639,7 +18639,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.55.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.55.0
       '@typescript-eslint/visitor-keys': 8.55.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 9.0.5
       semver: 7.8.5
       tinyglobby: 0.2.15
@@ -18654,7 +18654,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.2(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.2
       '@typescript-eslint/visitor-keys': 8.58.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.4
       semver: 7.8.5
       tinyglobby: 0.2.15
@@ -18877,7 +18877,7 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
       ast-v8-to-istanbul: 0.3.12
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -18903,7 +18903,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.4.0(postcss@8.5.10))(msw@2.12.10(@types/node@24.12.2)(@typescript/typescript6@6.0.2))(vite@7.3.0(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.0.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.4.0(postcss@8.5.26))(msw@2.12.10(@types/node@25.0.2)(typescript@5.9.3))(vite@7.3.0(@types/node@25.0.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -19005,7 +19005,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.4.0(postcss@8.5.10))(msw@2.12.10(@types/node@24.12.2)(@typescript/typescript6@6.0.2))(vite@7.3.0(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.0.2)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@27.4.0(postcss@8.5.26))(msw@2.12.10(@types/node@25.0.2)(typescript@5.9.3))(vite@7.3.0(@types/node@25.0.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -19162,7 +19162,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19552,7 +19552,7 @@ snapshots:
       babel-plugin-react-native-web: 0.21.2
       babel-plugin-syntax-hermes-parser: 0.29.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       react-refresh: 0.14.2
       resolve-from: 5.0.0
     optionalDependencies:
@@ -19618,7 +19618,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -20459,7 +20459,7 @@ snapshots:
       chalk: 4.1.2
       cli-progress: 3.12.0
       dateformat: 4.6.3
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       diff: 7.0.0
       dotenv: 16.3.1
       env-paths: 2.2.0
@@ -20793,7 +20793,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4(jiti@1.21.7)
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
@@ -20952,7 +20952,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -20993,7 +20993,7 @@ snapshots:
       ajv: 6.15.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -21313,7 +21313,7 @@ snapshots:
       '@react-navigation/native': 7.1.25(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0)
       '@react-navigation/native-stack': 7.8.6(@react-navigation/native@7.1.25(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0)
       client-only: 0.0.1
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       expo: 54.0.29(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.19)(graphql@16.8.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0)
       expo-constants: 18.0.12(expo@54.0.29)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))
@@ -21381,7 +21381,7 @@ snapshots:
   expo-system-ui@6.0.9(expo@54.0.29)(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0)):
     dependencies:
       '@react-native/normalize-colors': 0.81.5
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       expo: 54.0.29(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.19)(graphql@16.8.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0)
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0)
     optionalDependencies:
@@ -21400,7 +21400,7 @@ snapshots:
       '@expo/spawn-async': 1.7.2
       arg: 4.1.0
       chalk: 4.1.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       expo: 54.0.29(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.19)(graphql@16.8.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0)
       expo-eas-client: 1.0.8
       expo-manifests: 1.0.10(expo@54.0.29)
@@ -21471,7 +21471,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -21630,7 +21630,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -21804,7 +21804,7 @@ snapshots:
   gaxios@7.1.3:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
       rimraf: 5.0.10
     transitivePeerDependencies:
@@ -21818,9 +21818,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  geist@1.7.0(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
+  geist@1.7.0(next@16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
     dependencies:
-      next: 16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   generator-function@2.0.1: {}
 
@@ -22151,7 +22151,7 @@ snapshots:
   http-call@5.3.0:
     dependencies:
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       is-retry-allowed: 1.2.0
       is-stream: 2.0.1
       parse-json: 4.0.0
@@ -22171,14 +22171,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22212,7 +22212,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22554,7 +22561,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -22563,7 +22570,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -23133,7 +23140,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.0
       saxes: 6.0.0
@@ -23162,7 +23169,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.0
       saxes: 6.0.0
@@ -23836,7 +23843,7 @@ snapshots:
     dependencies:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       metro-core: 0.83.2
     transitivePeerDependencies:
       - supports-color
@@ -23845,7 +23852,7 @@ snapshots:
     dependencies:
       exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       metro-core: 0.83.3
     transitivePeerDependencies:
       - supports-color
@@ -23894,7 +23901,7 @@ snapshots:
 
   metro-file-map@0.83.2:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -23908,7 +23915,7 @@ snapshots:
 
   metro-file-map@0.83.3:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       fb-watchman: 2.0.2
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -24075,7 +24082,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 2.0.0
       connect: 3.7.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -24122,7 +24129,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 2.0.0
       connect: 3.7.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -24408,7 +24415,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -24635,7 +24642,7 @@ snapshots:
   nativewind@4.2.1(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       comment-json: 4.5.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       react-native-css-interop: 0.2.1(react-native-reanimated@4.1.6(@babel/core@7.29.0)(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -24677,7 +24684,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
+      styled-jsx: 5.1.6(react@19.2.5)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
       '@next/swc-darwin-x64': 16.2.6
@@ -24695,7 +24702,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.3.1
       '@swc/helpers': 0.5.23
@@ -24704,7 +24711,7 @@ snapshots:
       postcss: 8.5.23
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
+      styled-jsx: 5.1.6(react@19.2.5)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.3.1
       '@next/swc-darwin-x64': 16.3.1
@@ -24779,12 +24786,12 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuqs@2.8.9(next@16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
+  nuqs@2.8.9(next@16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.5
     optionalDependencies:
-      next: 16.3.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.3.1(@opentelemetry/api@1.9.1)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   nwsapi@2.2.23: {}
 
@@ -25278,7 +25285,7 @@ snapshots:
   portfinder@1.0.38:
     dependencies:
       async: 3.2.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -25608,7 +25615,7 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       lightningcss: 1.27.0
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native-community/cli@20.1.2(typescript@5.9.3))(@types/react@19.2.13)(react@19.1.0)
@@ -26115,7 +26122,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -26236,7 +26243,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -26347,7 +26354,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -26760,12 +26767,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.5):
+  styled-jsx@5.1.6(react@19.2.5):
     dependencies:
       client-only: 0.0.1
       react: 19.2.5
-    optionalDependencies:
-      '@babel/core': 7.29.0
 
   styleq@0.1.3: {}
 
@@ -27104,7 +27109,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.27.1
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -27525,7 +27530,7 @@ snapshots:
   vite-node@3.2.4(@types/node@25.0.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.3.0(@types/node@25.0.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -27545,7 +27550,7 @@ snapshots:
 
   vite-tsconfig-paths@5.1.4(@typescript/typescript6@6.0.2)(vite@7.3.0(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       globrex: 0.1.2
       tsconfck: 3.1.6(@typescript/typescript6@6.0.2)
     optionalDependencies:
@@ -27616,7 +27621,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3


### PR DESCRIPTION
## What

The checkout is a standalone entity and should not necessarily follow Orbit's design system. Therefore this PR will ban the usage of Orbit inside checkout.

## Screenshots

### PWYW light

| Before | After  |
|--------|--------|
| <img width="1840" height="1135" alt="before_Screenshot 2026-09-02 at 15 13 32" src="https://github.com/user-attachments/assets/6e433405-f817-4c53-be2a-d81298bda19c" /> | <img width="1840" height="1135" alt="after_Screenshot 2026-09-02 at 15 10 54" src="https://github.com/user-attachments/assets/cbd3f2f8-b802-4aed-9f97-3d90bdc70c9e" /> |

### PWYW dark

| Before | After  |
|--------|--------|
| <img width="1840" height="1135" alt="before_Screenshot 2026-09-02 at 15 13 23" src="https://github.com/user-attachments/assets/54ac5c16-d2ce-4baa-80a3-574016e7de25" /> | <img width="1840" height="1135" alt="after_Screenshot 2026-09-02 at 15 11 45" src="https://github.com/user-attachments/assets/77a02583-f48e-4cfb-bdfb-e36a080a291d" /> |

### Unit stepper light

| Before | After  |
|--------|--------|
| <img width="1840" height="1135" alt="before_Screenshot 2026-09-02 at 15 13 30" src="https://github.com/user-attachments/assets/55da7753-04db-4b52-83b6-9ae96f9efc72" /> | <img width="1840" height="1135" alt="after_Screenshot 2026-09-02 at 15 10 56" src="https://github.com/user-attachments/assets/23b8a25f-33ff-48c2-a251-a85d455fd01a" /> |


### Unit stepper dark

| Before | After  |
|--------|--------|
| <img width="1840" height="1135" alt="before_Screenshot 2026-09-02 at 15 13 24" src="https://github.com/user-attachments/assets/b94f386b-4163-4d06-962d-9d6fe09dcaae" /> | <img width="1840" height="1135" alt="after_Screenshot 2026-09-02 at 15 11 47" src="https://github.com/user-attachments/assets/43bc9c2b-87de-4dd6-a1a6-9ac42fbbd5db" /> |


### Subscription light

| Before | After  |
|--------|--------|
| <img width="1840" height="1135" alt="before_Screenshot 2026-09-02 at 15 13 29" src="https://github.com/user-attachments/assets/6cf7e463-b569-45bc-909c-cfba1aec6fb2" /> | <img width="1840" height="1135" alt="after_Screenshot 2026-09-02 at 15 11 18" src="https://github.com/user-attachments/assets/ab25d2de-0043-48b9-b750-d17f53cc5da8" /> |






### Subscription dark

| Before | After  |
|--------|--------|
| <img width="1840" height="1135" alt="before_Screenshot 2026-09-02 at 15 13 25" src="https://github.com/user-attachments/assets/237775f6-3914-4cac-9b69-70fd8f93d70c" /> | <img width="1840" height="1135" alt="after_Screenshot 2026-09-02 at 15 11 48" src="https://github.com/user-attachments/assets/1cb5bafd-a0d7-4cca-8062-d93f0d0f441e" /> |




