### PR TITLE
secrets encryption: Cutover reading of SlackApp's secrets to only encrypted

### DIFF
--- a/server/polar/models/slack_app.py
+++ b/server/polar/models/slack_app.py
@@ -93,19 +93,19 @@ class SlackApp(RecordModel):
         return relationship(Organization, lazy="raise")
 
     async def get_client_secret(self) -> str | None:
-        if self.client_secret_encrypted is not None:
-            return await self.client_secret_encrypted.decrypt(id=str(self.id))
-        return self.client_secret
+        if self.client_secret_encrypted is None:
+            return None
+        return await self.client_secret_encrypted.decrypt(id=str(self.id))
 
     async def get_signing_secret(self) -> str | None:
-        if self.signing_secret_encrypted is not None:
-            return await self.signing_secret_encrypted.decrypt(id=str(self.id))
-        return self.signing_secret
+        if self.signing_secret_encrypted is None:
+            return None
+        return await self.signing_secret_encrypted.decrypt(id=str(self.id))
 
     async def get_bot_token(self) -> str | None:
-        if self.bot_token_encrypted is not None:
-            return await self.bot_token_encrypted.decrypt(id=str(self.id))
-        return self.bot_token
+        if self.bot_token_encrypted is None:
+            return None
+        return await self.bot_token_encrypted.decrypt(id=str(self.id))
 
     @classmethod
     async def encrypt_client_secret(

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -52,7 +52,6 @@ async def _create_integration(
     benefit: Benefit,
     *,
     bot_token: str | None = "xoxb-test-token",
-    encrypted_only: bool = False,
 ) -> SlackApp:
     installed = bot_token is not None
     integration = SlackApp(
@@ -65,7 +64,7 @@ async def _create_integration(
         team_id="T1" if installed else None,
         team_name="Test team" if installed else None,
         bot_user_id="U1" if installed else None,
-        bot_token=None if encrypted_only else bot_token,
+        bot_token=bot_token,
         authed_user_id="U2" if installed else None,
         scopes=["channels:manage"] if installed else None,
     )
@@ -1584,37 +1583,6 @@ class TestSlackSharedChannelGrant:
             properties={**_BASE_PROPERTIES, "team_invitees": ["U01", "U02"]},
         )
         await _create_integration(save_fixture, benefit)
-        client = _mock_client(mocker)
-        strategy = _strategy(session, redis, client)
-
-        await strategy.grant(
-            benefit,
-            customer,
-            {"invited_email": "admin@customer.example"},
-        )
-
-        client.conversations_invite.assert_awaited_once_with(
-            bot_token="xoxb-test-token", channel="C123", users=["U01", "U02"]
-        )
-
-    async def test_grant_uses_encrypted_only_bot_token(
-        self,
-        session: AsyncSession,
-        redis: Redis,
-        save_fixture: SaveFixture,
-        mocker: MockerFixture,
-        customer: Customer,
-        organization: Organization,
-    ) -> None:
-        benefit = await create_benefit(
-            save_fixture,
-            organization=organization,
-            type=BenefitType.slack_shared_channel,
-            properties={**_BASE_PROPERTIES, "team_invitees": ["U01", "U02"]},
-        )
-        await _create_integration(
-            save_fixture, benefit, bot_token="xoxb-test-token", encrypted_only=True
-        )
         client = _mock_client(mocker)
         strategy = _strategy(session, redis, client)
 

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1596,6 +1596,37 @@ class TestSlackSharedChannelGrant:
             bot_token="xoxb-test-token", channel="C123", users=["U01", "U02"]
         )
 
+    async def test_grant_reads_bot_token_when_plaintext_absent(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={**_BASE_PROPERTIES, "team_invitees": ["U01", "U02"]},
+        )
+        integration = await _create_integration(save_fixture, benefit)
+        integration.bot_token = None
+        await save_fixture(integration)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        client.conversations_invite.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="C123", users=["U01", "U02"]
+        )
+
     async def test_grant_skips_invite_when_team_invitees_empty(
         self,
         session: AsyncSession,

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -69,11 +69,16 @@ async def _create_integration(
         authed_user_id="U2" if installed else None,
         scopes=["channels:manage"] if installed else None,
     )
-    if encrypted_only and bot_token is not None:
-        integration.id = SlackApp.generate_id()
-        integration.bot_token_encrypted = await SlackApp.encrypt_bot_token(
-            integration.id, bot_token
-        )
+    integration.id = SlackApp.generate_id()
+    integration.client_secret_encrypted = await SlackApp.encrypt_client_secret(
+        integration.id, integration.client_secret
+    )
+    integration.signing_secret_encrypted = await SlackApp.encrypt_signing_secret(
+        integration.id, integration.signing_secret
+    )
+    integration.bot_token_encrypted = await SlackApp.encrypt_bot_token(
+        integration.id, bot_token
+    )
     await save_fixture(integration)
     benefit.properties = {
         **benefit.properties,

--- a/server/tests/benefit/test_service.py
+++ b/server/tests/benefit/test_service.py
@@ -64,6 +64,16 @@ async def create_slack_integration(
         authed_user_id="U2",
         scopes=["channels:manage"],
     )
+    integration.id = SlackApp.generate_id()
+    integration.client_secret_encrypted = await SlackApp.encrypt_client_secret(
+        integration.id, integration.client_secret
+    )
+    integration.signing_secret_encrypted = await SlackApp.encrypt_signing_secret(
+        integration.id, integration.signing_secret
+    )
+    integration.bot_token_encrypted = await SlackApp.encrypt_bot_token(
+        integration.id, integration.bot_token
+    )
     await save_fixture(integration)
     return integration
 

--- a/server/tests/integrations/slack/test_endpoints.py
+++ b/server/tests/integrations/slack/test_endpoints.py
@@ -59,6 +59,16 @@ async def _create_integration(
         authed_user_id="U2" if bot_token else None,
         scopes=["channels:manage"] if bot_token else None,
     )
+    integration.id = SlackApp.generate_id()
+    integration.client_secret_encrypted = await SlackApp.encrypt_client_secret(
+        integration.id, integration.client_secret
+    )
+    integration.signing_secret_encrypted = await SlackApp.encrypt_signing_secret(
+        integration.id, signing_secret
+    )
+    integration.bot_token_encrypted = await SlackApp.encrypt_bot_token(
+        integration.id, bot_token
+    )
     await save_fixture(integration)
     return integration
 

--- a/server/tests/integrations/slack/test_endpoints.py
+++ b/server/tests/integrations/slack/test_endpoints.py
@@ -704,3 +704,36 @@ class TestEvents:
         assert integration is not None
         assert integration.bot_token is None
         assert integration.revoked_at is not None
+
+    async def test_event_callback_verifies_when_plaintext_signing_secret_absent(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        session: AsyncSession,
+    ) -> None:
+        integration = await _create_integration(save_fixture, organization)
+        integration.signing_secret = None
+        await save_fixture(integration)
+        payload = {
+            "type": "event_callback",
+            "api_app_id": "A0TESTAPPID",
+            "event": {"type": "tokens_revoked"},
+        }
+        body = json.dumps(payload).encode()
+        ts, sig = _slack_signature(signing_secret="ss-test-secret", body=body)
+        response = await client.post(
+            "/v1/integrations/slack/events",
+            content=body,
+            headers={
+                "x-slack-signature": sig,
+                "x-slack-request-timestamp": ts,
+                "content-type": "application/json",
+            },
+        )
+        assert response.status_code == 200
+
+        repo = SlackAppRepository.from_session(session)
+        loaded = await repo.get_by_app_id("A0TESTAPPID")
+        assert loaded is not None
+        assert loaded.revoked_at is not None

--- a/server/tests/integrations/slack/test_service.py
+++ b/server/tests/integrations/slack/test_service.py
@@ -71,6 +71,16 @@ async def _create_integration(
         authed_user_id="U2" if bot_token else None,
         scopes=["channels:manage"] if bot_token else None,
     )
+    integration.id = SlackApp.generate_id()
+    integration.client_secret_encrypted = await SlackApp.encrypt_client_secret(
+        integration.id, integration.client_secret
+    )
+    integration.signing_secret_encrypted = await SlackApp.encrypt_signing_secret(
+        integration.id, integration.signing_secret
+    )
+    integration.bot_token_encrypted = await SlackApp.encrypt_bot_token(
+        integration.id, bot_token
+    )
     await save_fixture(integration)
     if benefit is not None:
         benefit.properties = {

--- a/server/tests/models/test_slack_app.py
+++ b/server/tests/models/test_slack_app.py
@@ -68,7 +68,7 @@ class TestEncryptClassmethods:
 
 @pytest.mark.asyncio
 class TestGetSecrets:
-    async def test_prefers_encrypted(self, organization: Organization) -> None:
+    async def test_decrypts_encrypted(self, organization: Organization) -> None:
         integration = _build(organization)
         integration.id = SlackApp.generate_id()
         integration.client_secret_encrypted = await SlackApp.encrypt_client_secret(
@@ -88,20 +88,12 @@ class TestGetSecrets:
         assert await integration.get_signing_secret() == "ss-encrypted"
         assert await integration.get_bot_token() == "xoxb-encrypted"
 
-    async def test_falls_back_to_plain(self, organization: Organization) -> None:
+    async def test_none_without_encrypted(self, organization: Organization) -> None:
         integration = _build(organization)
         integration.id = SlackApp.generate_id()
         integration.client_secret = "cs-plain"
         integration.signing_secret = "ss-plain"
         integration.bot_token = "xoxb-plain"
-
-        assert await integration.get_client_secret() == "cs-plain"
-        assert await integration.get_signing_secret() == "ss-plain"
-        assert await integration.get_bot_token() == "xoxb-plain"
-
-    async def test_none_without_encrypted(self, organization: Organization) -> None:
-        integration = _build(organization)
-        integration.id = SlackApp.generate_id()
 
         assert await integration.get_client_secret() is None
         assert await integration.get_signing_secret() is None
@@ -119,7 +111,7 @@ class TestGetSecrets:
         integration.bot_token = None
 
         assert await integration.get_client_secret() == "cs-encrypted"
-        assert await integration.get_signing_secret() == "ss-plain"
+        assert await integration.get_signing_secret() is None
         assert await integration.get_bot_token() is None
 
 


### PR DESCRIPTION
Another step towards completing the [Secrets encryption migration plan](https://github.com/polarsource/polar/blob/main/handbook/engineering/design-documents/secrets-encryption.mdx#appendix-c-migration-plan).

Stop reading these unencrypted `SlackApp` properties:
- `client_secret`
- `signing_secret`
- `bot_token`

Backfill has run, all 1(!) rows

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

