### PR TITLE
feat(checkout): tiered metered pricing display

### DIFF
--- a/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
@@ -5,6 +5,7 @@ import {
   createCheckout,
   createFixedPrice,
   createMeteredPrice,
+  createMeteredTiersPrice,
 } from '../test-utils/makeCheckout'
 import MeteredChargesDetails from './MeteredChargesDetails'
 
@@ -68,6 +69,25 @@ describe('MeteredChargesDetails', () => {
     )
 
     expect(container.innerHTML).toBe('')
+  })
+
+  it('renders a tiered metered price at its starting rate', () => {
+    const base = createCheckout()
+    const checkout = createCheckout({
+      prices: { prod_1: [base.product_price, createMeteredTiersPrice()] },
+    })
+
+    render(<MeteredChargesDetails checkout={checkout} locale="en" />)
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /additional metered charges may apply/i,
+      }),
+    )
+
+    expect(screen.getByTestId('detail-row-API Calls')).toHaveTextContent(
+      '$9.00',
+    )
   })
 
   it('is collapsed by default', () => {

--- a/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
@@ -71,7 +71,7 @@ describe('MeteredChargesDetails', () => {
     expect(container.innerHTML).toBe('')
   })
 
-  it('renders a tiered metered price at its starting rate', () => {
+  it('lists the tiers under a tiered price instead of repeating its rate', () => {
     const base = createCheckout()
     const checkout = createCheckout({
       prices: { prod_1: [base.product_price, createMeteredTiersPrice()] },
@@ -85,9 +85,11 @@ describe('MeteredChargesDetails', () => {
       }),
     )
 
-    expect(screen.getByTestId('detail-row-API Calls')).toHaveTextContent(
+    expect(screen.getByTestId('detail-row-API Calls')).not.toHaveTextContent(
       '$9.00',
     )
+    expect(screen.getByTestId('detail-row-1–1,000')).toHaveTextContent('$9.00')
+    expect(screen.getByTestId('detail-row-1,001+')).toHaveTextContent('$4.50')
   })
 
   it('is collapsed by default', () => {

--- a/clients/packages/checkout/src/components/MeteredChargesDetails.tsx
+++ b/clients/packages/checkout/src/components/MeteredChargesDetails.tsx
@@ -8,11 +8,12 @@ import {
   type TranslateFn,
 } from '@polar-sh/i18n'
 import { cn } from '@polar-sh/ui/lib/utils'
-import { useId, useState } from 'react'
+import { Fragment, useId, useState } from 'react'
 import { hasProductCheckout } from '../guards'
 import { getMeteredPrices } from '../utils/product'
 import DetailRow from './DetailRow'
 import MeteredPriceLabel from './MeteredPriceLabel'
+import MeteredTierRows, { hasMeteredTierRows } from './MeteredTierRows'
 import ChevronDownIcon from './icons/ChevronDownIcon'
 
 const getIncludedUnitsByMeter = (
@@ -90,24 +91,32 @@ const MeteredChargesDetails = ({
               meteredPrice.meter.id,
             )
             return (
-              <DetailRow
-                key={meteredPrice.id}
-                title={meteredPrice.meter.name}
-                subtitle={
-                  includedUnits
-                    ? t('checkout.pricing.meteredIncluded', {
-                        units: `${numberFormat.format(includedUnits)} ${getUnitNoun(meteredPrice.meter, t)}`,
-                      })
-                    : undefined
-                }
-                emphasis
-              >
-                <MeteredPriceLabel
+              <Fragment key={meteredPrice.id}>
+                <DetailRow
+                  title={meteredPrice.meter.name}
+                  subtitle={
+                    includedUnits
+                      ? t('checkout.pricing.meteredIncluded', {
+                          units: `${numberFormat.format(includedUnits)} ${getUnitNoun(meteredPrice.meter, t)}`,
+                        })
+                      : undefined
+                  }
+                  emphasis
+                >
+                  {!hasMeteredTierRows(meteredPrice) && (
+                    <MeteredPriceLabel
+                      price={meteredPrice}
+                      locale={locale}
+                      discount={checkout.discount}
+                    />
+                  )}
+                </DetailRow>
+                <MeteredTierRows
                   price={meteredPrice}
                   locale={locale}
                   discount={checkout.discount}
                 />
-              </DetailRow>
+              </Fragment>
             )
           })}
         </div>

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
@@ -1,7 +1,10 @@
 import { schemas } from '@polar-sh/client'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import { createMeteredPrice } from '../test-utils/makeCheckout'
+import {
+  createMeteredPrice,
+  createMeteredTiersPrice,
+} from '../test-utils/makeCheckout'
 import MeteredPriceLabel from './MeteredPriceLabel'
 
 const percentageDiscount = (basisPoints: number) =>
@@ -168,6 +171,53 @@ describe('MeteredPriceLabel', () => {
       )
 
       expect(container.textContent).toContain('/ unit')
+    })
+  })
+
+  describe('tiered price', () => {
+    it('renders the first tier rate', () => {
+      const price = createMeteredTiersPrice()
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$9.00')
+      expect(container.textContent).not.toContain('$4.50')
+      expect(container.textContent).toContain('/ unit')
+    })
+
+    it('reads the first tier by bound, not by array order', () => {
+      const price = createMeteredTiersPrice({
+        tiers: {
+          type: 'graduated',
+          tiers: [
+            { bound: null, unit_amount: '450' },
+            { bound: 1000, unit_amount: '900' },
+          ],
+        },
+      })
+
+      const { container } = render(
+        <MeteredPriceLabel price={price} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('$9.00')
+    })
+
+    it('discounts the first tier rate', () => {
+      const price = createMeteredTiersPrice()
+
+      render(
+        <MeteredPriceLabel
+          price={price}
+          locale="en"
+          discount={percentageDiscount(5000)}
+        />,
+      )
+
+      expect(screen.getByText('$9.00')).toHaveClass('line-through')
+      expect(screen.getByText('$4.50')).toBeInTheDocument()
     })
   })
 

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -2,10 +2,11 @@ import type { schemas } from '@polar-sh/client'
 import { DEFAULT_LOCALE, type AcceptedLocale } from '@polar-sh/i18n'
 import { getMeterUnitFormat } from '@polar-sh/ui/lib/meterUnit'
 import { cn } from '@polar-sh/ui/lib/utils'
+import { getStartingUnitAmount, type MeteredPrice } from '../utils/product'
 import MeteredRate from './MeteredRate'
 
 interface MeteredPriceLabelProps {
-  price: schemas['ProductPriceMeteredUnit']
+  price: MeteredPrice
   locale?: AcceptedLocale
   discount?: schemas['CheckoutPublic']['discount']
 }
@@ -23,7 +24,7 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
   return (
     <div className="flex flex-row items-baseline gap-x-1">
       <MeteredRate
-        amount={Number.parseFloat(price.unit_amount) * scale}
+        amount={getStartingUnitAmount(price) * scale}
         currency={price.price_currency}
         locale={locale}
         discount={discount}

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -1,8 +1,8 @@
 import type { schemas } from '@polar-sh/client'
-import { formatCurrency } from '@polar-sh/currency'
 import { DEFAULT_LOCALE, type AcceptedLocale } from '@polar-sh/i18n'
 import { getMeterUnitFormat } from '@polar-sh/ui/lib/meterUnit'
 import { cn } from '@polar-sh/ui/lib/utils'
+import MeteredRate from './MeteredRate'
 
 interface MeteredPriceLabelProps {
   price: schemas['ProductPriceMeteredUnit']
@@ -20,25 +20,14 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
     customMultiplier: price.meter.custom_multiplier,
   })
 
-  const format = formatCurrency('subcent', locale)
-  const baseAmount = Number.parseFloat(price.unit_amount) * scale
-  const discountedAmount =
-    discount && 'basis_points' in discount
-      ? baseAmount * (1 - discount.basis_points / 10000)
-      : null
-
   return (
     <div className="flex flex-row items-baseline gap-x-1">
-      {discountedAmount !== null ? (
-        <>
-          <span className="dark:text-polar-500 text-gray-400 line-through">
-            {format(baseAmount, price.price_currency)}
-          </span>
-          <span>{format(discountedAmount, price.price_currency)}</span>
-        </>
-      ) : (
-        format(baseAmount, price.price_currency)
-      )}
+      <MeteredRate
+        amount={Number.parseFloat(price.unit_amount) * scale}
+        currency={price.price_currency}
+        locale={locale}
+        discount={discount}
+      />
       <span
         className={cn(
           'dark:text-polar-400 text-[max(12px,0.5em)] text-gray-500',

--- a/clients/packages/checkout/src/components/MeteredPricesDisplay.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredPricesDisplay.test.tsx
@@ -4,6 +4,7 @@ import {
   createCheckout,
   createFixedPrice,
   createMeteredPrice,
+  createMeteredTiersPrice,
 } from '../test-utils/makeCheckout'
 import MeteredPricesDisplay from './MeteredPricesDisplay'
 
@@ -63,6 +64,22 @@ describe('MeteredPricesDisplay', () => {
 
       expect(container.textContent).toContain('API Calls')
       expect(container.textContent).toContain('$0.0005')
+    })
+
+    it('shows a tiered metered price from its starting rate', () => {
+      const fixedPrice = createFixedPrice({ id: 'price_fixed' })
+      const checkout = createCheckout({
+        product_price: fixedPrice,
+        prices: { prod_1: [fixedPrice, createMeteredTiersPrice()] },
+      })
+
+      const { container } = render(
+        <MeteredPricesDisplay checkout={checkout} locale="en" />,
+      )
+
+      expect(container.textContent).toContain('API Calls')
+      expect(container.textContent).toContain('From')
+      expect(container.textContent).toContain('$9.00')
     })
 
     it('filters out the currently selected price', () => {

--- a/clients/packages/checkout/src/components/MeteredRate.tsx
+++ b/clients/packages/checkout/src/components/MeteredRate.tsx
@@ -1,0 +1,38 @@
+import type { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { DEFAULT_LOCALE, type AcceptedLocale } from '@polar-sh/i18n'
+
+interface MeteredRateProps {
+  amount: number
+  currency: string
+  locale?: AcceptedLocale
+  discount?: schemas['CheckoutPublic']['discount']
+}
+
+const MeteredRate: React.FC<MeteredRateProps> = ({
+  amount,
+  currency,
+  locale = DEFAULT_LOCALE,
+  discount,
+}) => {
+  const format = formatCurrency('subcent', locale)
+  const discountedAmount =
+    discount && 'basis_points' in discount
+      ? amount * (1 - discount.basis_points / 10000)
+      : null
+
+  if (discountedAmount === null) {
+    return <>{format(amount, currency)}</>
+  }
+
+  return (
+    <>
+      <span className="dark:text-polar-500 text-gray-400 line-through">
+        {format(amount, currency)}
+      </span>
+      <span>{format(discountedAmount, currency)}</span>
+    </>
+  )
+}
+
+export default MeteredRate

--- a/clients/packages/checkout/src/components/MeteredTierRows.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredTierRows.test.tsx
@@ -1,0 +1,108 @@
+import { schemas } from '@polar-sh/client'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  createMeteredPrice,
+  createMeteredTiersPrice,
+} from '../test-utils/makeCheckout'
+import MeteredTierRows from './MeteredTierRows'
+
+const percentageDiscount = {
+  id: 'disc_1',
+  name: 'test',
+  type: 'percentage',
+  duration: 'once',
+  code: null,
+  basis_points: 5000,
+} satisfies schemas['CheckoutPublic']['discount']
+
+const graduated = (
+  tiers: schemas['ProductPriceMeteredTiers']['tiers']['tiers'],
+) => createMeteredTiersPrice({ tiers: { type: 'graduated', tiers } })
+
+describe('MeteredTierRows', () => {
+  it('orders tiers by bound and starts each one past the tier below', () => {
+    const price = graduated([
+      { bound: null, unit_amount: '100' },
+      { bound: 5000, unit_amount: '450' },
+      { bound: 1000, unit_amount: '900' },
+    ])
+
+    render(<MeteredTierRows price={price} locale="en" />)
+
+    const rows = screen.getAllByTestId(/^detail-row-/)
+    expect(rows.map((row) => row.getAttribute('data-testid'))).toEqual([
+      'detail-row-1–1,000',
+      'detail-row-1,001–5,000',
+      'detail-row-5,001+',
+    ])
+    expect(rows[0]).toHaveTextContent('$9.00')
+    expect(rows[1]).toHaveTextContent('$4.50')
+    expect(rows[2]).toHaveTextContent('$1.00')
+  })
+
+  it('renders nothing for a single unbounded tier', () => {
+    const price = graduated([{ bound: null, unit_amount: '900' }])
+
+    const { container } = render(<MeteredTierRows price={price} locale="en" />)
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing for a flat metered price', () => {
+    const { container } = render(
+      <MeteredTierRows price={createMeteredPrice()} locale="en" />,
+    )
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('explains that volume tiers reprice the whole quantity', () => {
+    const price = createMeteredTiersPrice({
+      tiers: {
+        type: 'volume',
+        tiers: [
+          { bound: 1000, unit_amount: '900' },
+          { bound: null, unit_amount: '450' },
+        ],
+      },
+    })
+
+    const { container } = render(<MeteredTierRows price={price} locale="en" />)
+
+    expect(container.textContent).toContain(
+      'All usage is billed at the rate for the range it falls in',
+    )
+  })
+
+  it('leaves graduated tiers unexplained', () => {
+    const price = graduated([
+      { bound: 1000, unit_amount: '900' },
+      { bound: null, unit_amount: '450' },
+    ])
+
+    const { container } = render(<MeteredTierRows price={price} locale="en" />)
+
+    expect(container.textContent).not.toContain('All usage is billed')
+  })
+
+  it('discounts every tier rate', () => {
+    const price = graduated([
+      { bound: 1000, unit_amount: '900' },
+      { bound: null, unit_amount: '300' },
+    ])
+
+    render(
+      <MeteredTierRows
+        price={price}
+        locale="en"
+        discount={percentageDiscount}
+      />,
+    )
+
+    expect(screen.getByText('$9.00')).toHaveClass('line-through')
+    expect(screen.getByText('$3.00')).toHaveClass('line-through')
+    expect(screen.getByText('$4.50')).toBeInTheDocument()
+    expect(screen.getByText('$1.50')).toBeInTheDocument()
+  })
+})

--- a/clients/packages/checkout/src/components/MeteredTierRows.tsx
+++ b/clients/packages/checkout/src/components/MeteredTierRows.tsx
@@ -1,0 +1,77 @@
+import type { schemas } from '@polar-sh/client'
+import {
+  DEFAULT_LOCALE,
+  useTranslations,
+  type AcceptedLocale,
+} from '@polar-sh/i18n'
+import { getMeterUnitFormat } from '@polar-sh/ui/lib/meterUnit'
+import { getMeteredTiers, type MeteredPrice } from '../utils/product'
+import DetailRow from './DetailRow'
+import MeteredRate from './MeteredRate'
+
+interface MeteredTierRowsProps {
+  price: MeteredPrice
+  locale?: AcceptedLocale
+  discount?: schemas['CheckoutPublic']['discount']
+}
+
+export const hasMeteredTierRows = (price: MeteredPrice): boolean =>
+  getMeteredTiers(price).length > 1
+
+const MeteredTierRows: React.FC<MeteredTierRowsProps> = ({
+  price,
+  locale = DEFAULT_LOCALE,
+  discount,
+}) => {
+  const t = useTranslations(locale)
+
+  if (price.amount_type !== 'metered_tiers' || !hasMeteredTierRows(price)) {
+    return null
+  }
+
+  const tiers = getMeteredTiers(price)
+  const { scale, label } = getMeterUnitFormat(price.meter.unit ?? 'scalar', {
+    customLabel: price.meter.custom_label,
+    customMultiplier: price.meter.custom_multiplier,
+  })
+  const formatUnits = new Intl.NumberFormat(locale)
+
+  return (
+    <>
+      {tiers.map((tier, index) => {
+        // Bounds are inclusive, so a tier starts one unit past the one below it.
+        const from = formatUnits.format((tiers[index - 1]?.bound ?? 0) + 1)
+        const title =
+          tier.bound == null
+            ? t('checkout.pricing.tiers.andAbove', { from })
+            : t('checkout.pricing.tiers.range', {
+                from,
+                to: formatUnits.format(tier.bound),
+              })
+
+        return (
+          <DetailRow key={title} title={title} className="text-gray-600">
+            <span className="flex flex-row items-baseline gap-x-1">
+              <MeteredRate
+                amount={Number.parseFloat(tier.unit_amount) * scale}
+                currency={price.price_currency}
+                locale={locale}
+                discount={discount}
+              />
+              <span className="dark:text-polar-400 text-[max(12px,0.5em)] text-gray-500">
+                / {label}
+              </span>
+            </span>
+          </DetailRow>
+        )
+      })}
+      {price.tiers.type === 'volume' && (
+        <span className="dark:text-polar-500 text-xs text-gray-400">
+          {t('checkout.pricing.tiers.volumeExplainer')}
+        </span>
+      )}
+    </>
+  )
+}
+
+export default MeteredTierRows

--- a/clients/packages/checkout/src/components/ProductPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/ProductPriceLabel.tsx
@@ -4,7 +4,11 @@ import {
   useTranslations,
   type AcceptedLocale,
 } from '@polar-sh/i18n'
-import { isLegacyRecurringPrice } from '../utils/product'
+import {
+  getMeteredTiers,
+  isLegacyRecurringPrice,
+  isMeteredPrice,
+} from '../utils/product'
 import { getBasePricePerUnit } from '../utils/units'
 import AmountLabel from './AmountLabel'
 import MeteredPriceLabel from './MeteredPriceLabel'
@@ -75,11 +79,12 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
         locale={locale}
       />
     )
-  } else if (price.amount_type === 'metered_unit') {
+  } else if (isMeteredPrice(price)) {
     return (
       <div className="flex flex-row gap-1 text-[min(1em,24px)]">
         {price.meter.name}
         {' — '}
+        {getMeteredTiers(price).length > 1 && t('checkout.pricing.tiers.from')}
         <MeteredPriceLabel price={price} locale={locale} />
       </div>
     )

--- a/clients/packages/checkout/src/test-utils/makeCheckout.ts
+++ b/clients/packages/checkout/src/test-utils/makeCheckout.ts
@@ -103,6 +103,33 @@ export function createMeteredPrice(
   }
 }
 
+export function createMeteredTiersPrice(
+  overrides: Partial<schemas['ProductPriceMeteredTiers']> = {},
+): schemas['ProductPriceMeteredTiers'] {
+  return {
+    ...priceDefaults,
+    id: 'price_metered_tiers_1',
+    amount_type: 'metered_tiers',
+    tiers: {
+      type: 'graduated',
+      tiers: [
+        { bound: 1000, unit_amount: '900' },
+        { bound: null, unit_amount: '450' },
+      ],
+    },
+    cap_amount: null,
+    meter_id: 'meter_1',
+    meter: {
+      id: 'meter_1',
+      name: 'API Calls',
+      unit: 'scalar',
+      custom_label: null,
+      custom_multiplier: null,
+    },
+    ...overrides,
+  }
+}
+
 const defaults: ProductCheckoutPublic = {
   // SDK CheckoutPublic required fields
   id: 'checkout_1',

--- a/clients/packages/checkout/src/utils/product.test.ts
+++ b/clients/packages/checkout/src/utils/product.test.ts
@@ -41,6 +41,25 @@ const makeMeteredPrice = (
     ...overrides,
   }) as schemas['ProductPriceMeteredUnit']
 
+const makeMeteredTiersPrice = (
+  overrides?: Partial<schemas['ProductPriceMeteredTiers']>,
+): schemas['ProductPriceMeteredTiers'] =>
+  ({
+    id: 'price_metered_tiers',
+    amount_type: 'metered_tiers',
+    price_currency: 'usd',
+    tiers: {
+      type: 'graduated',
+      tiers: [
+        { bound: 1000, unit_amount: '100' },
+        { bound: null, unit_amount: '50' },
+      ],
+    },
+    cap_amount: null,
+    meter: { id: 'm_1', name: 'API calls' },
+    ...overrides,
+  }) as schemas['ProductPriceMeteredTiers']
+
 describe('isLegacyRecurringPrice', () => {
   it('returns true for legacy prices', () => {
     expect(isLegacyRecurringPrice(makeLegacyPrice())).toBe(true)
@@ -73,6 +92,10 @@ describe('isMeteredPrice', () => {
     expect(isMeteredPrice(makeMeteredPrice())).toBe(true)
   })
 
+  it('returns true for metered tiers prices', () => {
+    expect(isMeteredPrice(makeMeteredTiersPrice())).toBe(true)
+  })
+
   it('returns false for fixed prices', () => {
     expect(isMeteredPrice(makePrice({ amount_type: 'fixed' }))).toBe(false)
   })
@@ -88,6 +111,20 @@ describe('getMeteredPrices', () => {
     const result = getMeteredPrices(prices)
     expect(result).toHaveLength(1)
     expect(result[0].amount_type).toBe('metered_unit')
+  })
+
+  it('keeps tiered metered prices alongside flat ones', () => {
+    const prices = [
+      makePrice({}),
+      makeMeteredPrice(),
+      makeMeteredTiersPrice(),
+    ] as schemas['ProductPrice'][]
+
+    const result = getMeteredPrices(prices)
+    expect(result.map((price) => price.amount_type)).toEqual([
+      'metered_unit',
+      'metered_tiers',
+    ])
   })
 
   it('filters by currency when provided', () => {

--- a/clients/packages/checkout/src/utils/product.ts
+++ b/clients/packages/checkout/src/utils/product.ts
@@ -34,7 +34,7 @@ export const getMeteredTiers = (price: MeteredPrice): MeteredTier[] =>
   price.amount_type === 'metered_tiers'
     ? price.tiers.tiers.toSorted(
         (a, b) =>
-          Number(a.bound === null) - Number(b.bound === null) ||
+          Number(a.bound == null) - Number(b.bound == null) ||
           (a.bound ?? 0) - (b.bound ?? 0),
       )
     : []

--- a/clients/packages/checkout/src/utils/product.ts
+++ b/clients/packages/checkout/src/utils/product.ts
@@ -9,16 +9,39 @@ export const hasLegacyRecurringPrices = (
 ): prices is schemas['LegacyRecurringProductPrice'][] =>
   prices.some(isLegacyRecurringPrice)
 
+export type MeteredPrice =
+  | schemas['ProductPriceMeteredUnit']
+  | schemas['ProductPriceMeteredTiers']
+
+export type MeteredTier =
+  schemas['ProductPriceMeteredTiers']['tiers']['tiers'][number]
+
 export const isMeteredPrice = (
   price: schemas['ProductPrice'] | schemas['LegacyRecurringProductPrice'],
-): price is schemas['ProductPriceMeteredUnit'] =>
-  price.amount_type === 'metered_unit'
+): price is MeteredPrice =>
+  price.amount_type === 'metered_unit' || price.amount_type === 'metered_tiers'
 
 export const getMeteredPrices = (
   prices: schemas['ProductPrice'][],
   currency?: string | null,
-): schemas['ProductPriceMeteredUnit'][] =>
+): MeteredPrice[] =>
   prices.filter(
-    (price): price is schemas['ProductPriceMeteredUnit'] =>
+    (price): price is MeteredPrice =>
       isMeteredPrice(price) && (!currency || price.price_currency === currency),
+  )
+
+export const getMeteredTiers = (price: MeteredPrice): MeteredTier[] =>
+  price.amount_type === 'metered_tiers'
+    ? price.tiers.tiers.toSorted(
+        (a, b) =>
+          Number(a.bound === null) - Number(b.bound === null) ||
+          (a.bound ?? 0) - (b.bound ?? 0),
+      )
+    : []
+
+export const getStartingUnitAmount = (price: MeteredPrice): number =>
+  Number.parseFloat(
+    price.amount_type === 'metered_tiers'
+      ? getMeteredTiers(price)[0].unit_amount
+      : price.unit_amount,
   )

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -197,7 +197,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -394,7 +398,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -591,7 +599,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -791,7 +803,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -991,7 +1007,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1180,7 +1200,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1372,7 +1396,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1561,7 +1589,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1750,7 +1782,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1939,7 +1975,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2131,7 +2171,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "tr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2323,7 +2367,11 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   },
   "pl": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2515,6 +2563,10 @@
     "checkout.footer.mandateSubscriptionDiscounted": "By clicking \"{buttonLabel},\" you authorize Polar Software, Inc., our online reseller and merchant of record, to immediately charge your selected payment method the discounted amount shown above, and the regular price on each billing date after your discount ends, until you cancel, and agree to the {buyerTermsLink}.",
     "checkout.pricing.firstPayment": "First payment",
     "checkout.pricing.totalAfterTrial": "Total after trial",
-    "checkout.trial.hero.freeUntil": "Free until {date}"
+    "checkout.trial.hero.freeUntil": "Free until {date}",
+    "checkout.pricing.tiers.from": "From",
+    "checkout.pricing.tiers.range": "{from}–{to}",
+    "checkout.pricing.tiers.andAbove": "{from}+",
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
   }
 }

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -119,6 +119,13 @@ export default {
       },
       firstPayment: 'Erste Zahlung',
       totalAfterTrial: 'Gesamtbetrag nach Testphase',
+      tiers: {
+        from: 'Ab',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer:
+          'Die gesamte Nutzung wird zum Tarif des Bereichs abgerechnet, in den sie fällt',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -128,6 +128,13 @@ export default {
             'Generic plural noun for metered usage units, used in quantity phrases like "10,000 units included".',
         },
       },
+      tiers: {
+        from: {
+          value: 'From',
+          _llmContext:
+            'Prefix before the cheapest rate of a tiered usage-based price, e.g. "From $0.05 / unit", meaning the rate shown is the starting one and higher usage is billed differently. Fragment, not a sentence.',
+        },
+      },
       dueToday: {
         value: 'Due today',
         _llmContext:

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -134,6 +134,21 @@ export default {
           _llmContext:
             'Prefix before the cheapest rate of a tiered usage-based price, e.g. "From $0.05 / unit", meaning the rate shown is the starting one and higher usage is billed differently. Fragment, not a sentence.',
         },
+        range: {
+          value: '{from}–{to}',
+          _llmContext:
+            'A usage range in the tier table of a metered price on checkout, e.g. "1–1,000". Both values are already-formatted unit counts. Keep it a bare numeric range with no unit noun.',
+        },
+        andAbove: {
+          value: '{from}+',
+          _llmContext:
+            'The final, unbounded usage range in the tier table of a metered price, e.g. "1,001+". {from} is an already-formatted unit count.',
+        },
+        volumeExplainer: {
+          value: 'All usage is billed at the rate for the range it falls in',
+          _llmContext:
+            'Caption under the tier table of a volume-tiered metered price on checkout. It warns that crossing into a higher range reprices the entire usage, not just the part above the bound. Shown for volume tiers only; graduated tiers get no caption.',
+        },
       },
       dueToday: {
         value: 'Due today',

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -118,6 +118,13 @@ export default {
       },
       firstPayment: 'Primer pago',
       totalAfterTrial: 'Total después de la prueba',
+      tiers: {
+        from: 'Desde',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer:
+          'Todo el uso se cobra a la tarifa del tramo en el que cae',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -119,6 +119,13 @@ export default {
       },
       firstPayment: 'Premier paiement',
       totalAfterTrial: 'Total après essai',
+      tiers: {
+        from: 'À partir de',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer:
+          'Toute la consommation est facturée au tarif correspondant à la tranche dans laquelle elle se situe',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -118,6 +118,13 @@ export default {
       },
       firstPayment: 'Első fizetés',
       totalAfterTrial: 'Összesen a próbaidőszak után',
+      tiers: {
+        from: 'Ettől',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer:
+          'A teljes használatot annak a sávnak az árával számlázzuk, amelybe beleesik',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -119,6 +119,13 @@ export default {
       },
       firstPayment: 'Primo pagamento',
       totalAfterTrial: 'Totale dopo la prova',
+      tiers: {
+        from: 'Da',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer:
+          "Tutto l'utilizzo viene addebitato alla tariffa dell'intervallo in cui rientra",
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -118,6 +118,12 @@ export default {
       },
       firstPayment: '初回のお支払い',
       totalAfterTrial: '試用期間後の合計',
+      tiers: {
+        from: 'より',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer: 'すべての使用量は、該当する範囲の料金で請求されます',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -118,6 +118,12 @@ export default {
       },
       firstPayment: '첫 결제',
       totalAfterTrial: '체험 종료 후 총액',
+      tiers: {
+        from: '부터',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer: '모든 사용량은 해당 구간의 요금이 적용됩니다',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -119,6 +119,13 @@ export default {
       },
       firstPayment: 'Eerste betaling',
       totalAfterTrial: 'Totaal na proefperiode',
+      tiers: {
+        from: 'Vanaf',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer:
+          'Alle verbruik wordt berekend tegen het tarief van de schaal waarin het valt',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pl.ts
+++ b/clients/packages/i18n/src/locales/pl.ts
@@ -119,6 +119,13 @@ export default {
       },
       firstPayment: 'Pierwsza płatność',
       totalAfterTrial: 'Suma po okresie próbnym',
+      tiers: {
+        from: 'Od',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer:
+          'Całe użycie jest rozliczane według stawki dla zakresu, do którego należy',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -119,6 +119,13 @@ export default {
       },
       firstPayment: 'Primeiro pagamento',
       totalAfterTrial: 'Total após o período experimental',
+      tiers: {
+        from: 'A partir de',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer:
+          'Todo o consumo é faturado à tarifa da faixa em que se enquadra',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -119,6 +119,13 @@ export default {
       },
       firstPayment: 'Primeiro pagamento',
       totalAfterTrial: 'Total após o teste',
+      tiers: {
+        from: 'A partir de',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer:
+          'Todo o uso é cobrado pela tarifa da faixa em que se enquadra',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -118,6 +118,13 @@ export default {
       },
       firstPayment: 'Första betalning',
       totalAfterTrial: 'Totalt efter provperiod',
+      tiers: {
+        from: 'Från',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer:
+          'All användning debiteras med priset för det intervall det hamnar i',
+      },
     },
     trial: {
       hero: {

--- a/clients/packages/i18n/src/locales/tr.ts
+++ b/clients/packages/i18n/src/locales/tr.ts
@@ -118,6 +118,13 @@ export default {
       },
       firstPayment: 'İlk ödeme',
       totalAfterTrial: 'Deneme sonrası toplam',
+      tiers: {
+        from: 'Başlangıç',
+        range: '{from}–{to}',
+        andAbove: '{from}+',
+        volumeExplainer:
+          'Tüm kullanım, düştüğü aralığın tarifesine göre ücretlendirilir',
+      },
     },
     trial: {
       hero: {


### PR DESCRIPTION
## Summary

Supersedes @strandhvilliam's #14042, rewritten against the current backend.

**Graduated, collapsed.** The default. `From $12.00 / unit` under the price, detail rows behind the #13945 toggle.

<img width="518" height="941" alt="Screenshot 2026-09-02 at 17 09 18" src="https://github.com/user-attachments/assets/46f4be93-1f96-4119-91ce-0a7851dffddd" />

**Graduated, expanded.** One row per tier. Bounds are inclusive, so a tier starts one unit past the one below it. The meter line drops its rate: repeating `$12.00` directly above the row that already states it reads as two different prices.

<img width="518" height="941" alt="Screenshot 2026-09-02 at 17 09 27" src="https://github.com/user-attachments/assets/86a26e0e-bda1-42f4-8b42-0ffc182ae45b" />

**Volume, expanded.** Same table plus one caption.

<img width="518" height="941" alt="Screenshot 2026-09-02 at 17 10 31" src="https://github.com/user-attachments/assets/a094616d-6da9-43d8-8280-3f8eff607e32" />

**50% discount.** Every tier rate struck through and restated. The price line and the tier rows render rates through one component, so a discount cannot apply to one and not the other.

<img width="518" height="941" alt="Screenshot 2026-09-02 at 17 11 12" src="https://github.com/user-attachments/assets/840bb639-b0b5-4886-babe-b976c2a69ee1" />

**Flat `metered_unit` price, unchanged.**

<img width="518" height="941" alt="Screenshot 2026-09-02 at 17 11 50" src="https://github.com/user-attachments/assets/0afda986-d54b-4ed6-8df9-0122223bbd67" />

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

