### PR TITLE
Revert "fix(checkout): commit before redirecting from checkout link"

### DIFF
--- a/server/polar/checkout_link/endpoints.py
+++ b/server/polar/checkout_link/endpoints.py
@@ -255,10 +255,4 @@ async def redirect(
     }
     checkout_url = checkout_url.include_query_params(**query_params)
 
-    # Commit before redirecting: the client immediately fetches the checkout by
-    # its client secret, but get_db_session only commits after the response is
-    # sent. Without an explicit commit, that follow-up read can race ahead of the
-    # commit and 404 on a checkout that was just created.
-    await session.commit()
-
     return RedirectResponse(checkout_url)


### PR DESCRIPTION
Reverts polarsource/polar#14073

To see if the problem resurfaces

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

