### PR TITLE
Verify polar webhooks in SDK using both existing and standard methods

### DIFF
--- a/docs/integrate/webhooks/delivery.mdx
+++ b/docs/integrate/webhooks/delivery.mdx
@@ -106,7 +106,7 @@ in case you want to roll your own.
   including `whsec_`. Standard Webhooks libraries therefore need that whole
   secret **base64-encoded** before verification.
 
-  Polar SDKs try both that original Polar key and the Standard Webhooks key
+  Polar SDKs (version 1.0.0-alpha.19 and later) try both that original Polar key and the Standard Webhooks key
   (base64-decode of the `whsec_` remainder). You can keep passing the `whsec_…`
   secret as Polar shows it. Rolling your own verifier still needs the original
   Polar encoding until Polar starts signing with the spec key.

--- a/docs/integrate/webhooks/delivery.mdx
+++ b/docs/integrate/webhooks/delivery.mdx
@@ -102,11 +102,14 @@ easily validate signatures. Or you can follow their
 in case you want to roll your own.
 
 <Info>
-  **Note: Secret needs to be base64 encoded**
+  Polar currently signs with HMAC-SHA256 over the UTF-8 bytes of the full secret,
+  including `whsec_`. Standard Webhooks libraries therefore need that whole
+  secret **base64-encoded** before verification.
 
-One common gotcha with the specification is that the webhook secret is expected to be
-base64 encoded. You don't have to do this with our SDK as it takes care of the
-implementation details with better developer ergonomics.
+  Polar SDKs try both that original Polar key and the Standard Webhooks key
+  (base64-decode of the `whsec_` remainder). You can keep passing the `whsec_…`
+  secret as Polar shows it. Rolling your own verifier still needs the original
+  Polar encoding until Polar starts signing with the spec key.
 
 </Info>
 

--- a/sdk/generator/python/template/README.md
+++ b/sdk/generator/python/template/README.md
@@ -165,6 +165,9 @@ async def polar_webhook(request: Request) -> dict[str, bool]:
     return {"received": True}
 ```
 
-The signature is checked before the body is parsed. `validate_event` raises
-`PolarWebhookVerificationError` for invalid signatures and `PolarWebhookUnknownTypeError` when the
-event is not supported by the selected API version. Both inherit from `PolarWebhookError`.
+The signature is checked before the body is parsed. Verification accepts Polar's
+original HMAC key (UTF-8 bytes of the full secret, including `whsec_`) and the
+Standard Webhooks key (base64-decode of the remainder after `whsec_`).
+`validate_event` raises `PolarWebhookVerificationError` for invalid signatures and
+`PolarWebhookUnknownTypeError` when the event is not supported by the selected API
+version. Both inherit from `PolarWebhookError`.

--- a/sdk/generator/python/template/polar/webhooks.py
+++ b/sdk/generator/python/template/polar/webhooks.py
@@ -87,19 +87,31 @@ def _verify_signature(body: str, headers: dict[str, str], secret: str) -> None:
         raise PolarWebhookVerificationError("Message timestamp too new")
 
     signed_content = f"{webhook_id}.{math.floor(timestamp)}.{body}".encode()
-    expected_signature = hmac.new(
-        secret.encode(), signed_content, hashlib.sha256
-    ).digest()
-
-    for versioned_signature in webhook_signature.split():
-        version, separator, signature = versioned_signature.partition(",")
-        if version != "v1" or not separator:
-            continue
-        try:
-            decoded_signature = base64.b64decode(signature, validate=True)
-        except (binascii.Error, ValueError):
-            continue
-        if hmac.compare_digest(expected_signature, decoded_signature):
-            return
+    for signing_key in _signing_keys(secret):
+        expected_signature = hmac.new(
+            signing_key, signed_content, hashlib.sha256
+        ).digest()
+        for versioned_signature in webhook_signature.split():
+            version, separator, signature = versioned_signature.partition(",")
+            if version != "v1" or not separator:
+                continue
+            try:
+                decoded_signature = base64.b64decode(signature, validate=True)
+            except (binascii.Error, ValueError):
+                continue
+            if hmac.compare_digest(expected_signature, decoded_signature):
+                return
 
     raise PolarWebhookVerificationError("No matching signature found")
+
+
+def _signing_keys(secret: str) -> tuple[bytes, ...]:
+    keys: list[bytes] = [secret.encode()]
+    remainder = secret.removeprefix("whsec_")
+    try:
+        decoded = base64.b64decode(remainder, validate=True)
+    except (binascii.Error, ValueError):
+        return (keys[0],)
+    if decoded and decoded != keys[0]:
+        keys.append(decoded)
+    return tuple(keys)

--- a/sdk/generator/python/template/tests/test_webhooks.py
+++ b/sdk/generator/python/template/tests/test_webhooks.py
@@ -2,6 +2,7 @@ import base64
 import dataclasses
 import datetime
 import json
+import os
 import typing
 
 import pytest
@@ -55,6 +56,23 @@ def test_validate_event(as_bytes: bool) -> None:
     raw_body = body.encode() if as_bytes else body
 
     assert _validate_event(raw_body, _get_headers(body)) == DummyPayload(
+        type=_EVENT_TYPE, value="payload"
+    )
+
+
+def test_validate_event_accepts_standard_webhooks_secret() -> None:
+    key = os.urandom(32)
+    secret = "whsec_" + base64.b64encode(key).decode()
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+    timestamp = datetime.datetime.now(tz=datetime.UTC)
+    signature = Webhook(secret).sign("test-webhook", timestamp, body)
+    headers = {
+        "Webhook-Id": "test-webhook",
+        "Webhook-Timestamp": str(int(timestamp.timestamp())),
+        "Webhook-Signature": signature,
+    }
+
+    assert _validate_event(body, headers, secret) == DummyPayload(
         type=_EVENT_TYPE, value="payload"
     )
 

--- a/sdk/generator/typescript/template/README.md
+++ b/sdk/generator/typescript/template/README.md
@@ -125,6 +125,8 @@ app.post("/webhooks/polar", rawBody, async (request, response) => {
 ```
 
 The `express.raw` middleware is required because the signature must be checked against the body
-before it is parsed. `validateEvent` throws `PolarWebhookVerificationError` for invalid signatures
+before it is parsed. Verification accepts Polar's original HMAC key (UTF-8 bytes of the full
+secret, including `whsec_`) and the Standard Webhooks key (base64-decode of the remainder after
+`whsec_`). `validateEvent` throws `PolarWebhookVerificationError` for invalid signatures
 and `PolarWebhookUnknownTypeError` when the event is not supported by the selected API version.
 Both inherit from `PolarWebhookError`.

--- a/sdk/generator/typescript/template/src/webhooks.test.ts
+++ b/sdk/generator/typescript/template/src/webhooks.test.ts
@@ -59,6 +59,26 @@ describe("validateWebhook", () => {
     });
   });
 
+  test("validates a Standard Webhooks-formatted secret", async () => {
+    const key = globalThis.crypto.getRandomValues(new Uint8Array(32));
+    const secret = `whsec_${Buffer.from(key).toString("base64")}`;
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const timestamp = new Date();
+    const signature = new Webhook(secret).sign("test-webhook", timestamp, body);
+    const headers = {
+      "Webhook-Id": "test-webhook",
+      "Webhook-Timestamp": String(Math.floor(timestamp.getTime() / 1000)),
+      "Webhook-Signature": signature,
+    };
+
+    await expect(
+      validateWebhook<DummyPayload>(body, headers, secret, eventTypes),
+    ).resolves.toEqual({
+      type: "dummy.event",
+      value: "payload",
+    });
+  });
+
   test("rejects an invalid signature", async () => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
 

--- a/sdk/generator/typescript/template/src/webhooks.ts
+++ b/sdk/generator/typescript/template/src/webhooks.ts
@@ -90,12 +90,16 @@ const verifySignature = async (
   const signedContent = `${webhookId}.${Math.floor(timestamp)}.${body}`;
   const textEncoder = new TextEncoder();
   const signedContentBytes = textEncoder.encode(signedContent);
-  const signingKey = await globalThis.crypto.subtle.importKey(
-    "raw",
-    textEncoder.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["verify"],
+  const signingKeys = await Promise.all(
+    hmacKeys(secret).map((key) =>
+      globalThis.crypto.subtle.importKey(
+        "raw",
+        key,
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["verify"],
+      ),
+    ),
   );
 
   for (const versionedSignature of webhookSignature.split(" ")) {
@@ -104,20 +108,53 @@ const verifySignature = async (
       continue;
     }
     const decodedSignature = decodeBase64(signature);
-    if (
-      decodedSignature !== null &&
-      (await globalThis.crypto.subtle.verify(
-        "HMAC",
-        signingKey,
-        decodedSignature,
-        signedContentBytes,
-      ))
-    ) {
-      return;
+    if (decodedSignature === null) {
+      continue;
+    }
+    for (const signingKey of signingKeys) {
+      if (
+        await globalThis.crypto.subtle.verify(
+          "HMAC",
+          signingKey,
+          decodedSignature,
+          signedContentBytes,
+        )
+      ) {
+        return;
+      }
     }
   }
 
   throw new PolarWebhookVerificationError("No matching signature found");
+};
+
+const hmacKeys = (secret: string): BufferSource[] => {
+  const utf8Key = new TextEncoder().encode(secret);
+  const keys: BufferSource[] = [utf8Key];
+  const remainder = secret.startsWith("whsec_")
+    ? secret.slice("whsec_".length)
+    : secret;
+  const decoded = decodeBase64(remainder);
+  if (
+    decoded !== null &&
+    decoded.byteLength > 0 &&
+    !bytesEqual(decoded, utf8Key)
+  ) {
+    keys.push(decoded);
+  }
+  return keys;
+};
+
+const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean => {
+  if (left.byteLength !== right.byteLength) {
+    return false;
+  }
+  for (let index = 0; index < left.byteLength; index++) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+  return true;
 };
 
 const decodeBase64 = (value: string): Uint8Array<ArrayBuffer> | null => {

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -165,6 +165,9 @@ async def polar_webhook(request: Request) -> dict[str, bool]:
     return {"received": True}
 ```
 
-The signature is checked before the body is parsed. `validate_event` raises
-`PolarWebhookVerificationError` for invalid signatures and `PolarWebhookUnknownTypeError` when the
-event is not supported by the selected API version. Both inherit from `PolarWebhookError`.
+The signature is checked before the body is parsed. Verification accepts Polar's
+original HMAC key (UTF-8 bytes of the full secret, including `whsec_`) and the
+Standard Webhooks key (base64-decode of the remainder after `whsec_`).
+`validate_event` raises `PolarWebhookVerificationError` for invalid signatures and
+`PolarWebhookUnknownTypeError` when the event is not supported by the selected API
+version. Both inherit from `PolarWebhookError`.

--- a/sdk/python/polar/webhooks.py
+++ b/sdk/python/polar/webhooks.py
@@ -87,19 +87,31 @@ def _verify_signature(body: str, headers: dict[str, str], secret: str) -> None:
         raise PolarWebhookVerificationError("Message timestamp too new")
 
     signed_content = f"{webhook_id}.{math.floor(timestamp)}.{body}".encode()
-    expected_signature = hmac.new(
-        secret.encode(), signed_content, hashlib.sha256
-    ).digest()
-
-    for versioned_signature in webhook_signature.split():
-        version, separator, signature = versioned_signature.partition(",")
-        if version != "v1" or not separator:
-            continue
-        try:
-            decoded_signature = base64.b64decode(signature, validate=True)
-        except (binascii.Error, ValueError):
-            continue
-        if hmac.compare_digest(expected_signature, decoded_signature):
-            return
+    for signing_key in _signing_keys(secret):
+        expected_signature = hmac.new(
+            signing_key, signed_content, hashlib.sha256
+        ).digest()
+        for versioned_signature in webhook_signature.split():
+            version, separator, signature = versioned_signature.partition(",")
+            if version != "v1" or not separator:
+                continue
+            try:
+                decoded_signature = base64.b64decode(signature, validate=True)
+            except (binascii.Error, ValueError):
+                continue
+            if hmac.compare_digest(expected_signature, decoded_signature):
+                return
 
     raise PolarWebhookVerificationError("No matching signature found")
+
+
+def _signing_keys(secret: str) -> tuple[bytes, ...]:
+    keys: list[bytes] = [secret.encode()]
+    remainder = secret.removeprefix("whsec_")
+    try:
+        decoded = base64.b64decode(remainder, validate=True)
+    except (binascii.Error, ValueError):
+        return (keys[0],)
+    if decoded and decoded != keys[0]:
+        keys.append(decoded)
+    return tuple(keys)

--- a/sdk/python/tests/test_webhooks.py
+++ b/sdk/python/tests/test_webhooks.py
@@ -2,6 +2,7 @@ import base64
 import dataclasses
 import datetime
 import json
+import os
 import typing
 
 import pytest
@@ -55,6 +56,23 @@ def test_validate_event(as_bytes: bool) -> None:
     raw_body = body.encode() if as_bytes else body
 
     assert _validate_event(raw_body, _get_headers(body)) == DummyPayload(
+        type=_EVENT_TYPE, value="payload"
+    )
+
+
+def test_validate_event_accepts_standard_webhooks_secret() -> None:
+    key = os.urandom(32)
+    secret = "whsec_" + base64.b64encode(key).decode()
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+    timestamp = datetime.datetime.now(tz=datetime.UTC)
+    signature = Webhook(secret).sign("test-webhook", timestamp, body)
+    headers = {
+        "Webhook-Id": "test-webhook",
+        "Webhook-Timestamp": str(int(timestamp.timestamp())),
+        "Webhook-Signature": signature,
+    }
+
+    assert _validate_event(body, headers, secret) == DummyPayload(
         type=_EVENT_TYPE, value="payload"
     )
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -125,6 +125,8 @@ app.post("/webhooks/polar", rawBody, async (request, response) => {
 ```
 
 The `express.raw` middleware is required because the signature must be checked against the body
-before it is parsed. `validateEvent` throws `PolarWebhookVerificationError` for invalid signatures
+before it is parsed. Verification accepts Polar's original HMAC key (UTF-8 bytes of the full
+secret, including `whsec_`) and the Standard Webhooks key (base64-decode of the remainder after
+`whsec_`). `validateEvent` throws `PolarWebhookVerificationError` for invalid signatures
 and `PolarWebhookUnknownTypeError` when the event is not supported by the selected API version.
 Both inherit from `PolarWebhookError`.

--- a/sdk/typescript/src/webhooks.test.ts
+++ b/sdk/typescript/src/webhooks.test.ts
@@ -49,6 +49,26 @@ describe("validateWebhook", () => {
     });
   });
 
+  test("validates a Standard Webhooks-formatted secret", async () => {
+    const key = globalThis.crypto.getRandomValues(new Uint8Array(32));
+    const secret = `whsec_${Buffer.from(key).toString("base64")}`;
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const timestamp = new Date();
+    const signature = new Webhook(secret).sign("test-webhook", timestamp, body);
+    const headers = {
+      "Webhook-Id": "test-webhook",
+      "Webhook-Timestamp": String(Math.floor(timestamp.getTime() / 1000)),
+      "Webhook-Signature": signature,
+    };
+
+    await expect(
+      validateWebhook<DummyPayload>(body, headers, secret, eventTypes),
+    ).resolves.toEqual({
+      type: "dummy.event",
+      value: "payload",
+    });
+  });
+
   test("rejects an invalid signature", async () => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
 

--- a/sdk/typescript/src/webhooks.ts
+++ b/sdk/typescript/src/webhooks.ts
@@ -90,12 +90,16 @@ const verifySignature = async (
   const signedContent = `${webhookId}.${Math.floor(timestamp)}.${body}`;
   const textEncoder = new TextEncoder();
   const signedContentBytes = textEncoder.encode(signedContent);
-  const signingKey = await globalThis.crypto.subtle.importKey(
-    "raw",
-    textEncoder.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["verify"],
+  const signingKeys = await Promise.all(
+    hmacKeys(secret).map((key) =>
+      globalThis.crypto.subtle.importKey(
+        "raw",
+        key,
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["verify"],
+      ),
+    ),
   );
 
   for (const versionedSignature of webhookSignature.split(" ")) {
@@ -104,20 +108,53 @@ const verifySignature = async (
       continue;
     }
     const decodedSignature = decodeBase64(signature);
-    if (
-      decodedSignature !== null &&
-      (await globalThis.crypto.subtle.verify(
-        "HMAC",
-        signingKey,
-        decodedSignature,
-        signedContentBytes,
-      ))
-    ) {
-      return;
+    if (decodedSignature === null) {
+      continue;
+    }
+    for (const signingKey of signingKeys) {
+      if (
+        await globalThis.crypto.subtle.verify(
+          "HMAC",
+          signingKey,
+          decodedSignature,
+          signedContentBytes,
+        )
+      ) {
+        return;
+      }
     }
   }
 
   throw new PolarWebhookVerificationError("No matching signature found");
+};
+
+const hmacKeys = (secret: string): BufferSource[] => {
+  const utf8Key = new TextEncoder().encode(secret);
+  const keys: BufferSource[] = [utf8Key];
+  const remainder = secret.startsWith("whsec_")
+    ? secret.slice("whsec_".length)
+    : secret;
+  const decoded = decodeBase64(remainder);
+  if (
+    decoded !== null &&
+    decoded.byteLength > 0 &&
+    !bytesEqual(decoded, utf8Key)
+  ) {
+    keys.push(decoded);
+  }
+  return keys;
+};
+
+const bytesEqual = (left: Uint8Array, right: Uint8Array): boolean => {
+  if (left.byteLength !== right.byteLength) {
+    return false;
+  }
+  for (let index = 0; index < left.byteLength; index++) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+  return true;
 };
 
 const decodeBase64 = (value: string): Uint8Array<ArrayBuffer> | null => {


### PR DESCRIPTION
We want to switch to signing our webhooks using the standards compliant way (as defined by https://www.standardwebhooks.com).
To ensure a smooth rollout of that switch we want our SDKs to be able to verify both approaches before that roll out.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

