### PR TITLE
feat(dashboard): metered tier editor and display

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/meter/[meterId]/CustomerMeterPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/meter/[meterId]/CustomerMeterPage.tsx
@@ -14,6 +14,8 @@ import { useCustomerMeters } from '@/hooks/queries/customerMeters'
 import { useInfiniteEvents } from '@/hooks/queries/events'
 import { useMeterQuantities } from '@/hooks/queries/meters'
 import { Events } from '@/components/Events/Events'
+import { estimateMeteredCost } from '@/components/Products/ProductForm/Pricing/utils'
+import { isMeteredPrice, MeteredPrice } from '@/utils/product'
 import { ParsedMetricPeriod } from '@/hooks/queries/metrics'
 import { useSubscriptions } from '@/hooks/queries/subscriptions'
 import { getCustomerActivityStart } from '@/utils/customer'
@@ -127,8 +129,7 @@ const CustomerMeterPage = ({
   const unitPrice = useMemo(
     () =>
       subscription?.product.prices.find(
-        (p): p is schemas['ProductPriceMeteredUnit'] =>
-          p.amount_type === 'metered_unit' && p.meter_id === meter.id,
+        (p): p is MeteredPrice => isMeteredPrice(p) && p.meter_id === meter.id,
       ) ?? null,
     [subscription, meter.id],
   )
@@ -160,10 +161,8 @@ const CustomerMeterPage = ({
 
   const overages = useMemo(() => {
     if (!unitPrice || !customerMeter || customerMeter.balance >= 0) return null
-    const cost =
-      Math.abs(customerMeter.balance) * parseFloat(unitPrice.unit_amount)
     return {
-      cost: unitPrice.cap_amount ? Math.min(cost, unitPrice.cap_amount) : cost,
+      cost: estimateMeteredCost(unitPrice, Math.abs(customerMeter.balance)),
       currency: unitPrice.price_currency,
     }
   }, [customerMeter, unitPrice])

--- a/clients/apps/web/src/components/Customer/CustomerMeter.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerMeter.tsx
@@ -1,3 +1,5 @@
+import { estimateMeteredCost } from '@/components/Products/ProductForm/Pricing/utils'
+import { isMeteredPrice, MeteredPrice } from '@/utils/product'
 import { ParsedMeterQuantities } from '@/hooks/queries/meters'
 import { ParsedMetricPeriod } from '@/hooks/queries/metrics'
 import { schemas } from '@polar-sh/client'
@@ -21,8 +23,8 @@ export const CustomerMeter = ({
   const { meter } = customerMeter
 
   const unitPrice = customerMeter.subscription?.product.prices.find(
-    (price): price is schemas['ProductPriceMeteredUnit'] =>
-      price.amount_type === 'metered_unit' && price.meter_id === meter.id,
+    (price): price is MeteredPrice =>
+      isMeteredPrice(price) && price.meter_id === meter.id,
   )
 
   const overages = useMemo(() => {
@@ -35,13 +37,7 @@ export const CustomerMeter = ({
     }
 
     const overageUnits = Math.abs(customerMeter.balance)
-    const overageCost = overageUnits * parseFloat(unitPrice.unit_amount)
-
-    if (unitPrice.cap_amount) {
-      return Math.min(overageCost, unitPrice.cap_amount)
-    }
-
-    return overageCost
+    return estimateMeteredCost(unitPrice, overageUnits)
   }, [customerMeter.balance, unitPrice])
 
   const creditProgress = useMemo(() => {

--- a/clients/apps/web/src/components/Customer/CustomerPage/CustomerUsageView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerPage/CustomerUsageView.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { estimateMeteredCost } from '@/components/Products/ProductForm/Pricing/utils'
+import { isMeteredPrice, MeteredPrice } from '@/utils/product'
 import { useCustomerMeters } from '@/hooks/queries/customerMeters'
 import { useMultipleMeterQuantities } from '@/hooks/queries/meters'
 import { useSubscriptions } from '@/hooks/queries/subscriptions'
@@ -40,17 +42,14 @@ const getOverages = (cm: CustomerMeterWithSubscription) => {
   if (!cm.subscription || cm.balance >= 0) return null
 
   const unitPrice = cm.subscription.product.prices.find(
-    (price): price is schemas['ProductPriceMeteredUnit'] =>
-      price.amount_type === 'metered_unit' && price.meter_id === cm.meter.id,
+    (price): price is MeteredPrice =>
+      isMeteredPrice(price) && price.meter_id === cm.meter.id,
   )
   if (!unitPrice) return null
 
   const overageUnits = Math.abs(cm.balance)
-  const overageCost = overageUnits * parseFloat(unitPrice.unit_amount)
   return {
-    cost: unitPrice.cap_amount
-      ? Math.min(overageCost, unitPrice.cap_amount)
-      : overageCost,
+    cost: estimateMeteredCost(unitPrice, overageUnits),
     currency: unitPrice.price_currency,
   }
 }

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredPricingFields.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredPricingFields.tsx
@@ -73,6 +73,7 @@ export const MeteredPricingFields: React.FC<MeteredPricingFieldsProps> = ({
         price_currency: getValues(`prices.${index}.price_currency`),
         meter_id: getValues(`prices.${index}.meter_id`),
         cap_amount: getValues(`prices.${index}.cap_amount`),
+        tax_behavior: getValues(`prices.${index}.tax_behavior`),
       }
       const currentTiers = getValues(`prices.${index}.tiers`)
       if (value === 'fixed') {

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredPricingFields.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredPricingFields.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import { useMeters } from '@/hooks/queries/meters'
+import { schemas } from '@polar-sh/client'
+import { Box } from '@polar-sh/orbit/Box'
+import { formatCurrency } from '@polar-sh/currency'
+import MoneyInput from '@polar-sh/ui/components/atoms/MoneyInput'
+import { getMeterUnitFormat } from '@polar-sh/ui/lib/meterUnit'
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@polar-sh/orbit'
+import { InfoIcon } from 'lucide-react'
+import React, { useCallback, useMemo } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { ProductFormType } from '../ProductForm'
+import UnitAmountInput from '../UnitAmountInput'
+import { MeteredTierEditor } from './MeteredTierEditor'
+
+type MeteredPricingModel = 'fixed' | 'graduated' | 'volume'
+
+export interface MeteredPricingFieldsProps {
+  organization: schemas['Organization']
+  index: number
+  currency: string
+}
+
+export const MeteredPricingFields: React.FC<MeteredPricingFieldsProps> = ({
+  organization,
+  index,
+  currency,
+}) => {
+  const { control, setValue, watch, getValues } =
+    useFormContext<ProductFormType>()
+
+  const { data: meters } = useMeters(organization.id, {
+    sorting: ['name'],
+    limit: 30,
+    is_archived: false,
+  })
+
+  const meterId = watch(`prices.${index}.meter_id`)
+  const amountType = watch(`prices.${index}.amount_type`)
+  const unitAmount = watch(`prices.${index}.unit_amount`)
+  const tiersValue = watch(`prices.${index}.tiers`)
+  const tieredPricingEnabled =
+    organization.feature_settings?.metered_tiered_pricing_enabled ?? false
+
+  const pricingModel: MeteredPricingModel =
+    tieredPricingEnabled && amountType === 'metered_tiers' && tiersValue
+      ? tiersValue.type
+      : 'fixed'
+
+  // A flat rate and tiers are separate price types, so switching the model
+  // replaces the price rather than clearing one of its fields.
+  const handlePricingModelChange = useCallback(
+    (value: MeteredPricingModel) => {
+      const base = {
+        price_currency: getValues(`prices.${index}.price_currency`),
+        meter_id: getValues(`prices.${index}.meter_id`),
+        cap_amount: getValues(`prices.${index}.cap_amount`),
+      }
+      const currentTiers = getValues(`prices.${index}.tiers`)
+      if (value === 'fixed') {
+        setValue(`prices.${index}`, {
+          ...base,
+          amount_type: 'metered_unit',
+          unit_amount: Number(currentTiers?.tiers?.[0]?.unit_amount) || 0,
+        })
+      } else {
+        setValue(`prices.${index}`, {
+          ...base,
+          amount_type: 'metered_tiers',
+          tiers: {
+            type: value,
+            tiers: currentTiers?.tiers ?? [
+              {
+                bound: null,
+                unit_amount: getValues(`prices.${index}.unit_amount`) ?? 0,
+              },
+            ],
+          },
+        })
+      }
+      setValue(`prices.${index}.id`, '')
+    },
+    [getValues, setValue, index],
+  )
+
+  const pricePreview = useMemo(() => {
+    const selectedMeter = meters?.items.find(
+      (m: schemas['Meter']) => m.id === meterId,
+    )
+    const { scale, label } = getMeterUnitFormat(
+      selectedMeter?.unit ?? 'scalar',
+      {
+        customLabel: selectedMeter?.custom_label,
+        customMultiplier: selectedMeter?.custom_multiplier,
+      },
+    )
+    const cents = Number.parseFloat(String(unitAmount || '0'))
+    const formatted = formatCurrency('subcent')(cents * scale, currency)
+    return `${formatted} / ${label}`
+  }, [meterId, unitAmount, meters, currency])
+
+  return (
+    <>
+      {tieredPricingEnabled ? (
+        <FormItem>
+          <FormLabel>Pricing model</FormLabel>
+          <Box display="block">
+            <Select
+              value={pricingModel}
+              onValueChange={(v) =>
+                handlePricingModelChange(v as MeteredPricingModel)
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="fixed">Flat price per unit</SelectItem>
+                <SelectItem value="graduated">Graduated</SelectItem>
+                <SelectItem value="volume">Volume</SelectItem>
+              </SelectContent>
+            </Select>
+          </Box>
+        </FormItem>
+      ) : null}
+
+      {pricingModel === 'fixed' ? (
+        <FormField
+          control={control}
+          name={`prices.${index}.unit_amount`}
+          rules={{
+            required: 'This field is required',
+            validate: (value) =>
+              Number(value) > 0 || 'Amount must be greater than 0',
+          }}
+          render={({ field }) => {
+            return (
+              <FormItem>
+                <FormLabel>Amount per unit</FormLabel>
+                <FormControl>
+                  <UnitAmountInput
+                    {...field}
+                    name={field.name}
+                    currency={currency}
+                    value={field.value ?? ''}
+                    onValueChange={(v) => {
+                      field.onChange(v)
+                      setValue(`prices.${index}.id`, '')
+                    }}
+                  />
+                </FormControl>
+                <FormDescription>Displayed as {pricePreview}</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )
+          }}
+        />
+      ) : (
+        <MeteredTierEditor index={index} currency={currency} />
+      )}
+
+      <FormField
+        control={control}
+        name={`prices.${index}.cap_amount`}
+        render={({ field }) => {
+          return (
+            <FormItem>
+              <FormLabel>
+                <Box
+                  as="span"
+                  display="inline-flex"
+                  alignItems="center"
+                  columnGap="xs"
+                >
+                  Cap amount
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Box
+                        as="span"
+                        display="inline-flex"
+                        color="text-tertiary"
+                      >
+                        <InfoIcon className="h-3.5 w-3.5" />
+                      </Box>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-3xs">
+                      Optional maximum amount that can be charged, regardless of
+                      the number of units consumed.
+                    </TooltipContent>
+                  </Tooltip>
+                </Box>
+              </FormLabel>
+              <FormControl>
+                <MoneyInput
+                  {...field}
+                  name={field.name}
+                  currency={currency}
+                  value={field.value}
+                  onChange={(v) => {
+                    field.onChange(v)
+                    setValue(`prices.${index}.id`, '')
+                  }}
+                  placeholder={10000}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )
+        }}
+      />
+    </>
+  )
+}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredPricingFields.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredPricingFields.tsx
@@ -61,9 +61,7 @@ export const MeteredPricingFields: React.FC<MeteredPricingFieldsProps> = ({
     organization.feature_settings?.metered_tiered_pricing_enabled ?? false
 
   const pricingModel: MeteredPricingModel =
-    tieredPricingEnabled && amountType === 'metered_tiers' && tiersValue
-      ? tiersValue.type
-      : 'fixed'
+    amountType === 'metered_tiers' && tiersValue ? tiersValue.type : 'fixed'
 
   // A flat rate and tiers are separate price types, so switching the model
   // replaces the price rather than clearing one of its fields.

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredTierCard.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredTierCard.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { formatScalar } from '@/utils/formatters'
+import CloseOutlined from '@mui/icons-material/CloseOutlined'
+import { Button, Grid, Input, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import React from 'react'
+import { useFormContext } from 'react-hook-form'
+import { ProductFormType } from '../ProductForm'
+import UnitAmountInput from '../UnitAmountInput'
+
+export interface MeteredTierCardProps {
+  index: number
+  tierIndex: number
+  currency: string
+  hasSingleTier: boolean
+  title: string
+  previousBound: number
+  isLast: boolean
+  onRemove: () => void
+}
+
+export const MeteredTierCard: React.FC<MeteredTierCardProps> = ({
+  index,
+  tierIndex,
+  currency,
+  hasSingleTier,
+  title,
+  previousBound,
+  isLast,
+  onRemove,
+}) => {
+  const { control, setValue } = useFormContext<ProductFormType>()
+  const titleId = `metered-tier-title-${index}-${tierIndex}`
+
+  const handleBoundChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    onChange: (value: number | null) => void,
+  ) => {
+    if (isLast) {
+      return
+    }
+    const value = event.currentTarget.valueAsNumber
+    onChange(Number.isNaN(value) ? null : value)
+    setValue(`prices.${index}.id`, '')
+  }
+
+  const handleBoundBlur = (
+    event: React.FocusEvent<HTMLInputElement>,
+    onChange: (value: number | null) => void,
+    onBlur: () => void,
+  ) => {
+    onBlur()
+    if (isLast) {
+      onChange(null)
+      return
+    }
+    const parsed = event.currentTarget.valueAsNumber
+    const minAllowed = previousBound + 1
+    if (Number.isNaN(parsed)) {
+      onChange(minAllowed)
+      return
+    }
+    if (!Number.isInteger(parsed)) {
+      return
+    }
+    onChange(Math.max(parsed, minAllowed))
+  }
+
+  const fields = (
+    <Grid templateColumns="1fr 1fr" columnGap="m" alignItems="start">
+      <FormField
+        control={control}
+        name={`prices.${index}.tiers.tiers.${tierIndex}.bound` as const}
+        rules={{
+          required: isLast ? false : 'Required',
+          validate: (value) => {
+            if (isLast && value == null) {
+              return true
+            }
+            if (!Number.isInteger(value)) {
+              return 'Must be a whole number of units'
+            }
+            if (value != null && value <= previousBound) {
+              return `Must be greater than ${formatScalar(previousBound)}`
+            }
+            return true
+          },
+        }}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Up to</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                type="number"
+                min={previousBound + 1}
+                step={1}
+                value={field.value ?? ''}
+                readOnly={isLast}
+                placeholder={isLast ? 'Unlimited' : undefined}
+                onChange={(e) => handleBoundChange(e, field.onChange)}
+                onBlur={(e) => handleBoundBlur(e, field.onChange, field.onBlur)}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name={`prices.${index}.tiers.tiers.${tierIndex}.unit_amount` as const}
+        rules={{
+          required: 'This field is required',
+          min: { value: 0, message: 'Must be 0 or more' },
+        }}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Price per unit</FormLabel>
+            <FormControl>
+              <UnitAmountInput
+                {...field}
+                currency={currency}
+                value={field.value}
+                onValueChange={(v) => {
+                  field.onChange(v)
+                  setValue(`prices.${index}.id`, '')
+                }}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </Grid>
+  )
+
+  if (hasSingleTier) {
+    return fields
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      rowGap="m"
+      borderRadius="l"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+      backgroundColor="background-primary"
+      padding="l"
+      role="group"
+      aria-labelledby={titleId}
+    >
+      <Box alignItems="start" justifyContent="between" columnGap="m">
+        <Text id={titleId} as="span" variant="label" color="muted">
+          {title}
+        </Text>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className="-my-1 h-7 w-7"
+          onClick={onRemove}
+          aria-label={`Remove ${title}`}
+        >
+          <CloseOutlined className="h-3.5 w-3.5" />
+        </Button>
+      </Box>
+      {fields}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredTierEditor.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/MeteredTierEditor.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { Box } from '@polar-sh/orbit/Box'
+import { Button } from '@polar-sh/orbit'
+import React, { useCallback } from 'react'
+import { useFieldArray, useFormContext } from 'react-hook-form'
+import { ProductFormType } from '../ProductForm'
+import { MeteredTierCard } from './MeteredTierCard'
+
+const formatUnits = (value: number) => value.toLocaleString('en-US')
+
+const getMeteredTierTitle = (
+  bound: number | null | undefined,
+  previousBound: number,
+) => {
+  const from = previousBound + 1
+  if (bound == null) return `${formatUnits(from)}+`
+  if (bound === from) return `${formatUnits(from)}`
+  return `${formatUnits(from)}–${formatUnits(bound)}`
+}
+
+export interface MeteredTierEditorProps {
+  index: number
+  currency: string
+}
+
+export const MeteredTierEditor: React.FC<MeteredTierEditorProps> = ({
+  index,
+  currency,
+}) => {
+  const { control, setValue, watch, getValues } =
+    useFormContext<ProductFormType>()
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: `prices.${index}.tiers.tiers` as const,
+  })
+
+  const tiers = watch(`prices.${index}.tiers.tiers`)
+  const hasSingleTier = fields.length === 1
+
+  const forceLastTierUnbounded = useCallback(() => {
+    const currentTiers = getValues(`prices.${index}.tiers.tiers`)
+    if (!currentTiers || currentTiers.length === 0) return
+    setValue(
+      `prices.${index}.tiers.tiers.${currentTiers.length - 1}.bound`,
+      null,
+    )
+  }, [getValues, setValue, index])
+
+  const addTier = useCallback(() => {
+    const currentTiers = getValues(`prices.${index}.tiers.tiers`)
+    const lastTier = currentTiers?.[currentTiers.length - 1]
+    const previousBound = Number(
+      currentTiers?.[(currentTiers?.length ?? 0) - 2]?.bound ?? 0,
+    )
+    const newBound = previousBound > 0 ? previousBound * 2 : 1000
+
+    if (currentTiers && currentTiers.length > 0) {
+      setValue(
+        `prices.${index}.tiers.tiers.${currentTiers.length - 1}.bound`,
+        newBound,
+      )
+    }
+    append({ bound: null, unit_amount: lastTier?.unit_amount ?? 0 })
+    setValue(`prices.${index}.id`, '')
+  }, [getValues, append, setValue, index])
+
+  const removeTier = useCallback(
+    (tierIndex: number) => {
+      remove(tierIndex)
+      setValue(`prices.${index}.id`, '')
+      forceLastTierUnbounded()
+    },
+    [remove, setValue, index, forceLastTierUnbounded],
+  )
+
+  return (
+    <Box flexDirection="column" rowGap="l">
+      {fields.map((field, tierIndex) => {
+        const previousBound = Number(tiers?.[tierIndex - 1]?.bound ?? 0)
+        return (
+          <MeteredTierCard
+            key={field.id}
+            index={index}
+            tierIndex={tierIndex}
+            currency={currency}
+            hasSingleTier={hasSingleTier}
+            title={getMeteredTierTitle(
+              tiers?.[tierIndex]?.bound,
+              previousBound,
+            )}
+            previousBound={previousBound}
+            isLast={tierIndex === fields.length - 1}
+            onRemove={() => removeTier(tierIndex)}
+          />
+        )
+      })}
+
+      <Button
+        type="button"
+        variant="secondary"
+        size="sm"
+        onClick={addTier}
+        className="self-start"
+      >
+        Add tier
+      </Button>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceItem.tsx
@@ -33,6 +33,7 @@ const AMOUNT_TYPE_LABELS: Record<string, string> = {
   seat_based: 'Seats',
   unit_based: 'Units',
   metered_unit: 'Metered price',
+  metered_tiers: 'Metered price',
 }
 
 interface ProductPriceItemProps {
@@ -166,7 +167,8 @@ export const ProductPriceItem: React.FC<ProductPriceItemProps> = ({
           {amountType === 'unit_based' && (
             <ProductPriceUnitBasedItem index={index} currency={currency} />
           )}
-          {amountType === 'metered_unit' && (
+          {(amountType === 'metered_unit' ||
+            amountType === 'metered_tiers') && (
             <ProductPriceMeteredUnitItem
               organization={organization}
               index={index}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceItem.tsx
@@ -95,7 +95,13 @@ export const ProductPriceItem: React.FC<ProductPriceItemProps> = ({
                 <div className="flex flex-row items-center gap-2">
                   <FormControl>
                     <Select
-                      value={field.value}
+                      // Both metered types share this entry; the tiers variant
+                      // is chosen inside the metered fields, not here.
+                      value={
+                        field.value === 'metered_tiers'
+                          ? 'metered_unit'
+                          : field.value
+                      }
                       onValueChange={(v) => {
                         field.onChange(v)
                         onAmountTypeChange(

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceMeteredUnitItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceMeteredUnitItem.tsx
@@ -6,25 +6,20 @@ import { InlineModal } from '@polar-sh/orbit'
 import { useModal } from '@/components/Modal/useModal'
 import { SpinnerNoMargin } from '@polar-sh/orbit'
 import { useMeters } from '@/hooks/queries/meters'
-import { formatCurrency } from '@polar-sh/currency'
 import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
-import MoneyInput from '@polar-sh/ui/components/atoms/MoneyInput'
-import { getMeterUnitFormat } from '@polar-sh/ui/lib/meterUnit'
 import {
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@polar-sh/orbit'
-import { InfoIcon, PlusIcon } from 'lucide-react'
-import React, { useCallback, useMemo } from 'react'
+import { PlusIcon } from 'lucide-react'
+import React, { useCallback } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ProductFormType } from '../ProductForm'
-import UnitAmountInput from '../UnitAmountInput'
+import { MeteredPricingFields } from './MeteredPricingFields'
 
 export interface ProductPriceMeteredUnitItemProps {
   organization: schemas['Organization']
@@ -35,33 +30,13 @@ export interface ProductPriceMeteredUnitItemProps {
 export const ProductPriceMeteredUnitItem: React.FC<
   ProductPriceMeteredUnitItemProps
 > = ({ organization, index, currency }) => {
-  const { control, setValue, watch } = useFormContext<ProductFormType>()
+  const { control, setValue } = useFormContext<ProductFormType>()
 
   const { data: meters } = useMeters(organization.id, {
     sorting: ['name'],
     limit: 30,
     is_archived: false,
   })
-
-  const meterId = watch(`prices.${index}.meter_id`)
-  const unitAmount = watch(`prices.${index}.unit_amount`)
-
-  const pricePreview = useMemo(() => {
-    const selectedMeter = meters?.items.find(
-      (m: schemas['Meter']) => m.id === meterId,
-    )
-    const { scale, label } = getMeterUnitFormat(
-      selectedMeter?.unit ?? 'scalar',
-      {
-        customLabel: selectedMeter?.custom_label,
-        customMultiplier: selectedMeter?.custom_multiplier,
-      },
-    )
-    const cents = Number.parseFloat(String(unitAmount || '0'))
-    const scaled = cents * scale
-    const formatted = formatCurrency('subcent')(scaled, currency)
-    return `${formatted} / ${label}`
-  }, [meterId, unitAmount, meters, currency])
 
   const {
     isShown: isCreateMeterModalShown,
@@ -138,72 +113,10 @@ export const ProductPriceMeteredUnitItem: React.FC<
               )
             }}
           />
-          <FormField
-            control={control}
-            name={`prices.${index}.unit_amount`}
-            rules={{
-              min: 0,
-              required: 'This field is required',
-            }}
-            render={({ field }) => {
-              return (
-                <FormItem>
-                  <FormLabel>Amount per unit</FormLabel>
-                  <FormControl>
-                    <UnitAmountInput
-                      {...field}
-                      name={field.name}
-                      currency={currency}
-                      value={field.value}
-                      onValueChange={(v) => {
-                        field.onChange(v)
-                        setValue(`prices.${index}.id`, '')
-                      }}
-                    />
-                  </FormControl>
-                  <FormDescription>Displayed as {pricePreview}</FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )
-            }}
-          />
-          <FormField
-            control={control}
-            name={`prices.${index}.cap_amount`}
-            render={({ field }) => {
-              return (
-                <FormItem>
-                  <FormLabel>
-                    <span className="flex items-center gap-x-1.5">
-                      Cap amount
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <InfoIcon className="dark:text-polar-400 h-3.5 w-3.5 text-gray-400" />
-                        </TooltipTrigger>
-                        <TooltipContent className="max-w-3xs">
-                          Optional maximum amount that can be charged,
-                          regardless of the number of units consumed.
-                        </TooltipContent>
-                      </Tooltip>
-                    </span>
-                  </FormLabel>
-                  <FormControl>
-                    <MoneyInput
-                      {...field}
-                      name={field.name}
-                      currency={currency}
-                      value={field.value}
-                      onChange={(v) => {
-                        field.onChange(v)
-                        setValue(`prices.${index}.id`, '')
-                      }}
-                      placeholder={10000}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )
-            }}
+          <MeteredPricingFields
+            organization={organization}
+            index={index}
+            currency={currency}
           />
         </>
       )}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
@@ -70,9 +70,9 @@ describe('estimateMeteredCost', () => {
       { position: 'at the tier boundary', units: 1000, expected: 5000 },
       { position: 'across tiers', units: 2000, expected: 6000 },
       {
-        position: 'with fractional usage',
+        position: 'with fractional usage, rounded to whole cents',
         units: 1000.5,
-        expected: 5000.5,
+        expected: 5001,
       },
     ])('bills usage $position', ({ units, expected }) => {
       const p = tieredPrice(ladder('graduated'))
@@ -109,6 +109,11 @@ describe('estimateMeteredCost', () => {
     it('honours a zero cap, matching the server', () => {
       const p = price({ unit_amount: '0.5', cap_amount: 0 })
       expect(estimateMeteredCost(p, 100)).toBe(0)
+    })
+
+    it('rounds before capping, matching the server', () => {
+      const p = price({ unit_amount: '0.996', cap_amount: 100 })
+      expect(estimateMeteredCost(p, 100)).toBe(100)
     })
   })
 })

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
@@ -61,9 +61,7 @@ describe('estimateMeteredCost', () => {
   })
 
   it.each([0, -1])('costs nothing for %i units', (units) => {
-    expect(
-      estimateMeteredCost(tieredPrice(ladder('graduated')), units),
-    ).toBe(0)
+    expect(estimateMeteredCost(tieredPrice(ladder('graduated')), units)).toBe(0)
   })
 
   describe('graduated', () => {

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.test.ts
@@ -1,5 +1,119 @@
+import { schemas } from '@polar-sh/client'
 import { describe, expect, it } from 'vitest'
-import { shouldShowMeterCycle } from './utils'
+import { estimateMeteredCost, shouldShowMeterCycle } from './utils'
+
+type MeteredUnitPrice = schemas['ProductPriceMeteredUnit']
+type MeteredTiersPrice = schemas['ProductPriceMeteredTiers']
+type MeteredTiers = MeteredTiersPrice['tiers']
+
+const common = {
+  id: 'price_1',
+  created_at: '2026-01-01T00:00:00Z',
+  modified_at: null,
+  is_archived: false,
+  product_id: 'prod_1',
+  price_currency: 'usd',
+  cap_amount: null,
+  meter_id: 'meter_1',
+  meter: {
+    id: 'meter_1',
+    name: 'API Calls',
+    unit: 'scalar',
+    custom_label: null,
+    custom_multiplier: null,
+  },
+}
+
+const price = (overrides: Partial<MeteredUnitPrice> = {}): MeteredUnitPrice =>
+  ({
+    ...common,
+    amount_type: 'metered_unit',
+    unit_amount: '0.05',
+    ...overrides,
+  }) as MeteredUnitPrice
+
+const tieredPrice = (
+  tiersValue: MeteredTiers,
+  overrides: Partial<MeteredTiersPrice> = {},
+): MeteredTiersPrice =>
+  ({
+    ...common,
+    amount_type: 'metered_tiers',
+    tiers: tiersValue,
+    ...overrides,
+  }) as MeteredTiersPrice
+
+const tiers = (
+  tierType: MeteredTiers['type'],
+  list: { bound: number | null; unit_amount: string }[],
+): MeteredTiers => ({ type: tierType, tiers: list })
+
+// The ladder used across the tiered cases: 5c up to 1,000, then 1c.
+const ladder = (tierType: MeteredTiers['type']) =>
+  tiers(tierType, [
+    { bound: 1000, unit_amount: '5' },
+    { bound: null, unit_amount: '1' },
+  ])
+
+describe('estimateMeteredCost', () => {
+  it('multiplies units by a flat unit amount', () => {
+    expect(estimateMeteredCost(price({ unit_amount: '0.5' }), 100)).toBe(50)
+  })
+
+  it.each([0, -1])('costs nothing for %i units', (units) => {
+    expect(
+      estimateMeteredCost(tieredPrice(ladder('graduated')), units),
+    ).toBe(0)
+  })
+
+  describe('graduated', () => {
+    it.each([
+      { position: 'inside the first tier', units: 500, expected: 2500 },
+      { position: 'at the tier boundary', units: 1000, expected: 5000 },
+      { position: 'across tiers', units: 2000, expected: 6000 },
+      {
+        position: 'with fractional usage',
+        units: 1000.5,
+        expected: 5000.5,
+      },
+    ])('bills usage $position', ({ units, expected }) => {
+      const p = tieredPrice(ladder('graduated'))
+      expect(estimateMeteredCost(p, units)).toBe(expected)
+    })
+  })
+
+  describe('volume', () => {
+    it.each([
+      { position: 'inside the first tier', units: 500, expected: 2500 },
+      { position: 'at the tier boundary', units: 1000, expected: 5000 },
+      { position: 'after crossing the boundary', units: 2000, expected: 2000 },
+    ])('bills the whole quantity $position', ({ units, expected }) => {
+      const p = tieredPrice(ladder('volume'))
+      expect(estimateMeteredCost(p, units)).toBe(expected)
+    })
+  })
+
+  describe('single unbounded tier', () => {
+    it('behaves like a flat rate', () => {
+      const p = tieredPrice(
+        tiers('graduated', [{ bound: null, unit_amount: '5' }]),
+      )
+      expect(estimateMeteredCost(p, 250)).toBe(1250)
+    })
+  })
+
+  describe('cap amount', () => {
+    it('caps a tiered cost', () => {
+      const p = tieredPrice(ladder('graduated'), { cap_amount: 1000 })
+      expect(estimateMeteredCost(p, 2000)).toBe(1000)
+    })
+
+    it('honours a zero cap, matching the server', () => {
+      const p = price({ unit_amount: '0.5', cap_amount: 0 })
+      expect(estimateMeteredCost(p, 100)).toBe(0)
+    })
+  })
+})
 
 const base = {
   isEnabledForOrganization: true,

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
@@ -1,3 +1,4 @@
+import Big from 'big.js'
 import { schemas } from '@polar-sh/client'
 import { FreeProductPriceCreate, ProductFormType } from '../ProductForm'
 
@@ -80,11 +81,11 @@ type MeteredTiers = schemas['ProductPriceMeteredTiers']['tiers']
 const tieredCost = (
   { type: tierType, tiers }: MeteredTiers,
   units: number,
-): number => {
+): Big => {
   const parsed = tiers
     .map((tier) => ({
       bound: tier.bound ?? null,
-      unitAmount: Number.parseFloat(String(tier.unit_amount)),
+      unitAmount: String(tier.unit_amount),
     }))
     .sort(
       (a, b) =>
@@ -94,10 +95,10 @@ const tieredCost = (
 
   if (tierType === 'volume') {
     const tier = parsed.find((t) => t.bound === null || units <= t.bound)
-    return tier ? units * tier.unitAmount : 0
+    return tier ? new Big(units).times(tier.unitAmount) : new Big(0)
   }
 
-  let total = 0
+  let total = new Big(0)
   let remaining = units
   let previousBound = 0
   for (const { bound, unitAmount } of parsed) {
@@ -105,7 +106,7 @@ const tieredCost = (
     const capacity = bound === null ? null : bound - previousBound
     const unitsInTier =
       capacity === null ? remaining : Math.min(remaining, capacity)
-    total += unitsInTier * unitAmount
+    total = total.plus(new Big(unitsInTier).times(unitAmount))
     remaining -= unitsInTier
     if (bound !== null) previousBound = bound
   }
@@ -124,9 +125,9 @@ export const estimateMeteredCost = (
   const cost =
     price.amount_type === 'metered_tiers'
       ? tieredCost(price.tiers, units)
-      : units * Number.parseFloat(price.unit_amount)
+      : new Big(units).times(price.unit_amount)
 
-  const rounded = Math.round(cost)
+  const rounded = cost.round(0, Big.roundHalfUp).toNumber()
   if (price.cap_amount != null) {
     return Math.min(rounded, price.cap_amount)
   }

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
@@ -74,3 +74,57 @@ export const getActiveCurrencies = (
   }
   return Array.from(currencies)
 }
+
+type MeteredTiers = schemas['ProductPriceMeteredTiers']['tiers']
+
+const tieredCost = (
+  { type: tierType, tiers }: MeteredTiers,
+  units: number,
+): number => {
+  const parsed = tiers
+    .map((tier) => ({
+      bound: tier.bound ?? null,
+      unitAmount: Number.parseFloat(String(tier.unit_amount)),
+    }))
+    .sort(
+      (a, b) =>
+        Number(a.bound === null) - Number(b.bound === null) ||
+        (a.bound ?? 0) - (b.bound ?? 0),
+    )
+
+  if (tierType === 'volume') {
+    const tier = parsed.find((t) => t.bound === null || units <= t.bound)
+    return tier ? units * tier.unitAmount : 0
+  }
+
+  let total = 0
+  let remaining = units
+  let previousBound = 0
+  for (const { bound, unitAmount } of parsed) {
+    if (remaining <= 0) break
+    const capacity = bound === null ? null : bound - previousBound
+    const unitsInTier =
+      capacity === null ? remaining : Math.min(remaining, capacity)
+    total += unitsInTier * unitAmount
+    remaining -= unitsInTier
+    if (bound !== null) previousBound = bound
+  }
+  return total
+}
+
+export const estimateMeteredCost = (
+  price: schemas['ProductPriceMeteredUnit'] | schemas['ProductPriceMeteredTiers'],
+  units: number,
+): number => {
+  if (units <= 0) {
+    return 0
+  }
+  const cost =
+    price.amount_type === 'metered_tiers'
+      ? tieredCost(price.tiers, units)
+      : units * Number.parseFloat(price.unit_amount)
+  if (price.cap_amount != null) {
+    return Math.min(cost, price.cap_amount)
+  }
+  return cost
+}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
@@ -113,7 +113,9 @@ const tieredCost = (
 }
 
 export const estimateMeteredCost = (
-  price: schemas['ProductPriceMeteredUnit'] | schemas['ProductPriceMeteredTiers'],
+  price:
+    | schemas['ProductPriceMeteredUnit']
+    | schemas['ProductPriceMeteredTiers'],
   units: number,
 ): number => {
   if (units <= 0) {

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/utils.ts
@@ -125,8 +125,10 @@ export const estimateMeteredCost = (
     price.amount_type === 'metered_tiers'
       ? tieredCost(price.tiers, units)
       : units * Number.parseFloat(price.unit_amount)
+
+  const rounded = Math.round(cost)
   if (price.cap_amount != null) {
-    return Math.min(cost, price.cap_amount)
+    return Math.min(rounded, price.cap_amount)
   }
-  return cost
+  return rounded
 }

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -330,6 +330,28 @@ export const ProductPricingSection = ({
             unit_amount: 0,
             meter_id: meterId,
           }
+        } else if (price.amount_type === 'metered_tiers') {
+          const sourceTiers =
+            'tiers' in price && price.tiers?.tiers ? price.tiers.tiers : []
+          const meteredTiers = sourceTiers.map((t) => ({
+            bound: 'bound' in t ? (t.bound ?? null) : null,
+            unit_amount: 0,
+          }))
+          if (meteredTiers.length === 0) {
+            meteredTiers.push({ bound: null, unit_amount: 0 })
+          }
+          newPrice = {
+            ...baseCurrency,
+            amount_type: 'metered_tiers',
+            meter_id: 'meter_id' in price ? price.meter_id : '',
+            tiers: {
+              type:
+                'tiers' in price && price.tiers && 'type' in price.tiers
+                  ? price.tiers.type
+                  : 'volume',
+              tiers: meteredTiers,
+            },
+          }
         } else {
           newPrice = { ...baseCurrency, amount_type: 'free' }
         }

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -478,9 +478,13 @@ export const ProductPricingSection = ({
 
   const canAddUnitPricing = onlyStaticAmountType === 'fixed'
 
+  const hasMeteredPrice =
+    pricesForSelectedCurrency.length > staticPricesForSelectedCurrency.length
+
   const canAddBasePrice =
     onlyStaticAmountType === 'seat_based' ||
-    onlyStaticAmountType === 'unit_based'
+    onlyStaticAmountType === 'unit_based' ||
+    (staticPricesForSelectedCurrency.length === 0 && hasMeteredPrice)
 
   if (isLegacyRecurringProduct) {
     return (
@@ -711,9 +715,9 @@ export const ProductPricingSection = ({
                   onAmountTypeChange={handleAmountTypeChange}
                   canChangeType={!isMetered && staticPriceCount <= 1}
                   canRemove={
-                    staticPriceCount > 1 ||
-                    (isMetered &&
-                      (meteredPriceCount > 1 || staticPriceCount >= 1))
+                    isMetered
+                      ? meteredPriceCount > 1 || staticPriceCount >= 1
+                      : staticPriceCount > 1 || meteredPriceCount >= 1
                   }
                   key={`${selectedCurrency}-${index}`}
                 />

--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -424,8 +424,7 @@ export const ProductPricingSection = ({
 
         const indicesToRemove = currentPrices
           .map((p, i) =>
-            'amount_type' in p &&
-            p.amount_type === 'metered_unit' &&
+            isMeteredPrice(p as ProductPrice) &&
             'meter_id' in p &&
             p.meter_id === meterId
               ? i

--- a/clients/apps/web/src/components/Products/ProductForm/UnitAmountInput.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/UnitAmountInput.tsx
@@ -16,7 +16,7 @@ const UnitAmountInput = ({
   ...props
 }: ComponentProps<typeof Input> & {
   currency: string
-  onValueChange: (value: number) => void
+  onValueChange: (value: number | null) => void
 }) => {
   const { value, onValueChange, className, ...rest } = props
 
@@ -93,7 +93,13 @@ const UnitAmountInput = ({
       const input = e.target.value
       setDisplayValue(input)
 
-      if (input === '' || input.endsWith('.')) return
+      if (input === '') {
+        lastEmittedRef.current = null
+        onValueChange(null)
+        return
+      }
+
+      if (input.endsWith('.')) return
 
       const parsed = Number.parseFloat(input)
       if (isNaN(parsed)) return

--- a/clients/apps/web/src/components/Products/ProductPriceLabel.tsx
+++ b/clients/apps/web/src/components/Products/ProductPriceLabel.tsx
@@ -1,10 +1,14 @@
 import {
   getUnitLabels,
   isLegacyRecurringPrice,
+  isMeteredPrice,
+  MeteredPrice,
   isSeatBasedPrice,
   isUnitBasedPrice,
 } from '@/utils/product'
 import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { getMeterUnitFormat } from '@polar-sh/ui/lib/meterUnit'
 import AmountLabel from '../Shared/AmountLabel'
 
 interface ProductPriceLabelProps {
@@ -22,11 +26,7 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
       ['fixed', 'custom', 'seat_based', 'unit_based'].includes(amount_type),
   )
 
-  if (!staticPrice) {
-    return null
-  }
-
-  if (staticPrice.amount_type === 'fixed' && staticPrice.price_amount !== 0) {
+  if (staticPrice?.amount_type === 'fixed' && staticPrice.price_amount !== 0) {
     return (
       <AmountLabel
         amount={staticPrice.price_amount}
@@ -39,7 +39,7 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
         intervalCount={product.recurring_interval_count}
       />
     )
-  } else if (isSeatBasedPrice(staticPrice)) {
+  } else if (staticPrice && isSeatBasedPrice(staticPrice)) {
     const tiers = staticPrice.seat_tiers.tiers
 
     // Show the starting tier price with "from" indicator if multiple tiers
@@ -66,7 +66,7 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
       )
     }
     return null
-  } else if (isUnitBasedPrice(staticPrice)) {
+  } else if (staticPrice && isUnitBasedPrice(staticPrice)) {
     const tiers = staticPrice.tiers.tiers
 
     if (tiers.length > 0) {
@@ -92,11 +92,63 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
       )
     }
     return null
-  } else if (staticPrice.amount_type === 'custom') {
+  } else if (staticPrice?.amount_type === 'custom') {
     return <span className="text-[min(1em,24px)]">Pay what you want</span>
-  } else {
+  }
+
+  const meteredPrice = product.prices.find(
+    (price): price is MeteredPrice =>
+      price.price_currency === currency && isMeteredPrice(price),
+  )
+
+  if (meteredPrice) {
+    const { scale, label } = getMeterUnitFormat(
+      meteredPrice.meter.unit ?? 'scalar',
+      {
+        customLabel: meteredPrice.meter.custom_label,
+        customMultiplier: meteredPrice.meter.custom_multiplier,
+      },
+    )
+    const tiers =
+      meteredPrice.amount_type === 'metered_tiers'
+        ? meteredPrice.tiers.tiers
+        : []
+    const rawAmount =
+      tiers.length > 0
+        ? Number(tiers[0].unit_amount)
+        : meteredPrice.amount_type === 'metered_unit'
+          ? Number.parseFloat(meteredPrice.unit_amount)
+          : null
+
+    if (rawAmount != null) {
+      const hasMultipleTiers = tiers.length > 1
+
+      return (
+        <span className="inline-flex items-baseline gap-1.5">
+          {hasMultipleTiers && (
+            <span className="dark:text-polar-500 text-xs text-gray-500">
+              From
+            </span>
+          )}
+          <span>
+            {formatCurrency('subcent')(
+              rawAmount * scale,
+              meteredPrice.price_currency,
+            )}
+          </span>
+          <span className="dark:text-polar-500 text-xs text-gray-500">
+            / {label}
+          </span>
+        </span>
+      )
+    }
+  }
+
+  if (staticPrice) {
     return <span className="text-[min(1em,24px)]">Free</span>
   }
+
+  return null
 }
 
 export default ProductPriceLabel

--- a/clients/apps/web/src/utils/api/errors.ts
+++ b/clients/apps/web/src/utils/api/errors.ts
@@ -89,6 +89,7 @@ export const setProductValidationErrors = <TFieldValues extends FieldValues>(
         'seat_based',
         'unit_based',
         'metered_unit',
+        'metered_tiers',
       ]
       if (priceDiscriminatorValues.includes(segmentStr)) {
         // Check if previous segments match the pattern: "prices", then a number

--- a/clients/apps/web/src/utils/product.ts
+++ b/clients/apps/web/src/utils/product.ts
@@ -59,10 +59,14 @@ export const formPriceToApiPrice = (
     ? { ...price, amount_type: 'fixed', price_amount: 0 }
     : price
 
+export type MeteredPrice =
+  | schemas['ProductPriceMeteredUnit']
+  | schemas['ProductPriceMeteredTiers']
+
 export const isMeteredPrice = (
   price: schemas['ProductPrice'] | schemas['LegacyRecurringProductPrice'],
-): price is schemas['ProductPriceMeteredUnit'] =>
-  price.amount_type === 'metered_unit'
+): price is MeteredPrice =>
+  price.amount_type === 'metered_unit' || price.amount_type === 'metered_tiers'
 
 export const isSeatBasedPrice = (
   price: schemas['ProductPrice'],


### PR DESCRIPTION
## Summary

Villiam's work from #14041, adapted to the split metered price type.

Stacked on #14072. Supersedes #14041.


https://github.com/user-attachments/assets/d88e13b1-5f53-4cc0-9481-926eaf46080c


https://github.com/user-attachments/assets/4b442f69-e4bd-4c1e-a304-676d8ad15b04



## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

