### PR TITLE
Mark adapters as deprecated in the docs

### DIFF
--- a/docs/integrate/sdk/adapters/astro.mdx
+++ b/docs/integrate/sdk/adapters/astro.mdx
@@ -1,7 +1,18 @@
 ---
-title: "Astro"
+title: "Astro (deprecated)"
 description: "Payments and Checkouts made dead simple with Astro"
 ---
+
+<Warning>
+  **`@polar-sh/astro` is deprecated** and no longer maintained. Integrate with
+  the [TypeScript SDK](/integrate/sdk/typescript) directly instead. The
+  [`polar-integration` skill](https://github.com/polarsource/skills/tree/main/skills/polar-integration)
+  can help you migrate:
+
+  ```bash
+  npx skills add https://github.com/polarsource/skills --skill polar-integration
+  ```
+</Warning>
 
 ## Examples
 
@@ -39,7 +50,7 @@ Install the required Polar packages using the following command:
 
 Create a Checkout handler which takes care of redirections.
 
-```typescript icon="square-js" 
+```typescript icon="square-js"
 import { Checkout } from "@polar-sh/astro";
 import { POLAR_ACCESS_TOKEN, POLAR_SUCCESS_URL } from "astro:env/server";
 
@@ -67,7 +78,7 @@ Pass query params to this route.
 
 Create a customer portal where your customer can view orders and subscriptions.
 
-```typescript icon="square-js" 
+```typescript icon="square-js"
 import { CustomerPortal } from "@polar-sh/astro";
 import { POLAR_ACCESS_TOKEN } from "astro:env/server";
 
@@ -83,7 +94,7 @@ export const GET = CustomerPortal({
 
 A simple utility which resolves incoming webhook payloads by signing the webhook secret properly.
 
-```typescript icon="square-js" 
+```typescript icon="square-js"
 import { Webhooks } from '@polar-sh/astro';
 import { POLAR_WEBHOOK_SECRET } from "astro:env/server"
 

--- a/docs/integrate/sdk/adapters/deno.mdx
+++ b/docs/integrate/sdk/adapters/deno.mdx
@@ -1,7 +1,18 @@
 ---
-title: "Deno"
+title: "Deno (deprecated)"
 description: "Payments and Checkouts made dead simple with Deno"
 ---
+
+<Warning>
+  **`@polar-sh/deno` is deprecated** and no longer maintained. Integrate with
+  the [TypeScript SDK](/integrate/sdk/typescript) directly instead. The
+  [`polar-integration` skill](https://github.com/polarsource/skills/tree/main/skills/polar-integration)
+  can help you migrate:
+
+  ```bash
+  npx skills add https://github.com/polarsource/skills --skill polar-integration
+  ```
+</Warning>
 
 ## Examples
 
@@ -11,7 +22,7 @@ description: "Payments and Checkouts made dead simple with Deno"
 
 Create a Checkout handler which takes care of redirections.
 
-```typescript icon="square-js" 
+```typescript icon="square-js"
 import { Checkout } from "jsr:@polar-sh/deno";
 
 Deno.serve(
@@ -38,7 +49,7 @@ Pass query params to this route.
 
 Create a customer portal where your customer can view orders and subscriptions.
 
-```typescript icon="square-js" 
+```typescript icon="square-js"
 import { CustomerPortal } from "jsr:@polar-sh/deno";
 
 Deno.serve(
@@ -55,7 +66,7 @@ Deno.serve(
 
 A simple utility which resolves incoming webhook payloads by signing the webhook secret properly.
 
-```typescript icon="square-js" 
+```typescript icon="square-js"
 import { Webhooks } from "jsr:@polar-sh/deno";
 
 Deno.serve(

--- a/docs/integrate/sdk/adapters/elysia.mdx
+++ b/docs/integrate/sdk/adapters/elysia.mdx
@@ -1,7 +1,18 @@
 ---
-title: "Elysia"
+title: "Elysia (deprecated)"
 description: "Payments and Checkouts made dead simple with Elysia"
 ---
+
+<Warning>
+  **`@polar-sh/elysia` is deprecated** and no longer maintained. Integrate with
+  the [TypeScript SDK](/integrate/sdk/typescript) directly instead. The
+  [`polar-integration` skill](https://github.com/polarsource/skills/tree/main/skills/polar-integration)
+  can help you migrate:
+
+  ```bash
+  npx skills add https://github.com/polarsource/skills --skill polar-integration
+  ```
+</Warning>
 
 ## Examples
 
@@ -38,7 +49,7 @@ Install the required Polar packages using the following command:
 
 Create a Checkout handler which takes care of redirections.
 
-```typescript icon="square-js" 
+```typescript icon="square-js"
 import { Elysia } from "elysia";
 import { Checkout } from "@polar-sh/elysia";
 
@@ -71,7 +82,7 @@ Pass query params to this route.
 
 Create a customer portal where your customer can view orders and subscriptions.
 
-```typescript icon="square-js" 
+```typescript icon="square-js"
 import { Elysia } from "elysia";
 import { CustomerPortal } from "@polar-sh/elysia";
 
@@ -92,7 +103,7 @@ app.get(
 
 A simple utility which resolves incoming webhook payloads by signing the webhook secret properly.
 
-```typescript icon="square-js" 
+```typescript icon="square-js"
 import { Elysia } from 'elysia'
 import { Webhooks } from "@polar-sh/elysia";
 

--- a/docs/integrate/sdk/adapters/express.mdx
+++ b/docs/integrate/sdk/adapters/express.mdx
@@ -1,7 +1,18 @@
 ---
-title: "Express"
+title: "Express (deprecated)"
 description: "Payments and Checkouts made dead simple with Express"
 ---
+
+<Warning>
+  **`@polar-sh/express` is deprecated** and no longer maintained. Integrate with
+  the [TypeScript SDK](/integrate/sdk/typescript) directly instead. The
+  [`polar-integration` skill](https://github.com/polarsource/skills/tree/main/skills/polar-integration)
+  can help you migrate:
+
+  ```bash
+  npx skills add https://github.com/polarsource/skills --skill polar-integration
+  ```
+</Warning>
 
 ## Examples
 

--- a/docs/integrate/sdk/adapters/fastify.mdx
+++ b/docs/integrate/sdk/adapters/fastify.mdx
@@ -1,7 +1,18 @@
 ---
-title: "Fastify"
+title: "Fastify (deprecated)"
 description: "Payments and Checkouts made dead simple with Fastify"
 ---
+
+<Warning>
+  **`@polar-sh/fastify` is deprecated** and no longer maintained. Integrate with
+  the [TypeScript SDK](/integrate/sdk/typescript) directly instead. The
+  [`polar-integration` skill](https://github.com/polarsource/skills/tree/main/skills/polar-integration)
+  can help you migrate:
+
+  ```bash
+  npx skills add https://github.com/polarsource/skills --skill polar-integration
+  ```
+</Warning>
 
 ## Examples
 

--- a/docs/integrate/sdk/adapters/hono.mdx
+++ b/docs/integrate/sdk/adapters/hono.mdx
@@ -1,7 +1,18 @@
 ---
-title: "Hono"
+title: "Hono (deprecated)"
 description: "Payments and Checkouts made dead simple with Hono"
 ---
+
+<Warning>
+  **`@polar-sh/hono` is deprecated** and no longer maintained. Integrate with
+  the [TypeScript SDK](/integrate/sdk/typescript) directly instead — the
+  [`polar-integration` skill](https://github.com/polarsource/skills/tree/main/skills/polar-integration)
+  can help you migrate:
+
+  ```bash
+  npx skills add https://github.com/polarsource/skills --skill polar-integration
+  ```
+</Warning>
 
 ## Examples
 

--- a/docs/integrate/sdk/adapters/remix.mdx
+++ b/docs/integrate/sdk/adapters/remix.mdx
@@ -1,7 +1,18 @@
 ---
-title: "Remix"
+title: "Remix (deprecated)"
 description: "Payments and Checkouts made dead simple with Remix"
 ---
+
+<Warning>
+  **`@polar-sh/remix` is deprecated** and no longer maintained. Integrate with
+  the [TypeScript SDK](/integrate/sdk/typescript) directly instead. The
+  [`polar-integration` skill](https://github.com/polarsource/skills/tree/main/skills/polar-integration)
+  can help you migrate:
+
+  ```bash
+  npx skills add https://github.com/polarsource/skills --skill polar-integration
+  ```
+</Warning>
 
 ## Examples
 

--- a/docs/integrate/sdk/adapters/supabase.mdx
+++ b/docs/integrate/sdk/adapters/supabase.mdx
@@ -1,7 +1,18 @@
 ---
-title: "Supabase"
+title: "Supabase (deprecated)"
 description: "Payments and Checkouts made dead simple with Supabase"
 ---
+
+<Warning>
+  **`@polar-sh/supabase` is deprecated** and no longer maintained. Integrate with
+  the [TypeScript SDK](/integrate/sdk/typescript) directly instead. The
+  [`polar-integration` skill](https://github.com/polarsource/skills/tree/main/skills/polar-integration)
+  can help you migrate:
+
+  ```bash
+  npx skills add https://github.com/polarsource/skills --skill polar-integration
+  ```
+</Warning>
 
 ## Examples
 

--- a/docs/integrate/sdk/adapters/sveltekit.mdx
+++ b/docs/integrate/sdk/adapters/sveltekit.mdx
@@ -1,7 +1,18 @@
 ---
-title: "Sveltekit"
+title: "Sveltekit (deprecated)"
 description: "Payments and Checkouts made dead simple with Sveltekit"
 ---
+
+<Warning>
+  **`@polar-sh/sveltekit` is deprecated** and no longer maintained. Integrate with
+  the [TypeScript SDK](/integrate/sdk/typescript) directly instead. The
+  [`polar-integration` skill](https://github.com/polarsource/skills/tree/main/skills/polar-integration)
+  can help you migrate:
+
+  ```bash
+  npx skills add https://github.com/polarsource/skills --skill polar-integration
+  ```
+</Warning>
 
 ## Examples
 

--- a/docs/integrate/sdk/typescript.mdx
+++ b/docs/integrate/sdk/typescript.mdx
@@ -66,15 +66,15 @@ const polar = createPolar({
 
 Implement Checkout & Webhook handlers in few lines of code.
 
-- [Astro](/integrate/sdk/adapters/astro)
 - [Better Auth](/integrate/sdk/adapters/better-auth)
-- [Deno](/integrate/sdk/adapters/deno)
-- [Elysia](/integrate/sdk/adapters/elysia)
-- [Express](/integrate/sdk/adapters/express)
-- [Hono](/integrate/sdk/adapters/hono)
-- [Fastify](/integrate/sdk/adapters/fastify)
 - [Next.js](/integrate/sdk/adapters/nextjs)
 - [Nuxt](/integrate/sdk/adapters/nuxt)
-- [Remix](/integrate/sdk/adapters/remix)
-- [Sveltekit](/integrate/sdk/adapters/sveltekit)
 - [TanStack Start](/integrate/sdk/adapters/tanstack-start)
+
+Adapters for other frameworks are deprecated, use the SDK directly instead.
+The [`polar-integration` skill](https://github.com/polarsource/skills/tree/main/skills/polar-integration)
+can help you integrate or migrate:
+
+```bash
+npx skills add https://github.com/polarsource/skills --skill polar-integration
+```


### PR DESCRIPTION
## Summary

Mark our deprecated adapters as deprecated in our docs. **Do not merge** until the deprecation is finalized

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

