### PR TITLE
Show custom meter multiplier in the rate label

### DIFF
--- a/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredChargesDetails.test.tsx
@@ -180,6 +180,43 @@ describe('MeteredChargesDetails', () => {
     expect(row).toHaveTextContent('/ 1M tokens')
   })
 
+  it('surfaces the custom multiplier in the rate label so it reconciles with the included count', () => {
+    const base = createCheckout()
+    const meteredPrice = createMeteredPrice({
+      id: 'price_metered_1',
+      unit_amount: '0.5',
+      meter: {
+        id: 'meter_1',
+        name: 'API Calls',
+        unit: 'custom' as const,
+        custom_label: 'request',
+        custom_multiplier: 1000,
+      },
+    })
+    const checkout = createCheckout({
+      prices: {
+        prod_1: [base.product_price, meteredPrice],
+      },
+      product: {
+        ...base.product,
+        benefits: [createMeterCreditBenefit('meter_1', 10_000)],
+      },
+    })
+
+    render(<MeteredChargesDetails checkout={checkout} locale="en" />)
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /additional metered charges may apply/i,
+      }),
+    )
+
+    const row = screen.getByTestId('detail-row-API Calls')
+    expect(row).toHaveTextContent('10,000 request included')
+    expect(row).toHaveTextContent('$5.00')
+    expect(row).toHaveTextContent('/ 1,000 request')
+  })
+
   it('sums units across multiple credit benefits on the same meter', () => {
     render(
       <MeteredChargesDetails

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.test.tsx
@@ -151,7 +151,7 @@ describe('MeteredPriceLabel', () => {
       )
 
       expect(container.textContent).toContain('$5')
-      expect(container.textContent).toContain('/ request')
+      expect(container.textContent).toContain('/ 1,000 request')
     })
 
     it('falls back to "unit" label when custom_label is null', () => {
@@ -170,7 +170,7 @@ describe('MeteredPriceLabel', () => {
         <MeteredPriceLabel price={price} locale="en" />,
       )
 
-      expect(container.textContent).toContain('/ unit')
+      expect(container.textContent).toContain('/ 100 unit')
     })
   })
 

--- a/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
+++ b/clients/packages/checkout/src/components/MeteredPriceLabel.tsx
@@ -19,6 +19,7 @@ const MeteredPriceLabel: React.FC<MeteredPriceLabelProps> = ({
   const { scale, label } = getMeterUnitFormat(price.meter.unit ?? 'scalar', {
     customLabel: price.meter.custom_label,
     customMultiplier: price.meter.custom_multiplier,
+    locale,
   })
 
   return (

--- a/clients/packages/checkout/src/components/MeteredTierRows.tsx
+++ b/clients/packages/checkout/src/components/MeteredTierRows.tsx
@@ -33,6 +33,7 @@ const MeteredTierRows: React.FC<MeteredTierRowsProps> = ({
   const { scale, label } = getMeterUnitFormat(price.meter.unit ?? 'scalar', {
     customLabel: price.meter.custom_label,
     customMultiplier: price.meter.custom_multiplier,
+    locale,
   })
   const formatUnits = new Intl.NumberFormat(locale)
 

--- a/clients/packages/checkout/src/utils/meterUnit.test.ts
+++ b/clients/packages/checkout/src/utils/meterUnit.test.ts
@@ -49,12 +49,29 @@ describe('getMeterUnitFormat', () => {
       expect(scale).toBe(1000)
     })
 
-    it('returns customLabel as label', () => {
+    it('prefixes the label with the multiplier so the rate reads per N units', () => {
       const { label } = getMeterUnitFormat('custom', {
         customLabel: 'request',
         customMultiplier: 1000,
       })
-      expect(label).toBe('request')
+      expect(label).toBe('1,000 request')
+    })
+
+    it('formats the multiplier for the given locale', () => {
+      const { label } = getMeterUnitFormat('custom', {
+        customLabel: 'request',
+        customMultiplier: 1000,
+        locale: 'de-DE',
+      })
+      expect(label).toBe('1.000 request')
+    })
+
+    it('returns the bare label when the multiplier is 1', () => {
+      const { label } = getMeterUnitFormat('custom', {
+        customLabel: 'gigabyte',
+        customMultiplier: 1,
+      })
+      expect(label).toBe('gigabyte')
     })
 
     it('scales $5/1000 requests correctly', () => {
@@ -86,7 +103,7 @@ describe('getMeterUnitFormat', () => {
         customLabel: null,
         customMultiplier: 1000,
       })
-      expect(label).toBe('unit')
+      expect(label).toBe('1,000 unit')
     })
   })
 

--- a/clients/packages/ui/src/lib/meterUnit.ts
+++ b/clients/packages/ui/src/lib/meterUnit.ts
@@ -21,6 +21,8 @@ const UNIT_FORMATS: Record<Exclude<MeterUnit, 'custom'>, MeterUnitFormat> = {
  *
  * For custom units, pass `customLabel` and `customMultiplier` to override the
  * defaults. Without them, custom units fall back to scalar (scale=1, label="unit").
+ * When the multiplier is above 1 it is included in the label so the displayed
+ * rate reads as a price per `customMultiplier` base units.
  *
  * @example
  * // Token: $10 / 1M tokens
@@ -28,18 +30,27 @@ const UNIT_FORMATS: Record<Exclude<MeterUnit, 'custom'>, MeterUnitFormat> = {
  * const displayAmount = unitAmountCents * scale  // 0.001 * 1_000_000 = 1000 cents = $10
  *
  * @example
- * // Custom: $5 / 1000 requests
+ * // Custom: $5 / 1,000 requests
  * const { scale, label } = getMeterUnitFormat('custom', { customLabel: 'requests', customMultiplier: 1000 })
  * const displayAmount = unitAmountCents * scale  // 0.5 * 1000 = 500 cents = $5
  */
 export function getMeterUnitFormat(
   unit: MeterUnit,
-  options?: { customLabel?: string | null; customMultiplier?: number | null },
+  options?: {
+    customLabel?: string | null
+    customMultiplier?: number | null
+    locale?: string
+  },
 ): MeterUnitFormat {
   if (unit === 'custom') {
+    const scale = options?.customMultiplier ?? 1
+    const label = options?.customLabel ?? 'unit'
     return {
-      scale: options?.customMultiplier ?? 1,
-      label: options?.customLabel ?? 'unit',
+      scale,
+      label:
+        scale > 1
+          ? `${new Intl.NumberFormat(options?.locale ?? 'en-US').format(scale)} ${label}`
+          : label,
     }
   }
   return UNIT_FORMATS[unit] ?? UNIT_FORMATS.scalar


### PR DESCRIPTION
## Summary

Custom meters with a multiplier rendered the scaled rate under the bare unit noun (`$5.00 / request" for $5 per 1,000`). The label now properly shows the multiplier (`$5.00 / 1,000 request`).

Fixes: https://github.com/polarsource/feedback/issues/428

## Screenshots

| Before | After  |
|--------|--------|
| <img width="492" height="498" alt="mp-before" src="https://github.com/user-attachments/assets/58593de3-8cc7-472e-abeb-f8734df5d753" /> | <img width="492" height="498" alt="mp-after" src="https://github.com/user-attachments/assets/42140b81-c5a1-45bb-88e7-1a0377af71d4" /> |









<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

