### PR TITLE
Add RFC 9207 issuer identification

### DIFF
--- a/server/polar/oauth2/authorization_server.py
+++ b/server/polar/oauth2/authorization_server.py
@@ -10,6 +10,7 @@ from authlib.oauth2 import OAuth2Error
 from authlib.oauth2.rfc6749.errors import (
     UnsupportedResponseTypeError,
 )
+from authlib.oauth2.rfc6749.hooks import hooked
 from authlib.oauth2.rfc6750 import BearerTokenGenerator
 from authlib.oauth2.rfc7009 import RevocationEndpoint as _RevocationEndpoint
 from authlib.oauth2.rfc7591 import (
@@ -19,6 +20,7 @@ from authlib.oauth2.rfc7592 import (
     ClientConfigurationEndpoint as _ClientConfigurationEndpoint,
 )
 from authlib.oauth2.rfc7662 import IntrospectionEndpoint as _IntrospectionEndpoint
+from authlib.oauth2.rfc9207 import IssuerParameter as _IssuerParameter
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 from starlette.requests import Request
@@ -46,6 +48,21 @@ from .requests import StarletteJsonRequest, StarletteOAuth2Request
 from .service.oauth2_grant import oauth2_grant as oauth2_grant_service
 
 logger: Logger = structlog.get_logger(__name__)
+
+
+class OAuth2Response(Response):
+    @property
+    def location(self) -> str | None:
+        return self.headers.get("Location")
+
+    @location.setter
+    def location(self, value: str) -> None:
+        self.headers["Location"] = value
+
+
+class IssuerParameter(_IssuerParameter):
+    def get_issuer(self) -> str:
+        return ISSUER
 
 
 def _get_server_metadata(server: "AuthorizationServer") -> dict[str, typing.Any]:
@@ -307,6 +324,7 @@ class AuthorizationServer(_AuthorizationServer):
         self._error_uris = dict(error_uris) if error_uris is not None else None
 
         self.register_token_generator("default", self.create_bearer_token_generator())
+        self.register_extension(IssuerParameter())
 
     @classmethod
     def build(
@@ -394,7 +412,7 @@ class AuthorizationServer(_AuthorizationServer):
     ) -> Response:
         if isinstance(payload, dict):
             payload = json.dumps(payload)
-        return Response(payload, status_code, {k: v for k, v in headers})
+        return OAuth2Response(payload, status_code, {k: v for k, v in headers})
 
     def create_bearer_token_generator(self) -> BearerTokenGenerator:
         def _access_token_generator(
@@ -411,6 +429,7 @@ class AuthorizationServer(_AuthorizationServer):
 
         return BearerTokenGenerator(_access_token_generator, _refresh_token_generator)
 
+    @hooked
     def create_authorization_response(
         self,
         request: Request,

--- a/server/polar/oauth2/metadata.py
+++ b/server/polar/oauth2/metadata.py
@@ -42,6 +42,7 @@ class OAuth2AuthorizationServerMetadata(BaseModel):
     introspection_endpoint_auth_methods_supported: list[str] | None = None
     introspection_endpoint_auth_signing_alg_values_supported: list[str] | None = None
     code_challenge_methods_supported: list[str] | None = None
+    authorization_response_iss_parameter_supported: bool | None = None
 
 
 class OpenIDProviderMetadata(OAuth2AuthorizationServerMetadata):
@@ -95,6 +96,7 @@ def get_server_metadata(
         introspection_endpoint=url_for("oauth2:introspect_token"),
         introspection_endpoint_auth_methods_supported=authorization_server.introspection_endpoint_auth_methods_supported,
         code_challenge_methods_supported=authorization_server.code_challenge_methods_supported,
+        authorization_response_iss_parameter_supported=True,
         subject_types_supported=constants.SUBJECT_TYPES_SUPPORTED,
         id_token_signing_alg_values_supported=constants.ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED,
         claims_supported=constants.CLAIMS_SUPPORTED,

--- a/server/tests/oauth2/endpoints/test_oauth2.py
+++ b/server/tests/oauth2/endpoints/test_oauth2.py
@@ -596,6 +596,7 @@ class TestOAuth2Authorize:
         location = response.headers["location"]
         assert location.startswith(params["redirect_uri"])
         assert "code=" in location
+        assert parse_qs(urlparse(location).query)["iss"] == [settings.BASE_URL]
 
     @pytest.mark.auth
     async def test_new_scope(
@@ -796,6 +797,7 @@ class TestOAuth2Consent:
         assert response.status_code == 302
         location = response.headers["location"]
         assert "error=access_denied" in location
+        assert parse_qs(urlparse(location).query)["iss"] == [settings.BASE_URL]
 
     @pytest.mark.auth
     async def test_allow(

--- a/server/tests/oauth2/endpoints/test_well_known.py
+++ b/server/tests/oauth2/endpoints/test_well_known.py
@@ -25,3 +25,4 @@ async def test_openid_configuration(client: AsyncClient) -> None:
     assert len(json["revocation_endpoint_auth_methods_supported"]) > 0
     assert len(json["introspection_endpoint_auth_methods_supported"]) > 0
     assert len(json["code_challenge_methods_supported"]) > 0
+    assert json["authorization_response_iss_parameter_supported"] is True


### PR DESCRIPTION
## Summary

Adds RFC 9207 authorization server issuer identification for OAuth clients (Codex, specifically).

## What

- Advertise `authorization_response_iss_parameter_supported` in OAuth discovery metadata
- Register Authlib’s RFC 9207 `IssuerParameter` extension
- Include the canonical issuer in successful and error authorization redirects
- Cover discovery, authorization success, and authorization denial in tests

## Why

Codex rejects OAuth metadata whose authorization endpoint uses a different origin from the advertised issuer unless issuer-bound callbacks are supported. Polar serves authorization on the web origin and token exchange on the API origin.

## How

The OAuth server registers Authlib’s RFC 9207 extension with Polar’s canonical API issuer. A small Starlette response adapter exposes the location property expected by Authlib.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass
- [x] No unrelated changes or drive-by fixes are included
