### PR TITLE
ci/tinybird: Retry tinybird token

### DIFF
--- a/server/scripts/tinybird_test_workspace.py
+++ b/server/scripts/tinybird_test_workspace.py
@@ -138,10 +138,7 @@ def delete_workspace(host: str, workspace_id: str, user_token: str) -> None:
 @cli.command()
 def main() -> None:
     host = settings.TINYBIRD_API_URL
-    tokens = get_tokens(host)
-    if tokens is None:
-        raise typer.BadParameter(f"Tinybird is not reachable at {host}")
-
+    tokens = request("GET", f"{host}/tokens", timeout=2).json()
     _, workspace_token = create_workspace(host, tokens)
     deploy_schema(host, workspace_token)
     wait_for_ingestion(host, workspace_token)


### PR DESCRIPTION
Otherwise we fail too fast in startup


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

