### PR TITLE
fix(product): separate the tier input and read schemas

### DIFF
--- a/clients/packages/checkout/src/utils/units.ts
+++ b/clients/packages/checkout/src/utils/units.ts
@@ -44,7 +44,7 @@ export function getUnitLabels(
   return { unitLabel, unitLabelPlural }
 }
 
-type UnitTier = schemas['Tier-Output']
+type UnitTier = schemas['Tier']
 
 function sortTiers(tiers: UnitTier[]): UnitTier[] {
   return tiers.toSorted((a, b) => {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -32680,7 +32680,7 @@ export interface components {
       /** @description The meter associated to the price. */
       meter: components['schemas']['ProductPriceMeter']
       /** @description The pricing tiers based on consumed units. */
-      tiers: components['schemas']['Tiers-Output']
+      tiers: components['schemas']['Tiers']
     }
     /**
      * ProductPriceMeteredTiersCreate
@@ -32706,7 +32706,7 @@ export interface components {
        */
       meter_id: string
       /** @description Tiered pricing based on consumed units. */
-      tiers: components['schemas']['Tiers-Input']
+      tiers: components['schemas']['TiersInput']
       /**
        * Cap Amount
        * @description Optional maximum amount in cents that can be charged, regardless of the number of units consumed.
@@ -33013,7 +33013,7 @@ export interface components {
        */
       product_id: string
       /** @description Tiered pricing based on the purchased unit quantity. */
-      tiers: components['schemas']['Tiers-Output']
+      tiers: components['schemas']['Tiers']
       /**
        * Minimum Units
        * @description The minimum purchasable quantity (inclusive).
@@ -33053,7 +33053,7 @@ export interface components {
       /** @description The tax behavior of the price. If not set, it will default to the organization's default tax behavior. */
       tax_behavior?: components['schemas']['TaxBehaviorOption'] | null
       /** @description Tiered pricing based on the purchased unit quantity. */
-      tiers: components['schemas']['Tiers-Input']
+      tiers: components['schemas']['TiersInput']
       /**
        * Minimum Units
        * @description The minimum purchasable quantity (inclusive). Defaults to 1 when not set.
@@ -37064,26 +37064,27 @@ export interface components {
      *     Each tier starts where the previous one ended. The first starts at
      *     zero. `bound` is None on the last tier if it's unbounded. Rates are
      *     in cents and may be fractional.
-     */
-    'Tier-Input': {
-      /** Bound */
-      bound?: number | null
-      /** Unit Amount */
-      unit_amount: number | string
-    }
-    /**
-     * Tier
-     * @description A per-unit rate up to and including `bound`.
      *
-     *     Each tier starts where the previous one ended. The first starts at
-     *     zero. `bound` is None on the last tier if it's unbounded. Rates are
-     *     in cents and may be fractional.
+     *     Rates carry no precision bound: this schema reads stored rows, and a
+     *     bound tightened later would stop them loading. `TierInput` holds the
+     *     rules new rates must meet.
      */
-    'Tier-Output': {
+    Tier: {
       /** Bound */
       bound?: number | null
       /** Unit Amount */
       unit_amount: string
+    }
+    /**
+     * TierInput
+     * @description A tier submitted through the API. Rates go up to 19 whole digits, the
+     *     reach of the BigInteger amount columns, with 12 decimal places.
+     */
+    TierInput: {
+      /** Bound */
+      bound?: number | null
+      /** Unit Amount */
+      unit_amount: number | string
     }
     /**
      * TierType
@@ -37096,21 +37097,20 @@ export interface components {
      *     price type. Purchasable quantity bounds live in the `minimum_units` and
      *     `maximum_units` columns, not here.
      */
-    'Tiers-Input': {
+    Tiers: {
       type: components['schemas']['TierType']
       /** Tiers */
-      tiers: components['schemas']['Tier-Input'][]
+      tiers: components['schemas']['Tier'][]
     }
     /**
-     * Tiers
-     * @description The structure of the shared tiers JSONB column, used by every tiered
-     *     price type. Purchasable quantity bounds live in the `minimum_units` and
-     *     `maximum_units` columns, not here.
+     * TiersInput
+     * @description Tiers submitted through the API. Kept apart from `Tiers` so tightening
+     *     a rule here never stops a stored row from loading.
      */
-    'Tiers-Output': {
+    TiersInput: {
       type: components['schemas']['TierType']
       /** Tiers */
-      tiers: components['schemas']['Tier-Output'][]
+      tiers: components['schemas']['TierInput'][]
     }
     /**
      * TimeInterval

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -37077,8 +37077,8 @@ export interface components {
     }
     /**
      * TierInput
-     * @description A tier submitted through the API. Rates go up to 19 whole digits, the
-     *     reach of the BigInteger amount columns, with 12 decimal places.
+     * @description A tier submitted through the API. Rates stop at the reach of the
+     *     BigInteger amount columns, with 12 decimal places.
      */
     TierInput: {
       /** Bound */

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -88,6 +88,7 @@ from polar.product.tiers import (
     SeatTiersData,
     SeatTierType,
     Tiers,
+    TiersInput,
     UnboundedTierNotLastError,
     seat_tiers_to_tiers,
     seat_tiers_unit_bounds,
@@ -456,7 +457,7 @@ class ProductPriceMeteredTiersCreate(ProductPriceMeteredCreateBase):
     """
 
     amount_type: Literal[ProductPriceAmountType.metered_tiers]
-    tiers: Tiers = Field(description="Tiered pricing based on consumed units.")
+    tiers: TiersInput = Field(description="Tiered pricing based on consumed units.")
     cap_amount: Int32 | None = Field(
         default=None,
         ge=0,
@@ -486,7 +487,7 @@ class ProductPriceUnitBasedCreate(ProductPriceCreateBase):
     """
 
     amount_type: Literal[ProductPriceAmountType.unit_based]
-    tiers: Tiers = Field(
+    tiers: TiersInput = Field(
         description="Tiered pricing based on the purchased unit quantity."
     )
     minimum_units: int | None = Field(

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -612,7 +612,7 @@ class ProductService:
                         product=product,
                         source=source,
                         **price_schema.model_dump(exclude={"tiers"}),
-                        tiers=price_schema.tiers,
+                        tiers=price_schema.tiers.to_tiers(),
                     )
                 else:
                     price = model_class(

--- a/server/polar/product/tiers.py
+++ b/server/polar/product/tiers.py
@@ -30,6 +30,23 @@ class Tier(BaseModel):
     )
 
 
+def sort_and_check_bounds[TierT: Tier](tiers: list[TierT]) -> list[TierT]:
+    sorted_tiers = sorted(tiers, key=lambda tier: (tier.bound is None, tier.bound or 0))
+    for current, next_tier in pairwise(sorted_tiers):
+        if current.bound is None:
+            raise PydanticCustomError(
+                "unbounded_tier_not_last",
+                "Only the last tier can be unbounded",
+            )
+        if next_tier.bound == current.bound:
+            raise PydanticCustomError(
+                "duplicate_tier_bound",
+                "Tier bound values must be unique, got {bound} twice",
+                {"bound": current.bound},
+            )
+    return sorted_tiers
+
+
 class Tiers(BaseModel):
     """The structure of the shared tiers JSONB column, used by every tiered
     price type. Purchasable quantity bounds live in the `minimum_units` and
@@ -42,22 +59,7 @@ class Tiers(BaseModel):
     @field_validator("tiers")
     @classmethod
     def validate_tiers(cls, tiers: list[Tier]) -> list[Tier]:
-        sorted_tiers = sorted(
-            tiers, key=lambda tier: (tier.bound is None, tier.bound or 0)
-        )
-        for current, next_tier in pairwise(sorted_tiers):
-            if current.bound is None:
-                raise PydanticCustomError(
-                    "unbounded_tier_not_last",
-                    "Only the last tier can be unbounded",
-                )
-            if next_tier.bound == current.bound:
-                raise PydanticCustomError(
-                    "duplicate_tier_bound",
-                    "Tier bound values must be unique, got {bound} twice",
-                    {"bound": current.bound},
-                )
-        return sorted_tiers
+        return sort_and_check_bounds(tiers)
 
     def calculate(self, quantity: Decimal | int) -> Decimal:
         if quantity < 0:

--- a/server/polar/product/tiers.py
+++ b/server/polar/product/tiers.py
@@ -10,6 +10,8 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 from polar.exceptions import PolarError
 
+BIGINT_MAX = 9223372036854775807
+
 
 class TierType(StrEnum):
     volume = "volume"
@@ -33,13 +35,13 @@ class Tier(BaseModel):
 
 
 class TierInput(BaseModel):
-    """A tier submitted through the API. Rates go up to 19 whole digits, the
-    reach of the BigInteger amount columns, with 12 decimal places.
+    """A tier submitted through the API. Rates stop at the reach of the
+    BigInteger amount columns, with 12 decimal places.
     """
 
     bound: int | None = Field(default=None, gt=0)
     unit_amount: Decimal = Field(
-        ge=0, max_digits=31, decimal_places=12, allow_inf_nan=False
+        ge=0, le=BIGINT_MAX, max_digits=31, decimal_places=12, allow_inf_nan=False
     )
 
 

--- a/server/polar/product/tiers.py
+++ b/server/polar/product/tiers.py
@@ -22,12 +22,14 @@ class Tier(BaseModel):
     Each tier starts where the previous one ended. The first starts at
     zero. `bound` is None on the last tier if it's unbounded. Rates are
     in cents and may be fractional.
+
+    Rates carry no precision bound: this schema reads stored rows, and a
+    bound tightened later would stop them loading. `TierInput` holds the
+    rules new rates must meet.
     """
 
     bound: int | None = Field(default=None, gt=0)
-    unit_amount: Decimal = Field(
-        ge=0, max_digits=17, decimal_places=12, allow_inf_nan=False
-    )
+    unit_amount: Decimal = Field(ge=0, allow_inf_nan=False)
 
 
 class TierInput(BaseModel):

--- a/server/polar/product/tiers.py
+++ b/server/polar/product/tiers.py
@@ -138,7 +138,7 @@ class TiersInput(BaseModel):
 
 
 def validate_unit_bounds(
-    tiers: Tiers,
+    tiers: Tiers | TiersInput,
     *,
     minimum_units: int | None = None,
     maximum_units: int | None = None,

--- a/server/polar/product/tiers.py
+++ b/server/polar/product/tiers.py
@@ -30,7 +30,18 @@ class Tier(BaseModel):
     )
 
 
-def sort_and_check_bounds[TierT: Tier](tiers: list[TierT]) -> list[TierT]:
+class TierInput(BaseModel):
+    """A tier submitted through the API. Rates go up to 19 whole digits, the
+    reach of the BigInteger amount columns, with 12 decimal places.
+    """
+
+    bound: int | None = Field(default=None, gt=0)
+    unit_amount: Decimal = Field(
+        ge=0, max_digits=31, decimal_places=12, allow_inf_nan=False
+    )
+
+
+def sort_and_check_bounds[TierT: Tier | TierInput](tiers: list[TierT]) -> list[TierT]:
     sorted_tiers = sorted(tiers, key=lambda tier: (tier.bound is None, tier.bound or 0))
     for current, next_tier in pairwise(sorted_tiers):
         if current.bound is None:
@@ -101,6 +112,27 @@ class Tiers(BaseModel):
     @property
     def last_bound(self) -> int | None:
         return self.tiers[-1].bound
+
+
+class TiersInput(BaseModel):
+    """Tiers submitted through the API. Kept apart from `Tiers` so tightening
+    a rule here never stops a stored row from loading.
+    """
+
+    type: TierType
+    tiers: list[TierInput] = Field(min_length=1)
+
+    @field_validator("tiers")
+    @classmethod
+    def validate_tiers(cls, tiers: list[TierInput]) -> list[TierInput]:
+        return sort_and_check_bounds(tiers)
+
+    @property
+    def last_bound(self) -> int | None:
+        return self.tiers[-1].bound
+
+    def to_tiers(self) -> Tiers:
+        return Tiers.model_validate(self.model_dump())
 
 
 def validate_unit_bounds(

--- a/server/tests/product/test_schemas.py
+++ b/server/tests/product/test_schemas.py
@@ -19,7 +19,7 @@ from polar.product.schemas import (
     ProductPriceSeatTiers,
     ProductPriceUnitBasedCreate,
 )
-from polar.product.tiers import Tiers, TierType
+from polar.product.tiers import TiersInput, TierType
 from tests.fixtures.random_objects import METER_ID
 
 # PostgreSQL int4 range limit
@@ -113,7 +113,7 @@ class TestProductPriceMeteredTiersCreate:
             amount_type=ProductPriceAmountType.metered_tiers,
             price_currency=PresentmentCurrency.usd,
             meter_id=METER_ID,
-            tiers=Tiers.model_validate(
+            tiers=TiersInput.model_validate(
                 {
                     "type": TierType.graduated,
                     "tiers": [
@@ -132,7 +132,7 @@ class TestProductPriceMeteredTiersCreate:
                 amount_type=ProductPriceAmountType.metered_tiers,
                 price_currency=PresentmentCurrency.usd,
                 meter_id=METER_ID,
-                tiers=Tiers.model_validate(
+                tiers=TiersInput.model_validate(
                     {
                         "type": TierType.volume,
                         "tiers": [{"bound": 1000, "unit_amount": "0.5"}],

--- a/server/tests/product/test_service.py
+++ b/server/tests/product/test_service.py
@@ -57,7 +57,7 @@ from polar.product.schemas import (
 )
 from polar.product.service import product as product_service
 from polar.product.sorting import ProductSortProperty
-from polar.product.tiers import Tiers, TierType
+from polar.product.tiers import Tiers, TiersInput, TierType
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -803,7 +803,7 @@ class TestCreate:
 
         price = product.prices[0]
         assert isinstance(price, ProductPriceMeteredTiers)
-        assert price.tiers == price_schema.tiers
+        assert price.tiers == price_schema.tiers.to_tiers()
 
     @pytest.mark.auth
     async def test_tiered_metered_price_requires_the_feature_flag(
@@ -1284,7 +1284,7 @@ def _tiered_metered_price_create() -> ProductPriceMeteredTiersCreate:
         amount_type=ProductPriceAmountType.metered_tiers,
         price_currency=PresentmentCurrency.usd,
         meter_id=METER_ID,
-        tiers=Tiers.model_validate(
+        tiers=TiersInput.model_validate(
             {
                 "type": "graduated",
                 "tiers": [
@@ -1329,7 +1329,7 @@ def _unit_price_create(
         price_currency=currency,
         tax_behavior=tax_behavior,
         minimum_units=minimum_units,
-        tiers=Tiers.model_validate(
+        tiers=TiersInput.model_validate(
             {
                 "type": TierType.volume,
                 "tiers": [{"bound": None, "unit_amount": str(price_per_unit)}],

--- a/server/tests/product/test_tiers.py
+++ b/server/tests/product/test_tiers.py
@@ -10,6 +10,7 @@ from polar.product.tiers import (
     SeatTiersData,
     SeatTierType,
     Tiers,
+    TiersInput,
     TierType,
     UnboundedTierNotLastError,
     seat_tiers_to_tiers,
@@ -60,15 +61,6 @@ class TestTiersValidation:
             )
         assert exc.value.errors()[0]["type"] == "duplicate_tier_bound"
 
-    def test_rate_beyond_twelve_decimal_places_raises(self) -> None:
-        # Rates are stored in a Numeric(17, 12) column; anything finer would be
-        # silently truncated on write.
-        with pytest.raises(ValidationError):
-            _tiers_data(
-                TierType.volume,
-                [{"bound": None, "unit_amount": "0.1234567890123"}],
-            )
-
     def test_serializes_decimal_rates_as_strings(self) -> None:
         tiers = _tiers_data(
             TierType.volume,
@@ -78,6 +70,24 @@ class TestTiersValidation:
         assert serialized["type"] == "volume"
         assert serialized["tiers"][0]["bound"] is None
         assert serialized["tiers"][0]["unit_amount"] == "1E-12"
+
+
+class TestTiersInput:
+    def test_rate_beyond_twelve_decimal_places_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            TiersInput.model_validate(
+                {
+                    "type": TierType.volume,
+                    "tiers": [{"bound": None, "unit_amount": "0.1234567890123"}],
+                }
+            )
+
+    def test_accepts_a_rate_up_to_the_biginteger_range(self) -> None:
+        rate = "9" * 19
+        tiers = TiersInput.model_validate(
+            {"type": TierType.volume, "tiers": [{"bound": None, "unit_amount": rate}]}
+        )
+        assert tiers.tiers[0].unit_amount == Decimal(rate)
 
 
 class TestTiersCalculateVolume:

--- a/server/tests/product/test_tiers.py
+++ b/server/tests/product/test_tiers.py
@@ -89,6 +89,15 @@ class TestTiersInput:
         )
         assert tiers.tiers[0].unit_amount == Decimal(rate)
 
+    def test_reads_a_stored_rate_it_would_reject(self) -> None:
+        payload: dict[str, Any] = {
+            "type": TierType.volume,
+            "tiers": [{"bound": None, "unit_amount": "9" * 20}],
+        }
+        with pytest.raises(ValidationError):
+            TiersInput.model_validate(payload)
+        assert Tiers.model_validate(payload).tiers[0].unit_amount == Decimal("9" * 20)
+
 
 class TestTiersCalculateVolume:
     def test_fractional_rate(self) -> None:

--- a/server/tests/product/test_tiers.py
+++ b/server/tests/product/test_tiers.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from polar.product.tiers import (
+    BIGINT_MAX,
     InvalidQuantityError,
     NonContiguousTiersError,
     SeatTiersData,
@@ -83,11 +84,20 @@ class TestTiersInput:
             )
 
     def test_accepts_a_rate_up_to_the_biginteger_range(self) -> None:
-        rate = "9" * 19
+        rate = str(BIGINT_MAX)
         tiers = TiersInput.model_validate(
             {"type": TierType.volume, "tiers": [{"bound": None, "unit_amount": rate}]}
         )
         assert tiers.tiers[0].unit_amount == Decimal(rate)
+
+    def test_rate_beyond_the_biginteger_range_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            TiersInput.model_validate(
+                {
+                    "type": TierType.volume,
+                    "tiers": [{"bound": None, "unit_amount": str(BIGINT_MAX + 1)}],
+                }
+            )
 
     def test_reads_a_stored_rate_it_would_reject(self) -> None:
         payload: dict[str, Any] = {


### PR DESCRIPTION
## Summary

Easier read commit by commit, should fix https://polar-sh.sentry.io/issues/7706678098/?alert_rule_id=16426328&alert_type=issue&notification_uuid=6b7d423a-da03-4145-8d7b-75e0abc3ffa1&project=4505046565519360&referrer=slack


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

