### PR TITLE
fix(clients): replace toSorted with sort in bundled code

### DIFF
--- a/clients/adapters/better-auth/src/__tests__/organization/lifecycle.test.ts
+++ b/clients/adapters/better-auth/src/__tests__/organization/lifecycle.test.ts
@@ -118,7 +118,7 @@ const createAuthContext = (storedMemberships = memberships) => {
           ),
         )
         if (sortBy?.field === 'createdAt') {
-          result = result.toSorted(
+          result = [...result].sort(
             (left, right) =>
               left.createdAt.getTime() - right.createdAt.getTime(),
           )

--- a/clients/apps/web/src/utils/bulk.test.ts
+++ b/clients/apps/web/src/utils/bulk.test.ts
@@ -10,7 +10,7 @@ const account = <T>(result: {
     ...result.succeeded.map((entry) => entry.item),
     ...result.failed.map((entry) => entry.item),
     ...result.cancelled,
-  ].toSorted()
+  ].sort()
 
 describe('runBulk', () => {
   it('accounts for every input on success and failure', async () => {
@@ -69,7 +69,7 @@ describe('runBulk', () => {
 
     expect(result.succeeded).toEqual([{ item: 1, value: 1 }])
     expect(result.failed).toEqual([])
-    expect(result.cancelled.toSorted()).toEqual([2, 3, 4])
+    expect([...result.cancelled].sort()).toEqual([2, 3, 4])
     expect(account(result)).toEqual([1, 2, 3, 4])
   })
 

--- a/clients/apps/web/src/utils/order.ts
+++ b/clients/apps/web/src/utils/order.ts
@@ -110,7 +110,7 @@ export function getLatestFailedPayment(
   return (
     payments
       .filter((payment) => payment.status === 'failed')
-      .toSorted(
+      .sort(
         (a, b) =>
           parseISO(b.created_at).getTime() - parseISO(a.created_at).getTime(),
       )[0] ?? null

--- a/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
+++ b/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
@@ -154,7 +154,7 @@ const FixedSeatPrice = ({
   locale?: AcceptedLocale
 }) => {
   const t = useTranslations(locale ?? DEFAULT_LOCALE)
-  const sortedTiers = (seatPrice.seat_tiers?.tiers ?? []).toSorted(
+  const sortedTiers = [...(seatPrice.seat_tiers?.tiers ?? [])].sort(
     (a, b) => a.min_seats - b.min_seats,
   )
   const basePricePerSeat = sortedTiers[0]?.price_per_seat ?? 0

--- a/clients/packages/checkout/src/utils/product.ts
+++ b/clients/packages/checkout/src/utils/product.ts
@@ -32,7 +32,7 @@ export const getMeteredPrices = (
 
 export const getMeteredTiers = (price: MeteredPrice): MeteredTier[] =>
   price.amount_type === 'metered_tiers'
-    ? price.tiers.tiers.toSorted(
+    ? [...price.tiers.tiers].sort(
         (a, b) =>
           Number(a.bound == null) - Number(b.bound == null) ||
           (a.bound ?? 0) - (b.bound ?? 0),

--- a/clients/packages/checkout/src/utils/units.ts
+++ b/clients/packages/checkout/src/utils/units.ts
@@ -47,7 +47,7 @@ export function getUnitLabels(
 type UnitTier = schemas['Tier']
 
 function sortTiers(tiers: UnitTier[]): UnitTier[] {
-  return tiers.toSorted((a, b) => {
+  return [...tiers].sort((a, b) => {
     if (a.bound == null) return 1
     if (b.bound == null) return -1
     return a.bound - b.bound

--- a/clients/packages/typescript-config/bundled.json
+++ b/clients/packages/typescript-config/bundled.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./base.json",
   "compilerOptions": {
+    "lib": ["es2022", "es2023.intl", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleDetection": "force",
     "moduleResolution": "bundler"


### PR DESCRIPTION
## Summary

Closes #14111

Bundled code can't use ES2023 APIs.

`toSorted` is ES2023.

Our floor is Next 16's default target, `baseline widely available`:
Chrome/Edge 111, Firefox 111, Safari 16.4. `toSorted` needs Firefox 115.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

