### PR TITLE
fix(checkout): commit before redirecting from checkout link

### DIFF
--- a/server/polar/checkout_link/endpoints.py
+++ b/server/polar/checkout_link/endpoints.py
@@ -255,4 +255,10 @@ async def redirect(
     }
     checkout_url = checkout_url.include_query_params(**query_params)
 
+    # Commit before redirecting: the client immediately fetches the checkout by
+    # its client secret, but get_db_session only commits after the response is
+    # sent. Without an explicit commit, that follow-up read can race ahead of the
+    # commit and 404 on a checkout that was just created.
+    await session.commit()
+
     return RedirectResponse(checkout_url)


### PR DESCRIPTION
## Problem

Customers loading a checkout link occasionally hit a **404** on the checkout page that self-heals on retry. Investigated a real case in Logfire (`polar_c_ThwYq…`, checkout `d8d14903-…`):

| Time (UTC) | Event |
|---|---|
| 14:00:08.191 | `GET /polar_cl_4ejC7…` hits the checkout-link `redirect` handler |
| 14:00:08.653 | `INSERT INTO checkouts` runs (row's `created_at`) |
| 14:00:08.950 | Handler returns **307** to the checkout page — *transaction not yet committed* |
| **14:00:09.461** | Client SSR fetches `GET /v1/checkouts/client/polar_c_ThwYq…` → **404** |
| 14:00:43.722 | Same GET retried → **200** (row now visible) |

## Root cause

The read and the write both hit the **primary** (`polar_cpit_p9lf`), so this is **not** replica lag. It's a read-after-write race on the same DB:

- `get_db_session` commits in its post-`yield` block, which FastAPI runs **after the response is sent**.
- So `redirect` issues the 307 **before** its checkout INSERT is committed.
- The redirected client immediately fetches the checkout by client secret; under READ COMMITTED that separate transaction can't see the still-uncommitted row → 404. `flush()` doesn't help — the row must be **committed** to be visible to another request.

Normally the commit lands within a few ms so the window is invisible; under load it stretched past the client's follow-up read here.

## Fix

Explicitly `await session.commit()` at the end of the `redirect` handler, before returning the `RedirectResponse`, so the checkout is durable and visible before the client is told to go read it. This mirrors the existing `client_stream` endpoint, which commits before handing off to a long-lived response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

