### PR TITLE
Switch to signing webhooks the standard-compliant way

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
@@ -8,6 +8,7 @@ import WebhookContextView from '@/components/Settings/Webhook/WebhookContextView
 import DeliveriesTable from '@/components/Settings/Webhook/WebhookDeliveriesTable'
 import { WebhookFilter } from '@/components/Settings/Webhook/WebhookFilter'
 import { WebhookSignatureNotice } from '@/components/Settings/Webhook/WebhookSignatureNotice'
+import { WebhookSigningSchemeStatus } from '@/components/Settings/Webhook/WebhookSigningSchemeStatus'
 import { toast } from '@/components/Toast/use-toast'
 import { getStatusRedirect } from '@/components/Toast/utils'
 import {
@@ -18,7 +19,6 @@ import {
 } from '@/hooks/queries'
 import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
 import { extractApiErrorMessage } from '@/utils/api/errors'
-import { shouldShowWebhookSignatureNotice } from '@/utils/webhook/signatureNotice'
 import { operations, schemas } from '@polar-sh/client'
 import { Button, Switch, Text } from '@polar-sh/orbit'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
@@ -160,9 +160,9 @@ export default function ClientPage({
       className="gap-y-8"
       wide
     >
-      {shouldShowWebhookSignatureNotice(organization.created_at) ? (
-        <WebhookSignatureNotice />
-      ) : null}
+      <WebhookSignatureNotice
+        organizationCreatedAt={organization.created_at}
+      />
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 flex-col gap-1">
@@ -177,6 +177,12 @@ export default function ClientPage({
               <h3 className="text-lg break-words">{endpoint.url}</h3>
             )}
             <Text color="muted">API version {endpoint.api_version}</Text>
+            <WebhookSigningSchemeStatus
+              organizationCreatedAt={organization.created_at}
+              usesStandardWebhookSignature={
+                endpoint.uses_standard_webhook_signature
+              }
+            />
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <span className="text-sm text-gray-500" id="webhook-status-label">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
@@ -7,6 +7,7 @@ import { useModal } from '@/components/Modal/useModal'
 import WebhookContextView from '@/components/Settings/Webhook/WebhookContextView'
 import DeliveriesTable from '@/components/Settings/Webhook/WebhookDeliveriesTable'
 import { WebhookFilter } from '@/components/Settings/Webhook/WebhookFilter'
+import { WebhookSignatureNotice } from '@/components/Settings/Webhook/WebhookSignatureNotice'
 import { toast } from '@/components/Toast/use-toast'
 import { getStatusRedirect } from '@/components/Toast/utils'
 import {
@@ -17,6 +18,7 @@ import {
 } from '@/hooks/queries'
 import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
 import { extractApiErrorMessage } from '@/utils/api/errors'
+import { shouldShowWebhookSignatureNotice } from '@/utils/webhook/signatureNotice'
 import { operations, schemas } from '@polar-sh/client'
 import { Button, Switch, Text } from '@polar-sh/orbit'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
@@ -158,6 +160,9 @@ export default function ClientPage({
       className="gap-y-8"
       wide
     >
+      {shouldShowWebhookSignatureNotice(organization.created_at) ? (
+        <WebhookSignatureNotice />
+      ) : null}
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 flex-col gap-1">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
@@ -160,9 +160,7 @@ export default function ClientPage({
       className="gap-y-8"
       wide
     >
-      <WebhookSignatureNotice
-        organizationCreatedAt={organization.created_at}
-      />
+      <WebhookSignatureNotice organizationCreatedAt={organization.created_at} />
       <div className="flex flex-col gap-4">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 flex-col gap-1">

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookSettings.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookSettings.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useListWebhooksEndpoints } from '@/hooks/queries'
+import { shouldShowWebhookSignatureNotice } from '@/utils/webhook/signatureNotice'
 import { schemas } from '@polar-sh/client'
+import { Box } from '@polar-sh/orbit/Box'
 import { Button } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { ListGroup } from '@polar-sh/orbit'
@@ -10,6 +12,7 @@ import Link from 'next/link'
 import { InlineModal } from '@polar-sh/orbit'
 import { useModal } from '../../Modal/useModal'
 import NewWebhookModal from './NewWebhookModal'
+import { WebhookSignatureNotice } from './WebhookSignatureNotice'
 
 const WebhookSettings = (props: { org: schemas['Organization'] }) => {
   const {
@@ -24,9 +27,15 @@ const WebhookSettings = (props: { org: schemas['Organization'] }) => {
     page: 1,
   })
 
+  const showSignatureNotice = shouldShowWebhookSignatureNotice(
+    props.org.created_at,
+  )
+
   return (
     <>
-      <ListGroup>
+      <Box flexDirection="column" gap="l">
+        {showSignatureNotice ? <WebhookSignatureNotice /> : null}
+        <ListGroup>
         {endpoints.data?.items && endpoints.data.items.length > 0 ? (
           endpoints.data?.items.map((e) => {
             return (
@@ -60,7 +69,8 @@ const WebhookSettings = (props: { org: schemas['Organization'] }) => {
             </a>
           </div>
         </ListGroup.Item>
-      </ListGroup>
+        </ListGroup>
+      </Box>
       <InlineModal
         isShown={isNewWebhookModalShown}
         hide={hideNewWebhookModal}

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookSettings.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookSettings.tsx
@@ -32,39 +32,39 @@ const WebhookSettings = (props: { org: schemas['Organization'] }) => {
       <Box flexDirection="column" gap="l">
         <WebhookSignatureNotice organizationCreatedAt={props.org.created_at} />
         <ListGroup>
-        {endpoints.data?.items && endpoints.data.items.length > 0 ? (
-          endpoints.data?.items.map((e) => {
-            return (
-              <ListGroup.Item key={e.id}>
-                <Endpoint organization={props.org} endpoint={e} />
-              </ListGroup.Item>
-            )
-          })
-        ) : (
+          {endpoints.data?.items && endpoints.data.items.length > 0 ? (
+            endpoints.data?.items.map((e) => {
+              return (
+                <ListGroup.Item key={e.id}>
+                  <Endpoint organization={props.org} endpoint={e} />
+                </ListGroup.Item>
+              )
+            })
+          ) : (
+            <ListGroup.Item>
+              <p className="dark:text-polar-400 text-sm text-gray-500">
+                {`${props.org.name} doesn't have any webhooks yet`}
+              </p>
+            </ListGroup.Item>
+          )}
           <ListGroup.Item>
-            <p className="dark:text-polar-400 text-sm text-gray-500">
-              {`${props.org.name} doesn't have any webhooks yet`}
-            </p>
-          </ListGroup.Item>
-        )}
-        <ListGroup.Item>
-          <div className="flex flex-row items-center gap-x-4">
-            <Button asChild onClick={showNewWebhookModal}>
-              Add Endpoint
-            </Button>
-            <a
-              href="https://polar.sh/docs/integrate/webhooks/endpoints"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="shrink-0"
-            >
-              <Button className="gap-x-2" asChild variant="ghost">
-                <span>Documentation</span>
-                <ArrowUpRightIcon className="h-4 w-4" />
+            <div className="flex flex-row items-center gap-x-4">
+              <Button asChild onClick={showNewWebhookModal}>
+                Add Endpoint
               </Button>
-            </a>
-          </div>
-        </ListGroup.Item>
+              <a
+                href="https://polar.sh/docs/integrate/webhooks/endpoints"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="shrink-0"
+              >
+                <Button className="gap-x-2" asChild variant="ghost">
+                  <span>Documentation</span>
+                  <ArrowUpRightIcon className="h-4 w-4" />
+                </Button>
+              </a>
+            </div>
+          </ListGroup.Item>
         </ListGroup>
       </Box>
       <InlineModal

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookSettings.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookSettings.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useListWebhooksEndpoints } from '@/hooks/queries'
-import { shouldShowWebhookSignatureNotice } from '@/utils/webhook/signatureNotice'
 import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import { Button } from '@polar-sh/orbit'
@@ -13,6 +12,7 @@ import { InlineModal } from '@polar-sh/orbit'
 import { useModal } from '../../Modal/useModal'
 import NewWebhookModal from './NewWebhookModal'
 import { WebhookSignatureNotice } from './WebhookSignatureNotice'
+import { WebhookSigningSchemeStatus } from './WebhookSigningSchemeStatus'
 
 const WebhookSettings = (props: { org: schemas['Organization'] }) => {
   const {
@@ -27,14 +27,10 @@ const WebhookSettings = (props: { org: schemas['Organization'] }) => {
     page: 1,
   })
 
-  const showSignatureNotice = shouldShowWebhookSignatureNotice(
-    props.org.created_at,
-  )
-
   return (
     <>
       <Box flexDirection="column" gap="l">
-        {showSignatureNotice ? <WebhookSignatureNotice /> : null}
+        <WebhookSignatureNotice organizationCreatedAt={props.org.created_at} />
         <ListGroup>
         {endpoints.data?.items && endpoints.data.items.length > 0 ? (
           endpoints.data?.items.map((e) => {
@@ -124,6 +120,12 @@ const Endpoint = ({
           <FormattedDateTime datetime={endpoint.created_at} dateStyle="long" />
           {' · '}API version {endpoint.api_version}
         </p>
+        <WebhookSigningSchemeStatus
+          organizationCreatedAt={organization.created_at}
+          usesStandardWebhookSignature={
+            endpoint.uses_standard_webhook_signature
+          }
+        />
       </div>
       <div className="dark:text-polar-400 text-gray-500">
         <Link

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookSignatureNotice.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookSignatureNotice.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { Alert } from '@polar-sh/orbit'
+
+const DOCS_HREF = 'https://polar.sh/docs/integrate/webhooks/delivery'
+
+export const WebhookSignatureNotice = () => {
+  return (
+    <Alert
+      variant="info"
+      title="Webhook signature changes"
+      description={
+        <>
+          We're changing how we sign webhook requests starting September 8 2026.
+          The new signatures will only apply to new endpoints and new endpoint secrets.
+          Before adding new webhook endpoints and/or resetting webhook secrets ensure you've read up
+          on the change in <a href={DOCS_HREF} target="_blank" className="underline">our docs</a>.
+        </>
+      }
+    />
+  )
+}

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookSignatureNotice.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookSignatureNotice.tsx
@@ -1,10 +1,19 @@
 'use client'
 
+import { shouldShowWebhookSignatureNotice } from '@/utils/webhook/signatureNotice'
 import { Alert } from '@polar-sh/orbit'
 
 const DOCS_HREF = 'https://polar.sh/docs/integrate/webhooks/delivery'
 
-export const WebhookSignatureNotice = () => {
+export const WebhookSignatureNotice = ({
+  organizationCreatedAt,
+}: {
+  organizationCreatedAt: string
+}) => {
+  if (!shouldShowWebhookSignatureNotice(organizationCreatedAt)) {
+    return null
+  }
+
   return (
     <Alert
       variant="info"

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookSignatureNotice.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookSignatureNotice.tsx
@@ -17,13 +17,20 @@ export const WebhookSignatureNotice = ({
   return (
     <Alert
       variant="info"
-      title="Webhook signature changes"
+      title="Webhook signatures"
       description={
         <>
-          We're changing how we sign webhook requests starting September 8 2026.
-          The new signatures will only apply to new endpoints and new endpoint secrets.
-          Before adding new webhook endpoints and/or resetting webhook secrets ensure you've read up
-          on the change in <a href={DOCS_HREF} target="_blank" className="underline">our docs</a>.
+          New endpoints and reset secrets use Standard Webhooks from 8 September
+          2026, 00:00 UTC. Read the{' '}
+          <a
+            href={DOCS_HREF}
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            delivery docs
+          </a>{' '}
+          before you add an endpoint or reset a secret.
         </>
       }
     />

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookSigningSchemeStatus.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookSigningSchemeStatus.tsx
@@ -18,7 +18,7 @@ export const WebhookSigningSchemeStatus = ({
       color={usesStandardWebhookSignature ? 'green' : 'gray'}
       status={
         usesStandardWebhookSignature
-          ? 'Standards-compliant signing'
+          ? 'Standard Webhooks'
           : 'Legacy signing'
       }
     />

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookSigningSchemeStatus.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookSigningSchemeStatus.tsx
@@ -17,9 +17,7 @@ export const WebhookSigningSchemeStatus = ({
       size="small"
       color={usesStandardWebhookSignature ? 'green' : 'gray'}
       status={
-        usesStandardWebhookSignature
-          ? 'Standard Webhooks'
-          : 'Legacy signing'
+        usesStandardWebhookSignature ? 'Standard Webhooks' : 'Legacy signing'
       }
     />
   )

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookSigningSchemeStatus.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookSigningSchemeStatus.tsx
@@ -1,0 +1,26 @@
+import { shouldShowWebhookSignatureNotice } from '@/utils/webhook/signatureNotice'
+import { Status } from '@polar-sh/orbit'
+
+export const WebhookSigningSchemeStatus = ({
+  organizationCreatedAt,
+  usesStandardWebhookSignature,
+}: {
+  organizationCreatedAt: string
+  usesStandardWebhookSignature: boolean
+}) => {
+  if (!shouldShowWebhookSignatureNotice(organizationCreatedAt)) {
+    return null
+  }
+
+  return (
+    <Status
+      size="small"
+      color={usesStandardWebhookSignature ? 'green' : 'gray'}
+      status={
+        usesStandardWebhookSignature
+          ? 'Standards-compliant signing'
+          : 'Legacy signing'
+      }
+    />
+  )
+}

--- a/clients/apps/web/src/utils/webhook/signatureNotice.ts
+++ b/clients/apps/web/src/utils/webhook/signatureNotice.ts
@@ -1,0 +1,9 @@
+export const WEBHOOK_STANDARD_SIGNATURE_CUTOFF = new Date(
+  '2026-09-08T00:00:00.000Z',
+)
+
+export function shouldShowWebhookSignatureNotice(
+  organizationCreatedAt: string,
+): boolean {
+  return new Date(organizationCreatedAt) < WEBHOOK_STANDARD_SIGNATURE_CUTOFF
+}

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -38863,6 +38863,11 @@ export interface components {
        * @description Whether the webhook endpoint is enabled and will receive events.
        */
       enabled: boolean
+      /**
+       * Uses Standard Webhook Signature
+       * @description Whether Polar signs deliveries to this endpoint with Standard Webhooks. False means Polar's original HMAC over the UTF-8 bytes of the full secret.
+       */
+      readonly uses_standard_webhook_signature: boolean
     }
     /** DeprecatedWebhookEndpointCreateWithSecret */
     WebhookEndpointCreate: {

--- a/docs/guides/encore.mdx
+++ b/docs/guides/encore.mdx
@@ -204,7 +204,12 @@ export const webhooks = api.raw(
 ```
 
 <Warning>
-  The `standardwebhooks` library expects the secret to be base64-encoded. Polar provides a raw string (starting with `polar_whs_`), so you must base64-encode the entire secret before passing it to `new Webhook()`.
+  Polar webhook signatures use two key derivations depending on when the secret
+  was generated. Polar SDKs (version 1.0.0-alpha.19 and later) try both. If you
+  verify with `standardwebhooks` directly: secrets created **on or after 8
+  September 2026, 00:00 UTC** can be passed to `new Webhook()` as-is (`whsec_…`).
+  Older Polar secrets need the **entire** secret UTF-8 string base64-encoded
+  first.
 </Warning>
 
 ## Local Development

--- a/docs/guides/encore.mdx
+++ b/docs/guides/encore.mdx
@@ -163,20 +163,22 @@ export const webhooks = api.raw(
       headers[key] = Array.isArray(value) ? value[0] : (value || "");
     }
 
-    // Verify the webhook signature
+    // Verify the webhook signature. Try Standard Webhooks first (secret as-is),
+    // then Polar's legacy HMAC (UTF-8 bytes of the full secret, including `whsec_`).
+    const secret = POLAR_WEBHOOK_SECRET().trim();
     let payload: any;
     try {
-      const base64Secret = Buffer.from(
-        POLAR_WEBHOOK_SECRET().trim(),
-        "utf-8"
-      ).toString("base64");
-      const wh = new Webhook(base64Secret);
-      payload = wh.verify(body, headers);
-    } catch (error: any) {
-      console.error("[Polar] Invalid webhook signature:", error?.message);
-      resp.writeHead(403);
-      resp.end(JSON.stringify({ error: "Invalid signature" }));
-      return;
+      payload = new Webhook(secret).verify(body, headers);
+    } catch {
+      try {
+        const legacySecret = Buffer.from(secret, "utf-8").toString("base64");
+        payload = new Webhook(legacySecret).verify(body, headers);
+      } catch (error: any) {
+        console.error("[Polar] Invalid webhook signature:", error?.message);
+        resp.writeHead(403);
+        resp.end(JSON.stringify({ error: "Invalid signature" }));
+        return;
+      }
     }
 
     // Handle the payload

--- a/docs/guides/laravel.mdx
+++ b/docs/guides/laravel.mdx
@@ -368,7 +368,9 @@ The next thing we do is to create a folder named Handler inside the app folder. 
 * PolarSignature.php
 * ProcessWebhook.php
 
-Inside app/Handler/PolarSignature.php, what we want to do is to validate that the request came from Polar. Add the code to that file.
+Inside app/Handler/PolarSignature.php, validate that the request came from Polar.
+Try Standard Webhooks first (secret as-is), then Polar's legacy HMAC (base64-encode the
+full `whsec_…` string). Add the code to that file.
 
 ```php
 // app/Handler/PolarSignature.php
@@ -377,7 +379,6 @@ Inside app/Handler/PolarSignature.php, what we want to do is to validate that th
 namespace App\Handler;
 
 use Illuminate\Http\Request;
-use Spatie\WebhookClient\Exceptions\WebhookFailed;
 use Spatie\WebhookClient\WebhookConfig;
 use Spatie\WebhookClient\SignatureValidator\SignatureValidator;
 
@@ -385,14 +386,26 @@ class PolarSignature implements SignatureValidator
 {
     public function isValid(Request $request, WebhookConfig $config): bool
     {
-        $signingSecret = base64_encode($config->signingSecret);
-        $wh = new \StandardWebhooks\Webhook($signingSecret);
-
-        return boolval( $wh->verify($request->getContent(), array(
+        $headers = array(
             "webhook-id" => $request->header("webhook-id"),
             "webhook-signature" => $request->header("webhook-signature"),
             "webhook-timestamp" => $request->header("webhook-timestamp"),
-        )));
+        );
+        $body = $request->getContent();
+        $secret = $config->signingSecret;
+
+        try {
+            (new \StandardWebhooks\Webhook($secret))->verify($body, $headers);
+            return true;
+        } catch (\Throwable) {
+            try {
+                $legacySecret = base64_encode($secret);
+                (new \StandardWebhooks\Webhook($legacySecret))->verify($body, $headers);
+                return true;
+            } catch (\Throwable) {
+                return false;
+            }
+        }
     }
 }
 ```

--- a/docs/integrate/webhooks/delivery.mdx
+++ b/docs/integrate/webhooks/delivery.mdx
@@ -102,15 +102,22 @@ easily validate signatures. Or you can follow their
 in case you want to roll your own.
 
 <Info>
-  Polar currently signs with HMAC-SHA256 over the UTF-8 bytes of the full secret,
-  including `whsec_`. Standard Webhooks libraries therefore need that whole
-  secret **base64-encoded** before verification.
+  **Signing schemes**
 
-  Polar SDKs (version 1.0.0-alpha.19 and later) try both that original Polar key and the Standard Webhooks key
-  (base64-decode of the `whsec_` remainder). You can keep passing the `whsec_…`
-  secret as Polar shows it. Rolling your own verifier still needs the original
-  Polar encoding until Polar starts signing with the spec key.
+  Polar sends a **single** `webhook-signature`. The HMAC key depends on when the
+  endpoint secret was generated:
 
+  **Secrets generated before 8 September 2026, 00:00 UTC** use Polar's original
+  key: HMAC over the UTF-8 bytes of the full secret, including `whsec_`.
+  Standard Webhooks libraries need that whole secret **base64-encoded** before
+  verification.
+
+  **Secrets generated on or after that instant** follow
+  [Standard Webhooks](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md)
+  exactly. Pass the `whsec_…` secret to a Standard Webhooks library as-is.
+
+  Polar SDKs (version 1.0.0-alpha.19 and later) try both keys. You can keep
+  passing the `whsec_…` secret as Polar shows it.
 </Info>
 
 ## IP Allowlist
@@ -221,6 +228,7 @@ A common cause is hosting providers like Vercel that redirect between `www` and 
 
 ### Invalid signature exceptions
 
-Rolling your own webhook validation logic? Make sure to base64 encode the secret
-you configured on Polar in your code before generating the signature to validate
-against.
+Rolling your own webhook validation logic? Match the scheme for that endpoint
+secret: older Polar secrets need the **entire** `whsec_…` string base64-encoded
+before HMAC; secrets generated on or after 8 September 2026, 00:00 UTC follow
+Standard Webhooks as-is. Polar SDKs (version 1.0.0-alpha.19 and later) try both.

--- a/docs/integrate/webhooks/delivery.mdx
+++ b/docs/integrate/webhooks/delivery.mdx
@@ -95,29 +95,27 @@ to be set to the secret you configured during the endpoint setup.
 
 ### Custom validation
 
-We follow the [Standard Webhooks](https://www.standardwebhooks.com/)
-standard which offers [many libraries across languages](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries) to
-easily validate signatures. Or you can follow their
-[specification](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md)
-in case you want to roll your own.
+Use a [Standard Webhooks library](https://github.com/standard-webhooks/standard-webhooks/tree/main/libraries)
+or follow the
+[specification](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md).
+
+Secrets generated on or after 8 September 2026, 00:00 UTC are Standard Webhooks.
+Older secrets are Polar HMAC.
 
 <Info>
   **Signing schemes**
 
-  Polar sends a **single** `webhook-signature`. The HMAC key depends on when the
-  endpoint secret was generated:
+  Polar sends one `webhook-signature`. The HMAC key is which secret you have.
 
-  **Secrets generated before 8 September 2026, 00:00 UTC** use Polar's original
-  key: HMAC over the UTF-8 bytes of the full secret, including `whsec_`.
-  Standard Webhooks libraries need that whole secret **base64-encoded** before
-  verification.
+  **Before 8 September 2026, 00:00 UTC:** Polar HMAC. Key is the UTF-8 bytes of
+  the full `whsec_…` string. Base64-encode that string before you hand it to a
+  Standard Webhooks library.
 
-  **Secrets generated on or after that instant** follow
-  [Standard Webhooks](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md)
-  exactly. Pass the `whsec_…` secret to a Standard Webhooks library as-is.
+  **On or after that instant:** [Standard Webhooks](https://github.com/standard-webhooks/standard-webhooks/blob/main/spec/standard-webhooks.md).
+  Pass the `whsec_…` secret to the library as-is.
 
-  Polar SDKs (version 1.0.0-alpha.19 and later) try both keys. You can keep
-  passing the `whsec_…` secret as Polar shows it.
+  Polar SDKs 1.0.0-alpha.19 and later try both keys. Pass the `whsec_…` secret
+  from the dashboard.
 </Info>
 
 ## IP Allowlist
@@ -228,7 +226,7 @@ A common cause is hosting providers like Vercel that redirect between `www` and 
 
 ### Invalid signature exceptions
 
-Rolling your own webhook validation logic? Older Polar secrets need the
-**entire** `whsec_…` string base64-encoded before HMAC; secrets generated on or
-after 8 September 2026, 00:00 UTC follow Standard Webhooks as-is. Polar SDKs
-(version 1.0.0-alpha.19 and later) try both.
+Rolling your own validation? Older secrets are Polar HMAC: base64-encode the
+entire `whsec_…` string. Secrets generated on or after 8 September 2026, 00:00
+UTC are Standard Webhooks: pass the secret as-is. Polar SDKs 1.0.0-alpha.19 and
+later try both.

--- a/docs/integrate/webhooks/delivery.mdx
+++ b/docs/integrate/webhooks/delivery.mdx
@@ -228,7 +228,7 @@ A common cause is hosting providers like Vercel that redirect between `www` and 
 
 ### Invalid signature exceptions
 
-Rolling your own webhook validation logic? Match the scheme for that endpoint
-secret: older Polar secrets need the **entire** `whsec_…` string base64-encoded
-before HMAC; secrets generated on or after 8 September 2026, 00:00 UTC follow
-Standard Webhooks as-is. Polar SDKs (version 1.0.0-alpha.19 and later) try both.
+Rolling your own webhook validation logic? Older Polar secrets need the
+**entire** `whsec_…` string base64-encoded before HMAC; secrets generated on or
+after 8 September 2026, 00:00 UTC follow Standard Webhooks as-is. Polar SDKs
+(version 1.0.0-alpha.19 and later) try both.

--- a/docs/integrate/webhooks/endpoints.mdx
+++ b/docs/integrate/webhooks/endpoints.mdx
@@ -5,9 +5,12 @@ description: "Get notifications asynchronously when events occur instead of
 having to poll for updates"
 ---
 
-Our webhook implementation follows the [Standard Webhooks](https://www.standardwebhooks.com/) specification
-and our SDKs offer:
-- Built-in webhook signature validation for security
+Secrets generated on or after 8 September 2026, 00:00 UTC follow
+[Standard Webhooks](https://www.standardwebhooks.com/). Older secrets use Polar HMAC.
+See [Handle incoming webhooks](/integrate/webhooks/delivery#custom-validation).
+
+Our SDKs offer:
+- Built-in webhook signature validation
 - Fully typed webhook payloads
 
 In addition, our webhooks offer built-in support for **Slack** & **Discord**

--- a/server/polar/webhook/constants.py
+++ b/server/polar/webhook/constants.py
@@ -8,3 +8,12 @@ WEBHOOK_SECRET_KEY_BYTES = 32
 # `secret_generated_at` after that column shipped but before spec signing.
 # Bump this if deploy slips so those rows do not flip scheme.
 WEBHOOK_STANDARD_SIGNATURE_CUTOFF = datetime(2026, 9, 8, tzinfo=UTC)
+
+
+def uses_standard_webhook_signature(secret_generated_at: datetime | None) -> bool:
+    if secret_generated_at is None:
+        return False
+    generated_at = secret_generated_at
+    if generated_at.tzinfo is None:
+        generated_at = generated_at.replace(tzinfo=UTC)
+    return generated_at >= WEBHOOK_STANDARD_SIGNATURE_CUTOFF

--- a/server/polar/webhook/constants.py
+++ b/server/polar/webhook/constants.py
@@ -1,1 +1,10 @@
+from datetime import UTC, datetime
+
 WEBHOOK_SECRET_PREFIX = "whsec_"
+WEBHOOK_SECRET_KEY_BYTES = 32
+
+# Secrets created before this instant keep Polar's original HMAC (UTF-8 of the
+# full `whsec_…` string). That includes endpoints stamped with
+# `secret_generated_at` after that column shipped but before spec signing.
+# Bump this if deploy slips so those rows do not flip scheme.
+WEBHOOK_STANDARD_SIGNATURE_CUTOFF = datetime(2026, 9, 8, tzinfo=UTC)

--- a/server/polar/webhook/schemas.py
+++ b/server/polar/webhook/schemas.py
@@ -1,8 +1,16 @@
 import ipaddress
+from datetime import datetime
 from typing import Annotated
 
 import idna
-from pydantic import UUID4, AfterValidator, AnyUrl, BeforeValidator, Field
+from pydantic import (
+    UUID4,
+    AfterValidator,
+    AnyUrl,
+    BeforeValidator,
+    Field,
+    computed_field,
+)
 from pydantic.json_schema import SkipJsonSchema
 
 from polar.kit.schemas import (
@@ -16,6 +24,9 @@ from polar.kit.versioning import APIVersion
 from polar.models.webhook_endpoint import WebhookEventType, WebhookFormat
 from polar.organization.schemas import OrganizationID
 from polar.version import CURRENT_API_VERSION, VERSIONS
+from polar.webhook.constants import (
+    uses_standard_webhook_signature as secret_uses_standard_webhook_signature,
+)
 
 LOCALHOST_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "[::1]"}
 
@@ -121,6 +132,19 @@ class WebhookEndpoint(IDSchema, TimestampedSchema):
     enabled: bool = Field(
         description="Whether the webhook endpoint is enabled and will receive events."
     )
+    secret_generated_at: SkipJsonSchema[datetime | None] = Field(
+        default=None, exclude=True
+    )
+
+    @computed_field(  # type: ignore[prop-decorator]
+        description=(
+            "Whether Polar signs deliveries to this endpoint with Standard Webhooks. "
+            "False means Polar's original HMAC over the UTF-8 bytes of the full secret."
+        ),
+    )
+    @property
+    def uses_standard_webhook_signature(self) -> bool:
+        return secret_uses_standard_webhook_signature(self.secret_generated_at)
 
 
 class WebhookEndpointCreate(Schema):

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -1,5 +1,7 @@
+import base64
 import datetime
 import json
+import secrets
 from collections.abc import Sequence
 from typing import Literal, cast, overload
 from uuid import UUID
@@ -63,7 +65,11 @@ from polar.webhook.repository import (
 )
 from polar.worker import enqueue_job
 
-from .constants import WEBHOOK_SECRET_PREFIX
+from .constants import (
+    WEBHOOK_SECRET_KEY_BYTES,
+    WEBHOOK_SECRET_PREFIX,
+    WEBHOOK_STANDARD_SIGNATURE_CUTOFF,
+)
 from .eventstream import publish_webhook_event
 from .schemas import (
     DeprecatedWebhookEndpointCreateWithSecret,
@@ -74,6 +80,13 @@ from .schemas import (
 from .webhooks import SkipEvent, UnsupportedTarget, WebhookPayloadTypeAdapter
 
 log: Logger = structlog.get_logger()
+
+
+def generate_webhook_secret() -> str:
+    if utc_now() < WEBHOOK_STANDARD_SIGNATURE_CUTOFF:
+        return generate_token(prefix=WEBHOOK_SECRET_PREFIX)
+    key = secrets.token_bytes(WEBHOOK_SECRET_KEY_BYTES)
+    return f"{WEBHOOK_SECRET_PREFIX}{base64.b64encode(key).decode()}"
 
 
 class WebhookError(PolarError): ...
@@ -150,7 +163,7 @@ class WebhookService:
             organization.id,
             OrganizationPermission.organization_manage,
         )
-        secret = generate_token(prefix=WEBHOOK_SECRET_PREFIX)
+        secret = generate_webhook_secret()
         if (
             isinstance(create_schema, DeprecatedWebhookEndpointCreateWithSecret)
             and create_schema.secret is not None
@@ -220,7 +233,7 @@ class WebhookService:
         return await repository.update(
             endpoint,
             update_dict={
-                "secret": generate_token(prefix=WEBHOOK_SECRET_PREFIX),
+                "secret": generate_webhook_secret(),
                 "secret_generated_at": utc_now(),
             },
         )

--- a/server/polar/webhook/tasks.py
+++ b/server/polar/webhook/tasks.py
@@ -1,6 +1,6 @@
 import base64
 from collections.abc import Mapping
-from datetime import UTC, datetime
+from datetime import datetime
 from ssl import SSLError
 from uuid import UUID
 
@@ -27,19 +27,10 @@ from polar.worker import (
     enqueue_job,
 )
 
-from .constants import WEBHOOK_STANDARD_SIGNATURE_CUTOFF
+from .constants import uses_standard_webhook_signature
 from .service import webhook as webhook_service
 
 log: Logger = structlog.get_logger()
-
-
-def uses_standard_webhook_signature(secret_generated_at: datetime | None) -> bool:
-    if secret_generated_at is None:
-        return False
-    generated_at = secret_generated_at
-    if generated_at.tzinfo is None:
-        generated_at = generated_at.replace(tzinfo=UTC)
-    return generated_at >= WEBHOOK_STANDARD_SIGNATURE_CUTOFF
 
 
 def sign_webhook(
@@ -50,10 +41,12 @@ def sign_webhook(
     *,
     secret_generated_at: datetime | None,
 ) -> str:
-    if uses_standard_webhook_signature(secret_generated_at):
-        return StandardWebhook(secret).sign(msg_id, timestamp, payload)
-    b64secret = base64.b64encode(secret.encode("utf-8")).decode("utf-8")
-    return StandardWebhook(b64secret).sign(msg_id, timestamp, payload)
+    key = (
+        secret
+        if uses_standard_webhook_signature(secret_generated_at)
+        else base64.b64encode(secret.encode("utf-8")).decode("utf-8")
+    )
+    return StandardWebhook(key).sign(msg_id, timestamp, payload)
 
 
 # Safety-guard max_retries: enough for all ordering retries within the age

--- a/server/polar/webhook/tasks.py
+++ b/server/polar/webhook/tasks.py
@@ -1,5 +1,6 @@
 import base64
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from ssl import SSLError
 from uuid import UUID
 
@@ -26,9 +27,33 @@ from polar.worker import (
     enqueue_job,
 )
 
+from .constants import WEBHOOK_STANDARD_SIGNATURE_CUTOFF
 from .service import webhook as webhook_service
 
 log: Logger = structlog.get_logger()
+
+
+def uses_standard_webhook_signature(secret_generated_at: datetime | None) -> bool:
+    if secret_generated_at is None:
+        return False
+    generated_at = secret_generated_at
+    if generated_at.tzinfo is None:
+        generated_at = generated_at.replace(tzinfo=UTC)
+    return generated_at >= WEBHOOK_STANDARD_SIGNATURE_CUTOFF
+
+
+def sign_webhook(
+    secret: str,
+    msg_id: str,
+    timestamp: datetime,
+    payload: str,
+    *,
+    secret_generated_at: datetime | None,
+) -> str:
+    if uses_standard_webhook_signature(secret_generated_at):
+        return StandardWebhook(secret).sign(msg_id, timestamp, payload)
+    b64secret = base64.b64encode(secret.encode("utf-8")).decode("utf-8")
+    return StandardWebhook(b64secret).sign(msg_id, timestamp, payload)
 
 
 # Safety-guard max_retries: enough for all ordering retries within the age
@@ -106,14 +131,13 @@ async def _webhook_event_send(
         session.add(event)
 
     ts = utc_now()
-
-    b64secret = base64.b64encode(event.webhook_endpoint.secret.encode("utf-8")).decode(
-        "utf-8"
+    signature = sign_webhook(
+        event.webhook_endpoint.secret,
+        str(event.id),
+        ts,
+        event.payload,
+        secret_generated_at=event.webhook_endpoint.secret_generated_at,
     )
-
-    # Sign the payload
-    wh = StandardWebhook(b64secret)
-    signature = wh.sign(str(event.id), ts, event.payload)
 
     headers: Mapping[str, str] = {
         "user-agent": "polar.sh webhooks",

--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -124,7 +124,7 @@ from polar.redis import Redis, create_redis
 from polar.support_case.service import support_case as support_case_service
 from polar.user.repository import UserRepository
 from polar.user.service import user as user_service
-from polar.webhook.constants import WEBHOOK_SECRET_PREFIX
+from polar.webhook.service import generate_webhook_secret
 from polar.worker import JobQueueManager
 from scripts.seed_polar_for_polar import (
     BENEFITS as POLAR_SELF_BENEFITS,
@@ -3139,7 +3139,7 @@ def polar_self_env() -> None:
             for w in existing_webhooks:
                 await session.delete(w)
 
-            webhook_secret = generate_token(prefix=WEBHOOK_SECRET_PREFIX)
+            webhook_secret = generate_webhook_secret()
             webhook = WebhookEndpoint(
                 organization_id=org.id,
                 url=WEBHOOK_URL,

--- a/server/tests/webhooks/test_webhooks.py
+++ b/server/tests/webhooks/test_webhooks.py
@@ -1,5 +1,8 @@
+import base64
 import json
+import secrets
 import uuid
+from datetime import timedelta
 from typing import Annotated, cast
 from unittest.mock import MagicMock
 
@@ -26,9 +29,20 @@ from polar.models.webhook_endpoint import (
 )
 from polar.models.webhook_event import WebhookEvent
 from polar.version import CURRENT_API_VERSION
+from polar.webhook.constants import (
+    WEBHOOK_SECRET_KEY_BYTES,
+    WEBHOOK_SECRET_PREFIX,
+    WEBHOOK_STANDARD_SIGNATURE_CUTOFF,
+)
 from polar.webhook.repository import WebhookDeliveryRepository
+from polar.webhook.service import generate_webhook_secret
 from polar.webhook.service import webhook as webhook_service
-from polar.webhook.tasks import _webhook_event_send, webhook_event_send
+from polar.webhook.tasks import (
+    _webhook_event_send,
+    sign_webhook,
+    uses_standard_webhook_signature,
+    webhook_event_send,
+)
 from polar.webhook.webhooks import BaseWebhookPayload
 from tests.fixtures.database import SaveFixture
 from tests.kit.test_versioning import CURRENT_VERSION, NEXT_VERSION
@@ -76,6 +90,125 @@ def test_versioned_raw_payload() -> None:
     assert "shared_field" in next_payload_data["data"]
     assert "current_field" not in next_payload_data["data"]
     assert "next_field" in next_payload_data["data"]
+
+
+class TestUsesStandardWebhookSignature:
+    def test_none_keeps_legacy(self) -> None:
+        assert uses_standard_webhook_signature(None) is False
+
+    def test_before_cutoff_keeps_legacy(self) -> None:
+        assert (
+            uses_standard_webhook_signature(
+                WEBHOOK_STANDARD_SIGNATURE_CUTOFF - timedelta(microseconds=1)
+            )
+            is False
+        )
+
+    def test_at_or_after_cutoff_uses_spec(self) -> None:
+        assert (
+            uses_standard_webhook_signature(WEBHOOK_STANDARD_SIGNATURE_CUTOFF) is True
+        )
+        assert (
+            uses_standard_webhook_signature(
+                WEBHOOK_STANDARD_SIGNATURE_CUTOFF + timedelta(days=1)
+            )
+            is True
+        )
+
+
+class TestGenerateWebhookSecret:
+    def test_always_prefixed(self) -> None:
+        secret = generate_webhook_secret()
+        assert secret.startswith(WEBHOOK_SECRET_PREFIX)
+
+    def test_spec_format_after_cutoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from polar.webhook import service
+
+        monkeypatch.setattr(
+            service,
+            "utc_now",
+            lambda: WEBHOOK_STANDARD_SIGNATURE_CUTOFF + timedelta(seconds=1),
+        )
+        secret = generate_webhook_secret()
+        remainder = secret.removeprefix(WEBHOOK_SECRET_PREFIX)
+        decoded = base64.b64decode(remainder)
+        assert len(decoded) == WEBHOOK_SECRET_KEY_BYTES
+
+    def test_polar_token_before_cutoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from polar.webhook import service
+
+        monkeypatch.setattr(
+            service,
+            "utc_now",
+            lambda: WEBHOOK_STANDARD_SIGNATURE_CUTOFF - timedelta(seconds=1),
+        )
+        secret = generate_webhook_secret()
+        remainder = secret.removeprefix(WEBHOOK_SECRET_PREFIX)
+        assert len(remainder) == 43
+
+
+class TestSignWebhook:
+    def test_legacy_matches_utf8_hmac(self) -> None:
+        secret = "whsec_legacyPolarToken"
+        payload = '{"foo":"bar"}'
+        timestamp = utc_now()
+        signature = sign_webhook(
+            secret,
+            "msg_1",
+            timestamp,
+            payload,
+            secret_generated_at=None,
+        )
+        StandardWebhook(secret.encode("utf-8")).verify(
+            payload.encode(),
+            {
+                "webhook-id": "msg_1",
+                "webhook-timestamp": str(int(timestamp.timestamp())),
+                "webhook-signature": signature,
+            },
+        )
+
+    def test_before_cutoff_stays_legacy_even_when_stamped(self) -> None:
+        secret = "whsec_legacyPolarToken"
+        payload = '{"foo":"bar"}'
+        timestamp = utc_now()
+        signature = sign_webhook(
+            secret,
+            "msg_1",
+            timestamp,
+            payload,
+            secret_generated_at=WEBHOOK_STANDARD_SIGNATURE_CUTOFF
+            - timedelta(microseconds=1),
+        )
+        StandardWebhook(secret.encode("utf-8")).verify(
+            payload.encode(),
+            {
+                "webhook-id": "msg_1",
+                "webhook-timestamp": str(int(timestamp.timestamp())),
+                "webhook-signature": signature,
+            },
+        )
+
+    def test_spec_matches_standard_webhooks_library(self) -> None:
+        key = secrets.token_bytes(WEBHOOK_SECRET_KEY_BYTES)
+        secret = f"{WEBHOOK_SECRET_PREFIX}{base64.b64encode(key).decode()}"
+        payload = '{"foo":"bar"}'
+        timestamp = utc_now()
+        signature = sign_webhook(
+            secret,
+            "msg_1",
+            timestamp,
+            payload,
+            secret_generated_at=WEBHOOK_STANDARD_SIGNATURE_CUTOFF,
+        )
+        StandardWebhook(secret).verify(
+            payload.encode(),
+            {
+                "webhook-id": "msg_1",
+                "webhook-timestamp": str(int(timestamp.timestamp())),
+                "webhook-signature": signature,
+            },
+        )
 
 
 @pytest.mark.asyncio
@@ -325,4 +458,77 @@ async def test_webhook_standard_webhooks_compatible(
     # Check that the generated signature is correct
     request = route_mock.calls.last.request
     w = StandardWebhook(secret.encode("utf-8"))
+    assert w.verify(request.content, cast(dict[str, str], request.headers)) is not None
+
+
+@pytest.mark.asyncio
+async def test_webhook_legacy_signature_when_secret_generated_before_cutoff(
+    session: AsyncSession,
+    save_fixture: SaveFixture,
+    respx_mock: respx.MockRouter,
+    organization: Organization,
+) -> None:
+    secret = "whsec_postColumnButPreSpec"
+    route_mock = respx_mock.post("https://example.com/hook").mock(
+        return_value=httpx.Response(200)
+    )
+
+    endpoint = WebhookEndpoint(
+        url="https://example.com/hook",
+        format=WebhookFormat.raw,
+        organization_id=organization.id,
+        secret=secret,
+        secret_generated_at=WEBHOOK_STANDARD_SIGNATURE_CUTOFF - timedelta(days=1),
+    )
+    await save_fixture(endpoint)
+
+    event = WebhookEvent(
+        webhook_endpoint_id=endpoint.id,
+        type=WebhookEventType.customer_created,
+        api_version=CURRENT_API_VERSION,
+        payload='{"foo":"bar"}',
+    )
+    await save_fixture(event)
+
+    await _webhook_event_send(session=session, webhook_event_id=event.id)
+
+    request = route_mock.calls.last.request
+    w = StandardWebhook(secret.encode("utf-8"))
+    assert w.verify(request.content, cast(dict[str, str], request.headers)) is not None
+
+
+@pytest.mark.asyncio
+async def test_webhook_spec_signature_when_secret_generated_at_cutoff(
+    session: AsyncSession,
+    save_fixture: SaveFixture,
+    respx_mock: respx.MockRouter,
+    organization: Organization,
+) -> None:
+    key = secrets.token_bytes(WEBHOOK_SECRET_KEY_BYTES)
+    secret = f"{WEBHOOK_SECRET_PREFIX}{base64.b64encode(key).decode()}"
+    route_mock = respx_mock.post("https://example.com/hook").mock(
+        return_value=httpx.Response(200)
+    )
+
+    endpoint = WebhookEndpoint(
+        url="https://example.com/hook",
+        format=WebhookFormat.raw,
+        organization_id=organization.id,
+        secret=secret,
+        secret_generated_at=WEBHOOK_STANDARD_SIGNATURE_CUTOFF,
+    )
+    await save_fixture(endpoint)
+
+    event = WebhookEvent(
+        webhook_endpoint_id=endpoint.id,
+        type=WebhookEventType.customer_created,
+        api_version=CURRENT_API_VERSION,
+        payload='{"foo":"bar"}',
+    )
+    await save_fixture(event)
+
+    await _webhook_event_send(session=session, webhook_event_id=event.id)
+
+    request = route_mock.calls.last.request
+    w = StandardWebhook(secret)
     assert w.verify(request.content, cast(dict[str, str], request.headers)) is not None

--- a/server/tests/webhooks/test_webhooks.py
+++ b/server/tests/webhooks/test_webhooks.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import timedelta
 from typing import Annotated, cast
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import httpx
 import pytest
@@ -33,14 +34,15 @@ from polar.webhook.constants import (
     WEBHOOK_SECRET_KEY_BYTES,
     WEBHOOK_SECRET_PREFIX,
     WEBHOOK_STANDARD_SIGNATURE_CUTOFF,
+    uses_standard_webhook_signature,
 )
 from polar.webhook.repository import WebhookDeliveryRepository
+from polar.webhook.schemas import WebhookEndpoint as WebhookEndpointSchema
 from polar.webhook.service import generate_webhook_secret
 from polar.webhook.service import webhook as webhook_service
 from polar.webhook.tasks import (
     _webhook_event_send,
     sign_webhook,
-    uses_standard_webhook_signature,
     webhook_event_send,
 )
 from polar.webhook.webhooks import BaseWebhookPayload
@@ -114,6 +116,39 @@ class TestUsesStandardWebhookSignature:
             )
             is True
         )
+
+
+class TestWebhookEndpointSchema:
+    def _payload(self, **overrides: object) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "id": uuid4(),
+            "created_at": utc_now(),
+            "modified_at": None,
+            "url": "https://example.com/hook",
+            "name": None,
+            "format": WebhookFormat.raw,
+            "secret": "whsec_test",
+            "organization_id": uuid4(),
+            "events": [],
+            "enabled": True,
+            "secret_generated_at": None,
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_null_secret_generated_at_is_legacy(self) -> None:
+        schema = WebhookEndpointSchema.model_validate(self._payload())
+        dumped = schema.model_dump()
+        assert schema.uses_standard_webhook_signature is False
+        assert "secret_generated_at" not in dumped
+        assert dumped["uses_standard_webhook_signature"] is False
+
+    def test_at_cutoff_uses_spec(self) -> None:
+        schema = WebhookEndpointSchema.model_validate(
+            self._payload(secret_generated_at=WEBHOOK_STANDARD_SIGNATURE_CUTOFF)
+        )
+        assert schema.uses_standard_webhook_signature is True
+        assert schema.model_dump()["uses_standard_webhook_signature"] is True
 
 
 class TestGenerateWebhookSecret:

--- a/server/tests/webhooks/test_webhooks.py
+++ b/server/tests/webhooks/test_webhooks.py
@@ -126,6 +126,7 @@ class TestWebhookEndpointSchema:
             "modified_at": None,
             "url": "https://example.com/hook",
             "name": None,
+            "api_version": CURRENT_API_VERSION,
             "format": WebhookFormat.raw,
             "secret": "whsec_test",
             "organization_id": uuid4(),


### PR DESCRIPTION
Switch our way of signing webhooks to follow the [https://www.standardwebhooks.com](<https://www.standardwebhooks.com>) approach.

To not break existing webhook integrations relying on our previous way of signing, we'll keep signing webhooks registered (or webhook secrets generated) before a cutoff date time.

SDK `1.0.0-alpha.19` and later supports both signature approaches.

Cut-off date set to *2026-09-08*

### Dashboard screenshots showing notices & badges

<img src="https://uploads.linear.app/c799ca0b-bcda-447b-abcc-b485d23898da/d3d9e9c1-3b8a-4afd-a528-e399292f2c00/cee51791-c3ba-4f6d-9430-8312542f6558?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2M3OTljYTBiLWJjZGEtNDQ3Yi1hYmNjLWI0ODVkMjM4OThkYS9kM2Q5ZTljMS0zYjhhLTRhZmQtYTUyOC1lMzk5MjkyZjJjMDAvY2VlNTE3OTEtYzNiYS00ZjZkLTk0MzAtODMxMjU0MmY2NTU4IiwiaWF0IjoxNzg4NTEzNDUwLCJleHAiOjE4MjAwODQwMTB9.iI6R0GsIe37cmYErSYM3WERyxkEBLojuUkSftpxXh58 " alt="webhooks-list-notice.png" width="3840" data-linear-height="2160" />

<img src="https://uploads.linear.app/c799ca0b-bcda-447b-abcc-b485d23898da/dd4e35df-e8bd-4a8d-bbd1-573ffe61b76c/c7003cc9-7f8e-4ed0-858b-593e78447136?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2M3OTljYTBiLWJjZGEtNDQ3Yi1hYmNjLWI0ODVkMjM4OThkYS9kZDRlMzVkZi1lOGJkLTRhOGQtYmJkMS01NzNmZmU2MWI3NmMvYzcwMDNjYzktN2Y4ZS00ZWQwLTg1OGItNTkzZTc4NDQ3MTM2IiwiaWF0IjoxNzg4NTEzNDUwLCJleHAiOjE4MjAwODQwMTB9.jgonRKfkVoawp9LoDYCkLyWNy5Cit18mzYrZSArNYpo " alt="webhooks-detail-notice.png" width="3840" data-linear-height="2160" />

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)