### PR TITLE
server/oauth2: fix issuer

### DIFF
--- a/server/polar/oauth2/constants.py
+++ b/server/polar/oauth2/constants.py
@@ -15,7 +15,7 @@ REFRESH_TOKEN_PREFIX: dict[SubType, str] = {
     SubType.organization: "polar_rt_o_",
 }
 
-ISSUER = "https://polar.sh"
+ISSUER = settings.BASE_URL
 SERVICE_DOCUMENTATION = "https://polar.sh/docs"
 SUBJECT_TYPES_SUPPORTED = ["public"]
 ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED = ["RS256"]


### PR DESCRIPTION

Following RFC8414, the issuer must corresponds to the root URL on which the metadata document is served.

This change uses the dynamic BASE_URL configuration variable to match the actual URL the server is served from.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

