### PR TITLE
ci: give MinIO more time to pass its service healthcheck

### DIFF
--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -282,7 +282,7 @@ jobs:
           --health-cmd "curl -I http://127.0.0.1:9000/minio/health/live"
           --health-interval 10s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 10
 
       tinybird:
         image: tinybirdco/tinybird-local:latest


### PR DESCRIPTION
Let's see if this band aid fixes the failing minio in tests

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

