### PR TITLE
server/tests/subscription: fix flaky time-based test

### DIFF
--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import timedelta
 
 import pytest
+from freezegun.api import freeze_time
 from pytest_mock import MockerFixture
 
 from polar.enums import SubscriptionRecurringInterval
@@ -315,6 +316,7 @@ class TestSubscriptionCycle:
         with pytest.raises(SubscriptionMeterCycleLag):
             await subscription_cycle(subscription.id)
 
+    @freeze_time("2026-01-01 12:00:00")
     async def test_billing_due_without_meter_lag_cycles(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION

This is currently blocking CI.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

