### PR TITLE
feat(sdk): support per-request access token overrides

### DIFF
--- a/sdk/generator/python/template/README.md
+++ b/sdk/generator/python/template/README.md
@@ -112,6 +112,15 @@ customer_state = polar.customers.get_state_external(
 )
 ```
 
+Override the access token for an individual request with `request_access_token`:
+
+```python
+customer_state = polar.customers.get_state_external(
+    "customer_external_id",
+    request_access_token="polar_at_u_override",
+)
+```
+
 Pass an `httpx.Timeout` instance to configure connect, read, write, and pool timeouts separately.
 
 ## Deserializing Data

--- a/sdk/generator/python/template/polar/base.py
+++ b/sdk/generator/python/template/polar/base.py
@@ -81,6 +81,7 @@ class BuildRequestMixin:
         query_params: dict[str, typing.Any] | None = None,
         body: typing.Any | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> httpx.Request:
         url = url.format(**(path_params or {}))
 
@@ -95,8 +96,11 @@ class BuildRequestMixin:
                 params[k] = v
 
         timeout = self._client.timeout if request_timeout is None else request_timeout
+        headers: dict[str, str] | None = None
+        if request_access_token is not None:
+            headers = {"Authorization": f"Bearer {request_access_token}"}
         return self._client.build_request(
-            method, url, params=params, json=body, timeout=timeout
+            method, url, params=params, json=body, timeout=timeout, headers=headers
         )
 
 

--- a/sdk/generator/python/template/polar/version/services/service.py
+++ b/sdk/generator/python/template/polar/version/services/service.py
@@ -82,6 +82,7 @@ class {{ service.name }}Sync(SyncServiceBase):
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> {{ method.response | type_annotation }}: ...
 
@@ -108,6 +109,7 @@ class {{ service.name }}Sync(SyncServiceBase):
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> {{ method.response | type_annotation }}: ...
 
@@ -132,6 +134,7 @@ class {{ service.name }}Sync(SyncServiceBase):
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         {% if method.body and (method.body.kind == 'union' or method.body.kind == 'union_ref') %}
         **kwargs: typing.Any,
         {% elif method.body %}
@@ -159,6 +162,7 @@ Args:
 
 {% endfor %}
     request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+    request_access_token: Access token override for this request.
 
 {% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}
@@ -179,6 +183,7 @@ Raises:
             path_params={ {% for param in method.path_params %}"{{ param.name }}": {{ param.parameter_name }}, {% endfor %} },
             query_params={ {% for param in method.query_params %}"{{ param.name }}": {{ param.parameter_name }}, {% endfor %} },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             {% if method.body %}
             body=kwargs,
             {% endif %}
@@ -221,6 +226,7 @@ Raises:
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> typing.Generator[{{ method.pagination.item_schema | type_annotation }}, None, None]: ...
 
@@ -247,6 +253,7 @@ Raises:
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> typing.Generator[{{ method.pagination.item_schema | type_annotation }}, None, None]: ...
 
@@ -271,6 +278,7 @@ Raises:
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         {% if method.body and (method.body.kind == 'union' or method.body.kind == 'union_ref') %}
         **kwargs: typing.Any,
         {% elif method.body %}
@@ -292,6 +300,7 @@ Args:
 
 {% endfor %}
     request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+    request_access_token: Access token override for each request.
 
 {% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}
@@ -318,6 +327,7 @@ Raises:
                 {{ param.parameter_name }}={{ param.parameter_name }},
                 {% endfor %}
                 request_timeout=request_timeout,
+                request_access_token=request_access_token,
                 {% if method.body %}
                 **kwargs,
                 {% endif %}
@@ -363,6 +373,7 @@ class {{ service.name }}Async(AsyncServiceBase):
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> {{ method.response | type_annotation }}: ...
 
@@ -389,6 +400,7 @@ class {{ service.name }}Async(AsyncServiceBase):
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> {{ method.response | type_annotation }}: ...
 
@@ -413,6 +425,7 @@ class {{ service.name }}Async(AsyncServiceBase):
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         {% if method.body and (method.body.kind == 'union' or method.body.kind == 'union_ref') %}
         **kwargs: typing.Any,
         {% elif method.body %}
@@ -440,6 +453,7 @@ Args:
 
 {% endfor %}
     request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+    request_access_token: Access token override for this request.
 
 {% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}
@@ -460,6 +474,7 @@ Raises:
             path_params={ {% for param in method.path_params %}"{{ param.name }}": {{ param.parameter_name }}, {% endfor %} },
             query_params={ {% for param in method.query_params %}"{{ param.name }}": {{ param.parameter_name }}, {% endfor %} },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             {% if method.body %}
             body=kwargs,
             {% endif %}
@@ -502,6 +517,7 @@ Raises:
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> typing.AsyncGenerator[{{ method.pagination.item_schema | type_annotation }}, None]: ...
 
@@ -528,6 +544,7 @@ Raises:
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[{{ variant.name }}],
     ) -> typing.AsyncGenerator[{{ method.pagination.item_schema | type_annotation }}, None]: ...
 
@@ -552,6 +569,7 @@ Raises:
         {% endif %}
         {% endfor %}
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         {% if method.body and (method.body.kind == 'union' or method.body.kind == 'union_ref') %}
         **kwargs: typing.Any,
         {% elif method.body %}
@@ -570,6 +588,7 @@ Raises:
     {{ param.parameter_name }}:{% if param.description %} {{ param.description }}{% endif %}
 
 {% endfor %}    request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+    request_access_token: Access token override for each request.
 
 {% if method.body %}
     **kwargs: {% if method.body.description %}{{ method.body.description }}{% else %}Request body parameters{% endif %}
@@ -596,6 +615,7 @@ Raises:
                 {{ param.parameter_name }}={{ param.parameter_name }},
                 {% endfor %}
                 request_timeout=request_timeout,
+                request_access_token=request_access_token,
                 {% if method.body %}
                 **kwargs,
                 {% endif %}

--- a/sdk/generator/python/template/tests/test_base.py
+++ b/sdk/generator/python/template/tests/test_base.py
@@ -97,6 +97,17 @@ class TestBuildRequest:
             "pool": 30.0,
         }
 
+    def test_request_access_token_override(
+        self, client: SyncClientBase | AsyncClientBase
+    ) -> None:
+        request = client.build_request(
+            method="GET",
+            url="/v1/items/",
+            request_access_token="polar_at_u_override",
+        )
+
+        assert request.headers["Authorization"] == "Bearer polar_at_u_override"
+
     @pytest.mark.parametrize("client_class", [SyncClientBase, AsyncClientBase])
     def test_advanced_client_timeout(
         self,

--- a/sdk/generator/typescript/template/README.md
+++ b/sdk/generator/typescript/template/README.md
@@ -58,6 +58,14 @@ const customerState = await polar.customers.getStateExternal("customer_external_
 });
 ```
 
+Override the access token for an individual request the same way:
+
+```typescript
+const customerState = await polar.customers.getStateExternal("customer_external_id", {
+  accessToken: "polar_at_u_override",
+});
+```
+
 ## Individual API Functions
 
 To import individual API functions for tree-shaking, create a core client and pass it to the

--- a/sdk/generator/typescript/template/src/base.test.ts
+++ b/sdk/generator/typescript/template/src/base.test.ts
@@ -114,6 +114,26 @@ describe("sendRequest", () => {
     },
   );
 
+  test("uses a per-request access token override", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+    const client = new ClientBase({
+      baseUrl: "https://api.polar.sh",
+      version: "2026-04",
+      accessToken: "polar_at_u_xxx",
+    });
+    const headers = new Headers({
+      Authorization: "Bearer polar_at_u_xxx",
+    });
+
+    await client.sendRequest(
+      ["https://api.polar.sh/v1/items/", { headers }],
+      { accessToken: "polar_at_u_override" },
+    );
+
+    const requestHeaders = fetch.mock.calls[0][1]?.headers as Headers;
+    expect(requestHeaders.get("Authorization")).toBe("Bearer polar_at_u_override");
+  });
+
   test("does not create a timeout signal when no timeout is configured", async () => {
     const client = new ClientBase({
       baseUrl: "https://api.polar.sh",

--- a/sdk/generator/typescript/template/src/base.ts
+++ b/sdk/generator/typescript/template/src/base.ts
@@ -114,6 +114,8 @@ export interface ClientOptions {
 export interface RequestOptions {
   /** Request timeout override, in seconds. */
   timeout?: number;
+  /** Access token override for this request. */
+  accessToken?: string;
 }
 
 const MAX_ABORT_SIGNAL_TIMEOUT_MS = 2_147_483_647;
@@ -178,6 +180,11 @@ export class ClientBase {
   ): Promise<Response> {
     const [fullUrl, requestInit] = request;
     const timeout = requestOptions?.timeout ?? this.options.timeout;
+    let headers = requestInit.headers;
+    if (requestOptions?.accessToken !== undefined) {
+      headers = new Headers(headers);
+      headers.set("Authorization", `Bearer ${requestOptions.accessToken}`);
+    }
     let signal = requestInit.signal;
     if (timeout !== undefined) {
       const timeoutMilliseconds = Math.ceil(timeout * 1000);
@@ -198,6 +205,7 @@ export class ClientBase {
     try {
       return await fetch(fullUrl, {
         ...requestInit,
+        headers,
         ...(signal ? { signal } : {}),
       });
     } catch (error) {

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -110,6 +110,15 @@ customer_state = polar.customers.get_state_external(
 )
 ```
 
+Override the access token for an individual request with `request_access_token`:
+
+```python
+customer_state = polar.customers.get_state_external(
+    "customer_external_id",
+    request_access_token="polar_at_u_override",
+)
+```
+
 Pass an `httpx.Timeout` instance to configure connect, read, write, and pool timeouts separately.
 
 ## Deserializing Data

--- a/sdk/python/polar/base.py
+++ b/sdk/python/polar/base.py
@@ -83,6 +83,7 @@ class BuildRequestMixin:
         query_params: dict[str, typing.Any] | None = None,
         body: typing.Any | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> httpx.Request:
         url = url.format(**(path_params or {}))
 
@@ -97,8 +98,11 @@ class BuildRequestMixin:
                 params[k] = v
 
         timeout = self._client.timeout if request_timeout is None else request_timeout
+        headers: dict[str, str] | None = None
+        if request_access_token is not None:
+            headers = {"Authorization": f"Bearer {request_access_token}"}
         return self._client.build_request(
-            method, url, params=params, json=body, timeout=timeout
+            method, url, params=params, json=body, timeout=timeout, headers=headers
         )
 
 

--- a/sdk/python/polar/v2026_04/services/benefit_grants.py
+++ b/sdk/python/polar/v2026_04/services/benefit_grants.py
@@ -33,6 +33,7 @@ class BenefitGrantsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[BenefitGrantSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitGrant:
         """
         List benefit grants across all benefits accessible to the authenticated subject.
@@ -48,6 +49,8 @@ class BenefitGrantsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -70,6 +73,7 @@ class BenefitGrantsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -88,6 +92,7 @@ class BenefitGrantsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[BenefitGrantSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[BenefitGrant, None, None]:
         """
         List benefit grants across all benefits accessible to the authenticated subject.
@@ -103,6 +108,8 @@ class BenefitGrantsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -124,6 +131,7 @@ class BenefitGrantsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -143,6 +151,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[BenefitGrantSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitGrant:
         """
         List benefit grants across all benefits accessible to the authenticated subject.
@@ -158,6 +167,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -180,6 +191,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -198,6 +210,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[BenefitGrantSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[BenefitGrant, None]:
         """
         List benefit grants across all benefits accessible to the authenticated subject.
@@ -213,6 +226,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -234,6 +249,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item

--- a/sdk/python/polar/v2026_04/services/benefits.py
+++ b/sdk/python/polar/v2026_04/services/benefits.py
@@ -62,6 +62,7 @@ class BenefitsSync(SyncServiceBase):
         sorting: builtins.list[BenefitSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefit:
         """
         List benefits.
@@ -79,6 +80,8 @@ class BenefitsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -103,6 +106,7 @@ class BenefitsSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -123,6 +127,7 @@ class BenefitsSync(SyncServiceBase):
         sorting: builtins.list[BenefitSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Benefit, None, None]:
         """
         List benefits.
@@ -140,6 +145,8 @@ class BenefitsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -163,6 +170,7 @@ class BenefitsSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -174,6 +182,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitCustomCreate],
     ) -> Benefit: ...
 
@@ -182,6 +191,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDiscordCreate],
     ) -> Benefit: ...
 
@@ -190,6 +200,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitGitHubRepositoryCreate],
     ) -> Benefit: ...
 
@@ -198,6 +209,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDownloadablesCreate],
     ) -> Benefit: ...
 
@@ -206,6 +218,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitLicenseKeysCreate],
     ) -> Benefit: ...
 
@@ -214,6 +227,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitMeterCreditCreate],
     ) -> Benefit: ...
 
@@ -222,6 +236,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitFeatureFlagCreate],
     ) -> Benefit: ...
 
@@ -230,6 +245,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitSlackSharedChannelCreate],
     ) -> Benefit: ...
 
@@ -237,6 +253,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Benefit:
         """
@@ -246,6 +263,8 @@ class BenefitsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -261,6 +280,7 @@ class BenefitsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -274,6 +294,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Benefit:
         """
         Get a benefit by ID.
@@ -283,6 +304,8 @@ class BenefitsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -300,6 +323,7 @@ class BenefitsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -313,6 +337,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a benefit.
@@ -326,6 +351,8 @@ class BenefitsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -344,6 +371,7 @@ class BenefitsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -359,6 +387,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitCustomUpdate],
     ) -> Benefit: ...
 
@@ -368,6 +397,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDiscordUpdate],
     ) -> Benefit: ...
 
@@ -377,6 +407,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitGitHubRepositoryUpdate],
     ) -> Benefit: ...
 
@@ -386,6 +417,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDownloadablesUpdate],
     ) -> Benefit: ...
 
@@ -395,6 +427,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitLicenseKeysUpdate],
     ) -> Benefit: ...
 
@@ -404,6 +437,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitMeterCreditUpdate],
     ) -> Benefit: ...
 
@@ -413,6 +447,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitFeatureFlagUpdate],
     ) -> Benefit: ...
 
@@ -422,6 +457,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitSlackSharedChannelUpdate],
     ) -> Benefit: ...
 
@@ -430,6 +466,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Benefit:
         """
@@ -440,6 +477,8 @@ class BenefitsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -458,6 +497,7 @@ class BenefitsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -474,6 +514,7 @@ class BenefitsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitDownloadableFile:
         """
         List the downloadable files for a benefit with their download statistics.
@@ -485,6 +526,8 @@ class BenefitsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -505,6 +548,7 @@ class BenefitsSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -522,6 +566,7 @@ class BenefitsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[BenefitDownloadableFile, None, None]:
         """
         List the downloadable files for a benefit with their download statistics.
@@ -533,6 +578,8 @@ class BenefitsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -551,6 +598,7 @@ class BenefitsSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -567,6 +615,7 @@ class BenefitsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitGrant:
         """
         List the individual grants for a benefit.
@@ -583,6 +632,8 @@ class BenefitsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -606,6 +657,7 @@ class BenefitsSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -624,6 +676,7 @@ class BenefitsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[BenefitGrant, None, None]:
         """
         List the individual grants for a benefit.
@@ -640,6 +693,8 @@ class BenefitsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -661,6 +716,7 @@ class BenefitsSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -682,6 +738,7 @@ class BenefitsAsync(AsyncServiceBase):
         sorting: builtins.list[BenefitSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefit:
         """
         List benefits.
@@ -699,6 +756,8 @@ class BenefitsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -723,6 +782,7 @@ class BenefitsAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -743,6 +803,7 @@ class BenefitsAsync(AsyncServiceBase):
         sorting: builtins.list[BenefitSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Benefit, None]:
         """
         List benefits.
@@ -760,6 +821,8 @@ class BenefitsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -783,6 +846,7 @@ class BenefitsAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -795,6 +859,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitCustomCreate],
     ) -> Benefit: ...
 
@@ -803,6 +868,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDiscordCreate],
     ) -> Benefit: ...
 
@@ -811,6 +877,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitGitHubRepositoryCreate],
     ) -> Benefit: ...
 
@@ -819,6 +886,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDownloadablesCreate],
     ) -> Benefit: ...
 
@@ -827,6 +895,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitLicenseKeysCreate],
     ) -> Benefit: ...
 
@@ -835,6 +904,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitMeterCreditCreate],
     ) -> Benefit: ...
 
@@ -843,6 +913,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitFeatureFlagCreate],
     ) -> Benefit: ...
 
@@ -851,6 +922,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitSlackSharedChannelCreate],
     ) -> Benefit: ...
 
@@ -858,6 +930,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Benefit:
         """
@@ -867,6 +940,8 @@ class BenefitsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -882,6 +957,7 @@ class BenefitsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -895,6 +971,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Benefit:
         """
         Get a benefit by ID.
@@ -904,6 +981,8 @@ class BenefitsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -921,6 +1000,7 @@ class BenefitsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -934,6 +1014,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a benefit.
@@ -947,6 +1028,8 @@ class BenefitsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -965,6 +1048,7 @@ class BenefitsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -980,6 +1064,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitCustomUpdate],
     ) -> Benefit: ...
 
@@ -989,6 +1074,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDiscordUpdate],
     ) -> Benefit: ...
 
@@ -998,6 +1084,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitGitHubRepositoryUpdate],
     ) -> Benefit: ...
 
@@ -1007,6 +1094,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDownloadablesUpdate],
     ) -> Benefit: ...
 
@@ -1016,6 +1104,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitLicenseKeysUpdate],
     ) -> Benefit: ...
 
@@ -1025,6 +1114,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitMeterCreditUpdate],
     ) -> Benefit: ...
 
@@ -1034,6 +1124,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitFeatureFlagUpdate],
     ) -> Benefit: ...
 
@@ -1043,6 +1134,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitSlackSharedChannelUpdate],
     ) -> Benefit: ...
 
@@ -1051,6 +1143,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Benefit:
         """
@@ -1061,6 +1154,8 @@ class BenefitsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1079,6 +1174,7 @@ class BenefitsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -1095,6 +1191,7 @@ class BenefitsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitDownloadableFile:
         """
         List the downloadable files for a benefit with their download statistics.
@@ -1106,6 +1203,8 @@ class BenefitsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1126,6 +1225,7 @@ class BenefitsAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1143,6 +1243,7 @@ class BenefitsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[BenefitDownloadableFile, None]:
         """
         List the downloadable files for a benefit with their download statistics.
@@ -1154,6 +1255,8 @@ class BenefitsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -1172,6 +1275,7 @@ class BenefitsAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -1189,6 +1293,7 @@ class BenefitsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitGrant:
         """
         List the individual grants for a benefit.
@@ -1205,6 +1310,8 @@ class BenefitsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1228,6 +1335,7 @@ class BenefitsAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1246,6 +1354,7 @@ class BenefitsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[BenefitGrant, None]:
         """
         List the individual grants for a benefit.
@@ -1262,6 +1371,8 @@ class BenefitsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -1283,6 +1394,7 @@ class BenefitsAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item

--- a/sdk/python/polar/v2026_04/services/checkout_links.py
+++ b/sdk/python/polar/v2026_04/services/checkout_links.py
@@ -39,6 +39,7 @@ class CheckoutLinksSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutLinkSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCheckoutLink:
         """
         List checkout links.
@@ -52,6 +53,8 @@ class CheckoutLinksSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -72,6 +75,7 @@ class CheckoutLinksSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -88,6 +92,7 @@ class CheckoutLinksSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutLinkSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CheckoutLink, None, None]:
         """
         List checkout links.
@@ -101,6 +106,8 @@ class CheckoutLinksSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -120,6 +127,7 @@ class CheckoutLinksSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -131,6 +139,7 @@ class CheckoutLinksSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProductPrice],
     ) -> CheckoutLink: ...
 
@@ -139,6 +148,7 @@ class CheckoutLinksSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProduct],
     ) -> CheckoutLink: ...
 
@@ -147,6 +157,7 @@ class CheckoutLinksSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProducts],
     ) -> CheckoutLink: ...
 
@@ -154,6 +165,7 @@ class CheckoutLinksSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CheckoutLink:
         """
@@ -163,6 +175,8 @@ class CheckoutLinksSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -178,6 +192,7 @@ class CheckoutLinksSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -191,6 +206,7 @@ class CheckoutLinksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CheckoutLink:
         """
         Get a checkout link by ID.
@@ -200,6 +216,8 @@ class CheckoutLinksSync(SyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -217,6 +235,7 @@ class CheckoutLinksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -230,6 +249,7 @@ class CheckoutLinksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a checkout link.
@@ -239,6 +259,8 @@ class CheckoutLinksSync(SyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -256,6 +278,7 @@ class CheckoutLinksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -269,6 +292,7 @@ class CheckoutLinksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkUpdate],
     ) -> CheckoutLink:
         """
@@ -279,6 +303,8 @@ class CheckoutLinksSync(SyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -297,6 +323,7 @@ class CheckoutLinksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -317,6 +344,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutLinkSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCheckoutLink:
         """
         List checkout links.
@@ -330,6 +358,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -350,6 +380,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -366,6 +397,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutLinkSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CheckoutLink, None]:
         """
         List checkout links.
@@ -379,6 +411,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -398,6 +432,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -410,6 +445,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProductPrice],
     ) -> CheckoutLink: ...
 
@@ -418,6 +454,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProduct],
     ) -> CheckoutLink: ...
 
@@ -426,6 +463,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProducts],
     ) -> CheckoutLink: ...
 
@@ -433,6 +471,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CheckoutLink:
         """
@@ -442,6 +481,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -457,6 +498,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -470,6 +512,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CheckoutLink:
         """
         Get a checkout link by ID.
@@ -479,6 +522,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -496,6 +541,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -509,6 +555,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a checkout link.
@@ -518,6 +565,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -535,6 +584,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -548,6 +598,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkUpdate],
     ) -> CheckoutLink:
         """
@@ -558,6 +609,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -576,6 +629,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/checkouts.py
+++ b/sdk/python/polar/v2026_04/services/checkouts.py
@@ -50,6 +50,7 @@ class CheckoutsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCheckout:
         """
         List checkout sessions.
@@ -67,6 +68,8 @@ class CheckoutsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -91,6 +94,7 @@ class CheckoutsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -111,6 +115,7 @@ class CheckoutsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Checkout, None, None]:
         """
         List checkout sessions.
@@ -128,6 +133,8 @@ class CheckoutsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -151,6 +158,7 @@ class CheckoutsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -161,6 +169,7 @@ class CheckoutsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutCreate],
     ) -> Checkout:
         """
@@ -170,6 +179,8 @@ class CheckoutsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -185,6 +196,7 @@ class CheckoutsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -198,6 +210,7 @@ class CheckoutsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Checkout:
         """
         Get a checkout session by ID.
@@ -207,6 +220,8 @@ class CheckoutsSync(SyncServiceBase):
         Args:
             id: The checkout session ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -224,6 +239,7 @@ class CheckoutsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -237,6 +253,7 @@ class CheckoutsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutUpdate],
     ) -> Checkout:
         """
@@ -247,6 +264,8 @@ class CheckoutsSync(SyncServiceBase):
         Args:
             id: The checkout session ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -266,6 +285,7 @@ class CheckoutsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -281,6 +301,7 @@ class CheckoutsSync(SyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CheckoutPublic:
         """
         Get a checkout session by client secret.
@@ -288,6 +309,8 @@ class CheckoutsSync(SyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -306,6 +329,7 @@ class CheckoutsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -320,6 +344,7 @@ class CheckoutsSync(SyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutUpdatePublic],
     ) -> CheckoutPublic:
         """
@@ -328,6 +353,8 @@ class CheckoutsSync(SyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -348,6 +375,7 @@ class CheckoutsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -364,6 +392,7 @@ class CheckoutsSync(SyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutConfirmStripe],
     ) -> CheckoutPublicConfirmed:
         """
@@ -374,6 +403,8 @@ class CheckoutsSync(SyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -395,6 +426,7 @@ class CheckoutsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -422,6 +454,7 @@ class CheckoutsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCheckout:
         """
         List checkout sessions.
@@ -439,6 +472,8 @@ class CheckoutsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -463,6 +498,7 @@ class CheckoutsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -483,6 +519,7 @@ class CheckoutsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Checkout, None]:
         """
         List checkout sessions.
@@ -500,6 +537,8 @@ class CheckoutsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -523,6 +562,7 @@ class CheckoutsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -534,6 +574,7 @@ class CheckoutsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutCreate],
     ) -> Checkout:
         """
@@ -543,6 +584,8 @@ class CheckoutsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -558,6 +601,7 @@ class CheckoutsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -571,6 +615,7 @@ class CheckoutsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Checkout:
         """
         Get a checkout session by ID.
@@ -580,6 +625,8 @@ class CheckoutsAsync(AsyncServiceBase):
         Args:
             id: The checkout session ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -597,6 +644,7 @@ class CheckoutsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -610,6 +658,7 @@ class CheckoutsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutUpdate],
     ) -> Checkout:
         """
@@ -620,6 +669,8 @@ class CheckoutsAsync(AsyncServiceBase):
         Args:
             id: The checkout session ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -639,6 +690,7 @@ class CheckoutsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -654,6 +706,7 @@ class CheckoutsAsync(AsyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CheckoutPublic:
         """
         Get a checkout session by client secret.
@@ -661,6 +714,8 @@ class CheckoutsAsync(AsyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -679,6 +734,7 @@ class CheckoutsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -693,6 +749,7 @@ class CheckoutsAsync(AsyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutUpdatePublic],
     ) -> CheckoutPublic:
         """
@@ -701,6 +758,8 @@ class CheckoutsAsync(AsyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -721,6 +780,7 @@ class CheckoutsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -737,6 +797,7 @@ class CheckoutsAsync(AsyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutConfirmStripe],
     ) -> CheckoutPublicConfirmed:
         """
@@ -747,6 +808,8 @@ class CheckoutsAsync(AsyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -768,6 +831,7 @@ class CheckoutsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/custom_fields.py
+++ b/sdk/python/polar/v2026_04/services/custom_fields.py
@@ -47,6 +47,7 @@ class CustomFieldsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomFieldSortProperty] | None = ["slug"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomField:
         """
         List custom fields.
@@ -61,6 +62,8 @@ class CustomFieldsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -82,6 +85,7 @@ class CustomFieldsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -99,6 +103,7 @@ class CustomFieldsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomFieldSortProperty] | None = ["slug"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomField, None, None]:
         """
         List custom fields.
@@ -113,6 +118,8 @@ class CustomFieldsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -133,6 +140,7 @@ class CustomFieldsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -144,6 +152,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateText],
     ) -> CustomField: ...
 
@@ -152,6 +161,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateNumber],
     ) -> CustomField: ...
 
@@ -160,6 +170,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateDate],
     ) -> CustomField: ...
 
@@ -168,6 +179,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateCheckbox],
     ) -> CustomField: ...
 
@@ -176,6 +188,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateSelect],
     ) -> CustomField: ...
 
@@ -183,6 +196,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomField:
         """
@@ -192,6 +206,8 @@ class CustomFieldsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -207,6 +223,7 @@ class CustomFieldsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -220,6 +237,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomField:
         """
         Get a custom field by ID.
@@ -229,6 +247,8 @@ class CustomFieldsSync(SyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -246,6 +266,7 @@ class CustomFieldsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -259,6 +280,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a custom field.
@@ -268,6 +290,8 @@ class CustomFieldsSync(SyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -285,6 +309,7 @@ class CustomFieldsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -299,6 +324,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateText],
     ) -> CustomField: ...
 
@@ -308,6 +334,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateNumber],
     ) -> CustomField: ...
 
@@ -317,6 +344,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateDate],
     ) -> CustomField: ...
 
@@ -326,6 +354,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateCheckbox],
     ) -> CustomField: ...
 
@@ -335,6 +364,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateSelect],
     ) -> CustomField: ...
 
@@ -343,6 +373,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomField:
         """
@@ -353,6 +384,8 @@ class CustomFieldsSync(SyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -371,6 +404,7 @@ class CustomFieldsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -392,6 +426,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomFieldSortProperty] | None = ["slug"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomField:
         """
         List custom fields.
@@ -406,6 +441,8 @@ class CustomFieldsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -427,6 +464,7 @@ class CustomFieldsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -444,6 +482,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomFieldSortProperty] | None = ["slug"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomField, None]:
         """
         List custom fields.
@@ -458,6 +497,8 @@ class CustomFieldsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -478,6 +519,7 @@ class CustomFieldsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -490,6 +532,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateText],
     ) -> CustomField: ...
 
@@ -498,6 +541,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateNumber],
     ) -> CustomField: ...
 
@@ -506,6 +550,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateDate],
     ) -> CustomField: ...
 
@@ -514,6 +559,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateCheckbox],
     ) -> CustomField: ...
 
@@ -522,6 +568,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateSelect],
     ) -> CustomField: ...
 
@@ -529,6 +576,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomField:
         """
@@ -538,6 +586,8 @@ class CustomFieldsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -553,6 +603,7 @@ class CustomFieldsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -566,6 +617,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomField:
         """
         Get a custom field by ID.
@@ -575,6 +627,8 @@ class CustomFieldsAsync(AsyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -592,6 +646,7 @@ class CustomFieldsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -605,6 +660,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a custom field.
@@ -614,6 +670,8 @@ class CustomFieldsAsync(AsyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -631,6 +689,7 @@ class CustomFieldsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -645,6 +704,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateText],
     ) -> CustomField: ...
 
@@ -654,6 +714,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateNumber],
     ) -> CustomField: ...
 
@@ -663,6 +724,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateDate],
     ) -> CustomField: ...
 
@@ -672,6 +734,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateCheckbox],
     ) -> CustomField: ...
 
@@ -681,6 +744,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateSelect],
     ) -> CustomField: ...
 
@@ -689,6 +753,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomField:
         """
@@ -699,6 +764,8 @@ class CustomFieldsAsync(AsyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -717,6 +784,7 @@ class CustomFieldsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/customer_meters.py
+++ b/sdk/python/polar/v2026_04/services/customer_meters.py
@@ -34,6 +34,7 @@ class CustomerMetersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerMeterSortProperty] | None = ["-modified_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerMeter:
         """
         List customer meters.
@@ -49,6 +50,8 @@ class CustomerMetersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -71,6 +74,7 @@ class CustomerMetersSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -89,6 +93,7 @@ class CustomerMetersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerMeterSortProperty] | None = ["-modified_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerMeter, None, None]:
         """
         List customer meters.
@@ -104,6 +109,8 @@ class CustomerMetersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -125,6 +132,7 @@ class CustomerMetersSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -136,6 +144,7 @@ class CustomerMetersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerMeter:
         """
         Get a customer meter by ID.
@@ -145,6 +154,8 @@ class CustomerMetersSync(SyncServiceBase):
         Args:
             id: The customer meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -162,6 +173,7 @@ class CustomerMetersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -183,6 +195,7 @@ class CustomerMetersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerMeterSortProperty] | None = ["-modified_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerMeter:
         """
         List customer meters.
@@ -198,6 +211,8 @@ class CustomerMetersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -220,6 +235,7 @@ class CustomerMetersAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -238,6 +254,7 @@ class CustomerMetersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerMeterSortProperty] | None = ["-modified_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerMeter, None]:
         """
         List customer meters.
@@ -253,6 +270,8 @@ class CustomerMetersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -274,6 +293,7 @@ class CustomerMetersAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -286,6 +306,7 @@ class CustomerMetersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerMeter:
         """
         Get a customer meter by ID.
@@ -295,6 +316,8 @@ class CustomerMetersAsync(AsyncServiceBase):
         Args:
             id: The customer meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -312,6 +335,7 @@ class CustomerMetersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_04/services/customer_portal/benefit_grants.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/benefit_grants.py
@@ -52,6 +52,7 @@ class BenefitGrantsSync(SyncServiceBase):
             "-granted_at",
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerBenefitGrant:
         """
         List benefits grants of the authenticated customer.
@@ -70,6 +71,8 @@ class BenefitGrantsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -95,6 +98,7 @@ class BenefitGrantsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -121,6 +125,7 @@ class BenefitGrantsSync(SyncServiceBase):
             "-granted_at",
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerBenefitGrant, None, None]:
         """
         List benefits grants of the authenticated customer.
@@ -139,6 +144,8 @@ class BenefitGrantsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -163,6 +170,7 @@ class BenefitGrantsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -174,6 +182,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerBenefitGrant:
         """
         Get a benefit grant by ID for the authenticated customer.
@@ -183,6 +192,8 @@ class BenefitGrantsSync(SyncServiceBase):
         Args:
             id: The benefit grant ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -200,6 +211,7 @@ class BenefitGrantsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -214,6 +226,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantDiscordUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -223,6 +236,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantGitHubRepositoryUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -232,6 +246,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantDownloadablesUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -241,6 +256,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantLicenseKeysUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -250,6 +266,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantCustomUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -259,6 +276,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantMeterCreditUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -268,6 +286,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantFeatureFlagUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -277,6 +296,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantSlackSharedChannelUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -285,6 +305,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerBenefitGrant:
         """
@@ -295,6 +316,8 @@ class BenefitGrantsSync(SyncServiceBase):
         Args:
             id: The benefit grant ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -314,6 +337,7 @@ class BenefitGrantsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -343,6 +367,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
             "-granted_at",
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerBenefitGrant:
         """
         List benefits grants of the authenticated customer.
@@ -361,6 +386,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -386,6 +413,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -412,6 +440,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
             "-granted_at",
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerBenefitGrant, None]:
         """
         List benefits grants of the authenticated customer.
@@ -430,6 +459,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -454,6 +485,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -466,6 +498,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerBenefitGrant:
         """
         Get a benefit grant by ID for the authenticated customer.
@@ -475,6 +508,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
         Args:
             id: The benefit grant ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -492,6 +527,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -506,6 +542,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantDiscordUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -515,6 +552,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantGitHubRepositoryUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -524,6 +562,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantDownloadablesUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -533,6 +572,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantLicenseKeysUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -542,6 +582,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantCustomUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -551,6 +592,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantMeterCreditUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -560,6 +602,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantFeatureFlagUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -569,6 +612,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantSlackSharedChannelUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -577,6 +621,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerBenefitGrant:
         """
@@ -587,6 +632,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
         Args:
             id: The benefit grant ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -606,6 +653,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/customer_portal/customer_meters.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/customer_meters.py
@@ -34,6 +34,7 @@ class CustomerMetersSync(SyncServiceBase):
             "-modified_at"
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerCustomerMeter:
         """
         List meters of the authenticated customer.
@@ -47,6 +48,8 @@ class CustomerMetersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -67,6 +70,7 @@ class CustomerMetersSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -87,6 +91,7 @@ class CustomerMetersSync(SyncServiceBase):
             "-modified_at"
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerCustomerMeter, None, None]:
         """
         List meters of the authenticated customer.
@@ -100,6 +105,8 @@ class CustomerMetersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -119,6 +126,7 @@ class CustomerMetersSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -130,6 +138,7 @@ class CustomerMetersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerCustomerMeter:
         """
         Get a meter by ID for the authenticated customer.
@@ -139,6 +148,8 @@ class CustomerMetersSync(SyncServiceBase):
         Args:
             id: The customer meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -156,6 +167,7 @@ class CustomerMetersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -177,6 +189,7 @@ class CustomerMetersAsync(AsyncServiceBase):
             "-modified_at"
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerCustomerMeter:
         """
         List meters of the authenticated customer.
@@ -190,6 +203,8 @@ class CustomerMetersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -210,6 +225,7 @@ class CustomerMetersAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -230,6 +246,7 @@ class CustomerMetersAsync(AsyncServiceBase):
             "-modified_at"
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerCustomerMeter, None]:
         """
         List meters of the authenticated customer.
@@ -243,6 +260,8 @@ class CustomerMetersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -262,6 +281,7 @@ class CustomerMetersAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -274,6 +294,7 @@ class CustomerMetersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerCustomerMeter:
         """
         Get a meter by ID for the authenticated customer.
@@ -283,6 +304,8 @@ class CustomerMetersAsync(AsyncServiceBase):
         Args:
             id: The customer meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -300,6 +323,7 @@ class CustomerMetersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_04/services/customer_portal/customer_session.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/customer_session.py
@@ -17,6 +17,7 @@ class CustomerSessionSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerCustomerSession:
         """
         Introspect the current session and return its information.
@@ -25,6 +26,8 @@ class CustomerSessionSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -38,6 +41,7 @@ class CustomerSessionSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, CustomerCustomerSession)
@@ -46,6 +50,7 @@ class CustomerSessionSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> PortalAuthenticatedUser:
         """
         Get information about the currently authenticated portal user.
@@ -54,6 +59,8 @@ class CustomerSessionSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -67,6 +74,7 @@ class CustomerSessionSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, PortalAuthenticatedUser)
@@ -77,6 +85,7 @@ class CustomerSessionAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerCustomerSession:
         """
         Introspect the current session and return its information.
@@ -85,6 +94,8 @@ class CustomerSessionAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -98,6 +109,7 @@ class CustomerSessionAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, CustomerCustomerSession)
@@ -106,6 +118,7 @@ class CustomerSessionAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> PortalAuthenticatedUser:
         """
         Get information about the currently authenticated portal user.
@@ -114,6 +127,8 @@ class CustomerSessionAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -127,6 +142,7 @@ class CustomerSessionAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, PortalAuthenticatedUser)

--- a/sdk/python/polar/v2026_04/services/customer_portal/customers.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/customers.py
@@ -40,6 +40,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerPortalCustomer:
         """
         Get authenticated customer.
@@ -48,6 +49,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -61,6 +64,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, CustomerPortalCustomer)
@@ -69,6 +73,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalCustomerUpdate],
     ) -> CustomerPortalCustomer:
         """
@@ -76,6 +81,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -91,6 +98,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -105,6 +113,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerPaymentMethod:
         """
         Get saved payment methods of the authenticated customer.
@@ -113,6 +122,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -130,6 +141,7 @@ class CustomersSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -145,6 +157,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerPaymentMethod, None, None]:
         """
         Get saved payment methods of the authenticated customer.
@@ -153,6 +166,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -169,6 +184,7 @@ class CustomersSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -179,6 +195,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPaymentMethodCreate],
     ) -> CustomerPaymentMethodCreateResponse:
         """
@@ -186,6 +203,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -202,6 +221,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -217,6 +237,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPaymentMethodConfirm],
     ) -> CustomerPaymentMethodCreateResponse:
         """
@@ -224,6 +245,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -240,6 +263,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -256,6 +280,7 @@ class CustomersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a payment method from the authenticated customer.
@@ -263,6 +288,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -281,6 +308,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -294,6 +322,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerEmailUpdateRequest],
     ) -> typing.Any:
         """
@@ -301,6 +330,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -316,6 +347,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -329,6 +361,7 @@ class CustomersSync(SyncServiceBase):
         *,
         token: str,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Check if an email change verification token is still valid.
@@ -336,6 +369,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             token:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -353,6 +388,7 @@ class CustomersSync(SyncServiceBase):
                 "token": token,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -365,6 +401,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerEmailUpdateVerifyRequest],
     ) -> CustomerEmailUpdateVerifyResponse:
         """
@@ -372,6 +409,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -388,6 +427,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -405,6 +445,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerPortalCustomer:
         """
         Get authenticated customer.
@@ -413,6 +454,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -426,6 +469,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, CustomerPortalCustomer)
@@ -434,6 +478,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalCustomerUpdate],
     ) -> CustomerPortalCustomer:
         """
@@ -441,6 +486,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -456,6 +503,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -470,6 +518,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerPaymentMethod:
         """
         Get saved payment methods of the authenticated customer.
@@ -478,6 +527,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -495,6 +546,7 @@ class CustomersAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -510,6 +562,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerPaymentMethod, None]:
         """
         Get saved payment methods of the authenticated customer.
@@ -518,6 +571,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -534,6 +589,7 @@ class CustomersAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -545,6 +601,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPaymentMethodCreate],
     ) -> CustomerPaymentMethodCreateResponse:
         """
@@ -552,6 +609,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -568,6 +627,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -583,6 +643,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPaymentMethodConfirm],
     ) -> CustomerPaymentMethodCreateResponse:
         """
@@ -590,6 +651,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -606,6 +669,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -622,6 +686,7 @@ class CustomersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a payment method from the authenticated customer.
@@ -629,6 +694,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -647,6 +714,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -660,6 +728,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerEmailUpdateRequest],
     ) -> typing.Any:
         """
@@ -667,6 +736,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -682,6 +753,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -695,6 +767,7 @@ class CustomersAsync(AsyncServiceBase):
         *,
         token: str,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Check if an email change verification token is still valid.
@@ -702,6 +775,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             token:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -719,6 +794,7 @@ class CustomersAsync(AsyncServiceBase):
                 "token": token,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -731,6 +807,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerEmailUpdateVerifyRequest],
     ) -> CustomerEmailUpdateVerifyResponse:
         """
@@ -738,6 +815,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -754,6 +833,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/customer_portal/downloadables.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/downloadables.py
@@ -26,6 +26,7 @@ class DownloadablesSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDownloadableRead:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -35,6 +36,8 @@ class DownloadablesSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -53,6 +56,7 @@ class DownloadablesSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -69,6 +73,7 @@ class DownloadablesSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[DownloadableRead, None, None]:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -78,6 +83,8 @@ class DownloadablesSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -95,6 +102,7 @@ class DownloadablesSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -110,6 +118,7 @@ class DownloadablesAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDownloadableRead:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -119,6 +128,8 @@ class DownloadablesAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -137,6 +148,7 @@ class DownloadablesAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -153,6 +165,7 @@ class DownloadablesAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[DownloadableRead, None]:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -162,6 +175,8 @@ class DownloadablesAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -179,6 +194,7 @@ class DownloadablesAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item

--- a/sdk/python/polar/v2026_04/services/customer_portal/license_keys.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/license_keys.py
@@ -38,6 +38,7 @@ class LicenseKeysSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceLicenseKeyRead:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -47,6 +48,8 @@ class LicenseKeysSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -67,6 +70,7 @@ class LicenseKeysSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -83,6 +87,7 @@ class LicenseKeysSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[LicenseKeyRead, None, None]:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -92,6 +97,8 @@ class LicenseKeysSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -111,6 +118,7 @@ class LicenseKeysSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -122,6 +130,7 @@ class LicenseKeysSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyWithActivations:
         """
         Get a license key.
@@ -131,6 +140,8 @@ class LicenseKeysSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -148,6 +159,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -161,6 +173,7 @@ class LicenseKeysSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyRead:
         """
         Rotate a license key.
@@ -174,6 +187,8 @@ class LicenseKeysSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -193,6 +208,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -207,6 +223,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyValidate],
     ) -> ValidatedLicenseKey:
         """
@@ -219,6 +236,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -235,6 +254,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -248,6 +268,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyActivate],
     ) -> LicenseKeyActivationRead:
         """
@@ -260,6 +281,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -277,6 +300,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -291,6 +315,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyDeactivate],
     ) -> None:
         """
@@ -303,6 +328,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -319,6 +346,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -337,6 +365,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceLicenseKeyRead:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -346,6 +375,8 @@ class LicenseKeysAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -366,6 +397,7 @@ class LicenseKeysAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -382,6 +414,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[LicenseKeyRead, None]:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -391,6 +424,8 @@ class LicenseKeysAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -410,6 +445,7 @@ class LicenseKeysAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -422,6 +458,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyWithActivations:
         """
         Get a license key.
@@ -431,6 +468,8 @@ class LicenseKeysAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -448,6 +487,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -461,6 +501,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyRead:
         """
         Rotate a license key.
@@ -474,6 +515,8 @@ class LicenseKeysAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -493,6 +536,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -507,6 +551,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyValidate],
     ) -> ValidatedLicenseKey:
         """
@@ -519,6 +564,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -535,6 +582,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -548,6 +596,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyActivate],
     ) -> LicenseKeyActivationRead:
         """
@@ -560,6 +609,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -577,6 +628,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -591,6 +643,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyDeactivate],
     ) -> None:
         """
@@ -603,6 +656,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -619,6 +674,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/customer_portal/members.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/members.py
@@ -42,6 +42,7 @@ class MembersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerPortalMember:
         """
         List all members of the customer's team.
@@ -52,6 +53,8 @@ class MembersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -71,6 +74,7 @@ class MembersSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -88,6 +92,7 @@ class MembersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerPortalMember, None, None]:
         """
         List all members of the customer's team.
@@ -98,6 +103,8 @@ class MembersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -116,6 +123,7 @@ class MembersSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -126,6 +134,7 @@ class MembersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalMemberCreate],
     ) -> CustomerPortalMember:
         """
@@ -139,6 +148,8 @@ class MembersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -157,6 +168,7 @@ class MembersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -173,6 +185,7 @@ class MembersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Remove a member from the team.
@@ -186,6 +199,8 @@ class MembersSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -206,6 +221,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -222,6 +238,7 @@ class MembersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalMemberUpdate],
     ) -> CustomerPortalMember:
         """
@@ -236,6 +253,8 @@ class MembersSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -257,6 +276,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -277,6 +297,7 @@ class MembersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerPortalMember:
         """
         List all members of the customer's team.
@@ -287,6 +308,8 @@ class MembersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -306,6 +329,7 @@ class MembersAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -323,6 +347,7 @@ class MembersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerPortalMember, None]:
         """
         List all members of the customer's team.
@@ -333,6 +358,8 @@ class MembersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -351,6 +378,7 @@ class MembersAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -362,6 +390,7 @@ class MembersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalMemberCreate],
     ) -> CustomerPortalMember:
         """
@@ -375,6 +404,8 @@ class MembersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -393,6 +424,7 @@ class MembersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -409,6 +441,7 @@ class MembersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Remove a member from the team.
@@ -422,6 +455,8 @@ class MembersAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -442,6 +477,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -458,6 +494,7 @@ class MembersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalMemberUpdate],
     ) -> CustomerPortalMember:
         """
@@ -472,6 +509,8 @@ class MembersAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -493,6 +532,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/customer_portal/orders.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/orders.py
@@ -50,6 +50,7 @@ class OrdersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerOrderSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerOrder:
         """
         List orders of the authenticated customer.
@@ -63,6 +64,8 @@ class OrdersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -85,6 +88,7 @@ class OrdersSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -105,6 +109,7 @@ class OrdersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerOrderSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerOrder, None, None]:
         """
         List orders of the authenticated customer.
@@ -118,6 +123,8 @@ class OrdersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -139,6 +146,7 @@ class OrdersSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -150,6 +158,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrder:
         """
         Get an order by ID for the authenticated customer.
@@ -157,6 +166,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -174,6 +185,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -187,6 +199,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerOrderUpdate],
     ) -> CustomerOrder:
         """
@@ -195,6 +208,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -213,6 +228,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -227,6 +243,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderInvoice:
         """
         Get an order's invoice data.
@@ -234,6 +251,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -251,6 +270,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -264,6 +284,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Trigger generation of an order's invoice.
@@ -271,6 +292,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -289,6 +312,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -303,6 +327,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderReceipt:
         """
         Get a presigned URL to download an order's receipt PDF.
@@ -310,6 +335,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -327,6 +354,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -340,6 +368,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderPaymentStatus:
         """
         Get the current payment status for an order.
@@ -347,6 +376,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -364,6 +395,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -377,6 +409,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerOrderConfirmPayment],
     ) -> CustomerOrderPaymentConfirmation:
         """
@@ -385,6 +418,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -405,6 +440,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -433,6 +469,7 @@ class OrdersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerOrderSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerOrder:
         """
         List orders of the authenticated customer.
@@ -446,6 +483,8 @@ class OrdersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -468,6 +507,7 @@ class OrdersAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -488,6 +528,7 @@ class OrdersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerOrderSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerOrder, None]:
         """
         List orders of the authenticated customer.
@@ -501,6 +542,8 @@ class OrdersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -522,6 +565,7 @@ class OrdersAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -534,6 +578,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrder:
         """
         Get an order by ID for the authenticated customer.
@@ -541,6 +586,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -558,6 +605,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -571,6 +619,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerOrderUpdate],
     ) -> CustomerOrder:
         """
@@ -579,6 +628,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -597,6 +648,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -611,6 +663,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderInvoice:
         """
         Get an order's invoice data.
@@ -618,6 +671,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -635,6 +690,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -648,6 +704,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Trigger generation of an order's invoice.
@@ -655,6 +712,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -673,6 +732,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -687,6 +747,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderReceipt:
         """
         Get a presigned URL to download an order's receipt PDF.
@@ -694,6 +755,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -711,6 +774,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -724,6 +788,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderPaymentStatus:
         """
         Get the current payment status for an order.
@@ -731,6 +796,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -748,6 +815,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -761,6 +829,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerOrderConfirmPayment],
     ) -> CustomerOrderPaymentConfirmation:
         """
@@ -769,6 +838,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -789,6 +860,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/customer_portal/organizations.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/organizations.py
@@ -21,6 +21,7 @@ class OrganizationsSync(SyncServiceBase):
         slug: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrganizationData:
         """
         Get a customer portal's organization by slug.
@@ -28,6 +29,8 @@ class OrganizationsSync(SyncServiceBase):
         Args:
             slug: The organization slug.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -45,6 +48,7 @@ class OrganizationsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -60,6 +64,7 @@ class OrganizationsAsync(AsyncServiceBase):
         slug: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrganizationData:
         """
         Get a customer portal's organization by slug.
@@ -67,6 +72,8 @@ class OrganizationsAsync(AsyncServiceBase):
         Args:
             slug: The organization slug.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -84,6 +91,7 @@ class OrganizationsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_04/services/customer_portal/seats.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/seats.py
@@ -44,6 +44,7 @@ class SeatsSync(SyncServiceBase):
         subscription_id: str | None = None,
         order_id: str | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatsList:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -52,6 +53,8 @@ class SeatsSync(SyncServiceBase):
             subscription_id: Subscription ID
             order_id: Order ID
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -72,6 +75,7 @@ class SeatsSync(SyncServiceBase):
                 "order_id": order_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -86,11 +90,14 @@ class SeatsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSeatAssign],
     ) -> CustomerSeat:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -110,6 +117,7 @@ class SeatsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -127,11 +135,14 @@ class SeatsSync(SyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -151,6 +162,7 @@ class SeatsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -166,11 +178,14 @@ class SeatsSync(SyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -191,6 +206,7 @@ class SeatsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -208,6 +224,7 @@ class SeatsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerSubscription:
         """
         List all subscriptions where the authenticated customer has claimed a seat.
@@ -218,6 +235,8 @@ class SeatsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -236,6 +255,7 @@ class SeatsSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -252,6 +272,7 @@ class SeatsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerSubscription, None, None]:
         """
         List all subscriptions where the authenticated customer has claimed a seat.
@@ -262,6 +283,8 @@ class SeatsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -279,6 +302,7 @@ class SeatsSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -293,6 +317,7 @@ class SeatsAsync(AsyncServiceBase):
         subscription_id: str | None = None,
         order_id: str | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatsList:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -301,6 +326,8 @@ class SeatsAsync(AsyncServiceBase):
             subscription_id: Subscription ID
             order_id: Order ID
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -321,6 +348,7 @@ class SeatsAsync(AsyncServiceBase):
                 "order_id": order_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -335,11 +363,14 @@ class SeatsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSeatAssign],
     ) -> CustomerSeat:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -359,6 +390,7 @@ class SeatsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -376,11 +408,14 @@ class SeatsAsync(AsyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -400,6 +435,7 @@ class SeatsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -415,11 +451,14 @@ class SeatsAsync(AsyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -440,6 +479,7 @@ class SeatsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -457,6 +497,7 @@ class SeatsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerSubscription:
         """
         List all subscriptions where the authenticated customer has claimed a seat.
@@ -467,6 +508,8 @@ class SeatsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -485,6 +528,7 @@ class SeatsAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -501,6 +545,7 @@ class SeatsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerSubscription, None]:
         """
         List all subscriptions where the authenticated customer has claimed a seat.
@@ -511,6 +556,8 @@ class SeatsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -528,6 +575,7 @@ class SeatsAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item

--- a/sdk/python/polar/v2026_04/services/customer_portal/subscriptions.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/subscriptions.py
@@ -46,6 +46,7 @@ class SubscriptionsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerSubscriptionSortProperty] | None = ["-started_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerSubscription:
         """
         List subscriptions of the authenticated customer.
@@ -60,6 +61,8 @@ class SubscriptionsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -81,6 +84,7 @@ class SubscriptionsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -100,6 +104,7 @@ class SubscriptionsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerSubscriptionSortProperty] | None = ["-started_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerSubscription, None, None]:
         """
         List subscriptions of the authenticated customer.
@@ -114,6 +119,8 @@ class SubscriptionsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -134,6 +141,7 @@ class SubscriptionsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -145,6 +153,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSubscription:
         """
         Get a subscription for the authenticated customer.
@@ -154,6 +163,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -171,6 +182,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -184,6 +196,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSubscription:
         """
         Cancel a subscription of the authenticated customer.
@@ -191,6 +204,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -209,6 +224,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -224,6 +240,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateProduct],
     ) -> CustomerSubscription: ...
 
@@ -233,6 +250,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateSeats],
     ) -> CustomerSubscription: ...
 
@@ -242,6 +260,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateUnits],
     ) -> CustomerSubscription: ...
 
@@ -251,6 +270,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionCancel],
     ) -> CustomerSubscription: ...
 
@@ -260,6 +280,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionPause],
     ) -> CustomerSubscription: ...
 
@@ -269,6 +290,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionResume],
     ) -> CustomerSubscription: ...
 
@@ -278,6 +300,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateClear],
     ) -> CustomerSubscription: ...
 
@@ -286,6 +309,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerSubscription:
         """
@@ -294,6 +318,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -315,6 +341,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -339,6 +366,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerSubscriptionSortProperty] | None = ["-started_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerSubscription:
         """
         List subscriptions of the authenticated customer.
@@ -353,6 +381,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -374,6 +404,7 @@ class SubscriptionsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -393,6 +424,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerSubscriptionSortProperty] | None = ["-started_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerSubscription, None]:
         """
         List subscriptions of the authenticated customer.
@@ -407,6 +439,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -427,6 +461,7 @@ class SubscriptionsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -439,6 +474,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSubscription:
         """
         Get a subscription for the authenticated customer.
@@ -448,6 +484,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -465,6 +503,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -478,6 +517,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSubscription:
         """
         Cancel a subscription of the authenticated customer.
@@ -485,6 +525,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -503,6 +545,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -518,6 +561,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateProduct],
     ) -> CustomerSubscription: ...
 
@@ -527,6 +571,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateSeats],
     ) -> CustomerSubscription: ...
 
@@ -536,6 +581,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateUnits],
     ) -> CustomerSubscription: ...
 
@@ -545,6 +591,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionCancel],
     ) -> CustomerSubscription: ...
 
@@ -554,6 +601,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionPause],
     ) -> CustomerSubscription: ...
 
@@ -563,6 +611,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionResume],
     ) -> CustomerSubscription: ...
 
@@ -572,6 +621,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateClear],
     ) -> CustomerSubscription: ...
 
@@ -580,6 +630,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerSubscription:
         """
@@ -588,6 +639,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -609,6 +662,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/customer_portal/wallets.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/wallets.py
@@ -30,6 +30,7 @@ class WalletsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerWalletSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerWallet:
         """
         List wallets of the authenticated customer.
@@ -39,6 +40,8 @@ class WalletsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -57,6 +60,7 @@ class WalletsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -71,6 +75,7 @@ class WalletsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerWalletSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerWallet, None, None]:
         """
         List wallets of the authenticated customer.
@@ -80,6 +85,8 @@ class WalletsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -97,6 +104,7 @@ class WalletsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -108,6 +116,7 @@ class WalletsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerWallet:
         """
         Get a wallet by ID for the authenticated customer.
@@ -115,6 +124,8 @@ class WalletsSync(SyncServiceBase):
         Args:
             id: The wallet ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -132,6 +143,7 @@ class WalletsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -149,6 +161,7 @@ class WalletsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerWalletSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerWallet:
         """
         List wallets of the authenticated customer.
@@ -158,6 +171,8 @@ class WalletsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -176,6 +191,7 @@ class WalletsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -190,6 +206,7 @@ class WalletsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerWalletSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerWallet, None]:
         """
         List wallets of the authenticated customer.
@@ -199,6 +216,8 @@ class WalletsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -216,6 +235,7 @@ class WalletsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -228,6 +248,7 @@ class WalletsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerWallet:
         """
         Get a wallet by ID for the authenticated customer.
@@ -235,6 +256,8 @@ class WalletsAsync(AsyncServiceBase):
         Args:
             id: The wallet ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -252,6 +275,7 @@ class WalletsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_04/services/customer_seats.py
+++ b/sdk/python/polar/v2026_04/services/customer_seats.py
@@ -49,6 +49,7 @@ class CustomerSeatsSync(SyncServiceBase):
         subscription_id: str | None = None,
         order_id: str | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatsList:
         """
         **Scopes**: `customer_seats:read`
@@ -57,6 +58,8 @@ class CustomerSeatsSync(SyncServiceBase):
             subscription_id:
             order_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -77,6 +80,7 @@ class CustomerSeatsSync(SyncServiceBase):
                 "order_id": order_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -91,6 +95,7 @@ class CustomerSeatsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SeatAssign],
     ) -> CustomerSeat:
         """
@@ -98,6 +103,8 @@ class CustomerSeatsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -117,6 +124,7 @@ class CustomerSeatsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -134,6 +142,7 @@ class CustomerSeatsSync(SyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         **Scopes**: `customer_seats:write`
@@ -141,6 +150,8 @@ class CustomerSeatsSync(SyncServiceBase):
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -160,6 +171,7 @@ class CustomerSeatsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -175,6 +187,7 @@ class CustomerSeatsSync(SyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         **Scopes**: `customer_seats:write`
@@ -182,6 +195,8 @@ class CustomerSeatsSync(SyncServiceBase):
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -202,6 +217,7 @@ class CustomerSeatsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -218,11 +234,14 @@ class CustomerSeatsSync(SyncServiceBase):
         invitation_token: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatClaimInfo:
         """
         Args:
             invitation_token:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -242,6 +261,7 @@ class CustomerSeatsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -256,11 +276,14 @@ class CustomerSeatsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SeatClaim],
     ) -> CustomerSeatClaimResponse:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -278,6 +301,7 @@ class CustomerSeatsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -296,6 +320,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
         subscription_id: str | None = None,
         order_id: str | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatsList:
         """
         **Scopes**: `customer_seats:read`
@@ -304,6 +329,8 @@ class CustomerSeatsAsync(AsyncServiceBase):
             subscription_id:
             order_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -324,6 +351,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
                 "order_id": order_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -338,6 +366,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SeatAssign],
     ) -> CustomerSeat:
         """
@@ -345,6 +374,8 @@ class CustomerSeatsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -364,6 +395,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -381,6 +413,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         **Scopes**: `customer_seats:write`
@@ -388,6 +421,8 @@ class CustomerSeatsAsync(AsyncServiceBase):
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -407,6 +442,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -422,6 +458,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         **Scopes**: `customer_seats:write`
@@ -429,6 +466,8 @@ class CustomerSeatsAsync(AsyncServiceBase):
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -449,6 +488,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -465,11 +505,14 @@ class CustomerSeatsAsync(AsyncServiceBase):
         invitation_token: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatClaimInfo:
         """
         Args:
             invitation_token:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -489,6 +532,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -503,11 +547,14 @@ class CustomerSeatsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SeatClaim],
     ) -> CustomerSeatClaimResponse:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -525,6 +572,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/customer_sessions.py
+++ b/sdk/python/polar/v2026_04/services/customer_sessions.py
@@ -26,6 +26,7 @@ class CustomerSessionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSessionCustomerIDCreate],
     ) -> CustomerSession: ...
 
@@ -34,6 +35,7 @@ class CustomerSessionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSessionCustomerExternalIDCreate],
     ) -> CustomerSession: ...
 
@@ -41,6 +43,7 @@ class CustomerSessionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerSession:
         """
@@ -53,6 +56,8 @@ class CustomerSessionsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -68,6 +73,7 @@ class CustomerSessionsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -83,6 +89,7 @@ class CustomerSessionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSessionCustomerIDCreate],
     ) -> CustomerSession: ...
 
@@ -91,6 +98,7 @@ class CustomerSessionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSessionCustomerExternalIDCreate],
     ) -> CustomerSession: ...
 
@@ -98,6 +106,7 @@ class CustomerSessionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerSession:
         """
@@ -110,6 +119,8 @@ class CustomerSessionsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -125,6 +136,7 @@ class CustomerSessionsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/customers/__init__.py
+++ b/sdk/python/polar/v2026_04/services/customers/__init__.py
@@ -55,6 +55,7 @@ class CustomersSync(SyncServiceBase):
         sorting: builtins.list[CustomerSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomer:
         """
         List customers.
@@ -71,6 +72,8 @@ class CustomersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -94,6 +97,7 @@ class CustomersSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -113,6 +117,7 @@ class CustomersSync(SyncServiceBase):
         sorting: builtins.list[CustomerSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Customer, None, None]:
         """
         List customers.
@@ -129,6 +134,8 @@ class CustomersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -151,6 +158,7 @@ class CustomersSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -162,6 +170,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerIndividualCreate],
     ) -> Customer: ...
 
@@ -170,6 +179,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerTeamCreate],
     ) -> Customer: ...
 
@@ -177,6 +187,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Customer:
         """
@@ -186,6 +197,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -201,6 +214,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -214,6 +228,7 @@ class CustomersSync(SyncServiceBase):
         *,
         organization_id: str | builtins.list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export customers as a CSV file.
@@ -223,6 +238,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             organization_id: Filter by organization ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -239,6 +256,7 @@ class CustomersSync(SyncServiceBase):
                 "organization_id": organization_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -251,6 +269,7 @@ class CustomersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Customer:
         """
         Get a customer by ID.
@@ -260,6 +279,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -277,6 +298,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -291,6 +313,7 @@ class CustomersSync(SyncServiceBase):
         *,
         anonymize: bool = False,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a customer.
@@ -315,6 +338,8 @@ class CustomersSync(SyncServiceBase):
             id: The customer ID.
             anonymize: If true, also anonymize the customer's personal data for GDPR compliance. This replaces email with a hashed version, hashes name and billing name (name preserved for businesses with tax_id), clears billing address, and removes OAuth account data.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -334,6 +359,7 @@ class CustomersSync(SyncServiceBase):
                 "anonymize": anonymize,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -347,6 +373,7 @@ class CustomersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerUpdate],
     ) -> Customer:
         """
@@ -357,6 +384,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -375,6 +404,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -389,6 +419,7 @@ class CustomersSync(SyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Customer:
         """
         Get a customer by external ID.
@@ -398,6 +429,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -415,6 +448,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -429,6 +463,7 @@ class CustomersSync(SyncServiceBase):
         *,
         anonymize: bool = False,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a customer by external ID.
@@ -443,6 +478,8 @@ class CustomersSync(SyncServiceBase):
             external_id: The customer external ID.
             anonymize: If true, also anonymize the customer's personal data for GDPR compliance.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -462,6 +499,7 @@ class CustomersSync(SyncServiceBase):
                 "anonymize": anonymize,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -475,6 +513,7 @@ class CustomersSync(SyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerUpdateExternalID],
     ) -> Customer:
         """
@@ -485,6 +524,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -503,6 +544,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -517,6 +559,7 @@ class CustomersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerState:
         """
         Get a customer state by ID.
@@ -532,6 +575,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -549,6 +594,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -562,6 +608,7 @@ class CustomersSync(SyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerState:
         """
         Get a customer state by external ID.
@@ -577,6 +624,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -594,6 +643,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -609,6 +659,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePaymentMethod:
         """
         Get saved payment methods of a customer.
@@ -620,6 +671,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -640,6 +693,7 @@ class CustomersSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -655,6 +709,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[PaymentMethod, None, None]:
         """
         Get saved payment methods of a customer.
@@ -666,6 +721,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -684,6 +741,7 @@ class CustomersSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -697,6 +755,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePaymentMethod:
         """
         Get saved payment methods of a customer by external ID.
@@ -708,6 +767,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -728,6 +789,7 @@ class CustomersSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -743,6 +805,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[PaymentMethod, None, None]:
         """
         Get saved payment methods of a customer by external ID.
@@ -754,6 +817,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -772,6 +837,7 @@ class CustomersSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -798,6 +864,7 @@ class CustomersAsync(AsyncServiceBase):
         sorting: builtins.list[CustomerSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomer:
         """
         List customers.
@@ -814,6 +881,8 @@ class CustomersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -837,6 +906,7 @@ class CustomersAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -856,6 +926,7 @@ class CustomersAsync(AsyncServiceBase):
         sorting: builtins.list[CustomerSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Customer, None]:
         """
         List customers.
@@ -872,6 +943,8 @@ class CustomersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -894,6 +967,7 @@ class CustomersAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -906,6 +980,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerIndividualCreate],
     ) -> Customer: ...
 
@@ -914,6 +989,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerTeamCreate],
     ) -> Customer: ...
 
@@ -921,6 +997,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Customer:
         """
@@ -930,6 +1007,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -945,6 +1024,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -958,6 +1038,7 @@ class CustomersAsync(AsyncServiceBase):
         *,
         organization_id: str | builtins.list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export customers as a CSV file.
@@ -967,6 +1048,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             organization_id: Filter by organization ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -983,6 +1066,7 @@ class CustomersAsync(AsyncServiceBase):
                 "organization_id": organization_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -995,6 +1079,7 @@ class CustomersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Customer:
         """
         Get a customer by ID.
@@ -1004,6 +1089,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1021,6 +1108,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1035,6 +1123,7 @@ class CustomersAsync(AsyncServiceBase):
         *,
         anonymize: bool = False,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a customer.
@@ -1059,6 +1148,8 @@ class CustomersAsync(AsyncServiceBase):
             id: The customer ID.
             anonymize: If true, also anonymize the customer's personal data for GDPR compliance. This replaces email with a hashed version, hashes name and billing name (name preserved for businesses with tax_id), clears billing address, and removes OAuth account data.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1078,6 +1169,7 @@ class CustomersAsync(AsyncServiceBase):
                 "anonymize": anonymize,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1091,6 +1183,7 @@ class CustomersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerUpdate],
     ) -> Customer:
         """
@@ -1101,6 +1194,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1119,6 +1214,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -1133,6 +1229,7 @@ class CustomersAsync(AsyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Customer:
         """
         Get a customer by external ID.
@@ -1142,6 +1239,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1159,6 +1258,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1173,6 +1273,7 @@ class CustomersAsync(AsyncServiceBase):
         *,
         anonymize: bool = False,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a customer by external ID.
@@ -1187,6 +1288,8 @@ class CustomersAsync(AsyncServiceBase):
             external_id: The customer external ID.
             anonymize: If true, also anonymize the customer's personal data for GDPR compliance.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1206,6 +1309,7 @@ class CustomersAsync(AsyncServiceBase):
                 "anonymize": anonymize,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1219,6 +1323,7 @@ class CustomersAsync(AsyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerUpdateExternalID],
     ) -> Customer:
         """
@@ -1229,6 +1334,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1247,6 +1354,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -1261,6 +1369,7 @@ class CustomersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerState:
         """
         Get a customer state by ID.
@@ -1276,6 +1385,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1293,6 +1404,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1306,6 +1418,7 @@ class CustomersAsync(AsyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerState:
         """
         Get a customer state by external ID.
@@ -1321,6 +1434,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1338,6 +1453,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1353,6 +1469,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePaymentMethod:
         """
         Get saved payment methods of a customer.
@@ -1364,6 +1481,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1384,6 +1503,7 @@ class CustomersAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1399,6 +1519,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[PaymentMethod, None]:
         """
         Get saved payment methods of a customer.
@@ -1410,6 +1531,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -1428,6 +1551,7 @@ class CustomersAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -1442,6 +1566,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePaymentMethod:
         """
         Get saved payment methods of a customer by external ID.
@@ -1453,6 +1578,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1473,6 +1600,7 @@ class CustomersAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1488,6 +1616,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[PaymentMethod, None]:
         """
         Get saved payment methods of a customer by external ID.
@@ -1499,6 +1628,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -1517,6 +1648,7 @@ class CustomersAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item

--- a/sdk/python/polar/v2026_04/services/customers/members.py
+++ b/sdk/python/polar/v2026_04/services/customers/members.py
@@ -40,6 +40,7 @@ class MembersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMember:
         """
         List the members of a customer.
@@ -53,6 +54,8 @@ class MembersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -75,6 +78,7 @@ class MembersSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -92,6 +96,7 @@ class MembersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Member, None, None]:
         """
         List the members of a customer.
@@ -105,6 +110,8 @@ class MembersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -125,6 +132,7 @@ class MembersSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -136,6 +144,7 @@ class MembersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberCreateFromCustomer],
     ) -> Member:
         """
@@ -149,6 +158,8 @@ class MembersSync(SyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -168,6 +179,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -187,6 +199,7 @@ class MembersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMember:
         """
         List the members of a customer identified by its external ID.
@@ -200,6 +213,8 @@ class MembersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -223,6 +238,7 @@ class MembersSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -241,6 +257,7 @@ class MembersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Member, None, None]:
         """
         List the members of a customer identified by its external ID.
@@ -254,6 +271,8 @@ class MembersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -275,6 +294,7 @@ class MembersSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -286,6 +306,7 @@ class MembersSync(SyncServiceBase):
         external_id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberCreateFromCustomer],
     ) -> Member:
         """
@@ -296,6 +317,8 @@ class MembersSync(SyncServiceBase):
         Args:
             external_id_path: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -316,6 +339,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -333,6 +357,7 @@ class MembersSync(SyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Member:
         """
         Get a member of a customer by its ID.
@@ -343,6 +368,8 @@ class MembersSync(SyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -361,6 +388,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -375,6 +403,7 @@ class MembersSync(SyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a member of a customer.
@@ -385,6 +414,8 @@ class MembersSync(SyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -403,6 +434,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -417,6 +449,7 @@ class MembersSync(SyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberUpdate],
     ) -> Member:
         """
@@ -430,6 +463,8 @@ class MembersSync(SyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -449,6 +484,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -464,6 +500,7 @@ class MembersSync(SyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Member:
         """
         Get a member by external ID for a customer identified by its external ID.
@@ -474,6 +511,8 @@ class MembersSync(SyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -493,6 +532,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -508,6 +548,7 @@ class MembersSync(SyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a member by external ID for a customer identified by its external ID.
@@ -518,6 +559,8 @@ class MembersSync(SyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -537,6 +580,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -552,6 +596,7 @@ class MembersSync(SyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberUpdate],
     ) -> Member:
         """
@@ -563,6 +608,8 @@ class MembersSync(SyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -583,6 +630,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -604,6 +652,7 @@ class MembersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMember:
         """
         List the members of a customer.
@@ -617,6 +666,8 @@ class MembersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -639,6 +690,7 @@ class MembersAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -656,6 +708,7 @@ class MembersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Member, None]:
         """
         List the members of a customer.
@@ -669,6 +722,8 @@ class MembersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -689,6 +744,7 @@ class MembersAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -701,6 +757,7 @@ class MembersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberCreateFromCustomer],
     ) -> Member:
         """
@@ -714,6 +771,8 @@ class MembersAsync(AsyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -733,6 +792,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -752,6 +812,7 @@ class MembersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMember:
         """
         List the members of a customer identified by its external ID.
@@ -765,6 +826,8 @@ class MembersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -788,6 +851,7 @@ class MembersAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -806,6 +870,7 @@ class MembersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Member, None]:
         """
         List the members of a customer identified by its external ID.
@@ -819,6 +884,8 @@ class MembersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -840,6 +907,7 @@ class MembersAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -852,6 +920,7 @@ class MembersAsync(AsyncServiceBase):
         external_id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberCreateFromCustomer],
     ) -> Member:
         """
@@ -862,6 +931,8 @@ class MembersAsync(AsyncServiceBase):
         Args:
             external_id_path: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -882,6 +953,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -899,6 +971,7 @@ class MembersAsync(AsyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Member:
         """
         Get a member of a customer by its ID.
@@ -909,6 +982,8 @@ class MembersAsync(AsyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -927,6 +1002,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -941,6 +1017,7 @@ class MembersAsync(AsyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a member of a customer.
@@ -951,6 +1028,8 @@ class MembersAsync(AsyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -969,6 +1048,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -983,6 +1063,7 @@ class MembersAsync(AsyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberUpdate],
     ) -> Member:
         """
@@ -996,6 +1077,8 @@ class MembersAsync(AsyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1015,6 +1098,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -1030,6 +1114,7 @@ class MembersAsync(AsyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Member:
         """
         Get a member by external ID for a customer identified by its external ID.
@@ -1040,6 +1125,8 @@ class MembersAsync(AsyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1059,6 +1146,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1074,6 +1162,7 @@ class MembersAsync(AsyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a member by external ID for a customer identified by its external ID.
@@ -1084,6 +1173,8 @@ class MembersAsync(AsyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1103,6 +1194,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1118,6 +1210,7 @@ class MembersAsync(AsyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberUpdate],
     ) -> Member:
         """
@@ -1129,6 +1222,8 @@ class MembersAsync(AsyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1149,6 +1244,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/discounts.py
+++ b/sdk/python/polar/v2026_04/services/discounts.py
@@ -38,6 +38,7 @@ class DiscountsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DiscountSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDiscount:
         """
         List discounts.
@@ -51,6 +52,8 @@ class DiscountsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -71,6 +74,7 @@ class DiscountsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -87,6 +91,7 @@ class DiscountsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DiscountSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Discount, None, None]:
         """
         List discounts.
@@ -100,6 +105,8 @@ class DiscountsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -119,6 +126,7 @@ class DiscountsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -130,6 +138,7 @@ class DiscountsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountFixedCreate],
     ) -> Discount: ...
 
@@ -138,6 +147,7 @@ class DiscountsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountPercentageCreate],
     ) -> Discount: ...
 
@@ -145,6 +155,7 @@ class DiscountsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Discount:
         """
@@ -154,6 +165,8 @@ class DiscountsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -169,6 +182,7 @@ class DiscountsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -182,6 +196,7 @@ class DiscountsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Discount:
         """
         Get a discount by ID.
@@ -191,6 +206,8 @@ class DiscountsSync(SyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -208,6 +225,7 @@ class DiscountsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -221,6 +239,7 @@ class DiscountsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a discount.
@@ -230,6 +249,8 @@ class DiscountsSync(SyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -247,6 +268,7 @@ class DiscountsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -260,6 +282,7 @@ class DiscountsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountUpdate],
     ) -> Discount:
         """
@@ -270,6 +293,8 @@ class DiscountsSync(SyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -288,6 +313,7 @@ class DiscountsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -308,6 +334,7 @@ class DiscountsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DiscountSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDiscount:
         """
         List discounts.
@@ -321,6 +348,8 @@ class DiscountsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -341,6 +370,7 @@ class DiscountsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -357,6 +387,7 @@ class DiscountsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DiscountSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Discount, None]:
         """
         List discounts.
@@ -370,6 +401,8 @@ class DiscountsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -389,6 +422,7 @@ class DiscountsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -401,6 +435,7 @@ class DiscountsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountFixedCreate],
     ) -> Discount: ...
 
@@ -409,6 +444,7 @@ class DiscountsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountPercentageCreate],
     ) -> Discount: ...
 
@@ -416,6 +452,7 @@ class DiscountsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Discount:
         """
@@ -425,6 +462,8 @@ class DiscountsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -440,6 +479,7 @@ class DiscountsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -453,6 +493,7 @@ class DiscountsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Discount:
         """
         Get a discount by ID.
@@ -462,6 +503,8 @@ class DiscountsAsync(AsyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -479,6 +522,7 @@ class DiscountsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -492,6 +536,7 @@ class DiscountsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a discount.
@@ -501,6 +546,8 @@ class DiscountsAsync(AsyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -518,6 +565,7 @@ class DiscountsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -531,6 +579,7 @@ class DiscountsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountUpdate],
     ) -> Discount:
         """
@@ -541,6 +590,8 @@ class DiscountsAsync(AsyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -559,6 +610,7 @@ class DiscountsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/disputes.py
+++ b/sdk/python/polar/v2026_04/services/disputes.py
@@ -35,6 +35,7 @@ class DisputesSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DisputeSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDispute:
         """
         List disputes.
@@ -49,6 +50,8 @@ class DisputesSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -70,6 +73,7 @@ class DisputesSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -87,6 +91,7 @@ class DisputesSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DisputeSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Dispute, None, None]:
         """
         List disputes.
@@ -101,6 +106,8 @@ class DisputesSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -121,6 +128,7 @@ class DisputesSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -132,6 +140,7 @@ class DisputesSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Dispute:
         """
         Get a dispute by ID.
@@ -141,6 +150,8 @@ class DisputesSync(SyncServiceBase):
         Args:
             id: The dispute ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -158,6 +169,7 @@ class DisputesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -171,6 +183,7 @@ class DisputesSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Dispute:
         """
         Accept a dispute, conceding the chargeback.
@@ -183,6 +196,8 @@ class DisputesSync(SyncServiceBase):
         Args:
             id: The dispute ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -201,6 +216,7 @@ class DisputesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -222,6 +238,7 @@ class DisputesAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DisputeSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDispute:
         """
         List disputes.
@@ -236,6 +253,8 @@ class DisputesAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -257,6 +276,7 @@ class DisputesAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -274,6 +294,7 @@ class DisputesAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DisputeSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Dispute, None]:
         """
         List disputes.
@@ -288,6 +309,8 @@ class DisputesAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -308,6 +331,7 @@ class DisputesAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -320,6 +344,7 @@ class DisputesAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Dispute:
         """
         Get a dispute by ID.
@@ -329,6 +354,8 @@ class DisputesAsync(AsyncServiceBase):
         Args:
             id: The dispute ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -346,6 +373,7 @@ class DisputesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -359,6 +387,7 @@ class DisputesAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Dispute:
         """
         Accept a dispute, conceding the chargeback.
@@ -371,6 +400,8 @@ class DisputesAsync(AsyncServiceBase):
         Args:
             id: The dispute ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -389,6 +420,7 @@ class DisputesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_04/services/event_types.py
+++ b/sdk/python/polar/v2026_04/services/event_types.py
@@ -42,6 +42,7 @@ class EventTypesSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventTypesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEventTypeWithStats:
         """
         List event types with aggregated statistics.
@@ -60,6 +61,8 @@ class EventTypesSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -85,6 +88,7 @@ class EventTypesSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -108,6 +112,7 @@ class EventTypesSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventTypesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[EventTypeWithStats, None, None]:
         """
         List event types with aggregated statistics.
@@ -126,6 +131,8 @@ class EventTypesSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -150,6 +157,7 @@ class EventTypesSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -161,6 +169,7 @@ class EventTypesSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[EventTypeUpdate],
     ) -> EventType:
         """
@@ -171,6 +180,8 @@ class EventTypesSync(SyncServiceBase):
         Args:
             id: The event type ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -189,6 +200,7 @@ class EventTypesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -214,6 +226,7 @@ class EventTypesAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventTypesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEventTypeWithStats:
         """
         List event types with aggregated statistics.
@@ -232,6 +245,8 @@ class EventTypesAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -257,6 +272,7 @@ class EventTypesAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -280,6 +296,7 @@ class EventTypesAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventTypesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[EventTypeWithStats, None]:
         """
         List event types with aggregated statistics.
@@ -298,6 +315,8 @@ class EventTypesAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -322,6 +341,7 @@ class EventTypesAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -334,6 +354,7 @@ class EventTypesAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[EventTypeUpdate],
     ) -> EventType:
         """
@@ -344,6 +365,8 @@ class EventTypesAsync(AsyncServiceBase):
         Args:
             id: The event type ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -362,6 +385,7 @@ class EventTypesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/events.py
+++ b/sdk/python/polar/v2026_04/services/events.py
@@ -53,6 +53,7 @@ class EventsSync(SyncServiceBase):
         sorting: builtins.list[EventSortProperty] | None = ["-timestamp"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEvent | ListResourceWithCursorPaginationEvent:
         """
         List events.
@@ -77,6 +78,8 @@ class EventsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -108,6 +111,7 @@ class EventsSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -131,6 +135,7 @@ class EventsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventNamesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEventName:
         """
         List event names.
@@ -147,6 +152,8 @@ class EventsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -170,6 +177,7 @@ class EventsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -189,6 +197,7 @@ class EventsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventNamesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[EventName, None, None]:
         """
         List event names.
@@ -205,6 +214,8 @@ class EventsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -227,6 +238,7 @@ class EventsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -238,6 +250,7 @@ class EventsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Event:
         """
         Get an event by ID.
@@ -247,6 +260,8 @@ class EventsSync(SyncServiceBase):
         Args:
             id: The event ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -264,6 +279,7 @@ class EventsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -276,6 +292,7 @@ class EventsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[EventsIngest],
     ) -> EventsIngestResponse:
         """
@@ -285,6 +302,8 @@ class EventsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -300,6 +319,7 @@ class EventsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -330,6 +350,7 @@ class EventsAsync(AsyncServiceBase):
         sorting: builtins.list[EventSortProperty] | None = ["-timestamp"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEvent | ListResourceWithCursorPaginationEvent:
         """
         List events.
@@ -354,6 +375,8 @@ class EventsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -385,6 +408,7 @@ class EventsAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -408,6 +432,7 @@ class EventsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventNamesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEventName:
         """
         List event names.
@@ -424,6 +449,8 @@ class EventsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -447,6 +474,7 @@ class EventsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -466,6 +494,7 @@ class EventsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventNamesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[EventName, None]:
         """
         List event names.
@@ -482,6 +511,8 @@ class EventsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -504,6 +535,7 @@ class EventsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -516,6 +548,7 @@ class EventsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Event:
         """
         Get an event by ID.
@@ -525,6 +558,8 @@ class EventsAsync(AsyncServiceBase):
         Args:
             id: The event ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -542,6 +577,7 @@ class EventsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -554,6 +590,7 @@ class EventsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[EventsIngest],
     ) -> EventsIngestResponse:
         """
@@ -563,6 +600,8 @@ class EventsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -578,6 +617,7 @@ class EventsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/files.py
+++ b/sdk/python/polar/v2026_04/services/files.py
@@ -39,6 +39,7 @@ class FilesSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceFileRead:
         """
         List files.
@@ -51,6 +52,8 @@ class FilesSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -70,6 +73,7 @@ class FilesSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -85,6 +89,7 @@ class FilesSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[FileRead, None, None]:
         """
         List files.
@@ -97,6 +102,8 @@ class FilesSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -115,6 +122,7 @@ class FilesSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -126,6 +134,7 @@ class FilesSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DownloadableFileCreate],
     ) -> FileUpload: ...
 
@@ -134,6 +143,7 @@ class FilesSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductMediaFileCreate],
     ) -> FileUpload: ...
 
@@ -142,6 +152,7 @@ class FilesSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationAvatarFileCreate],
     ) -> FileUpload: ...
 
@@ -150,6 +161,7 @@ class FilesSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SupportCaseAttachmentFileCreate],
     ) -> FileUpload: ...
 
@@ -157,6 +169,7 @@ class FilesSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> FileUpload:
         """
@@ -166,6 +179,8 @@ class FilesSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -181,6 +196,7 @@ class FilesSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -194,6 +210,7 @@ class FilesSync(SyncServiceBase):
         id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[FileUploadCompleted],
     ) -> FileRead:
         """
@@ -204,6 +221,8 @@ class FilesSync(SyncServiceBase):
         Args:
             id_path: The file ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -223,6 +242,7 @@ class FilesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -238,6 +258,7 @@ class FilesSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a file.
@@ -247,6 +268,8 @@ class FilesSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -265,6 +288,7 @@ class FilesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -279,6 +303,7 @@ class FilesSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[FilePatch],
     ) -> FileRead:
         """
@@ -289,6 +314,8 @@ class FilesSync(SyncServiceBase):
         Args:
             id: The file ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -308,6 +335,7 @@ class FilesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -328,6 +356,7 @@ class FilesAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceFileRead:
         """
         List files.
@@ -340,6 +369,8 @@ class FilesAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -359,6 +390,7 @@ class FilesAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -374,6 +406,7 @@ class FilesAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[FileRead, None]:
         """
         List files.
@@ -386,6 +419,8 @@ class FilesAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -404,6 +439,7 @@ class FilesAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -416,6 +452,7 @@ class FilesAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DownloadableFileCreate],
     ) -> FileUpload: ...
 
@@ -424,6 +461,7 @@ class FilesAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductMediaFileCreate],
     ) -> FileUpload: ...
 
@@ -432,6 +470,7 @@ class FilesAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationAvatarFileCreate],
     ) -> FileUpload: ...
 
@@ -440,6 +479,7 @@ class FilesAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SupportCaseAttachmentFileCreate],
     ) -> FileUpload: ...
 
@@ -447,6 +487,7 @@ class FilesAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> FileUpload:
         """
@@ -456,6 +497,8 @@ class FilesAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -471,6 +514,7 @@ class FilesAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -484,6 +528,7 @@ class FilesAsync(AsyncServiceBase):
         id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[FileUploadCompleted],
     ) -> FileRead:
         """
@@ -494,6 +539,8 @@ class FilesAsync(AsyncServiceBase):
         Args:
             id_path: The file ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -513,6 +560,7 @@ class FilesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -528,6 +576,7 @@ class FilesAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a file.
@@ -537,6 +586,8 @@ class FilesAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -555,6 +606,7 @@ class FilesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -569,6 +621,7 @@ class FilesAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[FilePatch],
     ) -> FileRead:
         """
@@ -579,6 +632,8 @@ class FilesAsync(AsyncServiceBase):
         Args:
             id: The file ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -598,6 +653,7 @@ class FilesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/license_keys.py
+++ b/sdk/python/polar/v2026_04/services/license_keys.py
@@ -45,6 +45,7 @@ class LicenseKeysSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceLicenseKeyRead:
         """
         Get license keys connected to the given organization & filters.
@@ -58,6 +59,8 @@ class LicenseKeysSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -80,6 +83,7 @@ class LicenseKeysSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -98,6 +102,7 @@ class LicenseKeysSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[LicenseKeyRead, None, None]:
         """
         Get license keys connected to the given organization & filters.
@@ -111,6 +116,8 @@ class LicenseKeysSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -132,6 +139,7 @@ class LicenseKeysSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -143,6 +151,7 @@ class LicenseKeysSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyWithActivations:
         """
         Get a license key.
@@ -152,6 +161,8 @@ class LicenseKeysSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -170,6 +181,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -184,6 +196,7 @@ class LicenseKeysSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyUpdate],
     ) -> LicenseKeyRead:
         """
@@ -194,6 +207,8 @@ class LicenseKeysSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -213,6 +228,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -228,6 +244,7 @@ class LicenseKeysSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyRead:
         """
         Rotate a license key.
@@ -241,6 +258,8 @@ class LicenseKeysSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -260,6 +279,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -276,6 +296,7 @@ class LicenseKeysSync(SyncServiceBase):
         activation_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyActivationRead:
         """
         Get a license key activation.
@@ -286,6 +307,8 @@ class LicenseKeysSync(SyncServiceBase):
             id:
             activation_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -305,6 +328,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -318,6 +342,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyValidate],
     ) -> ValidatedLicenseKey:
         """
@@ -327,6 +352,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -343,6 +370,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -356,6 +384,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyActivate],
     ) -> LicenseKeyActivationRead:
         """
@@ -365,6 +394,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -382,6 +413,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -396,6 +428,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyDeactivate],
     ) -> None:
         """
@@ -405,6 +438,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -421,6 +456,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -441,6 +477,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceLicenseKeyRead:
         """
         Get license keys connected to the given organization & filters.
@@ -454,6 +491,8 @@ class LicenseKeysAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -476,6 +515,7 @@ class LicenseKeysAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -494,6 +534,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[LicenseKeyRead, None]:
         """
         Get license keys connected to the given organization & filters.
@@ -507,6 +548,8 @@ class LicenseKeysAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -528,6 +571,7 @@ class LicenseKeysAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -540,6 +584,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyWithActivations:
         """
         Get a license key.
@@ -549,6 +594,8 @@ class LicenseKeysAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -567,6 +614,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -581,6 +629,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyUpdate],
     ) -> LicenseKeyRead:
         """
@@ -591,6 +640,8 @@ class LicenseKeysAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -610,6 +661,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -625,6 +677,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyRead:
         """
         Rotate a license key.
@@ -638,6 +691,8 @@ class LicenseKeysAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -657,6 +712,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -673,6 +729,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         activation_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyActivationRead:
         """
         Get a license key activation.
@@ -683,6 +740,8 @@ class LicenseKeysAsync(AsyncServiceBase):
             id:
             activation_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -702,6 +761,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -715,6 +775,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyValidate],
     ) -> ValidatedLicenseKey:
         """
@@ -724,6 +785,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -740,6 +803,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -753,6 +817,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyActivate],
     ) -> LicenseKeyActivationRead:
         """
@@ -762,6 +827,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -779,6 +846,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -793,6 +861,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyDeactivate],
     ) -> None:
         """
@@ -802,6 +871,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -818,6 +889,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/meters.py
+++ b/sdk/python/polar/v2026_04/services/meters.py
@@ -43,6 +43,7 @@ class MetersSync(SyncServiceBase):
         sorting: builtins.list[MeterSortProperty] | None = ["name"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMeter:
         """
         List meters.
@@ -58,6 +59,8 @@ class MetersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -80,6 +83,7 @@ class MetersSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -98,6 +102,7 @@ class MetersSync(SyncServiceBase):
         sorting: builtins.list[MeterSortProperty] | None = ["name"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Meter, None, None]:
         """
         List meters.
@@ -113,6 +118,8 @@ class MetersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -134,6 +141,7 @@ class MetersSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -144,6 +152,7 @@ class MetersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MeterCreate],
     ) -> Meter:
         """
@@ -153,6 +162,8 @@ class MetersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -168,6 +179,7 @@ class MetersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -181,6 +193,7 @@ class MetersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Meter:
         """
         Get a meter by ID.
@@ -190,6 +203,8 @@ class MetersSync(SyncServiceBase):
         Args:
             id: The meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -207,6 +222,7 @@ class MetersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -220,6 +236,7 @@ class MetersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MeterUpdate],
     ) -> Meter:
         """
@@ -230,6 +247,8 @@ class MetersSync(SyncServiceBase):
         Args:
             id: The meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -248,6 +267,7 @@ class MetersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -270,6 +290,7 @@ class MetersSync(SyncServiceBase):
         customer_aggregation_function: AggregationFunction | None = None,
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MeterQuantities:
         """
         Get quantities of a meter over a time period.
@@ -287,6 +308,8 @@ class MetersSync(SyncServiceBase):
             customer_aggregation_function: If set, will first compute the quantities per customer before aggregating them using the given function. If not set, the quantities will be aggregated across all events.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -313,6 +336,7 @@ class MetersSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -334,6 +358,7 @@ class MetersAsync(AsyncServiceBase):
         sorting: builtins.list[MeterSortProperty] | None = ["name"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMeter:
         """
         List meters.
@@ -349,6 +374,8 @@ class MetersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -371,6 +398,7 @@ class MetersAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -389,6 +417,7 @@ class MetersAsync(AsyncServiceBase):
         sorting: builtins.list[MeterSortProperty] | None = ["name"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Meter, None]:
         """
         List meters.
@@ -404,6 +433,8 @@ class MetersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -425,6 +456,7 @@ class MetersAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -436,6 +468,7 @@ class MetersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MeterCreate],
     ) -> Meter:
         """
@@ -445,6 +478,8 @@ class MetersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -460,6 +495,7 @@ class MetersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -473,6 +509,7 @@ class MetersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Meter:
         """
         Get a meter by ID.
@@ -482,6 +519,8 @@ class MetersAsync(AsyncServiceBase):
         Args:
             id: The meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -499,6 +538,7 @@ class MetersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -512,6 +552,7 @@ class MetersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MeterUpdate],
     ) -> Meter:
         """
@@ -522,6 +563,8 @@ class MetersAsync(AsyncServiceBase):
         Args:
             id: The meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -540,6 +583,7 @@ class MetersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -562,6 +606,7 @@ class MetersAsync(AsyncServiceBase):
         customer_aggregation_function: AggregationFunction | None = None,
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MeterQuantities:
         """
         Get quantities of a meter over a time period.
@@ -579,6 +624,8 @@ class MetersAsync(AsyncServiceBase):
             customer_aggregation_function: If set, will first compute the quantities per customer before aggregating them using the given function. If not set, the quantities will be aggregated across all events.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -605,6 +652,7 @@ class MetersAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_04/services/metrics.py
+++ b/sdk/python/polar/v2026_04/services/metrics.py
@@ -45,6 +45,7 @@ class MetricsSync(SyncServiceBase):
         customer_id: str | list[str] | None = None,
         metrics: list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricsResponse:
         """
         Get metrics about your orders and subscriptions.
@@ -64,6 +65,8 @@ class MetricsSync(SyncServiceBase):
             customer_id: Filter by customer ID.
             metrics: List of metric slugs to focus on. When provided, only the queries needed for these metrics will be executed, improving performance. If not provided, all metrics are returned.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -88,6 +91,7 @@ class MetricsSync(SyncServiceBase):
                 "metrics": metrics,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -110,6 +114,7 @@ class MetricsSync(SyncServiceBase):
         customer_id: str | list[str] | None = None,
         metrics: list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export metrics as a CSV file.
@@ -127,6 +132,8 @@ class MetricsSync(SyncServiceBase):
             customer_id: Filter by customer ID.
             metrics: List of metric slugs to include in the export. If not provided, all metrics are exported.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -151,6 +158,7 @@ class MetricsSync(SyncServiceBase):
                 "metrics": metrics,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -162,6 +170,7 @@ class MetricsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricsLimits:
         """
         Get the interval limits for the metrics endpoint.
@@ -170,6 +179,8 @@ class MetricsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -183,6 +194,7 @@ class MetricsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, MetricsLimits)
@@ -192,6 +204,7 @@ class MetricsSync(SyncServiceBase):
         *,
         organization_id: str | list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> list[MetricDashboardSchema]:
         """
         List user-defined metric dashboards.
@@ -201,6 +214,8 @@ class MetricsSync(SyncServiceBase):
         Args:
             organization_id: Filter by organization ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -217,6 +232,7 @@ class MetricsSync(SyncServiceBase):
                 "organization_id": organization_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -230,6 +246,7 @@ class MetricsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MetricDashboardCreate],
     ) -> MetricDashboardSchema:
         """
@@ -239,6 +256,8 @@ class MetricsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -254,6 +273,7 @@ class MetricsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -267,6 +287,7 @@ class MetricsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricDashboardSchema:
         """
         Get a user-defined metric dashboard by ID.
@@ -276,6 +297,8 @@ class MetricsSync(SyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -292,6 +315,7 @@ class MetricsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -304,6 +328,7 @@ class MetricsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a user-defined metric dashboard.
@@ -313,6 +338,8 @@ class MetricsSync(SyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -329,6 +356,7 @@ class MetricsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -341,6 +369,7 @@ class MetricsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MetricDashboardUpdate],
     ) -> MetricDashboardSchema:
         """
@@ -351,6 +380,8 @@ class MetricsSync(SyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -368,6 +399,7 @@ class MetricsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -393,6 +425,7 @@ class MetricsAsync(AsyncServiceBase):
         customer_id: str | list[str] | None = None,
         metrics: list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricsResponse:
         """
         Get metrics about your orders and subscriptions.
@@ -412,6 +445,8 @@ class MetricsAsync(AsyncServiceBase):
             customer_id: Filter by customer ID.
             metrics: List of metric slugs to focus on. When provided, only the queries needed for these metrics will be executed, improving performance. If not provided, all metrics are returned.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -436,6 +471,7 @@ class MetricsAsync(AsyncServiceBase):
                 "metrics": metrics,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -458,6 +494,7 @@ class MetricsAsync(AsyncServiceBase):
         customer_id: str | list[str] | None = None,
         metrics: list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export metrics as a CSV file.
@@ -475,6 +512,8 @@ class MetricsAsync(AsyncServiceBase):
             customer_id: Filter by customer ID.
             metrics: List of metric slugs to include in the export. If not provided, all metrics are exported.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -499,6 +538,7 @@ class MetricsAsync(AsyncServiceBase):
                 "metrics": metrics,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -510,6 +550,7 @@ class MetricsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricsLimits:
         """
         Get the interval limits for the metrics endpoint.
@@ -518,6 +559,8 @@ class MetricsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -531,6 +574,7 @@ class MetricsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, MetricsLimits)
@@ -540,6 +584,7 @@ class MetricsAsync(AsyncServiceBase):
         *,
         organization_id: str | list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> list[MetricDashboardSchema]:
         """
         List user-defined metric dashboards.
@@ -549,6 +594,8 @@ class MetricsAsync(AsyncServiceBase):
         Args:
             organization_id: Filter by organization ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -565,6 +612,7 @@ class MetricsAsync(AsyncServiceBase):
                 "organization_id": organization_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -578,6 +626,7 @@ class MetricsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MetricDashboardCreate],
     ) -> MetricDashboardSchema:
         """
@@ -587,6 +636,8 @@ class MetricsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -602,6 +653,7 @@ class MetricsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -615,6 +667,7 @@ class MetricsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricDashboardSchema:
         """
         Get a user-defined metric dashboard by ID.
@@ -624,6 +677,8 @@ class MetricsAsync(AsyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -640,6 +695,7 @@ class MetricsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -652,6 +708,7 @@ class MetricsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a user-defined metric dashboard.
@@ -661,6 +718,8 @@ class MetricsAsync(AsyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -677,6 +736,7 @@ class MetricsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -689,6 +749,7 @@ class MetricsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MetricDashboardUpdate],
     ) -> MetricDashboardSchema:
         """
@@ -699,6 +760,8 @@ class MetricsAsync(AsyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -716,6 +779,7 @@ class MetricsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/oauth2/__init__.py
+++ b/sdk/python/polar/v2026_04/services/oauth2/__init__.py
@@ -32,10 +32,13 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> AuthorizeResponseUser | AuthorizeResponseOrganization:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -49,6 +52,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(
@@ -59,12 +63,15 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> TokenResponse:
         """
         Request an access token using a valid grant.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -78,6 +85,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, TokenResponse)
@@ -86,12 +94,15 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> RevokeTokenResponse:
         """
         Revoke an access token or a refresh token.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -105,6 +116,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, RevokeTokenResponse)
@@ -113,12 +125,15 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> IntrospectTokenResponse:
         """
         Get information about an access token.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -132,6 +147,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, IntrospectTokenResponse)
@@ -140,12 +156,15 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> UserInfoUser | UserInfoOrganization:
         """
         Get information about the authenticated user.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -159,6 +178,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, UserInfoUser | UserInfoOrganization)
@@ -175,10 +195,13 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> AuthorizeResponseUser | AuthorizeResponseOrganization:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -192,6 +215,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(
@@ -202,12 +226,15 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> TokenResponse:
         """
         Request an access token using a valid grant.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -221,6 +248,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, TokenResponse)
@@ -229,12 +257,15 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> RevokeTokenResponse:
         """
         Revoke an access token or a refresh token.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -248,6 +279,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, RevokeTokenResponse)
@@ -256,12 +288,15 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> IntrospectTokenResponse:
         """
         Get information about an access token.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -275,6 +310,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, IntrospectTokenResponse)
@@ -283,12 +319,15 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> UserInfoUser | UserInfoOrganization:
         """
         Get information about the authenticated user.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -302,6 +341,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, UserInfoUser | UserInfoOrganization)

--- a/sdk/python/polar/v2026_04/services/oauth2/clients/oauth2.py
+++ b/sdk/python/polar/v2026_04/services/oauth2/clients/oauth2.py
@@ -23,6 +23,7 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OAuth2ClientConfiguration],
     ) -> typing.Any:
         """
@@ -30,6 +31,8 @@ class Oauth2Sync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -45,6 +48,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -58,6 +62,7 @@ class Oauth2Sync(SyncServiceBase):
         client_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Get an OAuth2 client by Client ID.
@@ -65,6 +70,8 @@ class Oauth2Sync(SyncServiceBase):
         Args:
             client_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -81,6 +88,7 @@ class Oauth2Sync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -93,6 +101,7 @@ class Oauth2Sync(SyncServiceBase):
         client_id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OAuth2ClientConfigurationUpdate],
     ) -> typing.Any:
         """
@@ -101,6 +110,8 @@ class Oauth2Sync(SyncServiceBase):
         Args:
             client_id_path:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -118,6 +129,7 @@ class Oauth2Sync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -131,6 +143,7 @@ class Oauth2Sync(SyncServiceBase):
         client_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete an OAuth2 client.
@@ -138,6 +151,8 @@ class Oauth2Sync(SyncServiceBase):
         Args:
             client_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -154,6 +169,7 @@ class Oauth2Sync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -167,6 +183,7 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OAuth2ClientConfiguration],
     ) -> typing.Any:
         """
@@ -174,6 +191,8 @@ class Oauth2Async(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -189,6 +208,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -202,6 +222,7 @@ class Oauth2Async(AsyncServiceBase):
         client_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Get an OAuth2 client by Client ID.
@@ -209,6 +230,8 @@ class Oauth2Async(AsyncServiceBase):
         Args:
             client_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -225,6 +248,7 @@ class Oauth2Async(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -237,6 +261,7 @@ class Oauth2Async(AsyncServiceBase):
         client_id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OAuth2ClientConfigurationUpdate],
     ) -> typing.Any:
         """
@@ -245,6 +270,8 @@ class Oauth2Async(AsyncServiceBase):
         Args:
             client_id_path:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -262,6 +289,7 @@ class Oauth2Async(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -275,6 +303,7 @@ class Oauth2Async(AsyncServiceBase):
         client_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete an OAuth2 client.
@@ -282,6 +311,8 @@ class Oauth2Async(AsyncServiceBase):
         Args:
             client_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -298,6 +329,7 @@ class Oauth2Async(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_04/services/orders.py
+++ b/sdk/python/polar/v2026_04/services/orders.py
@@ -61,6 +61,7 @@ class OrdersSync(SyncServiceBase):
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceOrder:
         """
         List orders.
@@ -84,6 +85,8 @@ class OrdersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -114,6 +117,7 @@ class OrdersSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -142,6 +146,7 @@ class OrdersSync(SyncServiceBase):
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Order, None, None]:
         """
         List orders.
@@ -165,6 +170,8 @@ class OrdersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -194,6 +201,7 @@ class OrdersSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -204,6 +212,7 @@ class OrdersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderCreate],
     ) -> Order:
         """
@@ -217,6 +226,8 @@ class OrdersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -232,6 +243,7 @@ class OrdersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -251,6 +263,7 @@ class OrdersSync(SyncServiceBase):
         timezone: str = "UTC",
         columns: OrderExportColumn | builtins.list[OrderExportColumn] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export orders as a CSV file.
@@ -266,6 +279,8 @@ class OrdersSync(SyncServiceBase):
             timezone: Time zone used to render dates in the CSV.
             columns: Columns to include in the CSV, in order. Defaults to email, created_at, product, net_amount, currency, status and invoice_number.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -288,6 +303,7 @@ class OrdersSync(SyncServiceBase):
                 "columns": columns,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -300,6 +316,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Order:
         """
         Get an order by ID.
@@ -309,6 +326,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -326,6 +345,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -339,6 +359,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderUpdate],
     ) -> Order:
         """
@@ -349,6 +370,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -367,6 +390,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -381,6 +405,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderFinalize],
     ) -> Order:
         """
@@ -397,6 +422,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -418,6 +445,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -435,6 +463,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> OrderInvoice:
         """
         Get an order's invoice data.
@@ -444,6 +473,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -461,6 +492,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -474,6 +506,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Trigger generation of an order's invoice.
@@ -483,6 +516,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -501,6 +536,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -515,6 +551,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> OrderReceipt:
         """
         Get a presigned URL to download an order's receipt PDF.
@@ -524,6 +561,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -541,6 +580,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -572,6 +612,7 @@ class OrdersAsync(AsyncServiceBase):
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceOrder:
         """
         List orders.
@@ -595,6 +636,8 @@ class OrdersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -625,6 +668,7 @@ class OrdersAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -653,6 +697,7 @@ class OrdersAsync(AsyncServiceBase):
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Order, None]:
         """
         List orders.
@@ -676,6 +721,8 @@ class OrdersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -705,6 +752,7 @@ class OrdersAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -716,6 +764,7 @@ class OrdersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderCreate],
     ) -> Order:
         """
@@ -729,6 +778,8 @@ class OrdersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -744,6 +795,7 @@ class OrdersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -763,6 +815,7 @@ class OrdersAsync(AsyncServiceBase):
         timezone: str = "UTC",
         columns: OrderExportColumn | builtins.list[OrderExportColumn] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export orders as a CSV file.
@@ -778,6 +831,8 @@ class OrdersAsync(AsyncServiceBase):
             timezone: Time zone used to render dates in the CSV.
             columns: Columns to include in the CSV, in order. Defaults to email, created_at, product, net_amount, currency, status and invoice_number.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -800,6 +855,7 @@ class OrdersAsync(AsyncServiceBase):
                 "columns": columns,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -812,6 +868,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Order:
         """
         Get an order by ID.
@@ -821,6 +878,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -838,6 +897,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -851,6 +911,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderUpdate],
     ) -> Order:
         """
@@ -861,6 +922,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -879,6 +942,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -893,6 +957,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderFinalize],
     ) -> Order:
         """
@@ -909,6 +974,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -930,6 +997,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -947,6 +1015,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> OrderInvoice:
         """
         Get an order's invoice data.
@@ -956,6 +1025,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -973,6 +1044,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -986,6 +1058,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Trigger generation of an order's invoice.
@@ -995,6 +1068,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1013,6 +1088,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1027,6 +1103,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> OrderReceipt:
         """
         Get a presigned URL to download an order's receipt PDF.
@@ -1036,6 +1113,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1053,6 +1132,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_04/services/organizations.py
+++ b/sdk/python/polar/v2026_04/services/organizations.py
@@ -38,6 +38,7 @@ class OrganizationsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[OrganizationSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceOrganization:
         """
         List organizations.
@@ -50,6 +51,8 @@ class OrganizationsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -69,6 +72,7 @@ class OrganizationsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -84,6 +88,7 @@ class OrganizationsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[OrganizationSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Organization, None, None]:
         """
         List organizations.
@@ -96,6 +101,8 @@ class OrganizationsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -114,6 +121,7 @@ class OrganizationsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -124,6 +132,7 @@ class OrganizationsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationCreate],
     ) -> Organization:
         """
@@ -133,6 +142,8 @@ class OrganizationsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -149,6 +160,7 @@ class OrganizationsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -163,6 +175,7 @@ class OrganizationsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Organization:
         """
         Get an organization by ID.
@@ -172,6 +185,8 @@ class OrganizationsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -189,6 +204,7 @@ class OrganizationsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -202,6 +218,7 @@ class OrganizationsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationUpdate],
     ) -> Organization:
         """
@@ -212,6 +229,8 @@ class OrganizationsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -232,6 +251,7 @@ class OrganizationsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -253,6 +273,7 @@ class OrganizationsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[OrganizationSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceOrganization:
         """
         List organizations.
@@ -265,6 +286,8 @@ class OrganizationsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -284,6 +307,7 @@ class OrganizationsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -299,6 +323,7 @@ class OrganizationsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[OrganizationSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Organization, None]:
         """
         List organizations.
@@ -311,6 +336,8 @@ class OrganizationsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -329,6 +356,7 @@ class OrganizationsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -340,6 +368,7 @@ class OrganizationsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationCreate],
     ) -> Organization:
         """
@@ -349,6 +378,8 @@ class OrganizationsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -365,6 +396,7 @@ class OrganizationsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -379,6 +411,7 @@ class OrganizationsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Organization:
         """
         Get an organization by ID.
@@ -388,6 +421,8 @@ class OrganizationsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -405,6 +440,7 @@ class OrganizationsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -418,6 +454,7 @@ class OrganizationsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationUpdate],
     ) -> Organization:
         """
@@ -428,6 +465,8 @@ class OrganizationsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -448,6 +487,7 @@ class OrganizationsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/payments.py
+++ b/sdk/python/polar/v2026_04/services/payments.py
@@ -38,6 +38,7 @@ class PaymentsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[PaymentSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePayment:
         """
         List payments.
@@ -56,6 +57,8 @@ class PaymentsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -81,6 +84,7 @@ class PaymentsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -102,6 +106,7 @@ class PaymentsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[PaymentSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Payment, None, None]:
         """
         List payments.
@@ -120,6 +125,8 @@ class PaymentsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -144,6 +151,7 @@ class PaymentsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -155,6 +163,7 @@ class PaymentsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Payment:
         """
         Get a payment by ID.
@@ -164,6 +173,8 @@ class PaymentsSync(SyncServiceBase):
         Args:
             id: The payment ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -181,6 +192,7 @@ class PaymentsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -205,6 +217,7 @@ class PaymentsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[PaymentSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePayment:
         """
         List payments.
@@ -223,6 +236,8 @@ class PaymentsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -248,6 +263,7 @@ class PaymentsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -269,6 +285,7 @@ class PaymentsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[PaymentSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Payment, None]:
         """
         List payments.
@@ -287,6 +304,8 @@ class PaymentsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -311,6 +330,7 @@ class PaymentsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -323,6 +343,7 @@ class PaymentsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Payment:
         """
         Get a payment by ID.
@@ -332,6 +353,8 @@ class PaymentsAsync(AsyncServiceBase):
         Args:
             id: The payment ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -349,6 +372,7 @@ class PaymentsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_04/services/products.py
+++ b/sdk/python/polar/v2026_04/services/products.py
@@ -47,6 +47,7 @@ class ProductsSync(SyncServiceBase):
         sorting: builtins.list[ProductSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceProduct:
         """
         List products.
@@ -66,6 +67,8 @@ class ProductsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -92,6 +95,7 @@ class ProductsSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -114,6 +118,7 @@ class ProductsSync(SyncServiceBase):
         sorting: builtins.list[ProductSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Product, None, None]:
         """
         List products.
@@ -133,6 +138,8 @@ class ProductsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -158,6 +165,7 @@ class ProductsSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -169,6 +177,7 @@ class ProductsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductCreateRecurring],
     ) -> Product: ...
 
@@ -177,6 +186,7 @@ class ProductsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductCreateOneTime],
     ) -> Product: ...
 
@@ -184,6 +194,7 @@ class ProductsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Product:
         """
@@ -193,6 +204,8 @@ class ProductsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -208,6 +221,7 @@ class ProductsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -221,6 +235,7 @@ class ProductsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Product:
         """
         Get a product by ID.
@@ -230,6 +245,8 @@ class ProductsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -247,6 +264,7 @@ class ProductsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -260,6 +278,7 @@ class ProductsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductUpdate],
     ) -> Product:
         """
@@ -270,6 +289,8 @@ class ProductsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -289,6 +310,7 @@ class ProductsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -304,6 +326,7 @@ class ProductsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductBenefitsUpdate],
     ) -> Product:
         """
@@ -314,6 +337,8 @@ class ProductsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -333,6 +358,7 @@ class ProductsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -360,6 +386,7 @@ class ProductsAsync(AsyncServiceBase):
         sorting: builtins.list[ProductSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceProduct:
         """
         List products.
@@ -379,6 +406,8 @@ class ProductsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -405,6 +434,7 @@ class ProductsAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -427,6 +457,7 @@ class ProductsAsync(AsyncServiceBase):
         sorting: builtins.list[ProductSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Product, None]:
         """
         List products.
@@ -446,6 +477,8 @@ class ProductsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -471,6 +504,7 @@ class ProductsAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -483,6 +517,7 @@ class ProductsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductCreateRecurring],
     ) -> Product: ...
 
@@ -491,6 +526,7 @@ class ProductsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductCreateOneTime],
     ) -> Product: ...
 
@@ -498,6 +534,7 @@ class ProductsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Product:
         """
@@ -507,6 +544,8 @@ class ProductsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -522,6 +561,7 @@ class ProductsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -535,6 +575,7 @@ class ProductsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Product:
         """
         Get a product by ID.
@@ -544,6 +585,8 @@ class ProductsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -561,6 +604,7 @@ class ProductsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -574,6 +618,7 @@ class ProductsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductUpdate],
     ) -> Product:
         """
@@ -584,6 +629,8 @@ class ProductsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -603,6 +650,7 @@ class ProductsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -618,6 +666,7 @@ class ProductsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductBenefitsUpdate],
     ) -> Product:
         """
@@ -628,6 +677,8 @@ class ProductsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -647,6 +698,7 @@ class ProductsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/refunds.py
+++ b/sdk/python/polar/v2026_04/services/refunds.py
@@ -40,6 +40,7 @@ class RefundsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[RefundSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceRefund:
         """
         List refunds.
@@ -58,6 +59,8 @@ class RefundsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -83,6 +86,7 @@ class RefundsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -104,6 +108,7 @@ class RefundsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[RefundSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Refund, None, None]:
         """
         List refunds.
@@ -122,6 +127,8 @@ class RefundsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -146,6 +153,7 @@ class RefundsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -156,6 +164,7 @@ class RefundsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[RefundCreate],
     ) -> Refund:
         """
@@ -165,6 +174,8 @@ class RefundsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -181,6 +192,7 @@ class RefundsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -206,6 +218,7 @@ class RefundsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[RefundSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceRefund:
         """
         List refunds.
@@ -224,6 +237,8 @@ class RefundsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -249,6 +264,7 @@ class RefundsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -270,6 +286,7 @@ class RefundsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[RefundSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Refund, None]:
         """
         List refunds.
@@ -288,6 +305,8 @@ class RefundsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -312,6 +331,7 @@ class RefundsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -323,6 +343,7 @@ class RefundsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[RefundCreate],
     ) -> Refund:
         """
@@ -332,6 +353,8 @@ class RefundsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -348,6 +371,7 @@ class RefundsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/subscriptions.py
+++ b/sdk/python/polar/v2026_04/services/subscriptions.py
@@ -68,6 +68,7 @@ class SubscriptionsSync(SyncServiceBase):
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceSubscription:
         """
         List subscriptions.
@@ -93,6 +94,8 @@ class SubscriptionsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -125,6 +128,7 @@ class SubscriptionsSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -155,6 +159,7 @@ class SubscriptionsSync(SyncServiceBase):
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Subscription, None, None]:
         """
         List subscriptions.
@@ -180,6 +185,8 @@ class SubscriptionsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -211,6 +218,7 @@ class SubscriptionsSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -222,6 +230,7 @@ class SubscriptionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCreateCustomer],
     ) -> Subscription: ...
 
@@ -230,6 +239,7 @@ class SubscriptionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCreateExternalCustomer],
     ) -> Subscription: ...
 
@@ -237,6 +247,7 @@ class SubscriptionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Subscription:
         """
@@ -251,6 +262,8 @@ class SubscriptionsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -266,6 +279,7 @@ class SubscriptionsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -288,6 +302,7 @@ class SubscriptionsSync(SyncServiceBase):
         | builtins.list[SubscriptionExportColumn]
         | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export subscriptions as a CSV file.
@@ -304,6 +319,8 @@ class SubscriptionsSync(SyncServiceBase):
             timezone: Time zone used to render dates in the CSV.
             columns: Columns to include in the CSV, in order. Defaults to email, started_at, product, amount, currency, status and recurring_interval.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -327,6 +344,7 @@ class SubscriptionsSync(SyncServiceBase):
                 "columns": columns,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -339,6 +357,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Subscription:
         """
         Get a subscription by ID.
@@ -348,6 +367,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -365,6 +386,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -378,6 +400,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Subscription:
         """
         Revoke a subscription, i.e cancel immediately.
@@ -387,6 +410,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -406,6 +431,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -422,6 +448,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateBase],
     ) -> Subscription: ...
 
@@ -431,6 +458,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateSeats],
     ) -> Subscription: ...
 
@@ -440,6 +468,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateUnits],
     ) -> Subscription: ...
 
@@ -449,6 +478,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateBillingPeriod],
     ) -> Subscription: ...
 
@@ -458,6 +488,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCancel],
     ) -> Subscription: ...
 
@@ -467,6 +498,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionRevoke],
     ) -> Subscription: ...
 
@@ -476,6 +508,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionPause],
     ) -> Subscription: ...
 
@@ -485,6 +518,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionResume],
     ) -> Subscription: ...
 
@@ -494,6 +528,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateClear],
     ) -> Subscription: ...
 
@@ -502,6 +537,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Subscription:
         """
@@ -512,6 +548,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -533,6 +571,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -570,6 +609,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceSubscription:
         """
         List subscriptions.
@@ -595,6 +635,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -627,6 +669,7 @@ class SubscriptionsAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -657,6 +700,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Subscription, None]:
         """
         List subscriptions.
@@ -682,6 +726,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -713,6 +759,7 @@ class SubscriptionsAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -725,6 +772,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCreateCustomer],
     ) -> Subscription: ...
 
@@ -733,6 +781,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCreateExternalCustomer],
     ) -> Subscription: ...
 
@@ -740,6 +789,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Subscription:
         """
@@ -754,6 +804,8 @@ class SubscriptionsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -769,6 +821,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -791,6 +844,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         | builtins.list[SubscriptionExportColumn]
         | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export subscriptions as a CSV file.
@@ -807,6 +861,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             timezone: Time zone used to render dates in the CSV.
             columns: Columns to include in the CSV, in order. Defaults to email, started_at, product, amount, currency, status and recurring_interval.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -830,6 +886,7 @@ class SubscriptionsAsync(AsyncServiceBase):
                 "columns": columns,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -842,6 +899,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Subscription:
         """
         Get a subscription by ID.
@@ -851,6 +909,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -868,6 +928,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -881,6 +942,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Subscription:
         """
         Revoke a subscription, i.e cancel immediately.
@@ -890,6 +952,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -909,6 +973,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -925,6 +990,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateBase],
     ) -> Subscription: ...
 
@@ -934,6 +1000,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateSeats],
     ) -> Subscription: ...
 
@@ -943,6 +1010,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateUnits],
     ) -> Subscription: ...
 
@@ -952,6 +1020,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateBillingPeriod],
     ) -> Subscription: ...
 
@@ -961,6 +1030,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCancel],
     ) -> Subscription: ...
 
@@ -970,6 +1040,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionRevoke],
     ) -> Subscription: ...
 
@@ -979,6 +1050,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionPause],
     ) -> Subscription: ...
 
@@ -988,6 +1060,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionResume],
     ) -> Subscription: ...
 
@@ -997,6 +1070,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateClear],
     ) -> Subscription: ...
 
@@ -1005,6 +1079,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Subscription:
         """
@@ -1015,6 +1090,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1036,6 +1113,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_04/services/webhooks.py
+++ b/sdk/python/polar/v2026_04/services/webhooks.py
@@ -36,6 +36,7 @@ class WebhooksSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceWebhookEndpoint:
         """
         List webhook endpoints.
@@ -47,6 +48,8 @@ class WebhooksSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -65,6 +68,7 @@ class WebhooksSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -79,6 +83,7 @@ class WebhooksSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[WebhookEndpoint, None, None]:
         """
         List webhook endpoints.
@@ -90,6 +95,8 @@ class WebhooksSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -107,6 +114,7 @@ class WebhooksSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -117,6 +125,7 @@ class WebhooksSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[WebhookEndpointCreate],
     ) -> WebhookEndpoint:
         """
@@ -126,6 +135,8 @@ class WebhooksSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -141,6 +152,7 @@ class WebhooksSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -154,6 +166,7 @@ class WebhooksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> WebhookEndpoint:
         """
         Get a webhook endpoint by ID.
@@ -163,6 +176,8 @@ class WebhooksSync(SyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -180,6 +195,7 @@ class WebhooksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -193,6 +209,7 @@ class WebhooksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a webhook endpoint.
@@ -202,6 +219,8 @@ class WebhooksSync(SyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -219,6 +238,7 @@ class WebhooksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -232,6 +252,7 @@ class WebhooksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[WebhookEndpointUpdate],
     ) -> WebhookEndpoint:
         """
@@ -242,6 +263,8 @@ class WebhooksSync(SyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -260,6 +283,7 @@ class WebhooksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -274,6 +298,7 @@ class WebhooksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> WebhookEndpoint:
         """
         Regenerate a webhook endpoint secret.
@@ -283,6 +308,8 @@ class WebhooksSync(SyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -300,6 +327,7 @@ class WebhooksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -321,6 +349,7 @@ class WebhooksSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceWebhookDelivery:
         """
         List webhook deliveries.
@@ -340,6 +369,8 @@ class WebhooksSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -364,6 +395,7 @@ class WebhooksSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -384,6 +416,7 @@ class WebhooksSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[WebhookDelivery, None, None]:
         """
         List webhook deliveries.
@@ -403,6 +436,8 @@ class WebhooksSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -426,6 +461,7 @@ class WebhooksSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -437,6 +473,7 @@ class WebhooksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Schedule the re-delivery of a webhook event.
@@ -446,6 +483,8 @@ class WebhooksSync(SyncServiceBase):
         Args:
             id: The webhook event ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -463,6 +502,7 @@ class WebhooksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -480,6 +520,7 @@ class WebhooksAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceWebhookEndpoint:
         """
         List webhook endpoints.
@@ -491,6 +532,8 @@ class WebhooksAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -509,6 +552,7 @@ class WebhooksAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -523,6 +567,7 @@ class WebhooksAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[WebhookEndpoint, None]:
         """
         List webhook endpoints.
@@ -534,6 +579,8 @@ class WebhooksAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -551,6 +598,7 @@ class WebhooksAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -562,6 +610,7 @@ class WebhooksAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[WebhookEndpointCreate],
     ) -> WebhookEndpoint:
         """
@@ -571,6 +620,8 @@ class WebhooksAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -586,6 +637,7 @@ class WebhooksAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -599,6 +651,7 @@ class WebhooksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> WebhookEndpoint:
         """
         Get a webhook endpoint by ID.
@@ -608,6 +661,8 @@ class WebhooksAsync(AsyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -625,6 +680,7 @@ class WebhooksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -638,6 +694,7 @@ class WebhooksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a webhook endpoint.
@@ -647,6 +704,8 @@ class WebhooksAsync(AsyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -664,6 +723,7 @@ class WebhooksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -677,6 +737,7 @@ class WebhooksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[WebhookEndpointUpdate],
     ) -> WebhookEndpoint:
         """
@@ -687,6 +748,8 @@ class WebhooksAsync(AsyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -705,6 +768,7 @@ class WebhooksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -719,6 +783,7 @@ class WebhooksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> WebhookEndpoint:
         """
         Regenerate a webhook endpoint secret.
@@ -728,6 +793,8 @@ class WebhooksAsync(AsyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -745,6 +812,7 @@ class WebhooksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -766,6 +834,7 @@ class WebhooksAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceWebhookDelivery:
         """
         List webhook deliveries.
@@ -785,6 +854,8 @@ class WebhooksAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -809,6 +880,7 @@ class WebhooksAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -829,6 +901,7 @@ class WebhooksAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[WebhookDelivery, None]:
         """
         List webhook deliveries.
@@ -848,6 +921,8 @@ class WebhooksAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -871,6 +946,7 @@ class WebhooksAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -883,6 +959,7 @@ class WebhooksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Schedule the re-delivery of a webhook event.
@@ -892,6 +969,8 @@ class WebhooksAsync(AsyncServiceBase):
         Args:
             id: The webhook event ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -909,6 +988,7 @@ class WebhooksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_10/services/benefit_grants.py
+++ b/sdk/python/polar/v2026_10/services/benefit_grants.py
@@ -33,6 +33,7 @@ class BenefitGrantsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[BenefitGrantSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitGrant:
         """
         List benefit grants across all benefits accessible to the authenticated subject.
@@ -48,6 +49,8 @@ class BenefitGrantsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -70,6 +73,7 @@ class BenefitGrantsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -88,6 +92,7 @@ class BenefitGrantsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[BenefitGrantSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[BenefitGrant, None, None]:
         """
         List benefit grants across all benefits accessible to the authenticated subject.
@@ -103,6 +108,8 @@ class BenefitGrantsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -124,6 +131,7 @@ class BenefitGrantsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -143,6 +151,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[BenefitGrantSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitGrant:
         """
         List benefit grants across all benefits accessible to the authenticated subject.
@@ -158,6 +167,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -180,6 +191,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -198,6 +210,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[BenefitGrantSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[BenefitGrant, None]:
         """
         List benefit grants across all benefits accessible to the authenticated subject.
@@ -213,6 +226,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -234,6 +249,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item

--- a/sdk/python/polar/v2026_10/services/benefits.py
+++ b/sdk/python/polar/v2026_10/services/benefits.py
@@ -62,6 +62,7 @@ class BenefitsSync(SyncServiceBase):
         sorting: builtins.list[BenefitSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefit:
         """
         List benefits.
@@ -79,6 +80,8 @@ class BenefitsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -103,6 +106,7 @@ class BenefitsSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -123,6 +127,7 @@ class BenefitsSync(SyncServiceBase):
         sorting: builtins.list[BenefitSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Benefit, None, None]:
         """
         List benefits.
@@ -140,6 +145,8 @@ class BenefitsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -163,6 +170,7 @@ class BenefitsSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -174,6 +182,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitCustomCreate],
     ) -> Benefit: ...
 
@@ -182,6 +191,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDiscordCreate],
     ) -> Benefit: ...
 
@@ -190,6 +200,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitGitHubRepositoryCreate],
     ) -> Benefit: ...
 
@@ -198,6 +209,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDownloadablesCreate],
     ) -> Benefit: ...
 
@@ -206,6 +218,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitLicenseKeysCreate],
     ) -> Benefit: ...
 
@@ -214,6 +227,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitMeterCreditCreate],
     ) -> Benefit: ...
 
@@ -222,6 +236,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitFeatureFlagCreate],
     ) -> Benefit: ...
 
@@ -230,6 +245,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitSlackSharedChannelCreate],
     ) -> Benefit: ...
 
@@ -237,6 +253,7 @@ class BenefitsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Benefit:
         """
@@ -246,6 +263,8 @@ class BenefitsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -261,6 +280,7 @@ class BenefitsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -274,6 +294,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Benefit:
         """
         Get a benefit by ID.
@@ -283,6 +304,8 @@ class BenefitsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -300,6 +323,7 @@ class BenefitsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -313,6 +337,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a benefit.
@@ -326,6 +351,8 @@ class BenefitsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -344,6 +371,7 @@ class BenefitsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -359,6 +387,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitCustomUpdate],
     ) -> Benefit: ...
 
@@ -368,6 +397,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDiscordUpdate],
     ) -> Benefit: ...
 
@@ -377,6 +407,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitGitHubRepositoryUpdate],
     ) -> Benefit: ...
 
@@ -386,6 +417,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDownloadablesUpdate],
     ) -> Benefit: ...
 
@@ -395,6 +427,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitLicenseKeysUpdate],
     ) -> Benefit: ...
 
@@ -404,6 +437,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitMeterCreditUpdate],
     ) -> Benefit: ...
 
@@ -413,6 +447,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitFeatureFlagUpdate],
     ) -> Benefit: ...
 
@@ -422,6 +457,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitSlackSharedChannelUpdate],
     ) -> Benefit: ...
 
@@ -430,6 +466,7 @@ class BenefitsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Benefit:
         """
@@ -440,6 +477,8 @@ class BenefitsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -458,6 +497,7 @@ class BenefitsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -474,6 +514,7 @@ class BenefitsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitDownloadableFile:
         """
         List the downloadable files for a benefit with their download statistics.
@@ -485,6 +526,8 @@ class BenefitsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -505,6 +548,7 @@ class BenefitsSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -522,6 +566,7 @@ class BenefitsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[BenefitDownloadableFile, None, None]:
         """
         List the downloadable files for a benefit with their download statistics.
@@ -533,6 +578,8 @@ class BenefitsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -551,6 +598,7 @@ class BenefitsSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -567,6 +615,7 @@ class BenefitsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitGrant:
         """
         List the individual grants for a benefit.
@@ -583,6 +632,8 @@ class BenefitsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -606,6 +657,7 @@ class BenefitsSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -624,6 +676,7 @@ class BenefitsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[BenefitGrant, None, None]:
         """
         List the individual grants for a benefit.
@@ -640,6 +693,8 @@ class BenefitsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -661,6 +716,7 @@ class BenefitsSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -682,6 +738,7 @@ class BenefitsAsync(AsyncServiceBase):
         sorting: builtins.list[BenefitSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefit:
         """
         List benefits.
@@ -699,6 +756,8 @@ class BenefitsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -723,6 +782,7 @@ class BenefitsAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -743,6 +803,7 @@ class BenefitsAsync(AsyncServiceBase):
         sorting: builtins.list[BenefitSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Benefit, None]:
         """
         List benefits.
@@ -760,6 +821,8 @@ class BenefitsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -783,6 +846,7 @@ class BenefitsAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -795,6 +859,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitCustomCreate],
     ) -> Benefit: ...
 
@@ -803,6 +868,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDiscordCreate],
     ) -> Benefit: ...
 
@@ -811,6 +877,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitGitHubRepositoryCreate],
     ) -> Benefit: ...
 
@@ -819,6 +886,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDownloadablesCreate],
     ) -> Benefit: ...
 
@@ -827,6 +895,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitLicenseKeysCreate],
     ) -> Benefit: ...
 
@@ -835,6 +904,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitMeterCreditCreate],
     ) -> Benefit: ...
 
@@ -843,6 +913,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitFeatureFlagCreate],
     ) -> Benefit: ...
 
@@ -851,6 +922,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitSlackSharedChannelCreate],
     ) -> Benefit: ...
 
@@ -858,6 +930,7 @@ class BenefitsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Benefit:
         """
@@ -867,6 +940,8 @@ class BenefitsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -882,6 +957,7 @@ class BenefitsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -895,6 +971,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Benefit:
         """
         Get a benefit by ID.
@@ -904,6 +981,8 @@ class BenefitsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -921,6 +1000,7 @@ class BenefitsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -934,6 +1014,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a benefit.
@@ -947,6 +1028,8 @@ class BenefitsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -965,6 +1048,7 @@ class BenefitsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -980,6 +1064,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitCustomUpdate],
     ) -> Benefit: ...
 
@@ -989,6 +1074,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDiscordUpdate],
     ) -> Benefit: ...
 
@@ -998,6 +1084,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitGitHubRepositoryUpdate],
     ) -> Benefit: ...
 
@@ -1007,6 +1094,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitDownloadablesUpdate],
     ) -> Benefit: ...
 
@@ -1016,6 +1104,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitLicenseKeysUpdate],
     ) -> Benefit: ...
 
@@ -1025,6 +1114,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitMeterCreditUpdate],
     ) -> Benefit: ...
 
@@ -1034,6 +1124,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitFeatureFlagUpdate],
     ) -> Benefit: ...
 
@@ -1043,6 +1134,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[BenefitSlackSharedChannelUpdate],
     ) -> Benefit: ...
 
@@ -1051,6 +1143,7 @@ class BenefitsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Benefit:
         """
@@ -1061,6 +1154,8 @@ class BenefitsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1079,6 +1174,7 @@ class BenefitsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -1095,6 +1191,7 @@ class BenefitsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitDownloadableFile:
         """
         List the downloadable files for a benefit with their download statistics.
@@ -1106,6 +1203,8 @@ class BenefitsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1126,6 +1225,7 @@ class BenefitsAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1143,6 +1243,7 @@ class BenefitsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[BenefitDownloadableFile, None]:
         """
         List the downloadable files for a benefit with their download statistics.
@@ -1154,6 +1255,8 @@ class BenefitsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -1172,6 +1275,7 @@ class BenefitsAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -1189,6 +1293,7 @@ class BenefitsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceBenefitGrant:
         """
         List the individual grants for a benefit.
@@ -1205,6 +1310,8 @@ class BenefitsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1228,6 +1335,7 @@ class BenefitsAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1246,6 +1354,7 @@ class BenefitsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[BenefitGrant, None]:
         """
         List the individual grants for a benefit.
@@ -1262,6 +1371,8 @@ class BenefitsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -1283,6 +1394,7 @@ class BenefitsAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item

--- a/sdk/python/polar/v2026_10/services/checkout_links.py
+++ b/sdk/python/polar/v2026_10/services/checkout_links.py
@@ -39,6 +39,7 @@ class CheckoutLinksSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutLinkSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCheckoutLink:
         """
         List checkout links.
@@ -52,6 +53,8 @@ class CheckoutLinksSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -72,6 +75,7 @@ class CheckoutLinksSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -88,6 +92,7 @@ class CheckoutLinksSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutLinkSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CheckoutLink, None, None]:
         """
         List checkout links.
@@ -101,6 +106,8 @@ class CheckoutLinksSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -120,6 +127,7 @@ class CheckoutLinksSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -131,6 +139,7 @@ class CheckoutLinksSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProductPrice],
     ) -> CheckoutLink: ...
 
@@ -139,6 +148,7 @@ class CheckoutLinksSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProduct],
     ) -> CheckoutLink: ...
 
@@ -147,6 +157,7 @@ class CheckoutLinksSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProducts],
     ) -> CheckoutLink: ...
 
@@ -154,6 +165,7 @@ class CheckoutLinksSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CheckoutLink:
         """
@@ -163,6 +175,8 @@ class CheckoutLinksSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -178,6 +192,7 @@ class CheckoutLinksSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -191,6 +206,7 @@ class CheckoutLinksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CheckoutLink:
         """
         Get a checkout link by ID.
@@ -200,6 +216,8 @@ class CheckoutLinksSync(SyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -217,6 +235,7 @@ class CheckoutLinksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -230,6 +249,7 @@ class CheckoutLinksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a checkout link.
@@ -239,6 +259,8 @@ class CheckoutLinksSync(SyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -256,6 +278,7 @@ class CheckoutLinksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -269,6 +292,7 @@ class CheckoutLinksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkUpdate],
     ) -> CheckoutLink:
         """
@@ -279,6 +303,8 @@ class CheckoutLinksSync(SyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -297,6 +323,7 @@ class CheckoutLinksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -317,6 +344,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutLinkSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCheckoutLink:
         """
         List checkout links.
@@ -330,6 +358,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -350,6 +380,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -366,6 +397,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutLinkSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CheckoutLink, None]:
         """
         List checkout links.
@@ -379,6 +411,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -398,6 +432,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -410,6 +445,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProductPrice],
     ) -> CheckoutLink: ...
 
@@ -418,6 +454,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProduct],
     ) -> CheckoutLink: ...
 
@@ -426,6 +463,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkCreateProducts],
     ) -> CheckoutLink: ...
 
@@ -433,6 +471,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CheckoutLink:
         """
@@ -442,6 +481,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -457,6 +498,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -470,6 +512,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CheckoutLink:
         """
         Get a checkout link by ID.
@@ -479,6 +522,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -496,6 +541,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -509,6 +555,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a checkout link.
@@ -518,6 +565,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -535,6 +584,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -548,6 +598,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutLinkUpdate],
     ) -> CheckoutLink:
         """
@@ -558,6 +609,8 @@ class CheckoutLinksAsync(AsyncServiceBase):
         Args:
             id: The checkout link ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -576,6 +629,7 @@ class CheckoutLinksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/checkouts.py
+++ b/sdk/python/polar/v2026_10/services/checkouts.py
@@ -50,6 +50,7 @@ class CheckoutsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCheckout:
         """
         List checkout sessions.
@@ -67,6 +68,8 @@ class CheckoutsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -91,6 +94,7 @@ class CheckoutsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -111,6 +115,7 @@ class CheckoutsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Checkout, None, None]:
         """
         List checkout sessions.
@@ -128,6 +133,8 @@ class CheckoutsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -151,6 +158,7 @@ class CheckoutsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -161,6 +169,7 @@ class CheckoutsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutCreate],
     ) -> Checkout:
         """
@@ -170,6 +179,8 @@ class CheckoutsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -185,6 +196,7 @@ class CheckoutsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -198,6 +210,7 @@ class CheckoutsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Checkout:
         """
         Get a checkout session by ID.
@@ -207,6 +220,8 @@ class CheckoutsSync(SyncServiceBase):
         Args:
             id: The checkout session ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -224,6 +239,7 @@ class CheckoutsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -237,6 +253,7 @@ class CheckoutsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutUpdate],
     ) -> Checkout:
         """
@@ -247,6 +264,8 @@ class CheckoutsSync(SyncServiceBase):
         Args:
             id: The checkout session ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -266,6 +285,7 @@ class CheckoutsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -281,6 +301,7 @@ class CheckoutsSync(SyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CheckoutPublic:
         """
         Get a checkout session by client secret.
@@ -288,6 +309,8 @@ class CheckoutsSync(SyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -306,6 +329,7 @@ class CheckoutsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -320,6 +344,7 @@ class CheckoutsSync(SyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutUpdatePublic],
     ) -> CheckoutPublic:
         """
@@ -328,6 +353,8 @@ class CheckoutsSync(SyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -348,6 +375,7 @@ class CheckoutsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -364,6 +392,7 @@ class CheckoutsSync(SyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutConfirmStripe],
     ) -> CheckoutPublicConfirmed:
         """
@@ -374,6 +403,8 @@ class CheckoutsSync(SyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -395,6 +426,7 @@ class CheckoutsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -422,6 +454,7 @@ class CheckoutsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCheckout:
         """
         List checkout sessions.
@@ -439,6 +472,8 @@ class CheckoutsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -463,6 +498,7 @@ class CheckoutsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -483,6 +519,7 @@ class CheckoutsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CheckoutSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Checkout, None]:
         """
         List checkout sessions.
@@ -500,6 +537,8 @@ class CheckoutsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -523,6 +562,7 @@ class CheckoutsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -534,6 +574,7 @@ class CheckoutsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutCreate],
     ) -> Checkout:
         """
@@ -543,6 +584,8 @@ class CheckoutsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -558,6 +601,7 @@ class CheckoutsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -571,6 +615,7 @@ class CheckoutsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Checkout:
         """
         Get a checkout session by ID.
@@ -580,6 +625,8 @@ class CheckoutsAsync(AsyncServiceBase):
         Args:
             id: The checkout session ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -597,6 +644,7 @@ class CheckoutsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -610,6 +658,7 @@ class CheckoutsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutUpdate],
     ) -> Checkout:
         """
@@ -620,6 +669,8 @@ class CheckoutsAsync(AsyncServiceBase):
         Args:
             id: The checkout session ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -639,6 +690,7 @@ class CheckoutsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -654,6 +706,7 @@ class CheckoutsAsync(AsyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CheckoutPublic:
         """
         Get a checkout session by client secret.
@@ -661,6 +714,8 @@ class CheckoutsAsync(AsyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -679,6 +734,7 @@ class CheckoutsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -693,6 +749,7 @@ class CheckoutsAsync(AsyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutUpdatePublic],
     ) -> CheckoutPublic:
         """
@@ -701,6 +758,8 @@ class CheckoutsAsync(AsyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -721,6 +780,7 @@ class CheckoutsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -737,6 +797,7 @@ class CheckoutsAsync(AsyncServiceBase):
         client_secret: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CheckoutConfirmStripe],
     ) -> CheckoutPublicConfirmed:
         """
@@ -747,6 +808,8 @@ class CheckoutsAsync(AsyncServiceBase):
         Args:
             client_secret: The checkout session client secret.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -768,6 +831,7 @@ class CheckoutsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/custom_fields.py
+++ b/sdk/python/polar/v2026_10/services/custom_fields.py
@@ -47,6 +47,7 @@ class CustomFieldsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomFieldSortProperty] | None = ["slug"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomField:
         """
         List custom fields.
@@ -61,6 +62,8 @@ class CustomFieldsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -82,6 +85,7 @@ class CustomFieldsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -99,6 +103,7 @@ class CustomFieldsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomFieldSortProperty] | None = ["slug"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomField, None, None]:
         """
         List custom fields.
@@ -113,6 +118,8 @@ class CustomFieldsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -133,6 +140,7 @@ class CustomFieldsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -144,6 +152,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateText],
     ) -> CustomField: ...
 
@@ -152,6 +161,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateNumber],
     ) -> CustomField: ...
 
@@ -160,6 +170,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateDate],
     ) -> CustomField: ...
 
@@ -168,6 +179,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateCheckbox],
     ) -> CustomField: ...
 
@@ -176,6 +188,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateSelect],
     ) -> CustomField: ...
 
@@ -183,6 +196,7 @@ class CustomFieldsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomField:
         """
@@ -192,6 +206,8 @@ class CustomFieldsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -207,6 +223,7 @@ class CustomFieldsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -220,6 +237,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomField:
         """
         Get a custom field by ID.
@@ -229,6 +247,8 @@ class CustomFieldsSync(SyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -246,6 +266,7 @@ class CustomFieldsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -259,6 +280,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a custom field.
@@ -268,6 +290,8 @@ class CustomFieldsSync(SyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -285,6 +309,7 @@ class CustomFieldsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -299,6 +324,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateText],
     ) -> CustomField: ...
 
@@ -308,6 +334,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateNumber],
     ) -> CustomField: ...
 
@@ -317,6 +344,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateDate],
     ) -> CustomField: ...
 
@@ -326,6 +354,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateCheckbox],
     ) -> CustomField: ...
 
@@ -335,6 +364,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateSelect],
     ) -> CustomField: ...
 
@@ -343,6 +373,7 @@ class CustomFieldsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomField:
         """
@@ -353,6 +384,8 @@ class CustomFieldsSync(SyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -371,6 +404,7 @@ class CustomFieldsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -392,6 +426,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomFieldSortProperty] | None = ["slug"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomField:
         """
         List custom fields.
@@ -406,6 +441,8 @@ class CustomFieldsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -427,6 +464,7 @@ class CustomFieldsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -444,6 +482,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomFieldSortProperty] | None = ["slug"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomField, None]:
         """
         List custom fields.
@@ -458,6 +497,8 @@ class CustomFieldsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -478,6 +519,7 @@ class CustomFieldsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -490,6 +532,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateText],
     ) -> CustomField: ...
 
@@ -498,6 +541,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateNumber],
     ) -> CustomField: ...
 
@@ -506,6 +550,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateDate],
     ) -> CustomField: ...
 
@@ -514,6 +559,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateCheckbox],
     ) -> CustomField: ...
 
@@ -522,6 +568,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldCreateSelect],
     ) -> CustomField: ...
 
@@ -529,6 +576,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomField:
         """
@@ -538,6 +586,8 @@ class CustomFieldsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -553,6 +603,7 @@ class CustomFieldsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -566,6 +617,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomField:
         """
         Get a custom field by ID.
@@ -575,6 +627,8 @@ class CustomFieldsAsync(AsyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -592,6 +646,7 @@ class CustomFieldsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -605,6 +660,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a custom field.
@@ -614,6 +670,8 @@ class CustomFieldsAsync(AsyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -631,6 +689,7 @@ class CustomFieldsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -645,6 +704,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateText],
     ) -> CustomField: ...
 
@@ -654,6 +714,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateNumber],
     ) -> CustomField: ...
 
@@ -663,6 +724,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateDate],
     ) -> CustomField: ...
 
@@ -672,6 +734,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateCheckbox],
     ) -> CustomField: ...
 
@@ -681,6 +744,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomFieldUpdateSelect],
     ) -> CustomField: ...
 
@@ -689,6 +753,7 @@ class CustomFieldsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomField:
         """
@@ -699,6 +764,8 @@ class CustomFieldsAsync(AsyncServiceBase):
         Args:
             id: The custom field ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -717,6 +784,7 @@ class CustomFieldsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/customer_meters.py
+++ b/sdk/python/polar/v2026_10/services/customer_meters.py
@@ -34,6 +34,7 @@ class CustomerMetersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerMeterSortProperty] | None = ["-modified_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerMeter:
         """
         List customer meters.
@@ -49,6 +50,8 @@ class CustomerMetersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -71,6 +74,7 @@ class CustomerMetersSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -89,6 +93,7 @@ class CustomerMetersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerMeterSortProperty] | None = ["-modified_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerMeter, None, None]:
         """
         List customer meters.
@@ -104,6 +109,8 @@ class CustomerMetersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -125,6 +132,7 @@ class CustomerMetersSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -136,6 +144,7 @@ class CustomerMetersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerMeter:
         """
         Get a customer meter by ID.
@@ -145,6 +154,8 @@ class CustomerMetersSync(SyncServiceBase):
         Args:
             id: The customer meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -162,6 +173,7 @@ class CustomerMetersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -183,6 +195,7 @@ class CustomerMetersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerMeterSortProperty] | None = ["-modified_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerMeter:
         """
         List customer meters.
@@ -198,6 +211,8 @@ class CustomerMetersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -220,6 +235,7 @@ class CustomerMetersAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -238,6 +254,7 @@ class CustomerMetersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerMeterSortProperty] | None = ["-modified_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerMeter, None]:
         """
         List customer meters.
@@ -253,6 +270,8 @@ class CustomerMetersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -274,6 +293,7 @@ class CustomerMetersAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -286,6 +306,7 @@ class CustomerMetersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerMeter:
         """
         Get a customer meter by ID.
@@ -295,6 +316,8 @@ class CustomerMetersAsync(AsyncServiceBase):
         Args:
             id: The customer meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -312,6 +335,7 @@ class CustomerMetersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_10/services/customer_portal/benefit_grants.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/benefit_grants.py
@@ -52,6 +52,7 @@ class BenefitGrantsSync(SyncServiceBase):
             "-granted_at",
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerBenefitGrant:
         """
         List benefits grants of the authenticated customer.
@@ -70,6 +71,8 @@ class BenefitGrantsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -95,6 +98,7 @@ class BenefitGrantsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -121,6 +125,7 @@ class BenefitGrantsSync(SyncServiceBase):
             "-granted_at",
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerBenefitGrant, None, None]:
         """
         List benefits grants of the authenticated customer.
@@ -139,6 +144,8 @@ class BenefitGrantsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -163,6 +170,7 @@ class BenefitGrantsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -174,6 +182,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerBenefitGrant:
         """
         Get a benefit grant by ID for the authenticated customer.
@@ -183,6 +192,8 @@ class BenefitGrantsSync(SyncServiceBase):
         Args:
             id: The benefit grant ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -200,6 +211,7 @@ class BenefitGrantsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -214,6 +226,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantDiscordUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -223,6 +236,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantGitHubRepositoryUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -232,6 +246,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantDownloadablesUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -241,6 +256,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantLicenseKeysUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -250,6 +266,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantCustomUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -259,6 +276,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantMeterCreditUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -268,6 +286,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantFeatureFlagUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -277,6 +296,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantSlackSharedChannelUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -285,6 +305,7 @@ class BenefitGrantsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerBenefitGrant:
         """
@@ -295,6 +316,8 @@ class BenefitGrantsSync(SyncServiceBase):
         Args:
             id: The benefit grant ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -314,6 +337,7 @@ class BenefitGrantsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -343,6 +367,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
             "-granted_at",
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerBenefitGrant:
         """
         List benefits grants of the authenticated customer.
@@ -361,6 +386,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -386,6 +413,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -412,6 +440,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
             "-granted_at",
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerBenefitGrant, None]:
         """
         List benefits grants of the authenticated customer.
@@ -430,6 +459,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -454,6 +485,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -466,6 +498,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerBenefitGrant:
         """
         Get a benefit grant by ID for the authenticated customer.
@@ -475,6 +508,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
         Args:
             id: The benefit grant ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -492,6 +527,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -506,6 +542,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantDiscordUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -515,6 +552,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantGitHubRepositoryUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -524,6 +562,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantDownloadablesUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -533,6 +572,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantLicenseKeysUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -542,6 +582,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantCustomUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -551,6 +592,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantMeterCreditUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -560,6 +602,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantFeatureFlagUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -569,6 +612,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerBenefitGrantSlackSharedChannelUpdate],
     ) -> CustomerBenefitGrant: ...
 
@@ -577,6 +621,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerBenefitGrant:
         """
@@ -587,6 +632,8 @@ class BenefitGrantsAsync(AsyncServiceBase):
         Args:
             id: The benefit grant ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -606,6 +653,7 @@ class BenefitGrantsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/customer_portal/customer_meters.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/customer_meters.py
@@ -34,6 +34,7 @@ class CustomerMetersSync(SyncServiceBase):
             "-modified_at"
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerCustomerMeter:
         """
         List meters of the authenticated customer.
@@ -47,6 +48,8 @@ class CustomerMetersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -67,6 +70,7 @@ class CustomerMetersSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -87,6 +91,7 @@ class CustomerMetersSync(SyncServiceBase):
             "-modified_at"
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerCustomerMeter, None, None]:
         """
         List meters of the authenticated customer.
@@ -100,6 +105,8 @@ class CustomerMetersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -119,6 +126,7 @@ class CustomerMetersSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -130,6 +138,7 @@ class CustomerMetersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerCustomerMeter:
         """
         Get a meter by ID for the authenticated customer.
@@ -139,6 +148,8 @@ class CustomerMetersSync(SyncServiceBase):
         Args:
             id: The customer meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -156,6 +167,7 @@ class CustomerMetersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -177,6 +189,7 @@ class CustomerMetersAsync(AsyncServiceBase):
             "-modified_at"
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerCustomerMeter:
         """
         List meters of the authenticated customer.
@@ -190,6 +203,8 @@ class CustomerMetersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -210,6 +225,7 @@ class CustomerMetersAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -230,6 +246,7 @@ class CustomerMetersAsync(AsyncServiceBase):
             "-modified_at"
         ],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerCustomerMeter, None]:
         """
         List meters of the authenticated customer.
@@ -243,6 +260,8 @@ class CustomerMetersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -262,6 +281,7 @@ class CustomerMetersAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -274,6 +294,7 @@ class CustomerMetersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerCustomerMeter:
         """
         Get a meter by ID for the authenticated customer.
@@ -283,6 +304,8 @@ class CustomerMetersAsync(AsyncServiceBase):
         Args:
             id: The customer meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -300,6 +323,7 @@ class CustomerMetersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_10/services/customer_portal/customer_session.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/customer_session.py
@@ -17,6 +17,7 @@ class CustomerSessionSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerCustomerSession:
         """
         Introspect the current session and return its information.
@@ -25,6 +26,8 @@ class CustomerSessionSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -38,6 +41,7 @@ class CustomerSessionSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, CustomerCustomerSession)
@@ -46,6 +50,7 @@ class CustomerSessionSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> PortalAuthenticatedUser:
         """
         Get information about the currently authenticated portal user.
@@ -54,6 +59,8 @@ class CustomerSessionSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -67,6 +74,7 @@ class CustomerSessionSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, PortalAuthenticatedUser)
@@ -77,6 +85,7 @@ class CustomerSessionAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerCustomerSession:
         """
         Introspect the current session and return its information.
@@ -85,6 +94,8 @@ class CustomerSessionAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -98,6 +109,7 @@ class CustomerSessionAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, CustomerCustomerSession)
@@ -106,6 +118,7 @@ class CustomerSessionAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> PortalAuthenticatedUser:
         """
         Get information about the currently authenticated portal user.
@@ -114,6 +127,8 @@ class CustomerSessionAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -127,6 +142,7 @@ class CustomerSessionAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, PortalAuthenticatedUser)

--- a/sdk/python/polar/v2026_10/services/customer_portal/customers.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/customers.py
@@ -40,6 +40,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerPortalCustomer:
         """
         Get authenticated customer.
@@ -48,6 +49,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -61,6 +64,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, CustomerPortalCustomer)
@@ -69,6 +73,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalCustomerUpdate],
     ) -> CustomerPortalCustomer:
         """
@@ -76,6 +81,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -91,6 +98,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -105,6 +113,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerPaymentMethod:
         """
         Get saved payment methods of the authenticated customer.
@@ -113,6 +122,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -130,6 +141,7 @@ class CustomersSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -145,6 +157,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerPaymentMethod, None, None]:
         """
         Get saved payment methods of the authenticated customer.
@@ -153,6 +166,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -169,6 +184,7 @@ class CustomersSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -179,6 +195,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPaymentMethodCreate],
     ) -> CustomerPaymentMethodCreateResponse:
         """
@@ -186,6 +203,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -202,6 +221,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -217,6 +237,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPaymentMethodConfirm],
     ) -> CustomerPaymentMethodCreateResponse:
         """
@@ -224,6 +245,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -240,6 +263,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -256,6 +280,7 @@ class CustomersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a payment method from the authenticated customer.
@@ -263,6 +288,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -281,6 +308,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -294,6 +322,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerEmailUpdateRequest],
     ) -> typing.Any:
         """
@@ -301,6 +330,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -316,6 +347,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -329,6 +361,7 @@ class CustomersSync(SyncServiceBase):
         *,
         token: str,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Check if an email change verification token is still valid.
@@ -336,6 +369,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             token:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -353,6 +388,7 @@ class CustomersSync(SyncServiceBase):
                 "token": token,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -365,6 +401,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerEmailUpdateVerifyRequest],
     ) -> CustomerEmailUpdateVerifyResponse:
         """
@@ -372,6 +409,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -388,6 +427,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -405,6 +445,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerPortalCustomer:
         """
         Get authenticated customer.
@@ -413,6 +454,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -426,6 +469,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, CustomerPortalCustomer)
@@ -434,6 +478,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalCustomerUpdate],
     ) -> CustomerPortalCustomer:
         """
@@ -441,6 +486,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -456,6 +503,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -470,6 +518,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerPaymentMethod:
         """
         Get saved payment methods of the authenticated customer.
@@ -478,6 +527,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -495,6 +546,7 @@ class CustomersAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -510,6 +562,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerPaymentMethod, None]:
         """
         Get saved payment methods of the authenticated customer.
@@ -518,6 +571,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -534,6 +589,7 @@ class CustomersAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -545,6 +601,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPaymentMethodCreate],
     ) -> CustomerPaymentMethodCreateResponse:
         """
@@ -552,6 +609,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -568,6 +627,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -583,6 +643,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPaymentMethodConfirm],
     ) -> CustomerPaymentMethodCreateResponse:
         """
@@ -590,6 +651,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -606,6 +669,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -622,6 +686,7 @@ class CustomersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a payment method from the authenticated customer.
@@ -629,6 +694,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -647,6 +714,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -660,6 +728,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerEmailUpdateRequest],
     ) -> typing.Any:
         """
@@ -667,6 +736,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -682,6 +753,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -695,6 +767,7 @@ class CustomersAsync(AsyncServiceBase):
         *,
         token: str,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Check if an email change verification token is still valid.
@@ -702,6 +775,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             token:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -719,6 +794,7 @@ class CustomersAsync(AsyncServiceBase):
                 "token": token,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -731,6 +807,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerEmailUpdateVerifyRequest],
     ) -> CustomerEmailUpdateVerifyResponse:
         """
@@ -738,6 +815,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -754,6 +833,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/customer_portal/downloadables.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/downloadables.py
@@ -26,6 +26,7 @@ class DownloadablesSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDownloadableRead:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -35,6 +36,8 @@ class DownloadablesSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -53,6 +56,7 @@ class DownloadablesSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -69,6 +73,7 @@ class DownloadablesSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[DownloadableRead, None, None]:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -78,6 +83,8 @@ class DownloadablesSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -95,6 +102,7 @@ class DownloadablesSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -110,6 +118,7 @@ class DownloadablesAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDownloadableRead:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -119,6 +128,8 @@ class DownloadablesAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -137,6 +148,7 @@ class DownloadablesAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -153,6 +165,7 @@ class DownloadablesAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[DownloadableRead, None]:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -162,6 +175,8 @@ class DownloadablesAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -179,6 +194,7 @@ class DownloadablesAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item

--- a/sdk/python/polar/v2026_10/services/customer_portal/license_keys.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/license_keys.py
@@ -38,6 +38,7 @@ class LicenseKeysSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceLicenseKeyRead:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -47,6 +48,8 @@ class LicenseKeysSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -67,6 +70,7 @@ class LicenseKeysSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -83,6 +87,7 @@ class LicenseKeysSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[LicenseKeyRead, None, None]:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -92,6 +97,8 @@ class LicenseKeysSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -111,6 +118,7 @@ class LicenseKeysSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -122,6 +130,7 @@ class LicenseKeysSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyWithActivations:
         """
         Get a license key.
@@ -131,6 +140,8 @@ class LicenseKeysSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -148,6 +159,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -161,6 +173,7 @@ class LicenseKeysSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyRead:
         """
         Rotate a license key.
@@ -174,6 +187,8 @@ class LicenseKeysSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -193,6 +208,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -207,6 +223,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyValidate],
     ) -> ValidatedLicenseKey:
         """
@@ -219,6 +236,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -235,6 +254,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -248,6 +268,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyActivate],
     ) -> LicenseKeyActivationRead:
         """
@@ -260,6 +281,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -277,6 +300,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -291,6 +315,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyDeactivate],
     ) -> None:
         """
@@ -303,6 +328,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -319,6 +346,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -337,6 +365,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceLicenseKeyRead:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -346,6 +375,8 @@ class LicenseKeysAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -366,6 +397,7 @@ class LicenseKeysAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -382,6 +414,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[LicenseKeyRead, None]:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -391,6 +424,8 @@ class LicenseKeysAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -410,6 +445,7 @@ class LicenseKeysAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -422,6 +458,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyWithActivations:
         """
         Get a license key.
@@ -431,6 +468,8 @@ class LicenseKeysAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -448,6 +487,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -461,6 +501,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyRead:
         """
         Rotate a license key.
@@ -474,6 +515,8 @@ class LicenseKeysAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -493,6 +536,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -507,6 +551,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyValidate],
     ) -> ValidatedLicenseKey:
         """
@@ -519,6 +564,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -535,6 +582,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -548,6 +596,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyActivate],
     ) -> LicenseKeyActivationRead:
         """
@@ -560,6 +609,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -577,6 +628,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -591,6 +643,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyDeactivate],
     ) -> None:
         """
@@ -603,6 +656,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -619,6 +674,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/customer_portal/members.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/members.py
@@ -42,6 +42,7 @@ class MembersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerPortalMember:
         """
         List all members of the customer's team.
@@ -52,6 +53,8 @@ class MembersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -71,6 +74,7 @@ class MembersSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -88,6 +92,7 @@ class MembersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerPortalMember, None, None]:
         """
         List all members of the customer's team.
@@ -98,6 +103,8 @@ class MembersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -116,6 +123,7 @@ class MembersSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -126,6 +134,7 @@ class MembersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalMemberCreate],
     ) -> CustomerPortalMember:
         """
@@ -139,6 +148,8 @@ class MembersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -157,6 +168,7 @@ class MembersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -173,6 +185,7 @@ class MembersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Remove a member from the team.
@@ -186,6 +199,8 @@ class MembersSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -206,6 +221,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -222,6 +238,7 @@ class MembersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalMemberUpdate],
     ) -> CustomerPortalMember:
         """
@@ -236,6 +253,8 @@ class MembersSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -257,6 +276,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -277,6 +297,7 @@ class MembersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerPortalMember:
         """
         List all members of the customer's team.
@@ -287,6 +308,8 @@ class MembersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -306,6 +329,7 @@ class MembersAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -323,6 +347,7 @@ class MembersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerPortalMember, None]:
         """
         List all members of the customer's team.
@@ -333,6 +358,8 @@ class MembersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -351,6 +378,7 @@ class MembersAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -362,6 +390,7 @@ class MembersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalMemberCreate],
     ) -> CustomerPortalMember:
         """
@@ -375,6 +404,8 @@ class MembersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -393,6 +424,7 @@ class MembersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -409,6 +441,7 @@ class MembersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Remove a member from the team.
@@ -422,6 +455,8 @@ class MembersAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -442,6 +477,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -458,6 +494,7 @@ class MembersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerPortalMemberUpdate],
     ) -> CustomerPortalMember:
         """
@@ -472,6 +509,8 @@ class MembersAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -493,6 +532,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/customer_portal/orders.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/orders.py
@@ -50,6 +50,7 @@ class OrdersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerOrderSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerOrder:
         """
         List orders of the authenticated customer.
@@ -63,6 +64,8 @@ class OrdersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -85,6 +88,7 @@ class OrdersSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -105,6 +109,7 @@ class OrdersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerOrderSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerOrder, None, None]:
         """
         List orders of the authenticated customer.
@@ -118,6 +123,8 @@ class OrdersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -139,6 +146,7 @@ class OrdersSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -150,6 +158,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrder:
         """
         Get an order by ID for the authenticated customer.
@@ -157,6 +166,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -174,6 +185,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -187,6 +199,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerOrderUpdate],
     ) -> CustomerOrder:
         """
@@ -195,6 +208,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -213,6 +228,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -227,6 +243,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderInvoice:
         """
         Get an order's invoice data.
@@ -234,6 +251,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -251,6 +270,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -264,6 +284,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Trigger generation of an order's invoice.
@@ -271,6 +292,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -289,6 +312,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -303,6 +327,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderReceipt:
         """
         Get a presigned URL to download an order's receipt PDF.
@@ -310,6 +335,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -327,6 +354,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -340,6 +368,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderPaymentStatus:
         """
         Get the current payment status for an order.
@@ -347,6 +376,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -364,6 +395,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -377,6 +409,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerOrderConfirmPayment],
     ) -> CustomerOrderPaymentConfirmation:
         """
@@ -385,6 +418,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -405,6 +440,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -433,6 +469,7 @@ class OrdersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerOrderSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerOrder:
         """
         List orders of the authenticated customer.
@@ -446,6 +483,8 @@ class OrdersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -468,6 +507,7 @@ class OrdersAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -488,6 +528,7 @@ class OrdersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerOrderSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerOrder, None]:
         """
         List orders of the authenticated customer.
@@ -501,6 +542,8 @@ class OrdersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -522,6 +565,7 @@ class OrdersAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -534,6 +578,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrder:
         """
         Get an order by ID for the authenticated customer.
@@ -541,6 +586,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -558,6 +605,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -571,6 +619,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerOrderUpdate],
     ) -> CustomerOrder:
         """
@@ -579,6 +628,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -597,6 +648,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -611,6 +663,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderInvoice:
         """
         Get an order's invoice data.
@@ -618,6 +671,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -635,6 +690,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -648,6 +704,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Trigger generation of an order's invoice.
@@ -655,6 +712,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -673,6 +732,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -687,6 +747,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderReceipt:
         """
         Get a presigned URL to download an order's receipt PDF.
@@ -694,6 +755,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -711,6 +774,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -724,6 +788,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrderPaymentStatus:
         """
         Get the current payment status for an order.
@@ -731,6 +796,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -748,6 +815,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -761,6 +829,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerOrderConfirmPayment],
     ) -> CustomerOrderPaymentConfirmation:
         """
@@ -769,6 +838,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -789,6 +860,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/customer_portal/organizations.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/organizations.py
@@ -21,6 +21,7 @@ class OrganizationsSync(SyncServiceBase):
         slug: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrganizationData:
         """
         Get a customer portal's organization by slug.
@@ -28,6 +29,8 @@ class OrganizationsSync(SyncServiceBase):
         Args:
             slug: The organization slug.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -45,6 +48,7 @@ class OrganizationsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -60,6 +64,7 @@ class OrganizationsAsync(AsyncServiceBase):
         slug: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerOrganizationData:
         """
         Get a customer portal's organization by slug.
@@ -67,6 +72,8 @@ class OrganizationsAsync(AsyncServiceBase):
         Args:
             slug: The organization slug.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -84,6 +91,7 @@ class OrganizationsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_10/services/customer_portal/seats.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/seats.py
@@ -44,6 +44,7 @@ class SeatsSync(SyncServiceBase):
         subscription_id: str | None = None,
         order_id: str | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatsList:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -52,6 +53,8 @@ class SeatsSync(SyncServiceBase):
             subscription_id: Subscription ID
             order_id: Order ID
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -72,6 +75,7 @@ class SeatsSync(SyncServiceBase):
                 "order_id": order_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -86,11 +90,14 @@ class SeatsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSeatAssign],
     ) -> CustomerSeat:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -110,6 +117,7 @@ class SeatsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -127,11 +135,14 @@ class SeatsSync(SyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -151,6 +162,7 @@ class SeatsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -166,11 +178,14 @@ class SeatsSync(SyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -191,6 +206,7 @@ class SeatsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -208,6 +224,7 @@ class SeatsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerSubscription:
         """
         List all subscriptions where the authenticated customer has claimed a seat.
@@ -218,6 +235,8 @@ class SeatsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -236,6 +255,7 @@ class SeatsSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -252,6 +272,7 @@ class SeatsSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerSubscription, None, None]:
         """
         List all subscriptions where the authenticated customer has claimed a seat.
@@ -262,6 +283,8 @@ class SeatsSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -279,6 +302,7 @@ class SeatsSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -293,6 +317,7 @@ class SeatsAsync(AsyncServiceBase):
         subscription_id: str | None = None,
         order_id: str | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatsList:
         """
         **Scopes**: `customer_portal:read` `customer_portal:write`
@@ -301,6 +326,8 @@ class SeatsAsync(AsyncServiceBase):
             subscription_id: Subscription ID
             order_id: Order ID
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -321,6 +348,7 @@ class SeatsAsync(AsyncServiceBase):
                 "order_id": order_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -335,11 +363,14 @@ class SeatsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSeatAssign],
     ) -> CustomerSeat:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -359,6 +390,7 @@ class SeatsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -376,11 +408,14 @@ class SeatsAsync(AsyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -400,6 +435,7 @@ class SeatsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -415,11 +451,14 @@ class SeatsAsync(AsyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -440,6 +479,7 @@ class SeatsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -457,6 +497,7 @@ class SeatsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerSubscription:
         """
         List all subscriptions where the authenticated customer has claimed a seat.
@@ -467,6 +508,8 @@ class SeatsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -485,6 +528,7 @@ class SeatsAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -501,6 +545,7 @@ class SeatsAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerSubscription, None]:
         """
         List all subscriptions where the authenticated customer has claimed a seat.
@@ -511,6 +556,8 @@ class SeatsAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -528,6 +575,7 @@ class SeatsAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item

--- a/sdk/python/polar/v2026_10/services/customer_portal/subscriptions.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/subscriptions.py
@@ -46,6 +46,7 @@ class SubscriptionsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerSubscriptionSortProperty] | None = ["-started_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerSubscription:
         """
         List subscriptions of the authenticated customer.
@@ -60,6 +61,8 @@ class SubscriptionsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -81,6 +84,7 @@ class SubscriptionsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -100,6 +104,7 @@ class SubscriptionsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerSubscriptionSortProperty] | None = ["-started_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerSubscription, None, None]:
         """
         List subscriptions of the authenticated customer.
@@ -114,6 +119,8 @@ class SubscriptionsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -134,6 +141,7 @@ class SubscriptionsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -145,6 +153,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSubscription:
         """
         Get a subscription for the authenticated customer.
@@ -154,6 +163,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -171,6 +182,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -184,6 +196,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSubscription:
         """
         Cancel a subscription of the authenticated customer.
@@ -191,6 +204,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -209,6 +224,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -224,6 +240,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateProduct],
     ) -> CustomerSubscription: ...
 
@@ -233,6 +250,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateSeats],
     ) -> CustomerSubscription: ...
 
@@ -242,6 +260,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateUnits],
     ) -> CustomerSubscription: ...
 
@@ -251,6 +270,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionCancel],
     ) -> CustomerSubscription: ...
 
@@ -260,6 +280,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionPause],
     ) -> CustomerSubscription: ...
 
@@ -269,6 +290,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionResume],
     ) -> CustomerSubscription: ...
 
@@ -278,6 +300,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateClear],
     ) -> CustomerSubscription: ...
 
@@ -286,6 +309,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerSubscription:
         """
@@ -294,6 +318,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -315,6 +341,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -339,6 +366,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerSubscriptionSortProperty] | None = ["-started_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerSubscription:
         """
         List subscriptions of the authenticated customer.
@@ -353,6 +381,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -374,6 +404,7 @@ class SubscriptionsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -393,6 +424,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerSubscriptionSortProperty] | None = ["-started_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerSubscription, None]:
         """
         List subscriptions of the authenticated customer.
@@ -407,6 +439,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -427,6 +461,7 @@ class SubscriptionsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -439,6 +474,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSubscription:
         """
         Get a subscription for the authenticated customer.
@@ -448,6 +484,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -465,6 +503,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -478,6 +517,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSubscription:
         """
         Cancel a subscription of the authenticated customer.
@@ -485,6 +525,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -503,6 +545,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -518,6 +561,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateProduct],
     ) -> CustomerSubscription: ...
 
@@ -527,6 +571,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateSeats],
     ) -> CustomerSubscription: ...
 
@@ -536,6 +581,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateUnits],
     ) -> CustomerSubscription: ...
 
@@ -545,6 +591,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionCancel],
     ) -> CustomerSubscription: ...
 
@@ -554,6 +601,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionPause],
     ) -> CustomerSubscription: ...
 
@@ -563,6 +611,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionResume],
     ) -> CustomerSubscription: ...
 
@@ -572,6 +621,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSubscriptionUpdateClear],
     ) -> CustomerSubscription: ...
 
@@ -580,6 +630,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerSubscription:
         """
@@ -588,6 +639,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -609,6 +662,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/customer_portal/wallets.py
+++ b/sdk/python/polar/v2026_10/services/customer_portal/wallets.py
@@ -30,6 +30,7 @@ class WalletsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerWalletSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerWallet:
         """
         List wallets of the authenticated customer.
@@ -39,6 +40,8 @@ class WalletsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -57,6 +60,7 @@ class WalletsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -71,6 +75,7 @@ class WalletsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerWalletSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[CustomerWallet, None, None]:
         """
         List wallets of the authenticated customer.
@@ -80,6 +85,8 @@ class WalletsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -97,6 +104,7 @@ class WalletsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -108,6 +116,7 @@ class WalletsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerWallet:
         """
         Get a wallet by ID for the authenticated customer.
@@ -115,6 +124,8 @@ class WalletsSync(SyncServiceBase):
         Args:
             id: The wallet ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -132,6 +143,7 @@ class WalletsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -149,6 +161,7 @@ class WalletsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerWalletSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomerWallet:
         """
         List wallets of the authenticated customer.
@@ -158,6 +171,8 @@ class WalletsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -176,6 +191,7 @@ class WalletsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -190,6 +206,7 @@ class WalletsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[CustomerWalletSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[CustomerWallet, None]:
         """
         List wallets of the authenticated customer.
@@ -199,6 +216,8 @@ class WalletsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -216,6 +235,7 @@ class WalletsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -228,6 +248,7 @@ class WalletsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerWallet:
         """
         Get a wallet by ID for the authenticated customer.
@@ -235,6 +256,8 @@ class WalletsAsync(AsyncServiceBase):
         Args:
             id: The wallet ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -252,6 +275,7 @@ class WalletsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_10/services/customer_seats.py
+++ b/sdk/python/polar/v2026_10/services/customer_seats.py
@@ -49,6 +49,7 @@ class CustomerSeatsSync(SyncServiceBase):
         subscription_id: str | None = None,
         order_id: str | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatsList:
         """
         **Scopes**: `customer_seats:read`
@@ -57,6 +58,8 @@ class CustomerSeatsSync(SyncServiceBase):
             subscription_id:
             order_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -77,6 +80,7 @@ class CustomerSeatsSync(SyncServiceBase):
                 "order_id": order_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -91,6 +95,7 @@ class CustomerSeatsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SeatAssign],
     ) -> CustomerSeat:
         """
@@ -98,6 +103,8 @@ class CustomerSeatsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -117,6 +124,7 @@ class CustomerSeatsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -134,6 +142,7 @@ class CustomerSeatsSync(SyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         **Scopes**: `customer_seats:write`
@@ -141,6 +150,8 @@ class CustomerSeatsSync(SyncServiceBase):
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -160,6 +171,7 @@ class CustomerSeatsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -175,6 +187,7 @@ class CustomerSeatsSync(SyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         **Scopes**: `customer_seats:write`
@@ -182,6 +195,8 @@ class CustomerSeatsSync(SyncServiceBase):
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -202,6 +217,7 @@ class CustomerSeatsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -218,11 +234,14 @@ class CustomerSeatsSync(SyncServiceBase):
         invitation_token: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatClaimInfo:
         """
         Args:
             invitation_token:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -242,6 +261,7 @@ class CustomerSeatsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -256,11 +276,14 @@ class CustomerSeatsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SeatClaim],
     ) -> CustomerSeatClaimResponse:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -278,6 +301,7 @@ class CustomerSeatsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -296,6 +320,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
         subscription_id: str | None = None,
         order_id: str | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatsList:
         """
         **Scopes**: `customer_seats:read`
@@ -304,6 +329,8 @@ class CustomerSeatsAsync(AsyncServiceBase):
             subscription_id:
             order_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -324,6 +351,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
                 "order_id": order_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -338,6 +366,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SeatAssign],
     ) -> CustomerSeat:
         """
@@ -345,6 +374,8 @@ class CustomerSeatsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -364,6 +395,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -381,6 +413,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         **Scopes**: `customer_seats:write`
@@ -388,6 +421,8 @@ class CustomerSeatsAsync(AsyncServiceBase):
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -407,6 +442,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -422,6 +458,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
         seat_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerSeat:
         """
         **Scopes**: `customer_seats:write`
@@ -429,6 +466,8 @@ class CustomerSeatsAsync(AsyncServiceBase):
         Args:
             seat_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -449,6 +488,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -465,11 +505,14 @@ class CustomerSeatsAsync(AsyncServiceBase):
         invitation_token: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> SeatClaimInfo:
         """
         Args:
             invitation_token:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -489,6 +532,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -503,11 +547,14 @@ class CustomerSeatsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SeatClaim],
     ) -> CustomerSeatClaimResponse:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -525,6 +572,7 @@ class CustomerSeatsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/customer_sessions.py
+++ b/sdk/python/polar/v2026_10/services/customer_sessions.py
@@ -26,6 +26,7 @@ class CustomerSessionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSessionCustomerIDCreate],
     ) -> CustomerSession: ...
 
@@ -34,6 +35,7 @@ class CustomerSessionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSessionCustomerExternalIDCreate],
     ) -> CustomerSession: ...
 
@@ -41,6 +43,7 @@ class CustomerSessionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerSession:
         """
@@ -53,6 +56,8 @@ class CustomerSessionsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -68,6 +73,7 @@ class CustomerSessionsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -83,6 +89,7 @@ class CustomerSessionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSessionCustomerIDCreate],
     ) -> CustomerSession: ...
 
@@ -91,6 +98,7 @@ class CustomerSessionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerSessionCustomerExternalIDCreate],
     ) -> CustomerSession: ...
 
@@ -98,6 +106,7 @@ class CustomerSessionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> CustomerSession:
         """
@@ -110,6 +119,8 @@ class CustomerSessionsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -125,6 +136,7 @@ class CustomerSessionsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/customers/__init__.py
+++ b/sdk/python/polar/v2026_10/services/customers/__init__.py
@@ -55,6 +55,7 @@ class CustomersSync(SyncServiceBase):
         sorting: builtins.list[CustomerSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomer:
         """
         List customers.
@@ -71,6 +72,8 @@ class CustomersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -94,6 +97,7 @@ class CustomersSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -113,6 +117,7 @@ class CustomersSync(SyncServiceBase):
         sorting: builtins.list[CustomerSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Customer, None, None]:
         """
         List customers.
@@ -129,6 +134,8 @@ class CustomersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -151,6 +158,7 @@ class CustomersSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -162,6 +170,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerIndividualCreate],
     ) -> Customer: ...
 
@@ -170,6 +179,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerTeamCreate],
     ) -> Customer: ...
 
@@ -177,6 +187,7 @@ class CustomersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Customer:
         """
@@ -186,6 +197,8 @@ class CustomersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -201,6 +214,7 @@ class CustomersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -214,6 +228,7 @@ class CustomersSync(SyncServiceBase):
         *,
         organization_id: str | builtins.list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export customers as a CSV file.
@@ -223,6 +238,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             organization_id: Filter by organization ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -239,6 +256,7 @@ class CustomersSync(SyncServiceBase):
                 "organization_id": organization_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -251,6 +269,7 @@ class CustomersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Customer:
         """
         Get a customer by ID.
@@ -260,6 +279,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -277,6 +298,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -291,6 +313,7 @@ class CustomersSync(SyncServiceBase):
         *,
         anonymize: bool = False,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a customer.
@@ -315,6 +338,8 @@ class CustomersSync(SyncServiceBase):
             id: The customer ID.
             anonymize: If true, also anonymize the customer's personal data for GDPR compliance. This replaces email with a hashed version, hashes name and billing name (name preserved for businesses with tax_id), clears billing address, and removes OAuth account data.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -334,6 +359,7 @@ class CustomersSync(SyncServiceBase):
                 "anonymize": anonymize,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -347,6 +373,7 @@ class CustomersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerUpdate],
     ) -> Customer:
         """
@@ -357,6 +384,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -375,6 +404,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -389,6 +419,7 @@ class CustomersSync(SyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Customer:
         """
         Get a customer by external ID.
@@ -398,6 +429,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -415,6 +448,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -429,6 +463,7 @@ class CustomersSync(SyncServiceBase):
         *,
         anonymize: bool = False,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a customer by external ID.
@@ -443,6 +478,8 @@ class CustomersSync(SyncServiceBase):
             external_id: The customer external ID.
             anonymize: If true, also anonymize the customer's personal data for GDPR compliance.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -462,6 +499,7 @@ class CustomersSync(SyncServiceBase):
                 "anonymize": anonymize,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -475,6 +513,7 @@ class CustomersSync(SyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerUpdateExternalID],
     ) -> Customer:
         """
@@ -485,6 +524,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -503,6 +544,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -517,6 +559,7 @@ class CustomersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerState:
         """
         Get a customer state by ID.
@@ -532,6 +575,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -549,6 +594,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -562,6 +608,7 @@ class CustomersSync(SyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerState:
         """
         Get a customer state by external ID.
@@ -577,6 +624,8 @@ class CustomersSync(SyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -594,6 +643,7 @@ class CustomersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -609,6 +659,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePaymentMethod:
         """
         Get saved payment methods of a customer.
@@ -620,6 +671,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -640,6 +693,7 @@ class CustomersSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -655,6 +709,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[PaymentMethod, None, None]:
         """
         Get saved payment methods of a customer.
@@ -666,6 +721,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -684,6 +741,7 @@ class CustomersSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -697,6 +755,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePaymentMethod:
         """
         Get saved payment methods of a customer by external ID.
@@ -708,6 +767,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -728,6 +789,7 @@ class CustomersSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -743,6 +805,7 @@ class CustomersSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[PaymentMethod, None, None]:
         """
         Get saved payment methods of a customer by external ID.
@@ -754,6 +817,8 @@ class CustomersSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -772,6 +837,7 @@ class CustomersSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -798,6 +864,7 @@ class CustomersAsync(AsyncServiceBase):
         sorting: builtins.list[CustomerSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceCustomer:
         """
         List customers.
@@ -814,6 +881,8 @@ class CustomersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -837,6 +906,7 @@ class CustomersAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -856,6 +926,7 @@ class CustomersAsync(AsyncServiceBase):
         sorting: builtins.list[CustomerSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Customer, None]:
         """
         List customers.
@@ -872,6 +943,8 @@ class CustomersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -894,6 +967,7 @@ class CustomersAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -906,6 +980,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerIndividualCreate],
     ) -> Customer: ...
 
@@ -914,6 +989,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerTeamCreate],
     ) -> Customer: ...
 
@@ -921,6 +997,7 @@ class CustomersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Customer:
         """
@@ -930,6 +1007,8 @@ class CustomersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -945,6 +1024,7 @@ class CustomersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -958,6 +1038,7 @@ class CustomersAsync(AsyncServiceBase):
         *,
         organization_id: str | builtins.list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export customers as a CSV file.
@@ -967,6 +1048,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             organization_id: Filter by organization ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -983,6 +1066,7 @@ class CustomersAsync(AsyncServiceBase):
                 "organization_id": organization_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -995,6 +1079,7 @@ class CustomersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Customer:
         """
         Get a customer by ID.
@@ -1004,6 +1089,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1021,6 +1108,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1035,6 +1123,7 @@ class CustomersAsync(AsyncServiceBase):
         *,
         anonymize: bool = False,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a customer.
@@ -1059,6 +1148,8 @@ class CustomersAsync(AsyncServiceBase):
             id: The customer ID.
             anonymize: If true, also anonymize the customer's personal data for GDPR compliance. This replaces email with a hashed version, hashes name and billing name (name preserved for businesses with tax_id), clears billing address, and removes OAuth account data.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1078,6 +1169,7 @@ class CustomersAsync(AsyncServiceBase):
                 "anonymize": anonymize,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1091,6 +1183,7 @@ class CustomersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerUpdate],
     ) -> Customer:
         """
@@ -1101,6 +1194,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1119,6 +1214,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -1133,6 +1229,7 @@ class CustomersAsync(AsyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Customer:
         """
         Get a customer by external ID.
@@ -1142,6 +1239,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1159,6 +1258,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1173,6 +1273,7 @@ class CustomersAsync(AsyncServiceBase):
         *,
         anonymize: bool = False,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a customer by external ID.
@@ -1187,6 +1288,8 @@ class CustomersAsync(AsyncServiceBase):
             external_id: The customer external ID.
             anonymize: If true, also anonymize the customer's personal data for GDPR compliance.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1206,6 +1309,7 @@ class CustomersAsync(AsyncServiceBase):
                 "anonymize": anonymize,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1219,6 +1323,7 @@ class CustomersAsync(AsyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[CustomerUpdateExternalID],
     ) -> Customer:
         """
@@ -1229,6 +1334,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1247,6 +1354,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -1261,6 +1369,7 @@ class CustomersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerState:
         """
         Get a customer state by ID.
@@ -1276,6 +1385,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1293,6 +1404,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1306,6 +1418,7 @@ class CustomersAsync(AsyncServiceBase):
         external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> CustomerState:
         """
         Get a customer state by external ID.
@@ -1321,6 +1434,8 @@ class CustomersAsync(AsyncServiceBase):
         Args:
             external_id: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1338,6 +1453,7 @@ class CustomersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1353,6 +1469,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePaymentMethod:
         """
         Get saved payment methods of a customer.
@@ -1364,6 +1481,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1384,6 +1503,7 @@ class CustomersAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1399,6 +1519,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[PaymentMethod, None]:
         """
         Get saved payment methods of a customer.
@@ -1410,6 +1531,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -1428,6 +1551,7 @@ class CustomersAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -1442,6 +1566,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePaymentMethod:
         """
         Get saved payment methods of a customer by external ID.
@@ -1453,6 +1578,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1473,6 +1600,7 @@ class CustomersAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1488,6 +1616,7 @@ class CustomersAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[PaymentMethod, None]:
         """
         Get saved payment methods of a customer by external ID.
@@ -1499,6 +1628,8 @@ class CustomersAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -1517,6 +1648,7 @@ class CustomersAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item

--- a/sdk/python/polar/v2026_10/services/customers/members.py
+++ b/sdk/python/polar/v2026_10/services/customers/members.py
@@ -40,6 +40,7 @@ class MembersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMember:
         """
         List the members of a customer.
@@ -53,6 +54,8 @@ class MembersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -75,6 +78,7 @@ class MembersSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -92,6 +96,7 @@ class MembersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Member, None, None]:
         """
         List the members of a customer.
@@ -105,6 +110,8 @@ class MembersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -125,6 +132,7 @@ class MembersSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -136,6 +144,7 @@ class MembersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberCreateFromCustomer],
     ) -> Member:
         """
@@ -149,6 +158,8 @@ class MembersSync(SyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -168,6 +179,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -187,6 +199,7 @@ class MembersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMember:
         """
         List the members of a customer identified by its external ID.
@@ -200,6 +213,8 @@ class MembersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -223,6 +238,7 @@ class MembersSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -241,6 +257,7 @@ class MembersSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Member, None, None]:
         """
         List the members of a customer identified by its external ID.
@@ -254,6 +271,8 @@ class MembersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -275,6 +294,7 @@ class MembersSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -286,6 +306,7 @@ class MembersSync(SyncServiceBase):
         external_id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberCreateFromCustomer],
     ) -> Member:
         """
@@ -296,6 +317,8 @@ class MembersSync(SyncServiceBase):
         Args:
             external_id_path: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -316,6 +339,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -333,6 +357,7 @@ class MembersSync(SyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Member:
         """
         Get a member of a customer by its ID.
@@ -343,6 +368,8 @@ class MembersSync(SyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -361,6 +388,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -375,6 +403,7 @@ class MembersSync(SyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a member of a customer.
@@ -385,6 +414,8 @@ class MembersSync(SyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -403,6 +434,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -417,6 +449,7 @@ class MembersSync(SyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberUpdate],
     ) -> Member:
         """
@@ -430,6 +463,8 @@ class MembersSync(SyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -449,6 +484,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -464,6 +500,7 @@ class MembersSync(SyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Member:
         """
         Get a member by external ID for a customer identified by its external ID.
@@ -474,6 +511,8 @@ class MembersSync(SyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -493,6 +532,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -508,6 +548,7 @@ class MembersSync(SyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a member by external ID for a customer identified by its external ID.
@@ -518,6 +559,8 @@ class MembersSync(SyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -537,6 +580,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -552,6 +596,7 @@ class MembersSync(SyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberUpdate],
     ) -> Member:
         """
@@ -563,6 +608,8 @@ class MembersSync(SyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -583,6 +630,7 @@ class MembersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -604,6 +652,7 @@ class MembersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMember:
         """
         List the members of a customer.
@@ -617,6 +666,8 @@ class MembersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -639,6 +690,7 @@ class MembersAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -656,6 +708,7 @@ class MembersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Member, None]:
         """
         List the members of a customer.
@@ -669,6 +722,8 @@ class MembersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -689,6 +744,7 @@ class MembersAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -701,6 +757,7 @@ class MembersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberCreateFromCustomer],
     ) -> Member:
         """
@@ -714,6 +771,8 @@ class MembersAsync(AsyncServiceBase):
         Args:
             id: The customer ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -733,6 +792,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -752,6 +812,7 @@ class MembersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMember:
         """
         List the members of a customer identified by its external ID.
@@ -765,6 +826,8 @@ class MembersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -788,6 +851,7 @@ class MembersAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -806,6 +870,7 @@ class MembersAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[MemberSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Member, None]:
         """
         List the members of a customer identified by its external ID.
@@ -819,6 +884,8 @@ class MembersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -840,6 +907,7 @@ class MembersAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -852,6 +920,7 @@ class MembersAsync(AsyncServiceBase):
         external_id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberCreateFromCustomer],
     ) -> Member:
         """
@@ -862,6 +931,8 @@ class MembersAsync(AsyncServiceBase):
         Args:
             external_id_path: The customer external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -882,6 +953,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -899,6 +971,7 @@ class MembersAsync(AsyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Member:
         """
         Get a member of a customer by its ID.
@@ -909,6 +982,8 @@ class MembersAsync(AsyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -927,6 +1002,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -941,6 +1017,7 @@ class MembersAsync(AsyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a member of a customer.
@@ -951,6 +1028,8 @@ class MembersAsync(AsyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -969,6 +1048,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -983,6 +1063,7 @@ class MembersAsync(AsyncServiceBase):
         member_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberUpdate],
     ) -> Member:
         """
@@ -996,6 +1077,8 @@ class MembersAsync(AsyncServiceBase):
             id: The customer ID.
             member_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1015,6 +1098,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -1030,6 +1114,7 @@ class MembersAsync(AsyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Member:
         """
         Get a member by external ID for a customer identified by its external ID.
@@ -1040,6 +1125,8 @@ class MembersAsync(AsyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1059,6 +1146,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1074,6 +1162,7 @@ class MembersAsync(AsyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a member by external ID for a customer identified by its external ID.
@@ -1084,6 +1173,8 @@ class MembersAsync(AsyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1103,6 +1194,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1118,6 +1210,7 @@ class MembersAsync(AsyncServiceBase):
         member_external_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MemberUpdate],
     ) -> Member:
         """
@@ -1129,6 +1222,8 @@ class MembersAsync(AsyncServiceBase):
             external_id: The customer external ID.
             member_external_id: The member external ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1149,6 +1244,7 @@ class MembersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/discounts.py
+++ b/sdk/python/polar/v2026_10/services/discounts.py
@@ -38,6 +38,7 @@ class DiscountsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DiscountSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDiscount:
         """
         List discounts.
@@ -51,6 +52,8 @@ class DiscountsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -71,6 +74,7 @@ class DiscountsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -87,6 +91,7 @@ class DiscountsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DiscountSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Discount, None, None]:
         """
         List discounts.
@@ -100,6 +105,8 @@ class DiscountsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -119,6 +126,7 @@ class DiscountsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -130,6 +138,7 @@ class DiscountsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountFixedCreate],
     ) -> Discount: ...
 
@@ -138,6 +147,7 @@ class DiscountsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountPercentageCreate],
     ) -> Discount: ...
 
@@ -145,6 +155,7 @@ class DiscountsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Discount:
         """
@@ -154,6 +165,8 @@ class DiscountsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -169,6 +182,7 @@ class DiscountsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -182,6 +196,7 @@ class DiscountsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Discount:
         """
         Get a discount by ID.
@@ -191,6 +206,8 @@ class DiscountsSync(SyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -208,6 +225,7 @@ class DiscountsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -221,6 +239,7 @@ class DiscountsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a discount.
@@ -230,6 +249,8 @@ class DiscountsSync(SyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -247,6 +268,7 @@ class DiscountsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -260,6 +282,7 @@ class DiscountsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountUpdate],
     ) -> Discount:
         """
@@ -270,6 +293,8 @@ class DiscountsSync(SyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -288,6 +313,7 @@ class DiscountsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -308,6 +334,7 @@ class DiscountsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DiscountSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDiscount:
         """
         List discounts.
@@ -321,6 +348,8 @@ class DiscountsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -341,6 +370,7 @@ class DiscountsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -357,6 +387,7 @@ class DiscountsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DiscountSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Discount, None]:
         """
         List discounts.
@@ -370,6 +401,8 @@ class DiscountsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -389,6 +422,7 @@ class DiscountsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -401,6 +435,7 @@ class DiscountsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountFixedCreate],
     ) -> Discount: ...
 
@@ -409,6 +444,7 @@ class DiscountsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountPercentageCreate],
     ) -> Discount: ...
 
@@ -416,6 +452,7 @@ class DiscountsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Discount:
         """
@@ -425,6 +462,8 @@ class DiscountsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -440,6 +479,7 @@ class DiscountsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -453,6 +493,7 @@ class DiscountsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Discount:
         """
         Get a discount by ID.
@@ -462,6 +503,8 @@ class DiscountsAsync(AsyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -479,6 +522,7 @@ class DiscountsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -492,6 +536,7 @@ class DiscountsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a discount.
@@ -501,6 +546,8 @@ class DiscountsAsync(AsyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -518,6 +565,7 @@ class DiscountsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -531,6 +579,7 @@ class DiscountsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DiscountUpdate],
     ) -> Discount:
         """
@@ -541,6 +590,8 @@ class DiscountsAsync(AsyncServiceBase):
         Args:
             id: The discount ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -559,6 +610,7 @@ class DiscountsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/disputes.py
+++ b/sdk/python/polar/v2026_10/services/disputes.py
@@ -35,6 +35,7 @@ class DisputesSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DisputeSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDispute:
         """
         List disputes.
@@ -49,6 +50,8 @@ class DisputesSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -70,6 +73,7 @@ class DisputesSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -87,6 +91,7 @@ class DisputesSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DisputeSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Dispute, None, None]:
         """
         List disputes.
@@ -101,6 +106,8 @@ class DisputesSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -121,6 +128,7 @@ class DisputesSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -132,6 +140,7 @@ class DisputesSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Dispute:
         """
         Get a dispute by ID.
@@ -141,6 +150,8 @@ class DisputesSync(SyncServiceBase):
         Args:
             id: The dispute ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -158,6 +169,7 @@ class DisputesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -171,6 +183,7 @@ class DisputesSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Dispute:
         """
         Accept a dispute, conceding the chargeback.
@@ -183,6 +196,8 @@ class DisputesSync(SyncServiceBase):
         Args:
             id: The dispute ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -201,6 +216,7 @@ class DisputesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -222,6 +238,7 @@ class DisputesAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DisputeSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceDispute:
         """
         List disputes.
@@ -236,6 +253,8 @@ class DisputesAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -257,6 +276,7 @@ class DisputesAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -274,6 +294,7 @@ class DisputesAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[DisputeSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Dispute, None]:
         """
         List disputes.
@@ -288,6 +309,8 @@ class DisputesAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -308,6 +331,7 @@ class DisputesAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -320,6 +344,7 @@ class DisputesAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Dispute:
         """
         Get a dispute by ID.
@@ -329,6 +354,8 @@ class DisputesAsync(AsyncServiceBase):
         Args:
             id: The dispute ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -346,6 +373,7 @@ class DisputesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -359,6 +387,7 @@ class DisputesAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Dispute:
         """
         Accept a dispute, conceding the chargeback.
@@ -371,6 +400,8 @@ class DisputesAsync(AsyncServiceBase):
         Args:
             id: The dispute ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -389,6 +420,7 @@ class DisputesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_10/services/event_types.py
+++ b/sdk/python/polar/v2026_10/services/event_types.py
@@ -42,6 +42,7 @@ class EventTypesSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventTypesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEventTypeWithStats:
         """
         List event types with aggregated statistics.
@@ -60,6 +61,8 @@ class EventTypesSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -85,6 +88,7 @@ class EventTypesSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -108,6 +112,7 @@ class EventTypesSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventTypesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[EventTypeWithStats, None, None]:
         """
         List event types with aggregated statistics.
@@ -126,6 +131,8 @@ class EventTypesSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -150,6 +157,7 @@ class EventTypesSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -161,6 +169,7 @@ class EventTypesSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[EventTypeUpdate],
     ) -> EventType:
         """
@@ -171,6 +180,8 @@ class EventTypesSync(SyncServiceBase):
         Args:
             id: The event type ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -189,6 +200,7 @@ class EventTypesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -214,6 +226,7 @@ class EventTypesAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventTypesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEventTypeWithStats:
         """
         List event types with aggregated statistics.
@@ -232,6 +245,8 @@ class EventTypesAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -257,6 +272,7 @@ class EventTypesAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -280,6 +296,7 @@ class EventTypesAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventTypesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[EventTypeWithStats, None]:
         """
         List event types with aggregated statistics.
@@ -298,6 +315,8 @@ class EventTypesAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -322,6 +341,7 @@ class EventTypesAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -334,6 +354,7 @@ class EventTypesAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[EventTypeUpdate],
     ) -> EventType:
         """
@@ -344,6 +365,8 @@ class EventTypesAsync(AsyncServiceBase):
         Args:
             id: The event type ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -362,6 +385,7 @@ class EventTypesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/events.py
+++ b/sdk/python/polar/v2026_10/services/events.py
@@ -53,6 +53,7 @@ class EventsSync(SyncServiceBase):
         sorting: builtins.list[EventSortProperty] | None = ["-timestamp"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEvent | ListResourceWithCursorPaginationEvent:
         """
         List events.
@@ -77,6 +78,8 @@ class EventsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -108,6 +111,7 @@ class EventsSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -131,6 +135,7 @@ class EventsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventNamesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEventName:
         """
         List event names.
@@ -147,6 +152,8 @@ class EventsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -170,6 +177,7 @@ class EventsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -189,6 +197,7 @@ class EventsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventNamesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[EventName, None, None]:
         """
         List event names.
@@ -205,6 +214,8 @@ class EventsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -227,6 +238,7 @@ class EventsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -238,6 +250,7 @@ class EventsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Event:
         """
         Get an event by ID.
@@ -247,6 +260,8 @@ class EventsSync(SyncServiceBase):
         Args:
             id: The event ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -264,6 +279,7 @@ class EventsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -276,6 +292,7 @@ class EventsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[EventsIngest],
     ) -> EventsIngestResponse:
         """
@@ -285,6 +302,8 @@ class EventsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -300,6 +319,7 @@ class EventsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -330,6 +350,7 @@ class EventsAsync(AsyncServiceBase):
         sorting: builtins.list[EventSortProperty] | None = ["-timestamp"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEvent | ListResourceWithCursorPaginationEvent:
         """
         List events.
@@ -354,6 +375,8 @@ class EventsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -385,6 +408,7 @@ class EventsAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -408,6 +432,7 @@ class EventsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventNamesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceEventName:
         """
         List event names.
@@ -424,6 +449,8 @@ class EventsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -447,6 +474,7 @@ class EventsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -466,6 +494,7 @@ class EventsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[EventNamesSortProperty] | None = ["-last_seen"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[EventName, None]:
         """
         List event names.
@@ -482,6 +511,8 @@ class EventsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -504,6 +535,7 @@ class EventsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -516,6 +548,7 @@ class EventsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Event:
         """
         Get an event by ID.
@@ -525,6 +558,8 @@ class EventsAsync(AsyncServiceBase):
         Args:
             id: The event ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -542,6 +577,7 @@ class EventsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -554,6 +590,7 @@ class EventsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[EventsIngest],
     ) -> EventsIngestResponse:
         """
@@ -563,6 +600,8 @@ class EventsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -578,6 +617,7 @@ class EventsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/files.py
+++ b/sdk/python/polar/v2026_10/services/files.py
@@ -39,6 +39,7 @@ class FilesSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceFileRead:
         """
         List files.
@@ -51,6 +52,8 @@ class FilesSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -70,6 +73,7 @@ class FilesSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -85,6 +89,7 @@ class FilesSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[FileRead, None, None]:
         """
         List files.
@@ -97,6 +102,8 @@ class FilesSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -115,6 +122,7 @@ class FilesSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -126,6 +134,7 @@ class FilesSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DownloadableFileCreate],
     ) -> FileUpload: ...
 
@@ -134,6 +143,7 @@ class FilesSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductMediaFileCreate],
     ) -> FileUpload: ...
 
@@ -142,6 +152,7 @@ class FilesSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationAvatarFileCreate],
     ) -> FileUpload: ...
 
@@ -150,6 +161,7 @@ class FilesSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SupportCaseAttachmentFileCreate],
     ) -> FileUpload: ...
 
@@ -157,6 +169,7 @@ class FilesSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> FileUpload:
         """
@@ -166,6 +179,8 @@ class FilesSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -181,6 +196,7 @@ class FilesSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -194,6 +210,7 @@ class FilesSync(SyncServiceBase):
         id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[FileUploadCompleted],
     ) -> FileRead:
         """
@@ -204,6 +221,8 @@ class FilesSync(SyncServiceBase):
         Args:
             id_path: The file ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -223,6 +242,7 @@ class FilesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -238,6 +258,7 @@ class FilesSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a file.
@@ -247,6 +268,8 @@ class FilesSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -265,6 +288,7 @@ class FilesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -279,6 +303,7 @@ class FilesSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[FilePatch],
     ) -> FileRead:
         """
@@ -289,6 +314,8 @@ class FilesSync(SyncServiceBase):
         Args:
             id: The file ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -308,6 +335,7 @@ class FilesSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -328,6 +356,7 @@ class FilesAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceFileRead:
         """
         List files.
@@ -340,6 +369,8 @@ class FilesAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -359,6 +390,7 @@ class FilesAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -374,6 +406,7 @@ class FilesAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[FileRead, None]:
         """
         List files.
@@ -386,6 +419,8 @@ class FilesAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -404,6 +439,7 @@ class FilesAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -416,6 +452,7 @@ class FilesAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[DownloadableFileCreate],
     ) -> FileUpload: ...
 
@@ -424,6 +461,7 @@ class FilesAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductMediaFileCreate],
     ) -> FileUpload: ...
 
@@ -432,6 +470,7 @@ class FilesAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationAvatarFileCreate],
     ) -> FileUpload: ...
 
@@ -440,6 +479,7 @@ class FilesAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SupportCaseAttachmentFileCreate],
     ) -> FileUpload: ...
 
@@ -447,6 +487,7 @@ class FilesAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> FileUpload:
         """
@@ -456,6 +497,8 @@ class FilesAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -471,6 +514,7 @@ class FilesAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -484,6 +528,7 @@ class FilesAsync(AsyncServiceBase):
         id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[FileUploadCompleted],
     ) -> FileRead:
         """
@@ -494,6 +539,8 @@ class FilesAsync(AsyncServiceBase):
         Args:
             id_path: The file ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -513,6 +560,7 @@ class FilesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -528,6 +576,7 @@ class FilesAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a file.
@@ -537,6 +586,8 @@ class FilesAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -555,6 +606,7 @@ class FilesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -569,6 +621,7 @@ class FilesAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[FilePatch],
     ) -> FileRead:
         """
@@ -579,6 +632,8 @@ class FilesAsync(AsyncServiceBase):
         Args:
             id: The file ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -598,6 +653,7 @@ class FilesAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/license_keys.py
+++ b/sdk/python/polar/v2026_10/services/license_keys.py
@@ -45,6 +45,7 @@ class LicenseKeysSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceLicenseKeyRead:
         """
         Get license keys connected to the given organization & filters.
@@ -58,6 +59,8 @@ class LicenseKeysSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -80,6 +83,7 @@ class LicenseKeysSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -98,6 +102,7 @@ class LicenseKeysSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[LicenseKeyRead, None, None]:
         """
         Get license keys connected to the given organization & filters.
@@ -111,6 +116,8 @@ class LicenseKeysSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -132,6 +139,7 @@ class LicenseKeysSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -143,6 +151,7 @@ class LicenseKeysSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyWithActivations:
         """
         Get a license key.
@@ -152,6 +161,8 @@ class LicenseKeysSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -170,6 +181,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -184,6 +196,7 @@ class LicenseKeysSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyUpdate],
     ) -> LicenseKeyRead:
         """
@@ -194,6 +207,8 @@ class LicenseKeysSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -213,6 +228,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -228,6 +244,7 @@ class LicenseKeysSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyRead:
         """
         Rotate a license key.
@@ -241,6 +258,8 @@ class LicenseKeysSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -260,6 +279,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -276,6 +296,7 @@ class LicenseKeysSync(SyncServiceBase):
         activation_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyActivationRead:
         """
         Get a license key activation.
@@ -286,6 +307,8 @@ class LicenseKeysSync(SyncServiceBase):
             id:
             activation_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -305,6 +328,7 @@ class LicenseKeysSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -318,6 +342,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyValidate],
     ) -> ValidatedLicenseKey:
         """
@@ -327,6 +352,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -343,6 +370,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -356,6 +384,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyActivate],
     ) -> LicenseKeyActivationRead:
         """
@@ -365,6 +394,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -382,6 +413,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -396,6 +428,7 @@ class LicenseKeysSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyDeactivate],
     ) -> None:
         """
@@ -405,6 +438,8 @@ class LicenseKeysSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -421,6 +456,7 @@ class LicenseKeysSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -441,6 +477,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceLicenseKeyRead:
         """
         Get license keys connected to the given organization & filters.
@@ -454,6 +491,8 @@ class LicenseKeysAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -476,6 +515,7 @@ class LicenseKeysAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -494,6 +534,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[LicenseKeyRead, None]:
         """
         Get license keys connected to the given organization & filters.
@@ -507,6 +548,8 @@ class LicenseKeysAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -528,6 +571,7 @@ class LicenseKeysAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -540,6 +584,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyWithActivations:
         """
         Get a license key.
@@ -549,6 +594,8 @@ class LicenseKeysAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -567,6 +614,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -581,6 +629,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyUpdate],
     ) -> LicenseKeyRead:
         """
@@ -591,6 +640,8 @@ class LicenseKeysAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -610,6 +661,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -625,6 +677,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyRead:
         """
         Rotate a license key.
@@ -638,6 +691,8 @@ class LicenseKeysAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -657,6 +712,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -673,6 +729,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         activation_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> LicenseKeyActivationRead:
         """
         Get a license key activation.
@@ -683,6 +740,8 @@ class LicenseKeysAsync(AsyncServiceBase):
             id:
             activation_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -702,6 +761,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -715,6 +775,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyValidate],
     ) -> ValidatedLicenseKey:
         """
@@ -724,6 +785,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -740,6 +803,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -753,6 +817,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyActivate],
     ) -> LicenseKeyActivationRead:
         """
@@ -762,6 +827,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -779,6 +846,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -793,6 +861,7 @@ class LicenseKeysAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[LicenseKeyDeactivate],
     ) -> None:
         """
@@ -802,6 +871,8 @@ class LicenseKeysAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -818,6 +889,7 @@ class LicenseKeysAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/meters.py
+++ b/sdk/python/polar/v2026_10/services/meters.py
@@ -43,6 +43,7 @@ class MetersSync(SyncServiceBase):
         sorting: builtins.list[MeterSortProperty] | None = ["name"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMeter:
         """
         List meters.
@@ -58,6 +59,8 @@ class MetersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -80,6 +83,7 @@ class MetersSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -98,6 +102,7 @@ class MetersSync(SyncServiceBase):
         sorting: builtins.list[MeterSortProperty] | None = ["name"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Meter, None, None]:
         """
         List meters.
@@ -113,6 +118,8 @@ class MetersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -134,6 +141,7 @@ class MetersSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -144,6 +152,7 @@ class MetersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MeterCreate],
     ) -> Meter:
         """
@@ -153,6 +162,8 @@ class MetersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -168,6 +179,7 @@ class MetersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -181,6 +193,7 @@ class MetersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Meter:
         """
         Get a meter by ID.
@@ -190,6 +203,8 @@ class MetersSync(SyncServiceBase):
         Args:
             id: The meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -207,6 +222,7 @@ class MetersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -220,6 +236,7 @@ class MetersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MeterUpdate],
     ) -> Meter:
         """
@@ -230,6 +247,8 @@ class MetersSync(SyncServiceBase):
         Args:
             id: The meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -248,6 +267,7 @@ class MetersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -270,6 +290,7 @@ class MetersSync(SyncServiceBase):
         customer_aggregation_function: AggregationFunction | None = None,
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MeterQuantities:
         """
         Get quantities of a meter over a time period.
@@ -287,6 +308,8 @@ class MetersSync(SyncServiceBase):
             customer_aggregation_function: If set, will first compute the quantities per customer before aggregating them using the given function. If not set, the quantities will be aggregated across all events.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -313,6 +336,7 @@ class MetersSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -334,6 +358,7 @@ class MetersAsync(AsyncServiceBase):
         sorting: builtins.list[MeterSortProperty] | None = ["name"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceMeter:
         """
         List meters.
@@ -349,6 +374,8 @@ class MetersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -371,6 +398,7 @@ class MetersAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -389,6 +417,7 @@ class MetersAsync(AsyncServiceBase):
         sorting: builtins.list[MeterSortProperty] | None = ["name"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Meter, None]:
         """
         List meters.
@@ -404,6 +433,8 @@ class MetersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -425,6 +456,7 @@ class MetersAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -436,6 +468,7 @@ class MetersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MeterCreate],
     ) -> Meter:
         """
@@ -445,6 +478,8 @@ class MetersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -460,6 +495,7 @@ class MetersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -473,6 +509,7 @@ class MetersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Meter:
         """
         Get a meter by ID.
@@ -482,6 +519,8 @@ class MetersAsync(AsyncServiceBase):
         Args:
             id: The meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -499,6 +538,7 @@ class MetersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -512,6 +552,7 @@ class MetersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MeterUpdate],
     ) -> Meter:
         """
@@ -522,6 +563,8 @@ class MetersAsync(AsyncServiceBase):
         Args:
             id: The meter ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -540,6 +583,7 @@ class MetersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -562,6 +606,7 @@ class MetersAsync(AsyncServiceBase):
         customer_aggregation_function: AggregationFunction | None = None,
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MeterQuantities:
         """
         Get quantities of a meter over a time period.
@@ -579,6 +624,8 @@ class MetersAsync(AsyncServiceBase):
             customer_aggregation_function: If set, will first compute the quantities per customer before aggregating them using the given function. If not set, the quantities will be aggregated across all events.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -605,6 +652,7 @@ class MetersAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_10/services/metrics.py
+++ b/sdk/python/polar/v2026_10/services/metrics.py
@@ -45,6 +45,7 @@ class MetricsSync(SyncServiceBase):
         customer_id: str | list[str] | None = None,
         metrics: list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricsResponse:
         """
         Get metrics about your orders and subscriptions.
@@ -64,6 +65,8 @@ class MetricsSync(SyncServiceBase):
             customer_id: Filter by customer ID.
             metrics: List of metric slugs to focus on. When provided, only the queries needed for these metrics will be executed, improving performance. If not provided, all metrics are returned.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -88,6 +91,7 @@ class MetricsSync(SyncServiceBase):
                 "metrics": metrics,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -110,6 +114,7 @@ class MetricsSync(SyncServiceBase):
         customer_id: str | list[str] | None = None,
         metrics: list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export metrics as a CSV file.
@@ -127,6 +132,8 @@ class MetricsSync(SyncServiceBase):
             customer_id: Filter by customer ID.
             metrics: List of metric slugs to include in the export. If not provided, all metrics are exported.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -151,6 +158,7 @@ class MetricsSync(SyncServiceBase):
                 "metrics": metrics,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -162,6 +170,7 @@ class MetricsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricsLimits:
         """
         Get the interval limits for the metrics endpoint.
@@ -170,6 +179,8 @@ class MetricsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -183,6 +194,7 @@ class MetricsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, MetricsLimits)
@@ -192,6 +204,7 @@ class MetricsSync(SyncServiceBase):
         *,
         organization_id: str | list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> list[MetricDashboardSchema]:
         """
         List user-defined metric dashboards.
@@ -201,6 +214,8 @@ class MetricsSync(SyncServiceBase):
         Args:
             organization_id: Filter by organization ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -217,6 +232,7 @@ class MetricsSync(SyncServiceBase):
                 "organization_id": organization_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -230,6 +246,7 @@ class MetricsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MetricDashboardCreate],
     ) -> MetricDashboardSchema:
         """
@@ -239,6 +256,8 @@ class MetricsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -254,6 +273,7 @@ class MetricsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -267,6 +287,7 @@ class MetricsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricDashboardSchema:
         """
         Get a user-defined metric dashboard by ID.
@@ -276,6 +297,8 @@ class MetricsSync(SyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -292,6 +315,7 @@ class MetricsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -304,6 +328,7 @@ class MetricsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a user-defined metric dashboard.
@@ -313,6 +338,8 @@ class MetricsSync(SyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -329,6 +356,7 @@ class MetricsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -341,6 +369,7 @@ class MetricsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MetricDashboardUpdate],
     ) -> MetricDashboardSchema:
         """
@@ -351,6 +380,8 @@ class MetricsSync(SyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -368,6 +399,7 @@ class MetricsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -393,6 +425,7 @@ class MetricsAsync(AsyncServiceBase):
         customer_id: str | list[str] | None = None,
         metrics: list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricsResponse:
         """
         Get metrics about your orders and subscriptions.
@@ -412,6 +445,8 @@ class MetricsAsync(AsyncServiceBase):
             customer_id: Filter by customer ID.
             metrics: List of metric slugs to focus on. When provided, only the queries needed for these metrics will be executed, improving performance. If not provided, all metrics are returned.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -436,6 +471,7 @@ class MetricsAsync(AsyncServiceBase):
                 "metrics": metrics,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -458,6 +494,7 @@ class MetricsAsync(AsyncServiceBase):
         customer_id: str | list[str] | None = None,
         metrics: list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export metrics as a CSV file.
@@ -475,6 +512,8 @@ class MetricsAsync(AsyncServiceBase):
             customer_id: Filter by customer ID.
             metrics: List of metric slugs to include in the export. If not provided, all metrics are exported.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -499,6 +538,7 @@ class MetricsAsync(AsyncServiceBase):
                 "metrics": metrics,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -510,6 +550,7 @@ class MetricsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricsLimits:
         """
         Get the interval limits for the metrics endpoint.
@@ -518,6 +559,8 @@ class MetricsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -531,6 +574,7 @@ class MetricsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, MetricsLimits)
@@ -540,6 +584,7 @@ class MetricsAsync(AsyncServiceBase):
         *,
         organization_id: str | list[str] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> list[MetricDashboardSchema]:
         """
         List user-defined metric dashboards.
@@ -549,6 +594,8 @@ class MetricsAsync(AsyncServiceBase):
         Args:
             organization_id: Filter by organization ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -565,6 +612,7 @@ class MetricsAsync(AsyncServiceBase):
                 "organization_id": organization_id,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -578,6 +626,7 @@ class MetricsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MetricDashboardCreate],
     ) -> MetricDashboardSchema:
         """
@@ -587,6 +636,8 @@ class MetricsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -602,6 +653,7 @@ class MetricsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -615,6 +667,7 @@ class MetricsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> MetricDashboardSchema:
         """
         Get a user-defined metric dashboard by ID.
@@ -624,6 +677,8 @@ class MetricsAsync(AsyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -640,6 +695,7 @@ class MetricsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -652,6 +708,7 @@ class MetricsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a user-defined metric dashboard.
@@ -661,6 +718,8 @@ class MetricsAsync(AsyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -677,6 +736,7 @@ class MetricsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -689,6 +749,7 @@ class MetricsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[MetricDashboardUpdate],
     ) -> MetricDashboardSchema:
         """
@@ -699,6 +760,8 @@ class MetricsAsync(AsyncServiceBase):
         Args:
             id: The metric dashboard ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -716,6 +779,7 @@ class MetricsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/oauth2/__init__.py
+++ b/sdk/python/polar/v2026_10/services/oauth2/__init__.py
@@ -32,10 +32,13 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> AuthorizeResponseUser | AuthorizeResponseOrganization:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -49,6 +52,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(
@@ -59,12 +63,15 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> TokenResponse:
         """
         Request an access token using a valid grant.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -78,6 +85,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, TokenResponse)
@@ -86,12 +94,15 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> RevokeTokenResponse:
         """
         Revoke an access token or a refresh token.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -105,6 +116,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, RevokeTokenResponse)
@@ -113,12 +125,15 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> IntrospectTokenResponse:
         """
         Get information about an access token.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -132,6 +147,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, IntrospectTokenResponse)
@@ -140,12 +156,15 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> UserInfoUser | UserInfoOrganization:
         """
         Get information about the authenticated user.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -159,6 +178,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         return parse_response_json(response, UserInfoUser | UserInfoOrganization)
@@ -175,10 +195,13 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> AuthorizeResponseUser | AuthorizeResponseOrganization:
         """
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -192,6 +215,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(
@@ -202,12 +226,15 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> TokenResponse:
         """
         Request an access token using a valid grant.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -221,6 +248,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, TokenResponse)
@@ -229,12 +257,15 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> RevokeTokenResponse:
         """
         Revoke an access token or a refresh token.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -248,6 +279,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, RevokeTokenResponse)
@@ -256,12 +288,15 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> IntrospectTokenResponse:
         """
         Get information about an access token.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -275,6 +310,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, IntrospectTokenResponse)
@@ -283,12 +319,15 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> UserInfoUser | UserInfoOrganization:
         """
         Get information about the authenticated user.
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -302,6 +341,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         return parse_response_json(response, UserInfoUser | UserInfoOrganization)

--- a/sdk/python/polar/v2026_10/services/oauth2/clients/oauth2.py
+++ b/sdk/python/polar/v2026_10/services/oauth2/clients/oauth2.py
@@ -23,6 +23,7 @@ class Oauth2Sync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OAuth2ClientConfiguration],
     ) -> typing.Any:
         """
@@ -30,6 +31,8 @@ class Oauth2Sync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -45,6 +48,7 @@ class Oauth2Sync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -58,6 +62,7 @@ class Oauth2Sync(SyncServiceBase):
         client_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Get an OAuth2 client by Client ID.
@@ -65,6 +70,8 @@ class Oauth2Sync(SyncServiceBase):
         Args:
             client_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -81,6 +88,7 @@ class Oauth2Sync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -93,6 +101,7 @@ class Oauth2Sync(SyncServiceBase):
         client_id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OAuth2ClientConfigurationUpdate],
     ) -> typing.Any:
         """
@@ -101,6 +110,8 @@ class Oauth2Sync(SyncServiceBase):
         Args:
             client_id_path:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -118,6 +129,7 @@ class Oauth2Sync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -131,6 +143,7 @@ class Oauth2Sync(SyncServiceBase):
         client_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete an OAuth2 client.
@@ -138,6 +151,8 @@ class Oauth2Sync(SyncServiceBase):
         Args:
             client_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -154,6 +169,7 @@ class Oauth2Sync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -167,6 +183,7 @@ class Oauth2Async(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OAuth2ClientConfiguration],
     ) -> typing.Any:
         """
@@ -174,6 +191,8 @@ class Oauth2Async(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -189,6 +208,7 @@ class Oauth2Async(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -202,6 +222,7 @@ class Oauth2Async(AsyncServiceBase):
         client_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Get an OAuth2 client by Client ID.
@@ -209,6 +230,8 @@ class Oauth2Async(AsyncServiceBase):
         Args:
             client_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -225,6 +248,7 @@ class Oauth2Async(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -237,6 +261,7 @@ class Oauth2Async(AsyncServiceBase):
         client_id_path: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OAuth2ClientConfigurationUpdate],
     ) -> typing.Any:
         """
@@ -245,6 +270,8 @@ class Oauth2Async(AsyncServiceBase):
         Args:
             client_id_path:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -262,6 +289,7 @@ class Oauth2Async(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -275,6 +303,7 @@ class Oauth2Async(AsyncServiceBase):
         client_id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete an OAuth2 client.
@@ -282,6 +311,8 @@ class Oauth2Async(AsyncServiceBase):
         Args:
             client_id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -298,6 +329,7 @@ class Oauth2Async(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_10/services/orders.py
+++ b/sdk/python/polar/v2026_10/services/orders.py
@@ -61,6 +61,7 @@ class OrdersSync(SyncServiceBase):
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceOrder:
         """
         List orders.
@@ -84,6 +85,8 @@ class OrdersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -114,6 +117,7 @@ class OrdersSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -142,6 +146,7 @@ class OrdersSync(SyncServiceBase):
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Order, None, None]:
         """
         List orders.
@@ -165,6 +170,8 @@ class OrdersSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -194,6 +201,7 @@ class OrdersSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -204,6 +212,7 @@ class OrdersSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderCreate],
     ) -> Order:
         """
@@ -217,6 +226,8 @@ class OrdersSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -232,6 +243,7 @@ class OrdersSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -251,6 +263,7 @@ class OrdersSync(SyncServiceBase):
         timezone: str = "UTC",
         columns: OrderExportColumn | builtins.list[OrderExportColumn] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export orders as a CSV file.
@@ -266,6 +279,8 @@ class OrdersSync(SyncServiceBase):
             timezone: Time zone used to render dates in the CSV.
             columns: Columns to include in the CSV, in order. Defaults to email, created_at, product, net_amount, currency, status and invoice_number.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -288,6 +303,7 @@ class OrdersSync(SyncServiceBase):
                 "columns": columns,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -300,6 +316,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Order:
         """
         Get an order by ID.
@@ -309,6 +326,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -326,6 +345,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -339,6 +359,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderUpdate],
     ) -> Order:
         """
@@ -349,6 +370,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -367,6 +390,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -381,6 +405,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderFinalize],
     ) -> Order:
         """
@@ -397,6 +422,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -418,6 +445,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -435,6 +463,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> OrderInvoice:
         """
         Get an order's invoice data.
@@ -444,6 +473,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -461,6 +492,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -474,6 +506,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Trigger generation of an order's invoice.
@@ -483,6 +516,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -501,6 +536,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -515,6 +551,7 @@ class OrdersSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> OrderReceipt:
         """
         Get a presigned URL to download an order's receipt PDF.
@@ -524,6 +561,8 @@ class OrdersSync(SyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -541,6 +580,7 @@ class OrdersSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -572,6 +612,7 @@ class OrdersAsync(AsyncServiceBase):
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceOrder:
         """
         List orders.
@@ -595,6 +636,8 @@ class OrdersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -625,6 +668,7 @@ class OrdersAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -653,6 +697,7 @@ class OrdersAsync(AsyncServiceBase):
         sorting: builtins.list[OrderSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Order, None]:
         """
         List orders.
@@ -676,6 +721,8 @@ class OrdersAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -705,6 +752,7 @@ class OrdersAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -716,6 +764,7 @@ class OrdersAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderCreate],
     ) -> Order:
         """
@@ -729,6 +778,8 @@ class OrdersAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -744,6 +795,7 @@ class OrdersAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -763,6 +815,7 @@ class OrdersAsync(AsyncServiceBase):
         timezone: str = "UTC",
         columns: OrderExportColumn | builtins.list[OrderExportColumn] | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export orders as a CSV file.
@@ -778,6 +831,8 @@ class OrdersAsync(AsyncServiceBase):
             timezone: Time zone used to render dates in the CSV.
             columns: Columns to include in the CSV, in order. Defaults to email, created_at, product, net_amount, currency, status and invoice_number.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -800,6 +855,7 @@ class OrdersAsync(AsyncServiceBase):
                 "columns": columns,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -812,6 +868,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Order:
         """
         Get an order by ID.
@@ -821,6 +878,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -838,6 +897,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -851,6 +911,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderUpdate],
     ) -> Order:
         """
@@ -861,6 +922,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -879,6 +942,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -893,6 +957,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrderFinalize],
     ) -> Order:
         """
@@ -909,6 +974,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -930,6 +997,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -947,6 +1015,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> OrderInvoice:
         """
         Get an order's invoice data.
@@ -956,6 +1025,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -973,6 +1044,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -986,6 +1058,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Trigger generation of an order's invoice.
@@ -995,6 +1068,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1013,6 +1088,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -1027,6 +1103,7 @@ class OrdersAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> OrderReceipt:
         """
         Get a presigned URL to download an order's receipt PDF.
@@ -1036,6 +1113,8 @@ class OrdersAsync(AsyncServiceBase):
         Args:
             id: The order ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -1053,6 +1132,7 @@ class OrdersAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_10/services/organizations.py
+++ b/sdk/python/polar/v2026_10/services/organizations.py
@@ -38,6 +38,7 @@ class OrganizationsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[OrganizationSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceOrganization:
         """
         List organizations.
@@ -50,6 +51,8 @@ class OrganizationsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -69,6 +72,7 @@ class OrganizationsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -84,6 +88,7 @@ class OrganizationsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[OrganizationSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Organization, None, None]:
         """
         List organizations.
@@ -96,6 +101,8 @@ class OrganizationsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -114,6 +121,7 @@ class OrganizationsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -124,6 +132,7 @@ class OrganizationsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationCreate],
     ) -> Organization:
         """
@@ -133,6 +142,8 @@ class OrganizationsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -149,6 +160,7 @@ class OrganizationsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -163,6 +175,7 @@ class OrganizationsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Organization:
         """
         Get an organization by ID.
@@ -172,6 +185,8 @@ class OrganizationsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -189,6 +204,7 @@ class OrganizationsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -202,6 +218,7 @@ class OrganizationsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationUpdate],
     ) -> Organization:
         """
@@ -212,6 +229,8 @@ class OrganizationsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -232,6 +251,7 @@ class OrganizationsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -253,6 +273,7 @@ class OrganizationsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[OrganizationSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceOrganization:
         """
         List organizations.
@@ -265,6 +286,8 @@ class OrganizationsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -284,6 +307,7 @@ class OrganizationsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -299,6 +323,7 @@ class OrganizationsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[OrganizationSortProperty] | None = ["created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Organization, None]:
         """
         List organizations.
@@ -311,6 +336,8 @@ class OrganizationsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -329,6 +356,7 @@ class OrganizationsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -340,6 +368,7 @@ class OrganizationsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationCreate],
     ) -> Organization:
         """
@@ -349,6 +378,8 @@ class OrganizationsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -365,6 +396,7 @@ class OrganizationsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -379,6 +411,7 @@ class OrganizationsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Organization:
         """
         Get an organization by ID.
@@ -388,6 +421,8 @@ class OrganizationsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -405,6 +440,7 @@ class OrganizationsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -418,6 +454,7 @@ class OrganizationsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[OrganizationUpdate],
     ) -> Organization:
         """
@@ -428,6 +465,8 @@ class OrganizationsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -448,6 +487,7 @@ class OrganizationsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/payments.py
+++ b/sdk/python/polar/v2026_10/services/payments.py
@@ -38,6 +38,7 @@ class PaymentsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[PaymentSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePayment:
         """
         List payments.
@@ -56,6 +57,8 @@ class PaymentsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -81,6 +84,7 @@ class PaymentsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -102,6 +106,7 @@ class PaymentsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[PaymentSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Payment, None, None]:
         """
         List payments.
@@ -120,6 +125,8 @@ class PaymentsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -144,6 +151,7 @@ class PaymentsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -155,6 +163,7 @@ class PaymentsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Payment:
         """
         Get a payment by ID.
@@ -164,6 +173,8 @@ class PaymentsSync(SyncServiceBase):
         Args:
             id: The payment ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -181,6 +192,7 @@ class PaymentsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -205,6 +217,7 @@ class PaymentsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[PaymentSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourcePayment:
         """
         List payments.
@@ -223,6 +236,8 @@ class PaymentsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -248,6 +263,7 @@ class PaymentsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -269,6 +285,7 @@ class PaymentsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[PaymentSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Payment, None]:
         """
         List payments.
@@ -287,6 +304,8 @@ class PaymentsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -311,6 +330,7 @@ class PaymentsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -323,6 +343,7 @@ class PaymentsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Payment:
         """
         Get a payment by ID.
@@ -332,6 +353,8 @@ class PaymentsAsync(AsyncServiceBase):
         Args:
             id: The payment ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -349,6 +372,7 @@ class PaymentsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/polar/v2026_10/services/products.py
+++ b/sdk/python/polar/v2026_10/services/products.py
@@ -47,6 +47,7 @@ class ProductsSync(SyncServiceBase):
         sorting: builtins.list[ProductSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceProduct:
         """
         List products.
@@ -66,6 +67,8 @@ class ProductsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -92,6 +95,7 @@ class ProductsSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -114,6 +118,7 @@ class ProductsSync(SyncServiceBase):
         sorting: builtins.list[ProductSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Product, None, None]:
         """
         List products.
@@ -133,6 +138,8 @@ class ProductsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -158,6 +165,7 @@ class ProductsSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -169,6 +177,7 @@ class ProductsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductCreateRecurring],
     ) -> Product: ...
 
@@ -177,6 +186,7 @@ class ProductsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductCreateOneTime],
     ) -> Product: ...
 
@@ -184,6 +194,7 @@ class ProductsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Product:
         """
@@ -193,6 +204,8 @@ class ProductsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -208,6 +221,7 @@ class ProductsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -221,6 +235,7 @@ class ProductsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Product:
         """
         Get a product by ID.
@@ -230,6 +245,8 @@ class ProductsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -247,6 +264,7 @@ class ProductsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -260,6 +278,7 @@ class ProductsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductUpdate],
     ) -> Product:
         """
@@ -270,6 +289,8 @@ class ProductsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -289,6 +310,7 @@ class ProductsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -304,6 +326,7 @@ class ProductsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductBenefitsUpdate],
     ) -> Product:
         """
@@ -314,6 +337,8 @@ class ProductsSync(SyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -333,6 +358,7 @@ class ProductsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -360,6 +386,7 @@ class ProductsAsync(AsyncServiceBase):
         sorting: builtins.list[ProductSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceProduct:
         """
         List products.
@@ -379,6 +406,8 @@ class ProductsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -405,6 +434,7 @@ class ProductsAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -427,6 +457,7 @@ class ProductsAsync(AsyncServiceBase):
         sorting: builtins.list[ProductSortProperty] | None = ["-created_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Product, None]:
         """
         List products.
@@ -446,6 +477,8 @@ class ProductsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -471,6 +504,7 @@ class ProductsAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -483,6 +517,7 @@ class ProductsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductCreateRecurring],
     ) -> Product: ...
 
@@ -491,6 +526,7 @@ class ProductsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductCreateOneTime],
     ) -> Product: ...
 
@@ -498,6 +534,7 @@ class ProductsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Product:
         """
@@ -507,6 +544,8 @@ class ProductsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -522,6 +561,7 @@ class ProductsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -535,6 +575,7 @@ class ProductsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Product:
         """
         Get a product by ID.
@@ -544,6 +585,8 @@ class ProductsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -561,6 +604,7 @@ class ProductsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -574,6 +618,7 @@ class ProductsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductUpdate],
     ) -> Product:
         """
@@ -584,6 +629,8 @@ class ProductsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -603,6 +650,7 @@ class ProductsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -618,6 +666,7 @@ class ProductsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[ProductBenefitsUpdate],
     ) -> Product:
         """
@@ -628,6 +677,8 @@ class ProductsAsync(AsyncServiceBase):
         Args:
             id:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -647,6 +698,7 @@ class ProductsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/refunds.py
+++ b/sdk/python/polar/v2026_10/services/refunds.py
@@ -40,6 +40,7 @@ class RefundsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[RefundSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceRefund:
         """
         List refunds.
@@ -58,6 +59,8 @@ class RefundsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -83,6 +86,7 @@ class RefundsSync(SyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -104,6 +108,7 @@ class RefundsSync(SyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[RefundSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Refund, None, None]:
         """
         List refunds.
@@ -122,6 +127,8 @@ class RefundsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -146,6 +153,7 @@ class RefundsSync(SyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -156,6 +164,7 @@ class RefundsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[RefundCreate],
     ) -> Refund:
         """
@@ -165,6 +174,8 @@ class RefundsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -181,6 +192,7 @@ class RefundsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -206,6 +218,7 @@ class RefundsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[RefundSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceRefund:
         """
         List refunds.
@@ -224,6 +237,8 @@ class RefundsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -249,6 +264,7 @@ class RefundsAsync(AsyncServiceBase):
                 "sorting": sorting,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -270,6 +286,7 @@ class RefundsAsync(AsyncServiceBase):
         limit: int = 10,
         sorting: builtins.list[RefundSortProperty] | None = ["-created_at"],
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Refund, None]:
         """
         List refunds.
@@ -288,6 +305,8 @@ class RefundsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -312,6 +331,7 @@ class RefundsAsync(AsyncServiceBase):
                 limit=limit,
                 sorting=sorting,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -323,6 +343,7 @@ class RefundsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[RefundCreate],
     ) -> Refund:
         """
@@ -332,6 +353,8 @@ class RefundsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -348,6 +371,7 @@ class RefundsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/subscriptions.py
+++ b/sdk/python/polar/v2026_10/services/subscriptions.py
@@ -68,6 +68,7 @@ class SubscriptionsSync(SyncServiceBase):
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceSubscription:
         """
         List subscriptions.
@@ -93,6 +94,8 @@ class SubscriptionsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -125,6 +128,7 @@ class SubscriptionsSync(SyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -155,6 +159,7 @@ class SubscriptionsSync(SyncServiceBase):
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[Subscription, None, None]:
         """
         List subscriptions.
@@ -180,6 +185,8 @@ class SubscriptionsSync(SyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -211,6 +218,7 @@ class SubscriptionsSync(SyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -222,6 +230,7 @@ class SubscriptionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCreateCustomer],
     ) -> Subscription: ...
 
@@ -230,6 +239,7 @@ class SubscriptionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCreateExternalCustomer],
     ) -> Subscription: ...
 
@@ -237,6 +247,7 @@ class SubscriptionsSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Subscription:
         """
@@ -251,6 +262,8 @@ class SubscriptionsSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -266,6 +279,7 @@ class SubscriptionsSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -288,6 +302,7 @@ class SubscriptionsSync(SyncServiceBase):
         | builtins.list[SubscriptionExportColumn]
         | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export subscriptions as a CSV file.
@@ -304,6 +319,8 @@ class SubscriptionsSync(SyncServiceBase):
             timezone: Time zone used to render dates in the CSV.
             columns: Columns to include in the CSV, in order. Defaults to email, started_at, product, amount, currency, status and recurring_interval.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -327,6 +344,7 @@ class SubscriptionsSync(SyncServiceBase):
                 "columns": columns,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -339,6 +357,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Subscription:
         """
         Get a subscription by ID.
@@ -348,6 +367,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -365,6 +386,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -378,6 +400,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Subscription:
         """
         Revoke a subscription, i.e cancel immediately.
@@ -387,6 +410,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -406,6 +431,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -422,6 +448,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateBase],
     ) -> Subscription: ...
 
@@ -431,6 +458,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateSeats],
     ) -> Subscription: ...
 
@@ -440,6 +468,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateUnits],
     ) -> Subscription: ...
 
@@ -449,6 +478,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateBillingPeriod],
     ) -> Subscription: ...
 
@@ -458,6 +488,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCancel],
     ) -> Subscription: ...
 
@@ -467,6 +498,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionRevoke],
     ) -> Subscription: ...
 
@@ -476,6 +508,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionPause],
     ) -> Subscription: ...
 
@@ -485,6 +518,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionResume],
     ) -> Subscription: ...
 
@@ -494,6 +528,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateClear],
     ) -> Subscription: ...
 
@@ -502,6 +537,7 @@ class SubscriptionsSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Subscription:
         """
@@ -512,6 +548,8 @@ class SubscriptionsSync(SyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -533,6 +571,7 @@ class SubscriptionsSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -570,6 +609,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceSubscription:
         """
         List subscriptions.
@@ -595,6 +635,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -627,6 +669,7 @@ class SubscriptionsAsync(AsyncServiceBase):
                 "metadata": metadata,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -657,6 +700,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         sorting: builtins.list[SubscriptionSortProperty] | None = ["-started_at"],
         metadata: MetadataQuery = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[Subscription, None]:
         """
         List subscriptions.
@@ -682,6 +726,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             sorting: Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order.
             metadata: Filter by metadata key-value pairs. It uses the `deepObject` style, e.g. `?metadata[key]=value`.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -713,6 +759,7 @@ class SubscriptionsAsync(AsyncServiceBase):
                 sorting=sorting,
                 metadata=metadata,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -725,6 +772,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCreateCustomer],
     ) -> Subscription: ...
 
@@ -733,6 +781,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCreateExternalCustomer],
     ) -> Subscription: ...
 
@@ -740,6 +789,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Subscription:
         """
@@ -754,6 +804,8 @@ class SubscriptionsAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -769,6 +821,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -791,6 +844,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         | builtins.list[SubscriptionExportColumn]
         | None = None,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> str:
         """
         Export subscriptions as a CSV file.
@@ -807,6 +861,8 @@ class SubscriptionsAsync(AsyncServiceBase):
             timezone: Time zone used to render dates in the CSV.
             columns: Columns to include in the CSV, in order. Defaults to email, started_at, product, amount, currency, status and recurring_interval.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -830,6 +886,7 @@ class SubscriptionsAsync(AsyncServiceBase):
                 "columns": columns,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -842,6 +899,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Subscription:
         """
         Get a subscription by ID.
@@ -851,6 +909,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -868,6 +928,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -881,6 +942,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> Subscription:
         """
         Revoke a subscription, i.e cancel immediately.
@@ -890,6 +952,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -909,6 +973,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -925,6 +990,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateBase],
     ) -> Subscription: ...
 
@@ -934,6 +1000,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateSeats],
     ) -> Subscription: ...
 
@@ -943,6 +1010,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateUnits],
     ) -> Subscription: ...
 
@@ -952,6 +1020,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateBillingPeriod],
     ) -> Subscription: ...
 
@@ -961,6 +1030,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionCancel],
     ) -> Subscription: ...
 
@@ -970,6 +1040,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionRevoke],
     ) -> Subscription: ...
 
@@ -979,6 +1050,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionPause],
     ) -> Subscription: ...
 
@@ -988,6 +1060,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionResume],
     ) -> Subscription: ...
 
@@ -997,6 +1070,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[SubscriptionUpdateClear],
     ) -> Subscription: ...
 
@@ -1005,6 +1079,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Any,
     ) -> Subscription:
         """
@@ -1015,6 +1090,8 @@ class SubscriptionsAsync(AsyncServiceBase):
         Args:
             id: The subscription ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -1036,6 +1113,7 @@ class SubscriptionsAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)

--- a/sdk/python/polar/v2026_10/services/webhooks.py
+++ b/sdk/python/polar/v2026_10/services/webhooks.py
@@ -36,6 +36,7 @@ class WebhooksSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceWebhookEndpoint:
         """
         List webhook endpoints.
@@ -47,6 +48,8 @@ class WebhooksSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -65,6 +68,7 @@ class WebhooksSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -79,6 +83,7 @@ class WebhooksSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[WebhookEndpoint, None, None]:
         """
         List webhook endpoints.
@@ -90,6 +95,8 @@ class WebhooksSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -107,6 +114,7 @@ class WebhooksSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -117,6 +125,7 @@ class WebhooksSync(SyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[WebhookEndpointCreate],
     ) -> WebhookEndpoint:
         """
@@ -126,6 +135,8 @@ class WebhooksSync(SyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -141,6 +152,7 @@ class WebhooksSync(SyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -154,6 +166,7 @@ class WebhooksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> WebhookEndpoint:
         """
         Get a webhook endpoint by ID.
@@ -163,6 +176,8 @@ class WebhooksSync(SyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -180,6 +195,7 @@ class WebhooksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -193,6 +209,7 @@ class WebhooksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a webhook endpoint.
@@ -202,6 +219,8 @@ class WebhooksSync(SyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -219,6 +238,7 @@ class WebhooksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -232,6 +252,7 @@ class WebhooksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[WebhookEndpointUpdate],
     ) -> WebhookEndpoint:
         """
@@ -242,6 +263,8 @@ class WebhooksSync(SyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -260,6 +283,7 @@ class WebhooksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = self.client.send_request(request)
@@ -274,6 +298,7 @@ class WebhooksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> WebhookEndpoint:
         """
         Regenerate a webhook endpoint secret.
@@ -283,6 +308,8 @@ class WebhooksSync(SyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -300,6 +327,7 @@ class WebhooksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -321,6 +349,7 @@ class WebhooksSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceWebhookDelivery:
         """
         List webhook deliveries.
@@ -340,6 +369,8 @@ class WebhooksSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -364,6 +395,7 @@ class WebhooksSync(SyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -384,6 +416,7 @@ class WebhooksSync(SyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Generator[WebhookDelivery, None, None]:
         """
         List webhook deliveries.
@@ -403,6 +436,8 @@ class WebhooksSync(SyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -426,6 +461,7 @@ class WebhooksSync(SyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             yield from response.items
             if page >= response.pagination.max_page:
@@ -437,6 +473,7 @@ class WebhooksSync(SyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Schedule the re-delivery of a webhook event.
@@ -446,6 +483,8 @@ class WebhooksSync(SyncServiceBase):
         Args:
             id: The webhook event ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -463,6 +502,7 @@ class WebhooksSync(SyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = self.client.send_request(request)
         method_errors = {
@@ -480,6 +520,7 @@ class WebhooksAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceWebhookEndpoint:
         """
         List webhook endpoints.
@@ -491,6 +532,8 @@ class WebhooksAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -509,6 +552,7 @@ class WebhooksAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -523,6 +567,7 @@ class WebhooksAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[WebhookEndpoint, None]:
         """
         List webhook endpoints.
@@ -534,6 +579,8 @@ class WebhooksAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -551,6 +598,7 @@ class WebhooksAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -562,6 +610,7 @@ class WebhooksAsync(AsyncServiceBase):
         self,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[WebhookEndpointCreate],
     ) -> WebhookEndpoint:
         """
@@ -571,6 +620,8 @@ class WebhooksAsync(AsyncServiceBase):
 
         Args:
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -586,6 +637,7 @@ class WebhooksAsync(AsyncServiceBase):
             path_params={},
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -599,6 +651,7 @@ class WebhooksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> WebhookEndpoint:
         """
         Get a webhook endpoint by ID.
@@ -608,6 +661,8 @@ class WebhooksAsync(AsyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -625,6 +680,7 @@ class WebhooksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -638,6 +694,7 @@ class WebhooksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> None:
         """
         Delete a webhook endpoint.
@@ -647,6 +704,8 @@ class WebhooksAsync(AsyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -664,6 +723,7 @@ class WebhooksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -677,6 +737,7 @@ class WebhooksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
         **kwargs: typing.Unpack[WebhookEndpointUpdate],
     ) -> WebhookEndpoint:
         """
@@ -687,6 +748,8 @@ class WebhooksAsync(AsyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
             **kwargs: Request body parameters
 
@@ -705,6 +768,7 @@ class WebhooksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
             body=kwargs,
         )
         response = await self.client.send_request(request)
@@ -719,6 +783,7 @@ class WebhooksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> WebhookEndpoint:
         """
         Regenerate a webhook endpoint secret.
@@ -728,6 +793,8 @@ class WebhooksAsync(AsyncServiceBase):
         Args:
             id: The webhook endpoint ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -745,6 +812,7 @@ class WebhooksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -766,6 +834,7 @@ class WebhooksAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> ListResourceWebhookDelivery:
         """
         List webhook deliveries.
@@ -785,6 +854,8 @@ class WebhooksAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -809,6 +880,7 @@ class WebhooksAsync(AsyncServiceBase):
                 "limit": limit,
             },
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {
@@ -829,6 +901,7 @@ class WebhooksAsync(AsyncServiceBase):
         page: int = 1,
         limit: int = 10,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.AsyncGenerator[WebhookDelivery, None]:
         """
         List webhook deliveries.
@@ -848,6 +921,8 @@ class WebhooksAsync(AsyncServiceBase):
             page: Page number, defaults to 1.
             limit: Size of a page, defaults to 10. Maximum is 100.
             request_timeout: Timeout override for each request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for each request.
+
 
 
         Returns:
@@ -871,6 +946,7 @@ class WebhooksAsync(AsyncServiceBase):
                 page=page,
                 limit=limit,
                 request_timeout=request_timeout,
+            request_access_token=request_access_token,
             )
             for item in response.items:
                 yield item
@@ -883,6 +959,7 @@ class WebhooksAsync(AsyncServiceBase):
         id: str,
         *,
         request_timeout: RequestTimeout | None = None,
+        request_access_token: str | None = None,
     ) -> typing.Any:
         """
         Schedule the re-delivery of a webhook event.
@@ -892,6 +969,8 @@ class WebhooksAsync(AsyncServiceBase):
         Args:
             id: The webhook event ID.
             request_timeout: Timeout override for this request, in seconds or as an httpx.Timeout instance.
+            request_access_token: Access token override for this request.
+
 
 
         Raises:
@@ -909,6 +988,7 @@ class WebhooksAsync(AsyncServiceBase):
             },
             query_params={},
             request_timeout=request_timeout,
+            request_access_token=request_access_token,
         )
         response = await self.client.send_request(request)
         method_errors = {

--- a/sdk/python/tests/test_base.py
+++ b/sdk/python/tests/test_base.py
@@ -101,6 +101,17 @@ class TestBuildRequest:
             "pool": 30.0,
         }
 
+    def test_request_access_token_override(
+        self, client: SyncClientBase | AsyncClientBase
+    ) -> None:
+        request = client.build_request(
+            method="GET",
+            url="/v1/items/",
+            request_access_token="polar_at_u_override",
+        )
+
+        assert request.headers["Authorization"] == "Bearer polar_at_u_override"
+
     @pytest.mark.parametrize("client_class", [SyncClientBase, AsyncClientBase])
     def test_advanced_client_timeout(
         self,

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -58,6 +58,14 @@ const customerState = await polar.customers.getStateExternal("customer_external_
 });
 ```
 
+Override the access token for an individual request the same way:
+
+```typescript
+const customerState = await polar.customers.getStateExternal("customer_external_id", {
+    accessToken: "polar_at_u_override",
+});
+```
+
 ## Individual API Functions
 
 To import individual API functions for tree-shaking, create a core client and pass it to the

--- a/sdk/typescript/src/base.test.ts
+++ b/sdk/typescript/src/base.test.ts
@@ -101,6 +101,26 @@ describe("sendRequest", () => {
     },
   );
 
+  test("uses a per-request access token override", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response());
+    const client = new ClientBase({
+      baseUrl: "https://api.polar.sh",
+      version: "2026-04",
+      accessToken: "polar_at_u_xxx",
+    });
+    const headers = new Headers({
+      Authorization: "Bearer polar_at_u_xxx",
+    });
+
+    await client.sendRequest(
+      ["https://api.polar.sh/v1/items/", { headers }],
+      { accessToken: "polar_at_u_override" },
+    );
+
+    const requestHeaders = fetch.mock.calls[0][1]?.headers as Headers;
+    expect(requestHeaders.get("Authorization")).toBe("Bearer polar_at_u_override");
+  });
+
   test("does not create a timeout signal when no timeout is configured", async () => {
     const client = new ClientBase({
       baseUrl: "https://api.polar.sh",

--- a/sdk/typescript/src/base.ts
+++ b/sdk/typescript/src/base.ts
@@ -105,6 +105,8 @@ export interface ClientOptions {
 export interface RequestOptions {
   /** Request timeout override, in seconds. */
   timeout?: number;
+  /** Access token override for this request. */
+  accessToken?: string;
 }
 
 const MAX_ABORT_SIGNAL_TIMEOUT_MS = 2_147_483_647;
@@ -165,6 +167,11 @@ export class ClientBase {
   ): Promise<Response> {
     const [fullUrl, requestInit] = request;
     const timeout = requestOptions?.timeout ?? this.options.timeout;
+    let headers = requestInit.headers;
+    if (requestOptions?.accessToken !== undefined) {
+      headers = new Headers(headers);
+      headers.set("Authorization", `Bearer ${requestOptions.accessToken}`);
+    }
     let signal = requestInit.signal;
     if (timeout !== undefined) {
       const timeoutMilliseconds = Math.ceil(timeout * 1000);
@@ -183,6 +190,7 @@ export class ClientBase {
     try {
       return await fetch(fullUrl, {
         ...requestInit,
+        headers,
         ...(signal ? { signal } : {}),
       });
     } catch (error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds per-request access token override support to both the Python and TypeScript Polar SDKs.

## What

- **TypeScript**: `RequestOptions` now accepts an optional `accessToken` field. When provided, `sendRequest` uses it for the `Authorization` header instead of the client's default token.
- **Python**: All service methods accept an optional `request_access_token` kwarg. When provided, `build_request` sets the `Authorization` header for that request.
- Updated generator templates, generated SDK code, README docs, and base-layer tests.

## Why

Callers sometimes need to make a single API request with a different token than the one the client was initialized with (for example, acting on behalf of another organization or using a short-lived token for one call).

## How

- TypeScript override is applied in `ClientBase.sendRequest` by cloning headers and replacing `Authorization`.
- Python override is applied in `BuildRequestMixin.build_request` by passing request-level headers to httpx.
- Service method signatures are updated via the Python generator template so future regenerations keep the kwarg.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass for SDK base tests
- [x] No unrelated changes or drive-by fixes are included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fb751f3-2941-41f9-94ba-fe1fcf2b774a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fb751f3-2941-41f9-94ba-fe1fcf2b774a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

