### PR TITLE
dashboard: let merchants cap the quantity on a unit-based price

### DIFF
--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceUnitBasedItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/ProductPriceUnitBasedItem.tsx
@@ -23,6 +23,7 @@ import { useFormContext } from 'react-hook-form'
 import { getUnitLabels } from '@/utils/product'
 import { ProductFormType } from '../ProductForm'
 import { UnitLabelFields } from './UnitLabelFields'
+import { UnitMaximumField } from './UnitMaximumField'
 import { UnitTierEditor } from './UnitTierEditor'
 
 type TieringModel = 'fixed' | 'graduated' | 'volume'
@@ -199,6 +200,8 @@ export const ProductPriceUnitBasedItem: React.FC<
           </FormItem>
         )}
       />
+
+      <UnitMaximumField index={index} unitLabelPlural={pluralNoun} />
 
       {typeof minimumUnits === 'number' && minimumUnits > 1 && (
         <Alert

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/UnitMaximumField.test.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/UnitMaximumField.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { FormProvider, useForm } from 'react-hook-form'
+import { type Control, FormProvider, useForm, useWatch } from 'react-hook-form'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@polar-sh/orbit', () => ({
@@ -19,6 +19,12 @@ type Values = {
     tiers: { type: string; tiers: Tier[] }
   }[]
 }
+
+const Tiers = ({ control }: { control: Control<Values> }) => (
+  <pre data-testid="tiers">
+    {JSON.stringify(useWatch({ control, name: 'prices.0.tiers.tiers' }))}
+  </pre>
+)
 
 const Harness = ({
   tiers,
@@ -40,12 +46,10 @@ const Harness = ({
   })
   return (
     <FormProvider {...form}>
+      <Tiers control={form.control} />
       <form data-testid="form" onSubmit={form.handleSubmit(() => {})}>
         <UnitMaximumField index={0} unitLabelPlural="devices" />
       </form>
-      <pre data-testid="tiers">
-        {JSON.stringify(form.watch('prices.0.tiers.tiers'))}
-      </pre>
     </FormProvider>
   )
 }
@@ -120,16 +124,32 @@ describe('UnitMaximumField', () => {
     render(<Harness tiers={tiered} />)
 
     fireEvent.change(maximumInput(), { target: { value: '10' } })
-    fireEvent.submit(screen.getByTestId('form'))
+    fireEvent.blur(maximumInput())
 
     expect(await screen.findByText(/greater than 10/)).toBeTruthy()
+  })
+
+  it('rejects a maximum well below the tier beneath it', async () => {
+    render(
+      <Harness
+        tiers={[
+          { bound: 1000, unit_amount: 1000 },
+          { bound: null, unit_amount: 800 },
+        ]}
+      />,
+    )
+
+    fireEvent.change(maximumInput(), { target: { value: '12' } })
+    fireEvent.blur(maximumInput())
+
+    expect(await screen.findByText(/greater than 1,?000/)).toBeTruthy()
   })
 
   it('rejects a maximum below the minimum', async () => {
     render(<Harness tiers={flat} minimumUnits={5} />)
 
     fireEvent.change(maximumInput(), { target: { value: '3' } })
-    fireEvent.submit(screen.getByTestId('form'))
+    fireEvent.blur(maximumInput())
 
     expect(await screen.findByText(/at least the minimum of 5/)).toBeTruthy()
   })

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/UnitMaximumField.test.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/UnitMaximumField.test.tsx
@@ -1,0 +1,136 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@polar-sh/orbit', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+}))
+
+const { UnitMaximumField } = await import('./UnitMaximumField')
+
+type Tier = { bound: number | null; unit_amount: number }
+
+type Values = {
+  prices: {
+    id: string
+    minimum_units: number | null
+    tiers: { type: string; tiers: Tier[] }
+  }[]
+}
+
+const Harness = ({
+  tiers,
+  minimumUnits = null,
+}: {
+  tiers: Tier[]
+  minimumUnits?: number | null
+}) => {
+  const form = useForm<Values>({
+    defaultValues: {
+      prices: [
+        {
+          id: 'price_1',
+          minimum_units: minimumUnits,
+          tiers: { type: 'volume', tiers },
+        },
+      ],
+    },
+  })
+  return (
+    <FormProvider {...form}>
+      <form data-testid="form" onSubmit={form.handleSubmit(() => {})}>
+        <UnitMaximumField index={0} unitLabelPlural="devices" />
+      </form>
+      <pre data-testid="tiers">
+        {JSON.stringify(form.watch('prices.0.tiers.tiers'))}
+      </pre>
+    </FormProvider>
+  )
+}
+
+const flat: Tier[] = [{ bound: null, unit_amount: 1000 }]
+const tiered: Tier[] = [
+  { bound: 10, unit_amount: 1000 },
+  { bound: null, unit_amount: 800 },
+]
+const cappedTiered: Tier[] = [
+  { bound: 10, unit_amount: 1000 },
+  { bound: 250, unit_amount: 800 },
+]
+
+const maximumInput = () =>
+  screen.getByLabelText('Maximum devices') as HTMLInputElement
+const tiersJson = () => screen.getByTestId('tiers').textContent
+
+describe('UnitMaximumField', () => {
+  afterEach(cleanup)
+
+  it('reads as unlimited when the last tier is unbounded', () => {
+    render(<Harness tiers={flat} />)
+
+    expect(maximumInput().value).toBe('')
+    expect(maximumInput().placeholder).toBe('Unlimited')
+  })
+
+  it('shows the last tier bound as the maximum', () => {
+    render(<Harness tiers={cappedTiered} />)
+
+    expect(maximumInput().value).toBe('250')
+  })
+
+  it('caps a flat price by bounding its only tier', () => {
+    render(<Harness tiers={flat} />)
+
+    fireEvent.change(maximumInput(), { target: { value: '100' } })
+
+    expect(tiersJson()).toBe(
+      JSON.stringify([{ bound: 100, unit_amount: 1000 }]),
+    )
+  })
+
+  it('caps a tiered price by bounding its last tier', () => {
+    render(<Harness tiers={tiered} />)
+
+    fireEvent.change(maximumInput(), { target: { value: '500' } })
+
+    expect(tiersJson()).toBe(
+      JSON.stringify([
+        { bound: 10, unit_amount: 1000 },
+        { bound: 500, unit_amount: 800 },
+      ]),
+    )
+  })
+
+  it('clears back to unlimited', () => {
+    render(<Harness tiers={cappedTiered} />)
+
+    fireEvent.change(maximumInput(), { target: { value: '' } })
+
+    expect(tiersJson()).toBe(
+      JSON.stringify([
+        { bound: 10, unit_amount: 1000 },
+        { bound: null, unit_amount: 800 },
+      ]),
+    )
+  })
+
+  it('rejects a maximum at or below the tier beneath it', async () => {
+    render(<Harness tiers={tiered} />)
+
+    fireEvent.change(maximumInput(), { target: { value: '10' } })
+    fireEvent.submit(screen.getByTestId('form'))
+
+    expect(await screen.findByText(/greater than 10/)).toBeTruthy()
+  })
+
+  it('rejects a maximum below the minimum', async () => {
+    render(<Harness tiers={flat} minimumUnits={5} />)
+
+    fireEvent.change(maximumInput(), { target: { value: '3' } })
+    fireEvent.submit(screen.getByTestId('form'))
+
+    expect(await screen.findByText(/at least the minimum of 5/)).toBeTruthy()
+  })
+})

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/UnitMaximumField.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/UnitMaximumField.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { Input } from '@polar-sh/orbit'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import React from 'react'
+import { useFormContext } from 'react-hook-form'
+import { ProductFormType } from '../ProductForm'
+
+export interface UnitMaximumFieldProps {
+  index: number
+  unitLabelPlural: string
+}
+
+export const UnitMaximumField: React.FC<UnitMaximumFieldProps> = ({
+  index,
+  unitLabelPlural,
+}) => {
+  const { control, setValue, watch } = useFormContext<ProductFormType>()
+
+  const tiers = watch(`prices.${index}.tiers.tiers`)
+  const minimumUnits = watch(`prices.${index}.minimum_units`)
+  const lastTier = Math.max((tiers?.length ?? 1) - 1, 0)
+  const previousBound = Number(tiers?.[lastTier - 1]?.bound ?? 0)
+
+  return (
+    <FormField
+      control={control}
+      name={`prices.${index}.tiers.tiers.${lastTier}.bound` as const}
+      rules={{
+        validate: (value) => {
+          if (value == null) {
+            return true
+          }
+          if (!Number.isInteger(Number(value))) {
+            return 'Must be a whole number of units'
+          }
+          if (Number(value) <= previousBound) {
+            return `Must be greater than ${previousBound}`
+          }
+          if (minimumUnits != null && Number(value) < Number(minimumUnits)) {
+            return `Must be at least the minimum of ${minimumUnits}`
+          }
+          return true
+        },
+      }}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>Maximum {unitLabelPlural}</FormLabel>
+          <FormControl>
+            <Input
+              {...field}
+              type="number"
+              min={Math.max(previousBound + 1, Number(minimumUnits) || 1)}
+              step={1}
+              value={field.value ?? ''}
+              placeholder="Unlimited"
+              onChange={(e) => {
+                const raw = e.target.value
+                if (raw === '') {
+                  field.onChange(null)
+                } else {
+                  const parsed = Number(raw)
+                  field.onChange(Number.isNaN(parsed) ? null : parsed)
+                }
+                setValue(`prices.${index}.id`, '')
+              }}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/UnitMaximumField.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/UnitMaximumField.tsx
@@ -21,7 +21,8 @@ export const UnitMaximumField: React.FC<UnitMaximumFieldProps> = ({
   index,
   unitLabelPlural,
 }) => {
-  const { control, setValue, watch } = useFormContext<ProductFormType>()
+  const { control, setValue, trigger, watch } =
+    useFormContext<ProductFormType>()
 
   const tiers = watch(`prices.${index}.tiers.tiers`)
   const minimumUnits = watch(`prices.${index}.minimum_units`)
@@ -69,6 +70,12 @@ export const UnitMaximumField: React.FC<UnitMaximumFieldProps> = ({
                   field.onChange(Number.isNaN(parsed) ? null : parsed)
                 }
                 setValue(`prices.${index}.id`, '')
+              }}
+              onBlur={() => {
+                field.onBlur()
+                // The product form validates on submit, but a bad cap is
+                // worth saying as soon as the merchant leaves the field.
+                trigger(field.name)
               }}
             />
           </FormControl>

--- a/clients/apps/web/src/components/Products/ProductForm/Pricing/UnitTierCard.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/Pricing/UnitTierCard.tsx
@@ -55,9 +55,6 @@ export const UnitTierCard: React.FC<UnitTierCardProps> = ({
     event: React.ChangeEvent<HTMLInputElement>,
     onChange: (value: number | null) => void,
   ) => {
-    if (isLast) {
-      return
-    }
     onChange(parseTierBoundInput(event.target.value))
     setValue(`prices.${index}.id`, '')
   }
@@ -68,10 +65,6 @@ export const UnitTierCard: React.FC<UnitTierCardProps> = ({
     onBlur: () => void,
   ) => {
     onBlur()
-    if (isLast) {
-      onChange(null)
-      return
-    }
     const parsed = parseTierBoundInput(event.target.value)
     const minAllowed = previousBound + 1
     if (parsed == null) {
@@ -115,6 +108,7 @@ export const UnitTierCard: React.FC<UnitTierCardProps> = ({
                 min={previousBound + 1}
                 step={1}
                 value={field.value ?? ''}
+                disabled={isLast}
                 placeholder={isLast ? 'Unlimited' : undefined}
                 onChange={(e) => handleBoundChange(e, field.onChange)}
                 onBlur={(e) => handleBoundBlur(e, field.onChange, field.onBlur)}


### PR DESCRIPTION
## Summary

Was missing from the initial implementation but the API and doc mention it.


https://github.com/user-attachments/assets/ed64646e-a7ad-4031-8d07-d0cb5c54e75d



## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

