### PR TITLE
server/benefit: declare proper individual schemas for BenefitPublic flavors

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -9156,6 +9156,57 @@ export interface components {
       /** Note */
       note: (string | null) | null
     }
+    /** BenefitCustomPublic */
+    BenefitCustomPublic: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the benefit.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'custom'
+      /**
+       * Description
+       * @description The description of the benefit.
+       */
+      description: string
+      /**
+       * Selectable
+       * @description Whether the benefit is selectable when creating a product.
+       */
+      selectable: boolean
+      /**
+       * Deletable
+       * @description Whether the benefit is deletable.
+       */
+      deletable: boolean
+      /**
+       * Is Deleted
+       * @description Whether the benefit is deleted.
+       */
+      is_deleted: boolean
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the benefit.
+       */
+      organization_id: string
+    }
     /** BenefitCustomSubscriber */
     BenefitCustomSubscriber: {
       /**
@@ -9466,6 +9517,57 @@ export interface components {
       /** Guild Token */
       readonly guild_token: string
     }
+    /** BenefitDiscordPublic */
+    BenefitDiscordPublic: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the benefit.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'discord'
+      /**
+       * Description
+       * @description The description of the benefit.
+       */
+      description: string
+      /**
+       * Selectable
+       * @description Whether the benefit is selectable when creating a product.
+       */
+      selectable: boolean
+      /**
+       * Deletable
+       * @description Whether the benefit is deletable.
+       */
+      deletable: boolean
+      /**
+       * Is Deleted
+       * @description Whether the benefit is deleted.
+       */
+      is_deleted: boolean
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the benefit.
+       */
+      organization_id: string
+    }
     /** BenefitDiscordSubscriber */
     BenefitDiscordSubscriber: {
       /**
@@ -9739,6 +9841,57 @@ export interface components {
       /** Files */
       files: string[]
     }
+    /** BenefitDownloadablesPublic */
+    BenefitDownloadablesPublic: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the benefit.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'downloadables'
+      /**
+       * Description
+       * @description The description of the benefit.
+       */
+      description: string
+      /**
+       * Selectable
+       * @description Whether the benefit is selectable when creating a product.
+       */
+      selectable: boolean
+      /**
+       * Deletable
+       * @description Whether the benefit is deletable.
+       */
+      deletable: boolean
+      /**
+       * Is Deleted
+       * @description Whether the benefit is deleted.
+       */
+      is_deleted: boolean
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the benefit.
+       */
+      organization_id: string
+    }
     /** BenefitDownloadablesSubscriber */
     BenefitDownloadablesSubscriber: {
       /**
@@ -9944,6 +10097,57 @@ export interface components {
      * @description Properties for a benefit of type `feature_flag`.
      */
     BenefitFeatureFlagProperties: Record<string, never>
+    /** BenefitFeatureFlagPublic */
+    BenefitFeatureFlagPublic: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the benefit.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'feature_flag'
+      /**
+       * Description
+       * @description The description of the benefit.
+       */
+      description: string
+      /**
+       * Selectable
+       * @description Whether the benefit is selectable when creating a product.
+       */
+      selectable: boolean
+      /**
+       * Deletable
+       * @description Whether the benefit is deletable.
+       */
+      deletable: boolean
+      /**
+       * Is Deleted
+       * @description Whether the benefit is deleted.
+       */
+      is_deleted: boolean
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the benefit.
+       */
+      organization_id: string
+    }
     /** BenefitFeatureFlagSubscriber */
     BenefitFeatureFlagSubscriber: {
       /**
@@ -10182,6 +10386,57 @@ export interface components {
        * @enum {string}
        */
       permission: 'pull' | 'triage' | 'push' | 'maintain' | 'admin'
+    }
+    /** BenefitGitHubRepositoryPublic */
+    BenefitGitHubRepositoryPublic: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the benefit.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'github_repository'
+      /**
+       * Description
+       * @description The description of the benefit.
+       */
+      description: string
+      /**
+       * Selectable
+       * @description Whether the benefit is selectable when creating a product.
+       */
+      selectable: boolean
+      /**
+       * Deletable
+       * @description Whether the benefit is deletable.
+       */
+      deletable: boolean
+      /**
+       * Is Deleted
+       * @description Whether the benefit is deleted.
+       */
+      is_deleted: boolean
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the benefit.
+       */
+      organization_id: string
     }
     /** BenefitGitHubRepositorySubscriber */
     BenefitGitHubRepositorySubscriber: {
@@ -11305,6 +11560,57 @@ export interface components {
       /** Limit Usage */
       limit_usage: number | null
     }
+    /** BenefitLicenseKeysPublic */
+    BenefitLicenseKeysPublic: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the benefit.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'license_keys'
+      /**
+       * Description
+       * @description The description of the benefit.
+       */
+      description: string
+      /**
+       * Selectable
+       * @description Whether the benefit is selectable when creating a product.
+       */
+      selectable: boolean
+      /**
+       * Deletable
+       * @description Whether the benefit is deletable.
+       */
+      deletable: boolean
+      /**
+       * Is Deleted
+       * @description Whether the benefit is deleted.
+       */
+      is_deleted: boolean
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the benefit.
+       */
+      organization_id: string
+    }
     /** BenefitLicenseKeysSubscriber */
     BenefitLicenseKeysSubscriber: {
       /**
@@ -11713,66 +12019,14 @@ export interface components {
         | null
     }
     BenefitPublic:
+      | components['schemas']['BenefitCustomPublic']
+      | components['schemas']['BenefitDiscordPublic']
+      | components['schemas']['BenefitGitHubRepositoryPublic']
+      | components['schemas']['BenefitDownloadablesPublic']
+      | components['schemas']['BenefitLicenseKeysPublic']
+      | components['schemas']['BenefitFeatureFlagPublic']
+      | components['schemas']['BenefitSlackSharedChannelPublic']
       | components['schemas']['BenefitMeterCreditPublic']
-      | components['schemas']['BenefitPublicGeneric']
-    /** BenefitPublicGeneric */
-    BenefitPublicGeneric: {
-      /**
-       * Id
-       * Format: uuid4
-       * @description The ID of the benefit.
-       */
-      id: string
-      /**
-       * Created At
-       * Format: date-time
-       * @description Creation timestamp of the object.
-       */
-      created_at: string
-      /**
-       * Modified At
-       * @description Last modification timestamp of the object.
-       */
-      modified_at: string | null
-      /**
-       * @description discriminator enum property added by openapi-typescript
-       * @enum {string}
-       */
-      type:
-        | 'custom'
-        | 'discord'
-        | 'downloadables'
-        | 'feature_flag'
-        | 'github_repository'
-        | 'license_keys'
-        | 'slack_shared_channel'
-      /**
-       * Description
-       * @description The description of the benefit.
-       */
-      description: string
-      /**
-       * Selectable
-       * @description Whether the benefit is selectable when creating a product.
-       */
-      selectable: boolean
-      /**
-       * Deletable
-       * @description Whether the benefit is deletable.
-       */
-      deletable: boolean
-      /**
-       * Is Deleted
-       * @description Whether the benefit is deleted.
-       */
-      is_deleted: boolean
-      /**
-       * Organization Id
-       * Format: uuid4
-       * @description The ID of the organization owning the benefit.
-       */
-      organization_id: string
-    }
     /**
      * BenefitRevokedEvent
      * @description An event created by Polar when a benefit is revoked from a customer.
@@ -12003,6 +12257,57 @@ export interface components {
        * @description Slack user IDs from the merchant workspace to invite to every channel created for this benefit.
        */
       team_invitees?: string[]
+    }
+    /** BenefitSlackSharedChannelPublic */
+    BenefitSlackSharedChannelPublic: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the benefit.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'slack_shared_channel'
+      /**
+       * Description
+       * @description The description of the benefit.
+       */
+      description: string
+      /**
+       * Selectable
+       * @description Whether the benefit is selectable when creating a product.
+       */
+      selectable: boolean
+      /**
+       * Deletable
+       * @description Whether the benefit is deletable.
+       */
+      deletable: boolean
+      /**
+       * Is Deleted
+       * @description Whether the benefit is deleted.
+       */
+      is_deleted: boolean
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the benefit.
+       */
+      organization_id: string
     }
     /** BenefitSlackSharedChannelSubscriber */
     BenefitSlackSharedChannelSubscriber: {
@@ -67417,6 +67722,9 @@ export const benefitCustomTypeValues: ReadonlyArray<
 export const benefitCustomCreateTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitCustomCreate']['type']
 > = ['custom']
+export const benefitCustomPublicTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['BenefitCustomPublic']['type']
+> = ['custom']
 export const benefitCycledEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitCycledEvent']['name']
 > = ['benefit.cycled']
@@ -67426,17 +67734,26 @@ export const benefitDiscordTypeValues: ReadonlyArray<
 export const benefitDiscordCreateTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitDiscordCreate']['type']
 > = ['discord']
+export const benefitDiscordPublicTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['BenefitDiscordPublic']['type']
+> = ['discord']
 export const benefitDownloadablesTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitDownloadables']['type']
 > = ['downloadables']
 export const benefitDownloadablesCreateTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitDownloadablesCreate']['type']
 > = ['downloadables']
+export const benefitDownloadablesPublicTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['BenefitDownloadablesPublic']['type']
+> = ['downloadables']
 export const benefitFeatureFlagTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitFeatureFlag']['type']
 > = ['feature_flag']
 export const benefitFeatureFlagCreateTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitFeatureFlagCreate']['type']
+> = ['feature_flag']
+export const benefitFeatureFlagPublicTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['BenefitFeatureFlagPublic']['type']
 > = ['feature_flag']
 export const benefitGitHubRepositoryTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitGitHubRepository']['type']
@@ -67450,6 +67767,9 @@ export const benefitGitHubRepositoryCreatePropertiesPermissionValues: ReadonlyAr
 export const benefitGitHubRepositoryPropertiesPermissionValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitGitHubRepositoryProperties']['permission']
 > = ['pull', 'triage', 'push', 'maintain', 'admin']
+export const benefitGitHubRepositoryPublicTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['BenefitGitHubRepositoryPublic']['type']
+> = ['github_repository']
 export const benefitGrantGitHubRepositoryPropertiesPermissionValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitGrantGitHubRepositoryProperties']['permission']
 > = ['pull', 'triage', 'push', 'maintain', 'admin']
@@ -67475,6 +67795,9 @@ export const benefitLicenseKeysTypeValues: ReadonlyArray<
 export const benefitLicenseKeysCreateTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitLicenseKeysCreate']['type']
 > = ['license_keys']
+export const benefitLicenseKeysPublicTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['BenefitLicenseKeysPublic']['type']
+> = ['license_keys']
 export const benefitMeterCreditTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitMeterCredit']['type']
 > = ['meter_credit']
@@ -67484,17 +67807,6 @@ export const benefitMeterCreditCreateTypeValues: ReadonlyArray<
 export const benefitMeterCreditPublicTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitMeterCreditPublic']['type']
 > = ['meter_credit']
-export const benefitPublicGenericTypeValues: ReadonlyArray<
-  FlattenedDeepRequired<components>['schemas']['BenefitPublicGeneric']['type']
-> = [
-  'custom',
-  'discord',
-  'downloadables',
-  'feature_flag',
-  'github_repository',
-  'license_keys',
-  'slack_shared_channel',
-]
 export const benefitRevokedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitRevokedEvent']['name']
 > = ['benefit.revoked']
@@ -67503,6 +67815,9 @@ export const benefitSlackSharedChannelTypeValues: ReadonlyArray<
 > = ['slack_shared_channel']
 export const benefitSlackSharedChannelCreateTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitSlackSharedChannelCreate']['type']
+> = ['slack_shared_channel']
+export const benefitSlackSharedChannelPublicTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['BenefitSlackSharedChannelPublic']['type']
 > = ['slack_shared_channel']
 export const benefitSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BenefitSortProperty']

--- a/server/polar/benefit/schemas.py
+++ b/server/polar/benefit/schemas.py
@@ -210,20 +210,45 @@ BenefitGrantWebhook = Annotated[
 
 
 # Properties that are public (when embedding products benefits in storefront and checkout)
-class BenefitPublicGeneric(BenefitPublicBase):
-    type: Literal[
-        BenefitType.custom,
-        BenefitType.discord,
-        BenefitType.github_repository,
-        BenefitType.downloadables,
-        BenefitType.license_keys,
-        BenefitType.feature_flag,
-        BenefitType.slack_shared_channel,
-    ]
+
+
+class BenefitCustomPublic(BenefitPublicBase):
+    type: Literal[BenefitType.custom]
+
+
+class BenefitDiscordPublic(BenefitPublicBase):
+    type: Literal[BenefitType.discord]
+
+
+class BenefitGitHubRepositoryPublic(BenefitPublicBase):
+    type: Literal[BenefitType.github_repository]
+
+
+class BenefitDownloadablesPublic(BenefitPublicBase):
+    type: Literal[BenefitType.downloadables]
+
+
+class BenefitLicenseKeysPublic(BenefitPublicBase):
+    type: Literal[BenefitType.license_keys]
+
+
+class BenefitFeatureFlagPublic(BenefitPublicBase):
+    type: Literal[BenefitType.feature_flag]
+
+
+class BenefitSlackSharedChannelPublic(BenefitPublicBase):
+    type: Literal[BenefitType.slack_shared_channel]
 
 
 BenefitPublic = Annotated[
-    BenefitMeterCreditPublic | BenefitPublicGeneric,
+    BenefitCustomPublic
+    | BenefitDiscordPublic
+    | BenefitGitHubRepositoryPublic
+    | BenefitDownloadablesPublic
+    | BenefitLicenseKeysPublic
+    | BenefitFeatureFlagPublic
+    | BenefitSlackSharedChannelPublic
+    | BenefitMeterCreditPublic,
     Discriminator("type"),
     SetSchemaReference("BenefitPublic"),
     MergeJSONSchema({"title": "BenefitPublic"}),

--- a/server/tests/benefit/test_schemas.py
+++ b/server/tests/benefit/test_schemas.py
@@ -1,0 +1,87 @@
+import pytest
+from pydantic import TypeAdapter
+
+from polar.benefit.schemas import BenefitPublic
+from polar.kit.visibility import Visibility
+from polar.models import Meter, Organization
+from polar.models.benefit import BenefitType
+from polar.product.schemas import BenefitPublicList
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_benefit
+
+
+@pytest.mark.asyncio
+class TestBenefitPublic:
+    async def test_meter_credit_properties(
+        self, save_fixture: SaveFixture, organization: Organization, meter: Meter
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.meter_credit,
+            properties={
+                "units": 10000,
+                "rollover": True,
+                "meter_id": str(meter.id),
+            },
+        )
+
+        adapter: TypeAdapter[BenefitPublic] = TypeAdapter(BenefitPublic)
+        benefit_schema = adapter.validate_python(benefit)
+
+        assert benefit_schema.id == benefit.id
+        assert benefit_schema.type == BenefitType.meter_credit
+        assert benefit_schema.properties.units == 10000
+        assert not hasattr(benefit_schema.properties, "rollover")
+
+    @pytest.mark.parametrize(
+        "benefit_type",
+        [t for t in BenefitType if t != BenefitType.meter_credit],
+    )
+    async def test_non_meter_credit_properties(
+        self,
+        save_fixture: SaveFixture,
+        benefit_type: BenefitType,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=benefit_type,
+        )
+
+        adapter: TypeAdapter[BenefitPublic] = TypeAdapter(BenefitPublic)
+        benefit_schema = adapter.validate_python(benefit)
+
+        assert benefit_schema.id == benefit.id
+        assert benefit_schema.type == benefit_type
+        assert not hasattr(benefit_schema, "properties")
+
+
+@pytest.mark.asyncio
+class TestBenefitPublicList:
+    async def test_excludes_non_public_benefits(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        public_benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            description="Public benefit",
+        )
+        private_benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            description="Private benefit",
+        )
+        private_benefit.visibility = Visibility.private
+        await save_fixture(private_benefit)
+
+        adapter: TypeAdapter[BenefitPublicList] = TypeAdapter(BenefitPublicList)
+        benefits = adapter.validate_python(
+            [public_benefit, private_benefit], from_attributes=True
+        )
+
+        assert len(benefits) == 1
+        assert benefits[0].description == "Public benefit"

--- a/server/tests/product/test_schemas.py
+++ b/server/tests/product/test_schemas.py
@@ -4,17 +4,11 @@ from typing import Any
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
-from polar.benefit.schemas import BenefitPublicGeneric
-from polar.benefit.strategies.meter_credit.schemas import BenefitMeterCreditPublic
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.currency import PresentmentCurrency
-from polar.kit.visibility import Visibility
-from polar.models import Meter, Organization
-from polar.models.benefit import BenefitType
 from polar.models.product_price import ProductPriceAmountType
 from polar.product.meter_interval import meter_interval_divides_billing_interval
 from polar.product.schemas import (
-    BenefitPublicList,
     ProductCreate,
     ProductCreateOneTime,
     ProductCreateRecurring,
@@ -25,8 +19,7 @@ from polar.product.schemas import (
     ProductPriceUnitBasedCreate,
 )
 from polar.product.tiers import TierType
-from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import METER_ID, create_benefit
+from tests.fixtures.random_objects import METER_ID
 
 # PostgreSQL int4 range limit
 INT_MAX_VALUE = 2_147_483_647
@@ -473,109 +466,6 @@ class TestProductCreateDiscriminator:
         # No recurring_interval error
         for e in errors:
             assert "recurring_interval" not in str(e["loc"])
-
-
-@pytest.mark.asyncio
-class TestBenefitPublicList:
-    async def test_excludes_non_public_benefits(
-        self,
-        save_fixture: SaveFixture,
-        organization: Organization,
-    ) -> None:
-        public_benefit = await create_benefit(
-            save_fixture,
-            organization=organization,
-            description="Public benefit",
-        )
-        private_benefit = await create_benefit(
-            save_fixture,
-            organization=organization,
-            description="Private benefit",
-        )
-        private_benefit.visibility = Visibility.private
-        await save_fixture(private_benefit)
-
-        adapter: TypeAdapter[BenefitPublicList] = TypeAdapter(BenefitPublicList)
-        benefits = adapter.validate_python(
-            [public_benefit, private_benefit], from_attributes=True
-        )
-
-        assert len(benefits) == 1
-        assert benefits[0].description == "Public benefit"
-
-    async def test_meter_credit_exposes_public_properties(
-        self,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        meter: Meter,
-    ) -> None:
-        benefit = await create_benefit(
-            save_fixture,
-            organization=organization,
-            type=BenefitType.meter_credit,
-            properties={
-                "units": 10000,
-                "rollover": True,
-                "meter_id": str(meter.id),
-            },
-        )
-
-        adapter: TypeAdapter[BenefitPublicList] = TypeAdapter(BenefitPublicList)
-        benefits = adapter.validate_python([benefit], from_attributes=True)
-
-        assert len(benefits) == 1
-        serialized = benefits[0]
-        assert isinstance(serialized, BenefitMeterCreditPublic)
-        assert serialized.properties.units == 10000
-        assert serialized.properties.meter_id == meter.id
-        assert not hasattr(serialized.properties, "rollover")
-
-    async def test_excludes_non_public_meter_credit_benefits(
-        self,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        meter: Meter,
-    ) -> None:
-        benefit = await create_benefit(
-            save_fixture,
-            organization=organization,
-            type=BenefitType.meter_credit,
-            properties={
-                "units": 10000,
-                "rollover": False,
-                "meter_id": str(meter.id),
-            },
-        )
-        benefit.visibility = Visibility.private
-        await save_fixture(benefit)
-
-        adapter: TypeAdapter[BenefitPublicList] = TypeAdapter(BenefitPublicList)
-        benefits = adapter.validate_python([benefit], from_attributes=True)
-
-        assert benefits == []
-
-    @pytest.mark.parametrize(
-        "benefit_type",
-        [t for t in BenefitType if t != BenefitType.meter_credit],
-    )
-    async def test_other_types_serialize_as_generic(
-        self,
-        benefit_type: BenefitType,
-        save_fixture: SaveFixture,
-        organization: Organization,
-    ) -> None:
-        benefit = await create_benefit(
-            save_fixture,
-            organization=organization,
-            type=benefit_type,
-        )
-
-        adapter: TypeAdapter[BenefitPublicList] = TypeAdapter(BenefitPublicList)
-        benefits = adapter.validate_python([benefit], from_attributes=True)
-
-        assert len(benefits) == 1
-        assert isinstance(benefits[0], BenefitPublicGeneric)
-        assert benefits[0].type == benefit_type
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

In 1d014572ea06c22858fb5a07713f530975d28c83, we introduced a specific public schema for meter credit benefit. Others were then all bucketed into a single `BenefitPublicSchema` schema, which is not very elegant and consistent when using it in the SDK.

This PR introduces a public variant for each type of benefit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

