### PR TITLE
server/scripts: tweak api version backfill script to order by event creation date

### DIFF
--- a/server/scripts/backfill_webhook_api_version.py
+++ b/server/scripts/backfill_webhook_api_version.py
@@ -55,6 +55,7 @@ async def backfill_webhook_api_version(
                 WebhookEvent.id.in_(
                     select(WebhookEvent.id)
                     .where(WebhookEvent.api_version.is_(None))
+                    .order_by(WebhookEvent.created_at.asc())
                     .limit(limit_bindparam())
                 ),
             )


### PR DESCRIPTION

Will allow to leverage a temporary index to speed up the backfill process.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

