### PR TITLE
Only delete a payout account when no organization uses it

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -4391,7 +4391,7 @@ async def delete_payout_account(
             account_type = payout_account.type
             stripe_id = payout_account.stripe_id
 
-            await payout_account_service.delete(session, payout_account, unlink=True)
+            await payout_account_service.unlink_and_maybe_delete(session, organization)
 
             timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
             delete_note = (

--- a/server/polar/backoffice/payout_accounts/endpoints.py
+++ b/server/polar/backoffice/payout_accounts/endpoints.py
@@ -327,7 +327,7 @@ async def delete(
             account_type = payout_account.type
             stripe_id = payout_account.stripe_id
 
-            await payout_account_service.delete(session, payout_account, unlink=True)
+            await payout_account_service.delete(session, payout_account)
 
             timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
             note = (

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -459,11 +459,11 @@ class OrganizationRepository(
         next_number = result.scalar_one()
         return next_number - 1
 
-    async def delete_payout_account(self, payout_account: UUID) -> None:
-        """Reset Organization.payout_account_id to None for any organization linked to the payout account."""
+    async def remove_payout_account(self, organization_id: UUID) -> None:
+        """Reset Organization.payout_account_id to None for a single organization."""
         stmt = (
             update(Organization)
-            .where(Organization.payout_account_id == payout_account)
+            .where(Organization.id == organization_id)
             .values(payout_account_id=None)
         )
         await self.session.execute(stmt)

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -459,11 +459,15 @@ class OrganizationRepository(
         next_number = result.scalar_one()
         return next_number - 1
 
-    async def remove_payout_account(self, organization_id: UUID) -> None:
-        """Reset Organization.payout_account_id to None for a single organization."""
+    async def remove_payout_account(
+        self, organization_id: UUID, payout_account_id: UUID
+    ) -> None:
         stmt = (
             update(Organization)
-            .where(Organization.id == organization_id)
+            .where(
+                Organization.id == organization_id,
+                Organization.payout_account_id == payout_account_id,
+            )
             .values(payout_account_id=None)
         )
         await self.session.execute(stmt)

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -886,18 +886,7 @@ class OrganizationService:
     async def _delete_payout_account(
         self, session: AsyncSession, organization: Organization
     ) -> None:
-        if organization.payout_account_id is None:
-            return
-
-        payout_account_repository = PayoutAccountRepository.from_session(session)
-        payout_account = await payout_account_repository.get_by_id(
-            organization.payout_account_id
-        )
-
-        if payout_account is None:
-            return
-
-        await payout_account_service.delete(session, payout_account, unlink=True)
+        await payout_account_service.unlink_and_maybe_delete(session, organization)
 
     async def set_payout_account(
         self,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -777,7 +777,7 @@ class OrganizationService:
             return check_result
 
         try:
-            await self._delete_payout_account(session, organization)
+            await payout_account_service.unlink_and_maybe_delete(session, organization)
         except Exception as e:
             log.error(
                 "organization.deletion.stripe_account_deletion_failed",
@@ -882,11 +882,6 @@ class OrganizationService:
         )
 
         return organization
-
-    async def _delete_payout_account(
-        self, session: AsyncSession, organization: Organization
-    ) -> None:
-        await payout_account_service.unlink_and_maybe_delete(session, organization)
 
     async def set_payout_account(
         self,

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -164,14 +164,6 @@ class PayoutAccountService:
         session: AsyncSession,
         payout_account: PayoutAccount,
     ) -> None:
-        """Delete a payout account that is no longer referenced by any organization.
-
-        A payout account can be shared by several organizations owned by the same
-        person, so it must never be deleted while any organization still links to
-        it. Callers that want to remove a specific organization's link (and only
-        delete the account when it becomes orphaned) must use
-        `unlink_and_maybe_delete`.
-        """
         organization_repository = OrganizationRepository.from_session(session)
         linked_organizations = await organization_repository.get_all_by_payout_account(
             payout_account.id
@@ -186,14 +178,6 @@ class PayoutAccountService:
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        """Unlink a single organization from its payout account.
-
-        The payout account is only actually deleted (Stripe account removed and
-        soft-deleted) once no other organization still references it. While it's
-        still shared, the account is left untouched — the pending-payout and
-        Stripe balance guards apply to the whole account and must not block or
-        destroy an account another organization depends on.
-        """
         payout_account_id = organization.payout_account_id
         if payout_account_id is None:
             return
@@ -208,7 +192,9 @@ class PayoutAccountService:
 
         # Still shared: just drop this organization's link, keep the account.
         if other_organizations:
-            await organization_repository.remove_payout_account(organization.id)
+            await organization_repository.remove_payout_account(
+                organization.id, payout_account_id
+            )
             return
 
         # Would be orphaned: run the deletion guards before unlinking so a failed
@@ -218,7 +204,9 @@ class PayoutAccountService:
         if payout_account is not None:
             await self._delete(session, payout_account)
 
-        await organization_repository.remove_payout_account(organization.id)
+        await organization_repository.remove_payout_account(
+            organization.id, payout_account_id
+        )
 
     async def _delete(
         self, session: AsyncSession, payout_account: PayoutAccount

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -163,20 +163,66 @@ class PayoutAccountService:
         self,
         session: AsyncSession,
         payout_account: PayoutAccount,
-        *,
-        unlink: bool = False,
     ) -> None:
-        # Verify the account is not linked to any organization
-        if not unlink:
-            organization_repository = OrganizationRepository.from_session(session)
-            linked_organizations = (
-                await organization_repository.get_all_by_payout_account(
-                    payout_account.id
-                )
-            )
-            if linked_organizations:
-                raise PayoutAccountLinkedToOrganization(payout_account.id)
+        """Delete a payout account that is no longer referenced by any organization.
 
+        A payout account can be shared by several organizations owned by the same
+        person, so it must never be deleted while any organization still links to
+        it. Callers that want to remove a specific organization's link (and only
+        delete the account when it becomes orphaned) must use
+        `unlink_and_maybe_delete`.
+        """
+        organization_repository = OrganizationRepository.from_session(session)
+        linked_organizations = await organization_repository.get_all_by_payout_account(
+            payout_account.id
+        )
+        if linked_organizations:
+            raise PayoutAccountLinkedToOrganization(payout_account.id)
+
+        await self._delete(session, payout_account)
+
+    async def unlink_and_maybe_delete(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """Unlink a single organization from its payout account.
+
+        The payout account is only actually deleted (Stripe account removed and
+        soft-deleted) once no other organization still references it. While it's
+        still shared, the account is left untouched — the pending-payout and
+        Stripe balance guards apply to the whole account and must not block or
+        destroy an account another organization depends on.
+        """
+        payout_account_id = organization.payout_account_id
+        if payout_account_id is None:
+            return
+
+        organization_repository = OrganizationRepository.from_session(session)
+        linked_organizations = await organization_repository.get_all_by_payout_account(
+            payout_account_id
+        )
+        other_organizations = [
+            linked for linked in linked_organizations if linked.id != organization.id
+        ]
+
+        # Still shared: just drop this organization's link, keep the account.
+        if other_organizations:
+            await organization_repository.remove_payout_account(organization.id)
+            return
+
+        # Would be orphaned: run the deletion guards before unlinking so a failed
+        # deletion (e.g. pending payouts) leaves the organization untouched.
+        repository = PayoutAccountRepository.from_session(session)
+        payout_account = await repository.get_by_id(payout_account_id)
+        if payout_account is not None:
+            await self._delete(session, payout_account)
+
+        await organization_repository.remove_payout_account(organization.id)
+
+    async def _delete(
+        self, session: AsyncSession, payout_account: PayoutAccount
+    ) -> None:
         # Verify there are no pending payouts for this account
         payout_repository = PayoutRepository.from_session(session)
         pending_payouts_count = await payout_repository.count_pending_by_payout_account(
@@ -196,11 +242,6 @@ class PayoutAccountService:
             if balance != 0:
                 raise PayoutAccountNonZeroBalance(payout_account.stripe_id)
             await stripe.delete_account(payout_account.stripe_id)
-
-        # Unlink the payout account from the organization before deleting
-        if unlink:
-            organization_repository = OrganizationRepository.from_session(session)
-            await organization_repository.delete_payout_account(payout_account.id)
 
         repository = PayoutAccountRepository.from_session(session)
         await repository.soft_delete(payout_account)

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -16,8 +16,10 @@ from polar.models.user import User
 from polar.models.user_session import UserSession
 from polar.organization_review.repository import OrganizationReviewRepository
 from polar.organization_review.schemas import AUPSection
+from polar.payout_account.repository import PayoutAccountRepository
 from polar.postgres import AsyncSession, get_db_session
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_payout_account
 
 
 @pytest_asyncio.fixture
@@ -347,6 +349,45 @@ class TestDeletePayoutAccount:
 
         assert response.status_code == 200
         assert "Delete Payout Account" in response.text
+
+    async def test_shared_account_only_unlinks_this_organization(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+        organization_second: Organization,
+        user: User,
+    ) -> None:
+        """Deleting the payout account from one organization's page must not
+        destroy an account another organization still shares."""
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, stripe_id="acct_shared"
+        )
+        organization_second.payout_account = payout_account
+        await save_fixture(organization_second)
+
+        stripe_mock = mocker.patch("polar.payout_account.service.stripe")
+        stripe_mock.delete_account = mocker.AsyncMock(return_value=None)
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/delete-payout-account",
+            data={"reason": "Merchant request"},
+        )
+
+        assert response.status_code in (200, 303)
+        stripe_mock.delete_account.assert_not_awaited()
+
+        await session.refresh(organization)
+        await session.refresh(organization_second)
+        assert organization.payout_account_id is None
+        assert organization_second.payout_account_id == payout_account.id
+
+        repository = PayoutAccountRepository.from_session(session)
+        persisted = await repository.get_by_id(payout_account.id, include_deleted=True)
+        assert persisted is not None
+        assert persisted.deleted_at is None
 
 
 @pytest.mark.asyncio

--- a/server/tests/backoffice/payout_accounts/test_endpoints.py
+++ b/server/tests/backoffice/payout_accounts/test_endpoints.py
@@ -152,7 +152,7 @@ class TestDelete:
         assert response.status_code == 200
         assert "Delete Payout Account" in response.text
 
-    async def test_post_deletes_payout_account(
+    async def test_post_deletes_orphaned_payout_account(
         self,
         backoffice_client: httpx.AsyncClient,
         mocker: MockerFixture,
@@ -163,6 +163,9 @@ class TestDelete:
         payout_account = await create_payout_account(
             save_fixture, organization, user, stripe_id="acct_todelete"
         )
+        # Only an orphaned (unlinked) account may be deleted from this page.
+        organization.payout_account = None
+        await save_fixture(organization)
 
         stripe_mock = mocker.patch("polar.payout_account.service.stripe")
         stripe_mock.account_exists = mocker.AsyncMock(return_value=True)
@@ -176,3 +179,29 @@ class TestDelete:
 
         assert response.status_code in (200, 303)
         stripe_mock.delete_account.assert_awaited_once_with(payout_account.stripe_id)
+
+    async def test_post_refuses_when_still_linked_to_organization(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        """A payout account still referenced by an organization is not deleted:
+        it could be shared by several organizations, so the account-centric page
+        must not orphan any of them."""
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, stripe_id="acct_todelete"
+        )
+
+        stripe_mock = mocker.patch("polar.payout_account.service.stripe")
+        stripe_mock.delete_account = mocker.AsyncMock(return_value=None)
+
+        response = await backoffice_client.post(
+            f"/payout-accounts/{payout_account.id}/delete",
+            data={"reason": "Merchant closed account"},
+        )
+
+        assert response.status_code == 422
+        stripe_mock.delete_account.assert_not_awaited()

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -1431,7 +1431,7 @@ class TestDeleteOrganization:
     ) -> None:
         # Mock payout account deletion to succeed (returns None on success)
         payout_account_delete_mock = mocker.patch(
-            "polar.organization.service.payout_account_service.delete",
+            "polar.organization.service.payout_account_service.unlink_and_maybe_delete",
             return_value=None,
         )
         mock_enqueue = mocker.patch("polar.organization.service.enqueue_job")
@@ -1464,7 +1464,7 @@ class TestDeleteOrganization:
         # Mock payout account deletion to fail with an exception
         # Mock payout account deletion to succeed (returns None on success)
         payout_account_delete_mock = mocker.patch(
-            "polar.organization.service.payout_account_service.delete",
+            "polar.organization.service.payout_account_service.unlink_and_maybe_delete",
             side_effect=PayoutAccountServiceError("Stripe account deletion failed"),
         )
         mock_enqueue = mocker.patch("polar.organization.service.enqueue_job")

--- a/server/tests/organization/test_repository.py
+++ b/server/tests/organization/test_repository.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -14,6 +15,7 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_active_subscription,
     create_canceled_subscription,
+    create_payout_account,
 )
 
 
@@ -54,6 +56,39 @@ class TestGetOwnerUser:
         repo = OrganizationRepository.from_session(session)
         owner_after_removal = await repo.get_owner_user(organization)
         assert owner_after_removal is None
+
+
+@pytest.mark.asyncio
+class TestRemovePayoutAccount:
+    async def test_removes_matching_payout_account(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        payout_account = await create_payout_account(save_fixture, organization, user)
+
+        repo = OrganizationRepository.from_session(session)
+        await repo.remove_payout_account(organization.id, payout_account.id)
+        await session.refresh(organization)
+
+        assert organization.payout_account_id is None
+
+    async def test_ignores_concurrently_rebound_payout_account(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        payout_account = await create_payout_account(save_fixture, organization, user)
+
+        repo = OrganizationRepository.from_session(session)
+        await repo.remove_payout_account(organization.id, uuid.uuid4())
+        await session.refresh(organization)
+
+        assert organization.payout_account_id == payout_account.id
 
 
 async def _set_status(

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -3733,7 +3733,7 @@ class TestRequestDeletion:
             save_fixture, organization, user, type=PayoutAccountType.stripe
         )
         payout_account_delete_mock = mocker.patch(
-            "polar.organization.service.payout_account_service.delete",
+            "polar.organization.service.payout_account_service.unlink_and_maybe_delete",
             return_value=None,
         )
 
@@ -3760,7 +3760,7 @@ class TestRequestDeletion:
             save_fixture, organization, user, type=PayoutAccountType.stripe
         )
         mocker.patch(
-            "polar.organization.service.payout_account_service.delete",
+            "polar.organization.service.payout_account_service.unlink_and_maybe_delete",
             side_effect=Exception("Stripe API error"),
         )
 

--- a/server/tests/payout_account/test_service.py
+++ b/server/tests/payout_account/test_service.py
@@ -7,6 +7,7 @@ from polar.enums import PayoutAccountStatus, PayoutAccountType
 from polar.integrations.stripe.service import StripeService
 from polar.models import Organization, User
 from polar.models.payout_attempt import PayoutAttemptStatus
+from polar.payout_account.repository import PayoutAccountRepository
 from polar.payout_account.service import (
     PayoutAccountHasPendingPayouts,
     PayoutAccountLinkedToOrganization,
@@ -171,8 +172,53 @@ class TestDelete:
             payout_account.stripe_id
         )
 
+
+@pytest.mark.asyncio
+class TestUnlinkAndMaybeDelete:
     @pytest.mark.auth
-    async def test_successful_deletion_unlinked(
+    async def test_shared_account_only_unlinks_requesting_organization(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        organization_second: Organization,
+        user: User,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        """A payout account shared by two organizations is kept intact when one
+        organization is unlinked, even if the account has pending payouts."""
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        organization_second.payout_account = payout_account
+        await save_fixture(organization_second)
+
+        # Pending payout on the shared account: it must NOT block the unlink.
+        account = await create_account(save_fixture, user)
+        await create_payout(
+            save_fixture,
+            payout_account=payout_account,
+            account=account,
+            attempts=[PayoutAttemptStatus.pending],
+        )
+
+        await payout_account_service.unlink_and_maybe_delete(session, organization)
+
+        await session.refresh(organization)
+        await session.refresh(organization_second)
+        assert organization.payout_account_id is None
+        assert organization_second.payout_account_id == payout_account.id
+
+        stripe_service_mock.delete_account.assert_not_called()  # type: ignore[attr-defined]
+
+        repository = PayoutAccountRepository.from_session(session)
+        persisted = await repository.get_by_id(payout_account.id, include_deleted=True)
+        assert persisted is not None
+        assert persisted.deleted_at is None
+
+    @pytest.mark.auth
+    async def test_last_organization_deletes_orphaned_account(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -181,7 +227,7 @@ class TestDelete:
         user: User,
         stripe_service_mock: StripeService,
     ) -> None:
-        """Successfully deletes a payout account if forcing organization unlinking."""
+        """Unlinking the last organization deletes the now-orphaned account."""
         payout_account = await create_payout_account(
             save_fixture, organization, user, type=PayoutAccountType.stripe
         )
@@ -190,11 +236,56 @@ class TestDelete:
         stripe_service_mock.retrieve_balance.return_value = ("usd", 0)  # type: ignore[attr-defined]
         stripe_service_mock.delete_account.return_value = None  # type: ignore[attr-defined]
 
-        await payout_account_service.delete(session, payout_account, unlink=True)
+        await payout_account_service.unlink_and_maybe_delete(session, organization)
+
+        await session.refresh(organization)
+        assert organization.payout_account_id is None
 
         stripe_service_mock.delete_account.assert_called_once_with(  # type: ignore[attr-defined]
             payout_account.stripe_id
         )
+
+        repository = PayoutAccountRepository.from_session(session)
+        persisted = await repository.get_by_id(payout_account.id, include_deleted=True)
+        assert persisted is not None
+        assert persisted.deleted_at is not None
+
+    @pytest.mark.auth
+    async def test_last_organization_with_pending_payout_raises(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user: User,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        """Unlinking the last organization of an account with pending payouts
+        raises and leaves the organization linked."""
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+
+        account = await create_account(save_fixture, user)
+        await create_payout(
+            save_fixture,
+            payout_account=payout_account,
+            account=account,
+            attempts=[PayoutAttemptStatus.pending],
+        )
+
+        with pytest.raises(PayoutAccountHasPendingPayouts):
+            await payout_account_service.unlink_and_maybe_delete(session, organization)
+
+        await session.refresh(organization)
+        assert organization.payout_account_id == payout_account.id
+
+        stripe_service_mock.delete_account.assert_not_called()  # type: ignore[attr-defined]
+
+        repository = PayoutAccountRepository.from_session(session)
+        persisted = await repository.get_by_id(payout_account.id, include_deleted=True)
+        assert persisted is not None
+        assert persisted.deleted_at is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A single Stripe payout account can be linked to more than one organization. Organization deletion right now would try to delete the payout account, so it checks on pending payouts. This works only under the assumption that one payout account is used by one organization.

In this PR, only actually delete a payout account when it is no longer referenced by any organization. When still shared, just unlink the requesting org and keep the account intact. This allows us to also loosen the check on pending payouts.

*Note:* this unblocks support, but it also feels a bit redundant, because from credit card networks, shared payout accounts can be considered transaction laundering, and we should remove the possibility of re-using payout accounts across merchants.