### PR TITLE
Sync OpenAPI to Gram

### DIFF
--- a/.github/workflows/gram-sync.yml
+++ b/.github/workflows/gram-sync.yml
@@ -1,0 +1,75 @@
+name: Sync OpenAPI to Gram
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "server/polar/**"
+      - "server/scripts/generate_openapi.py"
+      - "server/pyproject.toml"
+      - "server/uv.lock"
+      - "sdk/generator/**"
+  workflow_dispatch:
+
+concurrency:
+  group: gram-sync
+  cancel-in-progress: true
+
+jobs:
+  push-source:
+    name: "Push OpenAPI source"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      GRAM_API_KEY: ${{ secrets.GRAM_API_KEY }}
+      GRAM_ORG: polar
+      GRAM_PROJECT: default
+      POLAR_EMAIL_RENDERER_BINARY_PATH: "/tmp/email-renderer"
+      POLAR_PYDANTIC_AI_GATEWAY_API_KEY: "POLAR_PYDANTIC_AI_GATEWAY_API_KEY"
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version-file: "server/pyproject.toml"
+
+      - name: Set up server
+        working-directory: server
+        run: |
+          touch /tmp/email-renderer
+          uv sync --frozen
+          uv run task generate_dev_jwks
+
+      - name: Generate OpenAPI schema
+        working-directory: server
+        run: uv run -m scripts.generate_openapi > "$RUNNER_TEMP/raw.openapi.json"
+
+      - name: Install OpenAPI generator dependencies
+        working-directory: sdk/generator
+        run: uv sync --frozen
+
+      - name: Generate public OpenAPI schema
+        run: |
+          uv run --directory sdk/generator -m cli mcp-openapi \
+            "$RUNNER_TEMP/raw.openapi.json" \
+            --output "$RUNNER_TEMP/gram-openapi"
+
+      - name: Install Gram CLI
+        run: curl -fsSL https://raw.githubusercontent.com/speakeasy-api/cli/main/install-cli.sh | bash
+
+      - name: Push OpenAPI source
+        run: |
+          gram stage --config "$RUNNER_TEMP/gram.deploy.json" openapi \
+            --slug polar \
+            --name "Polar" \
+            --location "$RUNNER_TEMP/gram-openapi/raw.openapi.json"
+          gram push --config "$RUNNER_TEMP/gram.deploy.json" --method merge

--- a/.github/workflows/gram-sync.yml
+++ b/.github/workflows/gram-sync.yml
@@ -27,7 +27,6 @@ jobs:
       GRAM_ORG: polar
       GRAM_PROJECT: default
       POLAR_EMAIL_RENDERER_BINARY_PATH: "/tmp/email-renderer"
-      POLAR_PYDANTIC_AI_GATEWAY_API_KEY: "POLAR_PYDANTIC_AI_GATEWAY_API_KEY"
 
     steps:
       - uses: actions/checkout@v7.0.1

--- a/sdk/generator/cli.py
+++ b/sdk/generator/cli.py
@@ -8,6 +8,7 @@ import openapi_pydantic as op
 from generator.docs_openapi import DOCS_OPENAPI_PATH, generate_docs_openapi
 from generator.emitter import Prerelease
 from generator.ir import generate_ir
+from generator.mcp_openapi import generate_mcp_openapi
 from generator.release import regenerate_openapi, release_sdk
 from python.emitter import PythonEmitter
 
@@ -46,6 +47,19 @@ parser_docs_openapi.add_argument(
     type=str,
     default="0.0.0",
     help="SDK version represented by the code samples (default: 0.0.0).",
+)
+
+parser_mcp_openapi = subparsers.add_parser(
+    "mcp-openapi", help="Generate a public OpenAPI spec for MCP"
+)
+parser_mcp_openapi.add_argument(
+    "spec_paths", nargs="+", type=pathlib.Path, help="Paths to OpenAPI spec files."
+)
+parser_mcp_openapi.add_argument(
+    "--output",
+    type=pathlib.Path,
+    required=True,
+    help="Directory to write the generated OpenAPI specs.",
 )
 parser_generate.add_argument(
     "--language",
@@ -157,6 +171,16 @@ elif args.command == "docs-openapi":
             print(f"Error: Spec path {spec_path} is not a file.", file=sys.stderr)
             sys.exit(1)
     generate_docs_openapi(args.spec_paths, args.output, args.version)
+
+elif args.command == "mcp-openapi":
+    for spec_path in args.spec_paths:
+        if not spec_path.exists():
+            print(f"Error: Spec file {spec_path} does not exist.", file=sys.stderr)
+            sys.exit(1)
+        if not spec_path.is_file():
+            print(f"Error: Spec path {spec_path} is not a file.", file=sys.stderr)
+            sys.exit(1)
+    generate_mcp_openapi(args.spec_paths, args.output)
 
 elif args.command == "release":
     prerelease = None

--- a/sdk/generator/generator/docs_openapi.py
+++ b/sdk/generator/generator/docs_openapi.py
@@ -1,83 +1,15 @@
 import json
 import pathlib
-import subprocess
 import tempfile
-import typing
 
 import openapi_pydantic as op
 
 from generator.code_samples import generate_code_samples_overlay
 from generator.ir import generate_ir
 from generator.openapi import ROOT
+from generator.openapi_overlay import apply_overlay, remove_private_operations
 
-HTTP_METHODS = frozenset(
-    {"delete", "get", "head", "options", "patch", "post", "put", "trace"}
-)
 DOCS_OPENAPI_PATH = ROOT / "docs" / "openapi"
-
-
-def generate_private_operations_overlay(
-    schema: dict[str, typing.Any],
-) -> dict[str, typing.Any]:
-    actions: list[dict[str, typing.Any]] = []
-    for section_name in ("paths", "webhooks"):
-        section = schema.get(section_name, {})
-        if not isinstance(section, dict):
-            continue
-        for path, path_item in section.items():
-            if not isinstance(path_item, dict):
-                continue
-            operations = {
-                method: operation
-                for method, operation in path_item.items()
-                if method in HTTP_METHODS and isinstance(operation, dict)
-            }
-            private_methods = [
-                method
-                for method, operation in operations.items()
-                if "private" in operation.get("tags", [])
-            ]
-            if not private_methods:
-                continue
-            path_target = f"$[{json.dumps(section_name)}][{json.dumps(path)}]"
-            if len(private_methods) == len(operations):
-                actions.append({"target": path_target, "remove": True})
-                continue
-            actions.extend(
-                {
-                    "target": f"{path_target}[{json.dumps(method)}]",
-                    "remove": True,
-                }
-                for method in private_methods
-            )
-
-    version = schema.get("info", {}).get("version", "0.0.0")
-    return {
-        "overlay": "1.1.0",
-        "info": {
-            "title": "Remove private API operations",
-            "version": version,
-        },
-        "actions": actions,
-    }
-
-
-def apply_overlay(
-    openapi_path: pathlib.Path,
-    overlay_path: pathlib.Path,
-    output_path: pathlib.Path,
-) -> None:
-    subprocess.run(
-        [
-            "oas-patch",
-            "overlay",
-            str(openapi_path),
-            str(overlay_path),
-            "-o",
-            str(output_path),
-        ],
-        check=True,
-    )
 
 
 def generate_docs_openapi(
@@ -97,7 +29,6 @@ def generate_docs_openapi(
             temporary_path = pathlib.Path(temporary_directory)
             samples_overlay_path = temporary_path / "samples.overlay.json"
             samples_path = temporary_path / "samples.json"
-            private_overlay_path = temporary_path / "private.overlay.json"
             final_path = temporary_path / "openapi.json"
 
             samples_overlay = generate_code_samples_overlay(
@@ -109,11 +40,11 @@ def generate_docs_openapi(
             )
             apply_overlay(openapi_file, samples_overlay_path, samples_path)
 
-            private_overlay = generate_private_operations_overlay(openapi_spec_dict)
-            private_overlay_path.write_text(
-                json.dumps(private_overlay, indent=2, ensure_ascii=False) + "\n",
-                encoding="utf-8",
+            remove_private_operations(
+                samples_path,
+                openapi_spec_dict,
+                temporary_path,
+                final_path,
             )
-            apply_overlay(samples_path, private_overlay_path, final_path)
 
             final_path.replace(output_path / openapi_file.name)

--- a/sdk/generator/generator/mcp_openapi.py
+++ b/sdk/generator/generator/mcp_openapi.py
@@ -1,0 +1,23 @@
+import json
+import pathlib
+import tempfile
+
+from generator.openapi_overlay import remove_private_operations
+
+
+def generate_mcp_openapi(
+    openapi_files: list[pathlib.Path], output_path: pathlib.Path
+) -> None:
+    output_path.mkdir(parents=True, exist_ok=True)
+    for openapi_file in openapi_files:
+        openapi_spec_dict = json.loads(openapi_file.read_text(encoding="utf-8"))
+
+        with tempfile.TemporaryDirectory(
+            dir=output_path, prefix="openapi-generation-"
+        ) as temporary_directory:
+            temporary_path = pathlib.Path(temporary_directory)
+            final_path = temporary_path / "openapi.json"
+            remove_private_operations(
+                openapi_file, openapi_spec_dict, temporary_path, final_path
+            )
+            final_path.replace(output_path / openapi_file.name)

--- a/sdk/generator/generator/openapi_overlay.py
+++ b/sdk/generator/generator/openapi_overlay.py
@@ -1,0 +1,87 @@
+import json
+import pathlib
+import subprocess
+import typing
+
+HTTP_METHODS = frozenset(
+    {"delete", "get", "head", "options", "patch", "post", "put", "trace"}
+)
+
+
+def generate_private_operations_overlay(
+    schema: dict[str, typing.Any],
+) -> dict[str, typing.Any]:
+    actions: list[dict[str, typing.Any]] = []
+    for section_name in ("paths", "webhooks"):
+        section = schema.get(section_name, {})
+        if not isinstance(section, dict):
+            continue
+        for path, path_item in section.items():
+            if not isinstance(path_item, dict):
+                continue
+            operations = {
+                method: operation
+                for method, operation in path_item.items()
+                if method in HTTP_METHODS and isinstance(operation, dict)
+            }
+            private_methods = [
+                method
+                for method, operation in operations.items()
+                if "private" in operation.get("tags", [])
+            ]
+            if not private_methods:
+                continue
+            path_target = f"$[{json.dumps(section_name)}][{json.dumps(path)}]"
+            if len(private_methods) == len(operations):
+                actions.append({"target": path_target, "remove": True})
+                continue
+            actions.extend(
+                {
+                    "target": f"{path_target}[{json.dumps(method)}]",
+                    "remove": True,
+                }
+                for method in private_methods
+            )
+
+    version = schema.get("info", {}).get("version", "0.0.0")
+    return {
+        "overlay": "1.1.0",
+        "info": {
+            "title": "Remove private API operations",
+            "version": version,
+        },
+        "actions": actions,
+    }
+
+
+def apply_overlay(
+    openapi_path: pathlib.Path,
+    overlay_path: pathlib.Path,
+    output_path: pathlib.Path,
+) -> None:
+    subprocess.run(
+        [
+            "oas-patch",
+            "overlay",
+            str(openapi_path),
+            str(overlay_path),
+            "-o",
+            str(output_path),
+        ],
+        check=True,
+    )
+
+
+def remove_private_operations(
+    openapi_path: pathlib.Path,
+    openapi_spec_dict: dict[str, typing.Any],
+    temporary_path: pathlib.Path,
+    output_path: pathlib.Path,
+) -> None:
+    private_overlay_path = temporary_path / "private.overlay.json"
+    private_overlay = generate_private_operations_overlay(openapi_spec_dict)
+    private_overlay_path.write_text(
+        json.dumps(private_overlay, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    apply_overlay(openapi_path, private_overlay_path, output_path)

--- a/sdk/generator/tests/test_mcp_openapi.py
+++ b/sdk/generator/tests/test_mcp_openapi.py
@@ -1,0 +1,27 @@
+import json
+import pathlib
+import typing
+
+from generator.mcp_openapi import generate_mcp_openapi
+
+
+def test_generate_mcp_openapi_removes_private_operations(
+    tmp_path: pathlib.Path,
+) -> None:
+    schema: dict[str, typing.Any] = {
+        "openapi": "3.1.0",
+        "info": {"title": "Test", "version": "2026-04"},
+        "paths": {
+            "/public": {"get": {"tags": ["public"]}},
+            "/private": {"get": {"tags": ["private"]}},
+        },
+    }
+    source_path = tmp_path / "source.json"
+    output_path = tmp_path / "output"
+    source_path.write_text(json.dumps(schema), encoding="utf-8")
+
+    generate_mcp_openapi([source_path], output_path)
+
+    output = json.loads((output_path / source_path.name).read_text(encoding="utf-8"))
+    assert "/public" in output["paths"]
+    assert "/private" not in output["paths"]

--- a/sdk/generator/tests/test_openapi_overlay.py
+++ b/sdk/generator/tests/test_openapi_overlay.py
@@ -2,7 +2,10 @@ import json
 import pathlib
 import typing
 
-from generator.docs_openapi import apply_overlay, generate_private_operations_overlay
+from generator.openapi_overlay import (
+    apply_overlay,
+    generate_private_operations_overlay,
+)
 
 
 def test_private_operations_overlay_removes_private_operations(


### PR DESCRIPTION
Automating sending our OpenAPI spec to Gram to power our MCP.

I went back and forth quite a bit and decided to use our existing generator approach to create an MCP-specific version of our OpenAPI spec, similar to how we do for our docs, and strip the private API out of it.

In a follow-up PR, we can then look towards adding the `x-gram` support or other filtering/extending, and then use the generator as the source of truth.

The generator is then called from inside a CI/CD script that generates the OpenAPI spec on the fly and pushes it straight to Gram.