### PR TITLE
Add RFC 8414 metadata alias

### DIFF
--- a/server/polar/oauth2/endpoints/well_known.py
+++ b/server/polar/oauth2/endpoints/well_known.py
@@ -17,6 +17,7 @@ async def well_known_jwks() -> dict[str, Any]:
     return settings.JWKS.as_dict(is_private=False)
 
 
+@router.get("/oauth-authorization-server", name="well_known.oauth_authorization_server")
 @router.get("/openid-configuration", name="well_known.openid_configuration")
 async def well_known_openid_configuration(
     request: Request,

--- a/server/tests/oauth2/endpoints/test_well_known.py
+++ b/server/tests/oauth2/endpoints/test_well_known.py
@@ -16,8 +16,15 @@ async def test_jwks(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_openid_configuration(client: AsyncClient) -> None:
-    response = await client.get("/.well-known/openid-configuration")
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/.well-known/openid-configuration",
+        "/.well-known/oauth-authorization-server",
+    ],
+)
+async def test_authorization_server_metadata(client: AsyncClient, path: str) -> None:
+    response = await client.get(path)
 
     assert response.status_code == 200
 


### PR DESCRIPTION
Feel free to kill this, but since I'm having trouble with auto-discovery, I thought this alias could help as well, but I'm not sure if it'll actually make a difference.

From the RFC:

> By default, the well-known URI string used is "/.well-known/oauth-authorization-server"

> The same authorization server MAY choose to publish its metadata at multiple well-known locations derived from its issuer identifier, for example, publishing metadata at both "/.well-known/example-configuration" and "/.well-known/oauth-authorization-server".



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

