### PR TITLE
fix: keep a price when switching a metered product to one-time

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductPricingSection.tsx
@@ -108,9 +108,17 @@ export const ProductPricingSection = ({
     const filteredPrices = currentPrices.filter(
       (price) => !isMeteredPrice(price as ProductPrice),
     )
-    if (filteredPrices.length !== currentPrices.length) {
+    if (filteredPrices.length === currentPrices.length) return
+    if (filteredPrices.length > 0) {
       replace(filteredPrices)
+      return
     }
+
+    currentPrices.forEach((_, index) => {
+      setValue(`prices.${index}.amount_type`, 'fixed')
+      setValue(`prices.${index}.price_amount`, 0)
+      setValue(`prices.${index}.id`, '')
+    })
   }, [recurringInterval, recurringIntervalCount, setValue, getValues, replace])
 
   const [productType, setProductType] = useState<'one_time' | 'recurring'>(


### PR DESCRIPTION
## Summary

Fix a bug where selecting mettered prices on sub and moving back to one time would break the form and require a full refresh.

before:

https://github.com/user-attachments/assets/8fd39aae-61c6-4764-ab75-20b8ebaa5469



after:

https://github.com/user-attachments/assets/9396a4ec-0065-440b-a9bd-8f2462c8b63a




## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

