### PR TITLE
feat(orders): allow unit based pricing on off-session charges

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -26570,7 +26570,7 @@ export interface components {
       /**
        * Product Id
        * Format: uuid4
-       * @description The ID of the one-time product to charge for. Must belong to the order's organization. Only fixed-price and free products are supported.
+       * @description The ID of the one-time product to charge for. Must belong to the order's organization. Only fixed-price, free and unit-based products are supported.
        */
       product_id: string
       /**
@@ -26583,6 +26583,11 @@ export interface components {
        * @description A custom amount to charge, in the smallest currency unit. Overrides the product's price; defaults to the product's configured price (0 for free products). A positive amount must be at least the currency's minimum.
        */
       amount?: number | null
+      /**
+       * Units
+       * @description The number of units to charge for. Required when the product has unit-based pricing, and rejected otherwise. The amount comes from the price's tiers, unless `amount` overrides it.
+       */
+      units?: number | null
       /**
        * Description
        * @description A custom description for the order's line item, shown on the invoice and receipt (e.g. `5,000 tokens`). Defaults to the product name.

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -26580,12 +26580,12 @@ export interface components {
       currency?: string | null
       /**
        * Amount
-       * @description A custom amount to charge, in the smallest currency unit. Overrides the product's price; defaults to the product's configured price (0 for free products). A positive amount must be at least the currency's minimum.
+       * @description A custom amount to charge, in the smallest currency unit. Overrides the product's price; defaults to the product's configured price (0 for free products). A positive amount must be at least the currency's minimum. Can't be combined with `units`.
        */
       amount?: number | null
       /**
        * Units
-       * @description The number of units to charge for. Required when the product has unit-based pricing, and rejected otherwise. The amount comes from the price's tiers, unless `amount` overrides it.
+       * @description The number of units to charge for. Required when the product has unit-based pricing, and rejected otherwise. The amount comes from the price's tiers. Can't be combined with `amount`.
        */
       units?: number | null
       /**

--- a/docs/features/orders.mdx
+++ b/docs/features/orders.mdx
@@ -33,19 +33,37 @@ An off-session charge is a two-step flow: you create a **draft order**, then **f
 
 `POST /v1/orders/` creates an order in `draft` status with no invoice number — nothing is charged yet. You reference an existing customer and a one-time product, and optionally override the amount and description:
 
-| Field             | Required | Description                                                                                                            |
-| ----------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `customer_id`     | Yes      | The customer to charge. Must belong to the organization.                                                               |
-| `product_id`      | Yes      | A one-time product to charge for. Only fixed-price, free and unit-based products are supported.                        |
-| `units`           | No       | The number of units to charge for. Required for unit-based products, rejected for any other pricing.                   |
-| `amount`          | No       | A custom amount in the smallest currency unit (e.g. `2500` for $25.00). Overrides the product's price; defaults to it. |
-| `currency`        | No       | ISO 4217, lowercase (e.g. `usd`). Defaults to the organization's currency.                                             |
-| `description`     | No       | The line-item text shown on the invoice and receipt. Defaults to the product name.                                     |
-| `organization_id` | No       | Required unless you authenticate with an organization token.                                                           |
+<ParamField body="customer_id" type="string" required>
+  The customer to charge. Must belong to the organization.
+</ParamField>
+
+<ParamField body="product_id" type="string" required>
+  A one-time product to charge for. Only fixed-price, free and unit-based products are supported.
+</ParamField>
+
+<ParamField body="units" type="integer">
+  The number of units to charge for. Required for unit-based products, rejected for any other pricing. There is no customer to pick a quantity, so it has no default.
+
+  The quantity shows on the invoice line, e.g. `Acme Credits (500 credits)`, unless `description` replaces the text.
+</ParamField>
+
+<ParamField body="amount" type="integer">
+  A custom amount in the smallest currency unit (e.g. `2500` for $25.00). Overrides the product's price; defaults to it. Can't be combined with `units`.
+</ParamField>
+
+<ParamField body="currency" type="string">
+  ISO 4217, lowercase (e.g. `usd`). Defaults to the organization's currency.
+</ParamField>
+
+<ParamField body="description" type="string">
+  The line-item text shown on the invoice and receipt. Defaults to the product name.
+</ParamField>
+
+<ParamField body="organization_id" type="string">
+  Required unless you authenticate with an organization token.
+</ParamField>
 
 The customer must have a complete billing address (so Polar can calculate tax) and at least one saved payment method.
-
-For a unit-based product, `units` sets the quantity the amount is computed from. There is no customer to pick one, so it has no default. `amount` still overrides the computed price. The quantity shows on the invoice line, e.g. `Acme Credits (500 credits)`, unless `description` replaces the text.
 
 ```bash cURL
 curl --request POST \

--- a/docs/features/orders.mdx
+++ b/docs/features/orders.mdx
@@ -42,7 +42,7 @@ An off-session charge is a two-step flow: you create a **draft order**, then **f
 </ParamField>
 
 <ParamField body="units" type="integer">
-  The number of units to charge for. Required for unit-based products, rejected for any other pricing. There is no customer to pick a quantity, so it has no default.
+  The number of units to charge for. Required for unit-based products, rejected for any other pricing. 
 
   The quantity shows on the invoice line, e.g. `Acme Credits (500 credits)`, unless `description` replaces the text.
 </ParamField>

--- a/docs/features/orders.mdx
+++ b/docs/features/orders.mdx
@@ -36,13 +36,16 @@ An off-session charge is a two-step flow: you create a **draft order**, then **f
 | Field             | Required | Description                                                                                                            |
 | ----------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `customer_id`     | Yes      | The customer to charge. Must belong to the organization.                                                               |
-| `product_id`      | Yes      | A one-time product to charge for. Only fixed-price and free products are supported.                                    |
+| `product_id`      | Yes      | A one-time product to charge for. Only fixed-price, free and unit-based products are supported.                        |
+| `units`           | No       | The number of units to charge for. Required for unit-based products, rejected for any other pricing.                   |
 | `amount`          | No       | A custom amount in the smallest currency unit (e.g. `2500` for $25.00). Overrides the product's price; defaults to it. |
 | `currency`        | No       | ISO 4217, lowercase (e.g. `usd`). Defaults to the organization's currency.                                             |
 | `description`     | No       | The line-item text shown on the invoice and receipt. Defaults to the product name.                                     |
 | `organization_id` | No       | Required unless you authenticate with an organization token.                                                           |
 
 The customer must have a complete billing address (so Polar can calculate tax) and at least one saved payment method.
+
+For a unit-based product, `units` sets the quantity the amount is computed from. There is no customer to pick one, so it has no default. `amount` still overrides the computed price. The quantity shows on the invoice line, e.g. `Acme Credits (500 credits)`, unless `description` replaces the text.
 
 ```bash cURL
 curl --request POST \

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -112,6 +112,7 @@ from polar.product.price_set import (
 from polar.product.repository import ProductPriceRepository, ProductRepository
 from polar.product.schemas import ProductPriceCreateList
 from polar.product.service import product as product_service
+from polar.product.unit_price import validate_unit_limits
 from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.service import subscription as subscription_service
 from polar.tax.calculation import TaxCode
@@ -528,11 +529,11 @@ class CheckoutService:
                     if min_units is not None
                     else unit_price.get_minimum_purchasable_units()
                 )
-            self._validate_unit_limits(
+            validate_unit_limits(
                 unit_price,
                 checkout_create.units,
-                checkout_min_units=min_units,
-                checkout_max_units=max_units,
+                min_units=min_units,
+                max_units=max_units,
             )
         elif checkout_create.units is not None:
             raise PolarRequestValidationError(
@@ -2249,11 +2250,11 @@ class CheckoutService:
 
         # Handle unit updates for unit-based pricing
         if unit_price is not None and checkout_update.units is not None:
-            self._validate_unit_limits(
+            validate_unit_limits(
                 unit_price,
                 checkout_update.units,
-                checkout_min_units=checkout.min_units,
-                checkout_max_units=checkout.max_units,
+                min_units=checkout.min_units,
+                max_units=checkout.max_units,
             )
             checkout.units = checkout_update.units
             checkout.amount = calculate_upfront_amount(
@@ -2487,7 +2488,7 @@ class CheckoutService:
         units: int | None = None
         if unit_price is not None:
             units = checkout_update.units or unit_price.get_minimum_purchasable_units()
-            self._validate_unit_limits(unit_price, units)
+            validate_unit_limits(unit_price, units)
             checkout.units = units
         checkout.amount = calculate_upfront_amount(
             price_set.get_static_prices(), custom_amount=None, seats=seats, units=units
@@ -2789,57 +2790,6 @@ class CheckoutService:
                         "msg": f"max_seats must be at most {tier_maximum}.",
                         "input": max_seats,
                         "ctx": {"le": tier_maximum},
-                    }
-                ]
-            )
-
-    def _validate_unit_limits(
-        self,
-        price: UnitPrice | None,
-        units: int,
-        loc: tuple[str, ...] = ("body", "units"),
-        *,
-        checkout_min_units: int | None = None,
-        checkout_max_units: int | None = None,
-    ) -> None:
-        """Validate that a unit count is within the min/max bounds for a unit-based price."""
-        if price is None:
-            return
-
-        minimum_units = price.get_minimum_purchasable_units()
-        maximum_units = price.get_maximum_units()
-
-        # Narrow the effective range with checkout-level constraints
-        if checkout_min_units is not None:
-            minimum_units = max(minimum_units, checkout_min_units)
-        if checkout_max_units is not None:
-            if maximum_units is not None:
-                maximum_units = min(maximum_units, checkout_max_units)
-            else:
-                maximum_units = checkout_max_units
-
-        if units < minimum_units:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "greater_than_equal",
-                        "loc": loc,
-                        "msg": f"Minimum {minimum_units} units required.",
-                        "input": units,
-                        "ctx": {"ge": minimum_units},
-                    }
-                ]
-            )
-
-        if maximum_units is not None and units > maximum_units:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "less_than_equal",
-                        "loc": loc,
-                        "msg": f"Maximum {maximum_units} units allowed.",
-                        "input": units,
-                        "ctx": {"le": maximum_units},
                     }
                 ]
             )

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -10,6 +10,7 @@ from pydantic import (
     Field,
     computed_field,
     field_serializer,
+    model_validator,
 )
 from pydantic.json_schema import SkipJsonSchema
 
@@ -329,7 +330,7 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
             "A custom amount to charge, in the smallest currency unit. Overrides "
             "the product's price; defaults to the product's configured price "
             "(0 for free products). A positive amount must be at least the "
-            "currency's minimum."
+            "currency's minimum. Can't be combined with `units`."
         ),
     )
     units: Int32 | None = Field(
@@ -338,7 +339,7 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
         description=(
             "The number of units to charge for. Required when the product has "
             "unit-based pricing, and rejected otherwise. The amount comes from "
-            "the price's tiers, unless `amount` overrides it."
+            "the price's tiers. Can't be combined with `amount`."
         ),
     )
     # `BeforeValidator` runs the strip/empty→None normalization *before* the
@@ -353,6 +354,12 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
             "product name."
         ),
     )
+
+    @model_validator(mode="after")
+    def _validate_amount_and_units(self) -> "OrderCreate":
+        if self.amount is not None and self.units is not None:
+            raise ValueError("amount and units can't be set together")
+        return self
 
 
 class OrderUpdateBase(Schema):

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -25,6 +25,7 @@ from polar.kit.currency import format_currency
 from polar.kit.metadata import MetadataInputMixin, MetadataOutputMixin
 from polar.kit.schemas import (
     IDSchema,
+    Int32,
     MergeJSONSchema,
     Schema,
     TimestampedSchema,
@@ -310,7 +311,7 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
     product_id: UUID4 = Field(
         description="The ID of the one-time product to charge for. "
         "Must belong to the order's organization. "
-        "Only fixed-price and free products are supported."
+        "Only fixed-price, free and unit-based products are supported."
     )
     currency: str | None = Field(
         None,
@@ -329,6 +330,15 @@ class OrderCreate(MetadataInputMixin, CustomFieldDataInputMixin):
             "the product's price; defaults to the product's configured price "
             "(0 for free products). A positive amount must be at least the "
             "currency's minimum."
+        ),
+    )
+    units: Int32 | None = Field(
+        None,
+        ge=1,
+        description=(
+            "The number of units to charge for. Required when the product has "
+            "unit-based pricing, and rejected otherwise. The amount comes from "
+            "the price's tiers, unless `amount` overrides it."
         ),
     )
     # `BeforeValidator` runs the strip/empty→None normalization *before* the

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -103,12 +103,14 @@ from polar.product.guard import (
     is_custom_price,
     is_fixed_price,
     is_static_price,
+    is_unit_price,
 )
 from polar.product.price_set import (
     NoPricesForCurrencies,
     PriceSet,
 )
 from polar.product.repository import ProductRepository
+from polar.product.unit_price import validate_unit_limits
 from polar.receipt.service import receipt as receipt_service
 from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.service import SubscriptionUpdateContext
@@ -712,16 +714,18 @@ class OrderService:
         prices: Iterable[ProductPrice],
         *,
         amount: int | None,
+        units: int | None,
         label: str | None,
     ) -> Sequence[OrderItem]:
         """
         Build line items for an off-session draft order over a product's
-        fixed/free static prices.
+        fixed/free/unit-based static prices.
 
         `amount`, when provided, overrides the charge (the merchant sets a custom
         price for this order); otherwise the price's own amount is used — the
-        configured amount for fixed prices, 0 for free prices. `label` overrides
-        the line item's description, defaulting to the product name.
+        configured amount for fixed prices, the tiered amount for `units` units
+        for unit-based prices, 0 for free prices. `label` overrides the line
+        item's description, defaulting to the product name and its unit count.
         """
         items: list[OrderItem] = []
         for price in prices:
@@ -730,7 +734,11 @@ class OrderService:
             if amount is not None:
                 items.append(
                     OrderItem(
-                        label=label if label is not None else price.product.name,
+                        label=label
+                        if label is not None
+                        else OrderItem.format_price_label(
+                            price.product, price, seats=None, units=units
+                        ),
                         amount=amount,
                         tax_amount=0,
                         net_amount=amount,
@@ -739,7 +747,7 @@ class OrderService:
                     )
                 )
             else:
-                items.append(OrderItem.from_price(price, 0, label=label))
+                items.append(OrderItem.from_price(price, 0, units=units, label=label))
         return items
 
     def _validate_purchase_amount(self, payload: OrderCreate, currency: str) -> None:
@@ -955,25 +963,12 @@ class OrderService:
                     }
                 ]
             )
-        if product.has_unit_based_price:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "product_id"),
-                        "msg": (
-                            "Unit-based products are not supported by the "
-                            "off-session charge API."
-                        ),
-                        "input": payload.product_id,
-                    }
-                ]
-            )
 
-        # Off-session charges only support fixed-price and free products — the
-        # amount is predetermined by the product, or set by the merchant via
-        # `amount`, never chosen by the customer. Pay-what-you-want (custom)
-        # prices are rejected.
+        # Off-session charges only support fixed-price, free and unit-based
+        # products — the amount is predetermined by the product, computed from
+        # the units the merchant declares, or set by the merchant via `amount`,
+        # never chosen by the customer. Pay-what-you-want (custom) prices are
+        # rejected.
         static_prices = [price for price in product.prices if is_static_price(price)]
         if not static_prices:
             raise PolarRequestValidationError(
@@ -986,13 +981,19 @@ class OrderService:
                     }
                 ]
             )
-        if any(not is_fixed_price(price) for price in static_prices):
+        if any(
+            not (is_fixed_price(price) or is_unit_price(price))
+            for price in static_prices
+        ):
             raise PolarRequestValidationError(
                 [
                     {
                         "type": "value_error",
                         "loc": ("body", "product_id"),
-                        "msg": "Off-session charges only support fixed-price products.",
+                        "msg": (
+                            "Off-session charges only support fixed-price and "
+                            "unit-based products."
+                        ),
                         "input": payload.product_id,
                     }
                 ]
@@ -1044,11 +1045,41 @@ class OrderService:
                 ]
             ) from e
 
+        # The unit price comes from the currency-scoped set: tiers and bounds
+        # are configured per currency, so the quantity is validated against the
+        # price actually being charged.
+        unit_price = currency_prices.get_unit_price()
+        if unit_price is not None:
+            if payload.units is None:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "missing",
+                            "loc": ("body", "units"),
+                            "msg": "Units are required for unit-based pricing.",
+                            "input": None,
+                        }
+                    ]
+                )
+            validate_unit_limits(unit_price, payload.units)
+        elif payload.units is not None:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "units"),
+                        "msg": "Units can only be set for unit-based pricing.",
+                        "input": payload.units,
+                    }
+                ]
+            )
+
         self._validate_purchase_amount(payload, currency)
         items = list(
             self._build_draft_order_items(
                 currency_prices,
                 amount=payload.amount,
+                units=payload.units,
                 label=payload.description,
             )
         )
@@ -1138,6 +1169,7 @@ class OrderService:
                 custom_field_data=custom_field_data,
                 items=items,
                 seats=None,
+                units=payload.units,
             ),
             flush=True,
         )

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -723,7 +723,8 @@ class OrderService:
         fixed/free/unit-based static prices.
 
         `amount`, when provided, overrides the charge (the merchant sets a custom
-        price for this order); otherwise the price's own amount is used — the
+        price for this order); it excludes `units`, so it only ever applies to
+        fixed and free prices. Otherwise the price's own amount is used — the
         configured amount for fixed prices, the tiered amount for `units` units
         for unit-based prices, 0 for free prices. `label` overrides the line
         item's description, defaulting to the product name and its unit count.

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -100,6 +100,7 @@ from polar.payment.service import payment as payment_service
 from polar.payment_method.repository import PaymentMethodRepository
 from polar.payment_method.service import payment_method as payment_method_service
 from polar.product.guard import (
+    UnitPrice,
     is_custom_price,
     is_fixed_price,
     is_static_price,
@@ -792,6 +793,51 @@ class OrderService:
                 ]
             )
 
+    def _validate_computed_unit_amount(
+        self, amount: int, currency: str, price: UnitPrice, units: int
+    ) -> None:
+        """
+        A tiered amount must clear the same processor bounds as one the
+        merchant sets.
+        """
+        if amount == 0:
+            return
+        noun = price.get_unit_noun(units)
+        currency_minimum = get_minimum_currency_amount(currency)
+        if amount < currency_minimum:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "units"),
+                        "msg": (
+                            f"Charging {units} {noun} amounts to "
+                            f"{format_currency(amount, currency)}, below the "
+                            f"{format_currency(currency_minimum, currency)} "
+                            "minimum."
+                        ),
+                        "input": units,
+                    }
+                ]
+            )
+        currency_maximum = get_maximum_currency_amount(currency)
+        if amount > currency_maximum:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "units"),
+                        "msg": (
+                            f"Charging {units} {noun} amounts to "
+                            f"{format_currency(amount, currency)}, above the "
+                            f"{format_currency(currency_maximum, currency)} "
+                            "maximum."
+                        ),
+                        "input": units,
+                    }
+                ]
+            )
+
     async def _create_order_from_checkout(
         self,
         session: AsyncSession,
@@ -1094,6 +1140,11 @@ class OrderService:
         )
 
         subtotal_amount = sum(item.amount for item in items)
+        if payload.amount is None and unit_price is not None:
+            assert payload.units is not None
+            self._validate_computed_unit_amount(
+                subtotal_amount, currency, unit_price, payload.units
+            )
         discount_amount = 0
 
         order_id = uuid.uuid4()

--- a/server/polar/product/unit_price.py
+++ b/server/polar/product/unit_price.py
@@ -1,0 +1,58 @@
+from polar.exceptions import PolarRequestValidationError
+
+from .guard import UnitPrice
+
+
+def validate_unit_limits(
+    price: UnitPrice,
+    units: int,
+    loc: tuple[str, ...] = ("body", "units"),
+    *,
+    min_units: int | None = None,
+    max_units: int | None = None,
+) -> None:
+    """Validate a unit quantity against the price's minimum/maximum.
+
+    `min_units`/`max_units` narrow the price's own bounds with caller-level
+    constraints, like the ones a checkout carries. Shared by the checkout and
+    off-session order flows so both enforce identical bounds.
+    """
+    minimum_units = price.get_minimum_purchasable_units()
+    maximum_units = price.get_maximum_units()
+
+    if min_units is not None:
+        minimum_units = max(minimum_units, min_units)
+    if max_units is not None:
+        if maximum_units is not None:
+            maximum_units = min(maximum_units, max_units)
+        else:
+            maximum_units = max_units
+
+    if units < minimum_units:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "greater_than_equal",
+                    "loc": loc,
+                    "msg": f"Minimum {minimum_units} units required.",
+                    "input": units,
+                    "ctx": {"ge": minimum_units},
+                }
+            ]
+        )
+
+    if maximum_units is not None and units > maximum_units:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "type": "less_than_equal",
+                    "loc": loc,
+                    "msg": f"Maximum {maximum_units} units allowed.",
+                    "input": units,
+                    "ctx": {"le": maximum_units},
+                }
+            ]
+        )
+
+
+__all__ = ["validate_unit_limits"]

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -857,6 +857,33 @@ class TestCreateOrder:
         assert body["units"] == 3
         assert body["net_amount"] == 8700
 
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
+    async def test_amount_and_units_rejected(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user_organization: UserOrganization,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_unit_based(
+            save_fixture,
+            organization=off_session_organization,
+            price_per_unit=2900,
+            recurring_interval=None,
+        )
+        response = await client.post(
+            "/v1/orders/",
+            json={
+                "organization_id": str(off_session_organization.id),
+                "customer_id": str(customer.id),
+                "product_id": str(product.id),
+                "units": 3,
+                "amount": 5000,
+            },
+        )
+        assert response.status_code == 422
+
 
 @pytest.mark.asyncio
 class TestFinalizeOrderEndpoint:

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -14,7 +14,7 @@ from polar.models.order import OrderStatus
 from polar.order.service import PaymentFailed, PaymentFailedReason
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_order
+from tests.fixtures.random_objects import create_order, create_product_unit_based
 
 
 @pytest_asyncio.fixture
@@ -827,6 +827,35 @@ class TestCreateOrder:
             },
         )
         assert response.status_code == 422
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_write}))
+    async def test_valid_unit_based(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user_organization: UserOrganization,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_unit_based(
+            save_fixture,
+            organization=off_session_organization,
+            price_per_unit=2900,
+            recurring_interval=None,
+        )
+        response = await client.post(
+            "/v1/orders/",
+            json={
+                "organization_id": str(off_session_organization.id),
+                "customer_id": str(customer.id),
+                "product_id": str(product.id),
+                "units": 3,
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["units"] == 3
+        assert body["net_amount"] == 8700
 
 
 @pytest.mark.asyncio

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -7124,6 +7124,29 @@ class TestCreateDraftOrder:
         assert order.subtotal_amount == 5000
         assert order.items[0].label == "Product (3 units)"
 
+    async def test_computed_unit_amount_below_currency_minimum_rejected(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_unit_based(
+            save_fixture,
+            organization=off_session_organization,
+            price_per_unit=1,
+            recurring_interval=None,
+        )
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product.id,
+            units=1,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
 
 @pytest.mark.asyncio
 class TestFinalizeOrder:

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -97,6 +97,7 @@ from polar.order.service import (
 from polar.order.service import order as order_service
 from polar.product.guard import is_fixed_price, is_seat_price, is_static_price
 from polar.product.price_set import PriceSet
+from polar.product.tiers import Tiers, TierType
 from polar.subscription.service import SubscriptionService
 from polar.tax.calculation import (
     CalculationExpiredError,
@@ -6980,6 +6981,148 @@ class TestCreateDraftOrder:
             await order_service.create_draft_order(
                 session, off_session_organization, payload
             )
+
+    async def test_unit_based_product_requires_units(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_unit_based(
+            save_fixture,
+            organization=off_session_organization,
+            recurring_interval=None,
+        )
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product.id,
+            amount=5000,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+    async def test_units_on_non_unit_product_rejected(
+        self,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product_one_time.id,
+            units=3,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+    async def test_unit_based_product_priced_from_units(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_unit_based(
+            save_fixture,
+            organization=off_session_organization,
+            price_per_unit=2900,
+            recurring_interval=None,
+        )
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product.id,
+            units=3,
+        )
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+        assert order.units == 3
+        assert order.subtotal_amount == 8700
+        assert order.items[0].amount == 8700
+        assert order.items[0].label == "Product (3 units)"
+
+    async def test_units_below_minimum_rejected(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_unit_based(
+            save_fixture,
+            organization=off_session_organization,
+            minimum_units=5,
+            recurring_interval=None,
+        )
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product.id,
+            units=4,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+    async def test_units_above_maximum_rejected(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_unit_based(
+            save_fixture,
+            organization=off_session_organization,
+            tiers=Tiers.model_validate(
+                {
+                    "type": TierType.volume,
+                    "tiers": [{"bound": 100, "unit_amount": "2900"}],
+                }
+            ),
+            recurring_interval=None,
+        )
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product.id,
+            units=101,
+        )
+        with pytest.raises(PolarRequestValidationError):
+            await order_service.create_draft_order(
+                session, off_session_organization, payload
+            )
+
+    async def test_amount_overrides_unit_price(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        off_session_organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product_unit_based(
+            save_fixture,
+            organization=off_session_organization,
+            price_per_unit=2900,
+            recurring_interval=None,
+        )
+        payload = OrderCreate(
+            customer_id=customer.id,
+            product_id=product.id,
+            units=3,
+            amount=5000,
+        )
+        order = await order_service.create_draft_order(
+            session, off_session_organization, payload
+        )
+        assert order.units == 3
+        assert order.subtotal_amount == 5000
+        assert order.items[0].label == "Product (3 units)"
 
 
 @pytest.mark.asyncio

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -7098,32 +7098,6 @@ class TestCreateDraftOrder:
                 session, off_session_organization, payload
             )
 
-    async def test_amount_overrides_unit_price(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        off_session_organization: Organization,
-        customer: Customer,
-    ) -> None:
-        product = await create_product_unit_based(
-            save_fixture,
-            organization=off_session_organization,
-            price_per_unit=2900,
-            recurring_interval=None,
-        )
-        payload = OrderCreate(
-            customer_id=customer.id,
-            product_id=product.id,
-            units=3,
-            amount=5000,
-        )
-        order = await order_service.create_draft_order(
-            session, off_session_organization, payload
-        )
-        assert order.units == 3
-        assert order.subtotal_amount == 5000
-        assert order.items[0].label == "Product (3 units)"
-
     async def test_computed_unit_amount_below_currency_minimum_rejected(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
## Summary

Allow unit based pricing on off-session charges and update related documentation.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

