### PR TITLE
Restore backfill script for slack app encrypted secrets

### DIFF
--- a/server/scripts/backfill_slack_app_encrypted_secrets.py
+++ b/server/scripts/backfill_slack_app_encrypted_secrets.py
@@ -1,0 +1,193 @@
+"""Encrypt SlackApp secrets written before dual-write.
+
+Dry-run by default (counts rows only). Pass --execute to write:
+
+    uv run python -m scripts.backfill_slack_app_encrypted_secrets --execute
+"""
+
+import asyncio
+
+import typer
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.sql.elements import ColumnElement
+
+from polar.config import settings
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.kit.db.postgres import create_async_engine as _create_async_engine
+from polar.models import SlackApp
+
+from .helper import configure_script_logging, typer_async
+
+cli = typer.Typer()
+
+
+def _needs_backfill() -> ColumnElement[bool]:
+    """A row still to backfill: a plaintext secret exists but its ciphertext is
+    NULL. Each secret is independent, so any of the three qualifies the row."""
+    return or_(
+        and_(
+            SlackApp.client_secret.is_not(None),
+            SlackApp.client_secret_encrypted.is_(None),
+        ),
+        and_(
+            SlackApp.signing_secret.is_not(None),
+            SlackApp.signing_secret_encrypted.is_(None),
+        ),
+        and_(
+            SlackApp.bot_token.is_not(None),
+            SlackApp.bot_token_encrypted.is_(None),
+        ),
+    )
+
+
+async def run_backfill(
+    batch_size: int = 500,
+    sleep_seconds: float = 0.1,
+    dry_run: bool = False,
+    session: AsyncSession | None = None,
+) -> int:
+    """
+    Encrypt SlackApp secrets written before dual-write (rollout step 3; see the
+    design document, Appendix C).
+
+    Encryption calls the key provider once per secret, so this loops in Python
+    rather than a set-based SQL update. Each backfilled secret fills its
+    ciphertext column, so the row falls out of the predicate; the loop
+    terminates and reruns are safe.
+    """
+    engine = None
+    own_session = False
+
+    if session is None:
+        engine = _create_async_engine(
+            dsn=str(settings.get_postgres_dsn("asyncpg")),
+            application_name=f"{settings.ENV.value}.script",
+            debug=False,
+            pool_size=settings.DATABASE_POOL_SIZE,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+            command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+        session = sessionmaker()
+        own_session = True
+
+    total_encrypted = 0
+    batch_number = 0
+
+    try:
+        if dry_run:
+            count = (
+                await session.scalar(
+                    select(func.count()).select_from(SlackApp).where(_needs_backfill())
+                )
+                or 0
+            )
+            typer.echo(f"[dry-run] {count} slack apps would be encrypted")
+            return count
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            transient=False,
+        ) as progress:
+            task = progress.add_task("[cyan]Batch 0: 0 rows encrypted", total=None)
+
+            while True:
+                statement = (
+                    select(SlackApp)
+                    .where(_needs_backfill())
+                    .order_by(SlackApp.id)
+                    .limit(batch_size)
+                )
+                result = await session.execute(statement)
+                slack_apps = list(result.scalars().all())
+
+                if not slack_apps:
+                    progress.update(
+                        task,
+                        description=(
+                            f"[green]✓ Complete: {total_encrypted} rows encrypted"
+                        ),
+                    )
+                    break
+
+                for slack_app in slack_apps:
+                    if (
+                        slack_app.client_secret is not None
+                        and slack_app.client_secret_encrypted is None
+                    ):
+                        slack_app.client_secret_encrypted = (
+                            await SlackApp.encrypt_client_secret(
+                                slack_app.id, slack_app.client_secret
+                            )
+                        )
+                    if (
+                        slack_app.signing_secret is not None
+                        and slack_app.signing_secret_encrypted is None
+                    ):
+                        slack_app.signing_secret_encrypted = (
+                            await SlackApp.encrypt_signing_secret(
+                                slack_app.id, slack_app.signing_secret
+                            )
+                        )
+                    if (
+                        slack_app.bot_token is not None
+                        and slack_app.bot_token_encrypted is None
+                    ):
+                        slack_app.bot_token_encrypted = (
+                            await SlackApp.encrypt_bot_token(
+                                slack_app.id, slack_app.bot_token
+                            )
+                        )
+
+                await session.commit()
+                session.expunge_all()
+
+                batch_number += 1
+                total_encrypted += len(slack_apps)
+                progress.update(
+                    task,
+                    description=(
+                        f"[cyan]Batch {batch_number}: {total_encrypted} rows encrypted"
+                    ),
+                )
+
+                if sleep_seconds > 0:
+                    await asyncio.sleep(sleep_seconds)
+
+        return total_encrypted
+
+    finally:
+        if own_session:
+            await session.close()
+        if engine is not None:
+            await engine.dispose()
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(500, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+    execute: bool = typer.Option(
+        False, "--execute", help="Write encrypted secrets; without it, only counts rows"
+    ),
+) -> None:
+    """Encrypt SlackApp secrets written before dual-write."""
+    configure_script_logging()
+    total_encrypted = await run_backfill(
+        batch_size=batch_size, sleep_seconds=sleep_seconds, dry_run=not execute
+    )
+    if execute:
+        typer.echo(f"Encrypted {total_encrypted} slack apps")
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/scripts/test_backfill_slack_app_encrypted_secrets.py
+++ b/server/tests/scripts/test_backfill_slack_app_encrypted_secrets.py
@@ -1,0 +1,220 @@
+import pytest
+from sqlalchemy import select
+
+from polar.kit.db.postgres import AsyncSession
+from polar.kit.encryption import EncryptedString
+from polar.models import Organization, SlackApp
+from scripts.backfill_slack_app_encrypted_secrets import run_backfill
+from tests.fixtures.database import SaveFixture
+
+
+async def _create_legacy_slack_app(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    *,
+    slack_app_id: str,
+    client_secret: str | None = None,
+    signing_secret: str | None = None,
+    bot_token: str | None = None,
+) -> SlackApp:
+    """A row written before dual-write: plaintext secrets, NULL encrypted columns."""
+    slack_app = SlackApp(
+        organization_id=organization.id,
+        display_name="Test",
+        slack_app_id=slack_app_id,
+        client_id="100.200",
+        client_secret=client_secret,
+        signing_secret=signing_secret,
+        bot_token=bot_token,
+    )
+    await save_fixture(slack_app)
+    return slack_app
+
+
+async def _reload(session: AsyncSession, slack_app: SlackApp) -> SlackApp:
+    session.expunge_all()
+    loaded = await session.scalar(select(SlackApp).where(SlackApp.id == slack_app.id))
+    assert loaded is not None
+    return loaded
+
+
+@pytest.mark.asyncio
+class TestBackfillSlackAppEncryptedSecrets:
+    async def test_encrypts_legacy_rows(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        slack_app = await _create_legacy_slack_app(
+            save_fixture,
+            organization,
+            slack_app_id="A1",
+            client_secret="cs-legacy",
+            signing_secret="ss-legacy",
+            bot_token="xoxb-legacy",
+        )
+        assert slack_app.client_secret_encrypted is None
+        assert slack_app.signing_secret_encrypted is None
+        assert slack_app.bot_token_encrypted is None
+
+        encrypted = await run_backfill(batch_size=10, sleep_seconds=0, session=session)
+
+        assert encrypted == 1
+        loaded = await _reload(session, slack_app)
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        assert (
+            await loaded.client_secret_encrypted.decrypt(id=str(loaded.id))
+            == "cs-legacy"
+        )
+        assert isinstance(loaded.signing_secret_encrypted, EncryptedString)
+        assert (
+            await loaded.signing_secret_encrypted.decrypt(id=str(loaded.id))
+            == "ss-legacy"
+        )
+        assert isinstance(loaded.bot_token_encrypted, EncryptedString)
+        assert (
+            await loaded.bot_token_encrypted.decrypt(id=str(loaded.id)) == "xoxb-legacy"
+        )
+
+    async def test_encrypts_each_secret_independently(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        slack_app = await _create_legacy_slack_app(
+            save_fixture,
+            organization,
+            slack_app_id="A2",
+            client_secret="cs-only",
+            signing_secret=None,
+            bot_token=None,
+        )
+
+        await run_backfill(batch_size=10, sleep_seconds=0, session=session)
+
+        loaded = await _reload(session, slack_app)
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        assert loaded.signing_secret_encrypted is None
+        assert loaded.bot_token_encrypted is None
+
+    async def test_skips_rows_without_secrets(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        slack_app = await _create_legacy_slack_app(
+            save_fixture, organization, slack_app_id="A3"
+        )
+
+        encrypted = await run_backfill(batch_size=10, sleep_seconds=0, session=session)
+
+        assert encrypted == 0
+        loaded = await _reload(session, slack_app)
+        assert loaded.client_secret_encrypted is None
+        assert loaded.signing_secret_encrypted is None
+        assert loaded.bot_token_encrypted is None
+
+    async def test_does_not_overwrite_already_encrypted_secret(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        slack_app = await _create_legacy_slack_app(
+            save_fixture,
+            organization,
+            slack_app_id="A4",
+            client_secret="cs-plain",
+            signing_secret="ss-plain",
+        )
+        slack_app.client_secret_encrypted = await SlackApp.encrypt_client_secret(
+            slack_app.id, "cs-already-encrypted"
+        )
+        await save_fixture(slack_app)
+        assert isinstance(slack_app.client_secret_encrypted, EncryptedString)
+        existing_ciphertext = slack_app.client_secret_encrypted.encrypted_value
+
+        await run_backfill(batch_size=10, sleep_seconds=0, session=session)
+
+        loaded = await _reload(session, slack_app)
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        assert loaded.client_secret_encrypted.encrypted_value == existing_ciphertext
+        assert (
+            await loaded.client_secret_encrypted.decrypt(id=str(loaded.id))
+            == "cs-already-encrypted"
+        )
+        assert isinstance(loaded.signing_secret_encrypted, EncryptedString)
+        assert (
+            await loaded.signing_secret_encrypted.decrypt(id=str(loaded.id))
+            == "ss-plain"
+        )
+
+    async def test_processes_multiple_batches(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        for i in range(5):
+            await _create_legacy_slack_app(
+                save_fixture,
+                organization,
+                slack_app_id=f"A1{i}",
+                client_secret=f"cs-{i}",
+            )
+
+        encrypted = await run_backfill(batch_size=2, sleep_seconds=0, session=session)
+
+        assert encrypted == 5
+        remaining = await session.execute(
+            select(SlackApp).where(
+                SlackApp.client_secret.is_not(None),
+                SlackApp.client_secret_encrypted.is_(None),
+            )
+        )
+        assert remaining.scalars().first() is None
+
+    async def test_is_idempotent(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        slack_app = await _create_legacy_slack_app(
+            save_fixture,
+            organization,
+            slack_app_id="A5",
+            client_secret="cs-rerun",
+        )
+
+        assert await run_backfill(batch_size=10, sleep_seconds=0, session=session) == 1
+        loaded = await _reload(session, slack_app)
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        first_ciphertext = loaded.client_secret_encrypted.encrypted_value
+
+        assert await run_backfill(batch_size=10, sleep_seconds=0, session=session) == 0
+        loaded = await _reload(session, slack_app)
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        assert loaded.client_secret_encrypted.encrypted_value == first_ciphertext
+
+    async def test_dry_run_counts_without_writing(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        slack_app = await _create_legacy_slack_app(
+            save_fixture,
+            organization,
+            slack_app_id="A6",
+            client_secret="cs-dry-run",
+        )
+
+        count = await run_backfill(dry_run=True, session=session)
+
+        assert count == 1
+        loaded = await _reload(session, slack_app)
+        assert loaded.client_secret_encrypted is None


### PR DESCRIPTION
Still one row missing encrypted secrets, let's bring it back so we can (re-)run backfill
Originally introduced in #12945 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

