### PR TITLE
Checkout: Add CTA button color experiment

### DIFF
--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -108,6 +108,11 @@ const Checkout = ({
   })
   const trialDueTodayExperiment = hasActiveTrial && isTreatment
 
+  const { isTreatment: ctaColorExperiment } = useExperiment(
+    'checkout_cta_primary_color',
+    { trackExposure: !embed },
+  )
+
   const openedTrackedRef = useRef(false)
   useEffect(() => {
     if (openedTrackedRef.current) return
@@ -482,6 +487,7 @@ const Checkout = ({
             loadingLabel={label}
             theme={theme}
             themePreset={themePreset}
+            ctaColorExperiment={ctaColorExperiment}
             disabled={disableCheckout}
             isUpdatePending={isUpdatePending}
             locale={locale}

--- a/clients/apps/web/src/experiments/experiments.ts
+++ b/clients/apps/web/src/experiments/experiments.ts
@@ -24,4 +24,10 @@ export const experiments = {
     variants: ['control', 'treatment'] as const,
     defaultVariant: 'control',
   },
+  checkout_cta_primary_color: {
+    description:
+      'Alternative primary color for the checkout CTA button instead of the default black/white',
+    variants: ['control', 'treatment'] as const,
+    defaultVariant: 'control',
+  },
 } as const

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -76,6 +76,7 @@ interface BaseCheckoutFormProps {
   isWalletPayment?: boolean
   beforeSubmit?: React.ReactNode
   embed?: boolean
+  ctaColorExperiment?: boolean
 }
 
 const BaseCheckoutForm = ({
@@ -92,6 +93,7 @@ const BaseCheckoutForm = ({
   isWalletPayment,
   beforeSubmit,
   embed,
+  ctaColorExperiment,
 }: React.PropsWithChildren<BaseCheckoutFormProps>) => {
   const interval = hasProductCheckout(checkout)
     ? isLegacyRecurringProductPrice(checkout.product_price)
@@ -714,6 +716,7 @@ const BaseCheckoutForm = ({
             <div className="flex w-full flex-col items-center justify-center gap-y-2">
               <Button
                 type="submit"
+                variant={ctaColorExperiment ? 'primary' : 'default'}
                 size="lg"
                 wrapperClassNames="text-base"
                 className="w-full"
@@ -784,6 +787,7 @@ interface CheckoutFormProps {
   locale?: AcceptedLocale
   beforeSubmit?: React.ReactNode
   embed?: boolean
+  ctaColorExperiment?: boolean
 }
 
 const StripeCheckoutForm = (props: CheckoutFormProps) => {

--- a/clients/packages/checkout/src/components/ui/Button.tsx
+++ b/clients/packages/checkout/src/components/ui/Button.tsx
@@ -7,6 +7,8 @@ const baseClasses =
 const variantClasses = {
   default:
     'bg-black dark:bg-white dark:text-black text-white hover:opacity-85 transition-opacity duration-100',
+  primary:
+    'bg-[#0570de] text-white hover:opacity-85 transition-opacity duration-100',
   secondary:
     'text-black dark:text-white hover:bg-gray-200 dark:bg-polar-700 dark:hover:bg-polar-600 bg-gray-100 border dark:border-white/5 border-black/4',
   ghost:


### PR DESCRIPTION
## Summary

With the last update to Orbit, our checkout CTA turned black. This PR will add an experiment where the CTA will turn into blue (matching the other shades of blue in the checkout).

## Screenshots

| Control | Treatment  |
|--------|--------|
| <img width="1038" height="892" alt="control" src="https://github.com/user-attachments/assets/060aa147-71ba-4c5b-8c59-3795965cca81" /> | <img width="1038" height="892" alt="treatment" src="https://github.com/user-attachments/assets/6681a129-d3f5-4e51-a21d-c4e32bc87900" /> |







<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

