### PR TITLE
feat(sdk): allow methods to receive arbitrary metadata keys

### DIFF
--- a/sdk/generator/generator/ir.py
+++ b/sdk/generator/generator/ir.py
@@ -711,7 +711,7 @@ def _schema_to_model(
             normalize_model_name=normalize_model_name,
         )
     additional_properties = None
-    if not schema.properties and schema.additionalProperties is not None:
+    if schema.additionalProperties is not None:
         if isinstance(schema.additionalProperties, bool):
             if schema.additionalProperties:
                 additional_properties = PrimitiveType(kind="primitive", type="unknown")

--- a/sdk/generator/python/emitter.py
+++ b/sdk/generator/python/emitter.py
@@ -185,6 +185,10 @@ class PythonEmitter(EmitterBase):
                 {
                     **self.get_version_context(api),
                     "output_enum_imports": self._get_output_enum_imports(api),
+                    "output_uses_additional_properties": any(
+                        model.fields and model.additional_properties is not None
+                        for model in api.output_models
+                    ),
                 },
             )
             self.render_file(

--- a/sdk/generator/python/emitter.py
+++ b/sdk/generator/python/emitter.py
@@ -172,6 +172,10 @@ class PythonEmitter(EmitterBase):
                 {
                     **self.get_version_context(api),
                     "input_enum_imports": self._get_input_enum_imports(api),
+                    "input_uses_extra_items": any(
+                        model.fields and model.additional_properties is not None
+                        for model in api.input_models
+                    ),
                 },
             )
 

--- a/sdk/generator/python/emitter.py
+++ b/sdk/generator/python/emitter.py
@@ -185,7 +185,7 @@ class PythonEmitter(EmitterBase):
                 {
                     **self.get_version_context(api),
                     "output_enum_imports": self._get_output_enum_imports(api),
-                    "output_uses_additional_properties": any(
+                    "output_uses_extra_items": any(
                         model.fields and model.additional_properties is not None
                         for model in api.output_models
                     ),

--- a/sdk/generator/python/template/polar/base.py
+++ b/sdk/generator/python/template/polar/base.py
@@ -222,8 +222,16 @@ def _register_extra_items_typed_dict(
 ) -> None:
     global _retort
 
-    field_types = typing.get_type_hints(model)
-    required_keys = model.__required_keys__
+    field_types = typing.get_type_hints(model, include_extras=True)
+    required_keys = set(model.__required_keys__)
+    for key, field_type in field_types.items():
+        field_origin = typing.get_origin(field_type)
+        if field_origin is typing.Required:
+            required_keys.add(key)
+        elif field_origin is typing.NotRequired:
+            required_keys.discard(key)
+        if field_origin in (typing.Required, typing.NotRequired):
+            field_types[key] = typing.get_args(field_type)[0]
 
     def load_extra_items_typed_dict(data: object) -> dict[str, typing.Any]:
         if not isinstance(data, collections.abc.Mapping):

--- a/sdk/generator/python/template/polar/base.py
+++ b/sdk/generator/python/template/polar/base.py
@@ -1,3 +1,4 @@
+import abc
 import builtins
 import collections.abc
 import types
@@ -54,6 +55,20 @@ class PolarRateLimitError(PolarClientError):
     def __init__(self, status_code: typing.Literal[429], retry_after: int | None = None):
         super().__init__(status_code, "Rate limit exceeded")
         self.retry_after = retry_after
+
+
+class _AdditionalPropertiesModel(abc.ABC):
+    __slots__ = ()
+
+    @abc.abstractmethod
+    def _mark_additional_properties_model(self) -> None: ...
+
+
+class AdditionalPropertiesMixin(_AdditionalPropertiesModel):
+    __slots__ = ()
+
+    def _mark_additional_properties_model(self) -> None:
+        pass
 
 
 def resolve_base_url(

--- a/sdk/generator/python/template/polar/base.py
+++ b/sdk/generator/python/template/polar/base.py
@@ -1,4 +1,3 @@
-import abc
 import builtins
 import collections.abc
 import types
@@ -55,20 +54,6 @@ class PolarRateLimitError(PolarClientError):
     def __init__(self, status_code: typing.Literal[429], retry_after: int | None = None):
         super().__init__(status_code, "Rate limit exceeded")
         self.retry_after = retry_after
-
-
-class _AdditionalPropertiesModel(abc.ABC):
-    __slots__ = ()
-
-    @abc.abstractmethod
-    def _mark_additional_properties_model(self) -> None: ...
-
-
-class AdditionalPropertiesMixin(_AdditionalPropertiesModel):
-    __slots__ = ()
-
-    def _mark_additional_properties_model(self) -> None:
-        pass
 
 
 def resolve_base_url(
@@ -229,6 +214,38 @@ _retort = adaptix.Retort(
         ),
     ]
 )
+
+
+def _register_extra_items_typed_dict(
+    model: typing.Any,
+    extra_items_type: typing_extensions.TypeForm[typing.Any],
+) -> None:
+    global _retort
+
+    field_types = typing.get_type_hints(model)
+    required_keys = model.__required_keys__
+
+    def load_extra_items_typed_dict(data: object) -> dict[str, typing.Any]:
+        if not isinstance(data, collections.abc.Mapping):
+            raise adaptix.load_error.TypeLoadError(collections.abc.Mapping, data)
+
+        missing_keys = required_keys - data.keys()
+        if missing_keys:
+            raise adaptix.load_error.NoRequiredFieldsLoadError(missing_keys, data)
+
+        loaded: dict[str, typing.Any] = {}
+        for key, value in data.items():
+            if not isinstance(key, str):
+                raise adaptix.load_error.TypeLoadError(str, key)
+            if key in field_types:
+                loaded[key] = _retort.load(value, field_types[key])
+            else:
+                loaded[key] = _retort.load(value, extra_items_type)
+        return loaded
+
+    _retort = _retort.extend(
+        recipe=[adaptix.loader(model, load_extra_items_typed_dict)]
+    )
 
 
 def deserialize(

--- a/sdk/generator/python/template/polar/version/inputs.py
+++ b/sdk/generator/python/template/polar/version/inputs.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import typing
+{% if input_uses_extra_items %}
+
+import typing_extensions
+{% endif %}
 
 {% if input_enum_imports %}
 from polar.{{ version }}.literals import (
@@ -11,14 +15,14 @@ from polar.{{ version }}.literals import (
 {% endif %}
 
 {% for model in api.input_models %}
-{% if model.additional_properties %}
+{% if model.additional_properties and not model.fields %}
 {{ model.name }}: typing.TypeAlias = dict[str, {{ model.additional_properties | type_annotation }}]
 {% if model.description %}
 """{{ model.description }}"""
 {% endif %}
 
 {% else %}
-class {{ model.name }}(typing.TypedDict):
+class {{ model.name }}({% if model.additional_properties %}typing_extensions.TypedDict, extra_items={{ model.additional_properties | type_annotation }}{% else %}typing.TypedDict{% endif %}):
 {% if model.description %}
     """{{ model.description }}"""
 {% endif %}

--- a/sdk/generator/python/template/polar/version/outputs.py
+++ b/sdk/generator/python/template/polar/version/outputs.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import dataclasses
 import typing
 
+{% if output_uses_additional_properties %}
+from polar.base import AdditionalPropertiesMixin
+{% endif %}
 {% if output_enum_imports %}
 from polar.{{ version }}.literals import (
 {% for enum_name in output_enum_imports %}
@@ -20,7 +23,7 @@ from polar.{{ version }}.literals import (
 
 {% else %}
 @dataclasses.dataclass(kw_only=True, slots=True)
-class {{ model.name }}:
+class {{ model.name }}{% if model.additional_properties %}(AdditionalPropertiesMixin){% endif %}:
 {% if model.description %}
     """{{ model.description }}"""
 {% endif %}
@@ -39,6 +42,9 @@ class {{ model.name }}:
 {% else %}
     ...
 {% endfor %}
+{% if model.additional_properties %}
+    additional_properties: dict[str, {{ model.additional_properties | type_annotation }}] = dataclasses.field(default_factory=dict)
+{% endif %}
 {% endif %}
 {% endfor %}
 

--- a/sdk/generator/python/template/polar/version/outputs.py
+++ b/sdk/generator/python/template/polar/version/outputs.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import dataclasses
 import typing
 
-{% if output_uses_additional_properties %}
-from polar.base import AdditionalPropertiesMixin
+{% if output_uses_extra_items %}
+import typing_extensions
+
+from polar.base import _register_extra_items_typed_dict
 {% endif %}
 {% if output_enum_imports %}
 from polar.{{ version }}.literals import (
@@ -21,9 +23,29 @@ from polar.{{ version }}.literals import (
 """{{ model.description }}"""
 {% endif %}
 
+{% elif model.additional_properties %}
+class {{ model.name }}(
+    typing_extensions.TypedDict,
+    extra_items={{ model.additional_properties | type_annotation }},
+):
+{% if model.description %}
+    """{{ model.description }}"""
+{% endif %}
+{% for field in model.fields %}
+    {% if not field.required %}
+    {{ field.name }}: typing.NotRequired[{{ field.type | type_annotation }}]
+    {% else %}
+    {{ field.name }}: {{ field.type | type_annotation }}
+    {% endif %}
+    {% if field.description %}
+    """{{ field.description }}"""
+    {% endif %}
+
+{% endfor %}
+
 {% else %}
 @dataclasses.dataclass(kw_only=True, slots=True)
-class {{ model.name }}{% if model.additional_properties %}(AdditionalPropertiesMixin){% endif %}:
+class {{ model.name }}:
 {% if model.description %}
     """{{ model.description }}"""
 {% endif %}
@@ -42,9 +64,6 @@ class {{ model.name }}{% if model.additional_properties %}(AdditionalPropertiesM
 {% else %}
     ...
 {% endfor %}
-{% if model.additional_properties %}
-    additional_properties: dict[str, {{ model.additional_properties | type_annotation }}] = dataclasses.field(default_factory=dict)
-{% endif %}
 {% endif %}
 {% endfor %}
 
@@ -59,5 +78,14 @@ class {{ model.name }}{% if model.additional_properties %}(AdditionalPropertiesM
 """{{ union.description }}"""
 {% endif %}
 
+{% endif %}
+{% endfor %}
+
+{% for model in api.output_models %}
+{% if model.additional_properties and model.fields %}
+_register_extra_items_typed_dict(
+    {{ model.name }},
+    {{ model.additional_properties | type_annotation }},
+)
 {% endif %}
 {% endfor %}

--- a/sdk/generator/python/template/polar/version/outputs.py
+++ b/sdk/generator/python/template/polar/version/outputs.py
@@ -12,7 +12,7 @@ from polar.{{ version }}.literals import (
 {% endif %}
 
 {% for model in api.output_models %}
-{% if model.additional_properties %}
+{% if model.additional_properties and not model.fields %}
 {{ model.name }}: typing.TypeAlias = dict[str, {{ model.additional_properties | type_annotation }}]
 {% if model.description %}
 """{{ model.description }}"""

--- a/sdk/generator/python/template/tests/test_base.py
+++ b/sdk/generator/python/template/tests/test_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import typing
 
@@ -87,6 +89,12 @@ def test_deserialize_model_with_additional_properties() -> None:
         "details": ExtensibleDetails(name="example"),
         "custom": "value",
     }
+
+
+def test_deserialize_model_without_optional_fields() -> None:
+    model = deserialize({"known": 1, "custom": "value"}, ExtensibleModel)
+
+    assert model == {"known": 1, "custom": "value"}
 
 
 def test_deserialize_model_with_invalid_additional_property() -> None:

--- a/sdk/generator/python/template/tests/test_base.py
+++ b/sdk/generator/python/template/tests/test_base.py
@@ -78,7 +78,6 @@ def test_deserialize_model_with_additional_properties() -> None:
             "known": 1,
             "details": {"name": "example"},
             "custom": "value",
-            "large_integer": 9007199254740993,
         },
         ExtensibleModel,
     )
@@ -87,9 +86,7 @@ def test_deserialize_model_with_additional_properties() -> None:
         "known": 1,
         "details": ExtensibleDetails(name="example"),
         "custom": "value",
-        "large_integer": 9007199254740993,
     }
-    assert type(typing.cast(dict[str, object], model)["large_integer"]) is int
 
 
 def test_deserialize_model_with_invalid_additional_property() -> None:

--- a/sdk/generator/python/template/tests/test_base.py
+++ b/sdk/generator/python/template/tests/test_base.py
@@ -3,12 +3,13 @@ import typing
 
 import httpx
 import pytest
+import typing_extensions
 
 from polar import deserialize, PolarDeserializationError
 from polar.base import (
-    AdditionalPropertiesMixin,
     AsyncClientBase,
     SyncClientBase,
+    _register_extra_items_typed_dict,
     resolve_base_url,
 )
 
@@ -33,10 +34,23 @@ class Dog:
 Animal: typing.TypeAlias = Cat | Dog
 
 
-@dataclasses.dataclass(slots=True)
-class ExtensibleModel(AdditionalPropertiesMixin):
+@dataclasses.dataclass
+class ExtensibleDetails:
+    name: str
+
+
+class ExtensibleModel(
+    typing_extensions.TypedDict,
+    extra_items=str | int | float | bool,
+):
     known: int
-    additional_properties: dict[str, str] = dataclasses.field(default_factory=dict)
+    details: typing.NotRequired[ExtensibleDetails]
+
+
+_register_extra_items_typed_dict(
+    ExtensibleModel,
+    str | int | float | bool,
+)
 
 
 def test_deserialize_model() -> None:
@@ -59,12 +73,28 @@ def test_deserialize_union() -> None:
 
 
 def test_deserialize_model_with_additional_properties() -> None:
-    model = deserialize({"known": 1, "custom": "value"}, ExtensibleModel)
-
-    assert model == ExtensibleModel(
-        known=1,
-        additional_properties={"custom": "value"},
+    model = deserialize(
+        {
+            "known": 1,
+            "details": {"name": "example"},
+            "custom": "value",
+            "large_integer": 9007199254740993,
+        },
+        ExtensibleModel,
     )
+
+    assert model == {
+        "known": 1,
+        "details": ExtensibleDetails(name="example"),
+        "custom": "value",
+        "large_integer": 9007199254740993,
+    }
+    assert type(typing.cast(dict[str, object], model)["large_integer"]) is int
+
+
+def test_deserialize_model_with_invalid_additional_property() -> None:
+    with pytest.raises(PolarDeserializationError):
+        deserialize({"known": 1, "invalid": ["value"]}, ExtensibleModel)
 
 
 @pytest.mark.parametrize(

--- a/sdk/generator/python/template/tests/test_base.py
+++ b/sdk/generator/python/template/tests/test_base.py
@@ -5,7 +5,12 @@ import httpx
 import pytest
 
 from polar import deserialize, PolarDeserializationError
-from polar.base import AsyncClientBase, SyncClientBase, resolve_base_url
+from polar.base import (
+    AdditionalPropertiesMixin,
+    AsyncClientBase,
+    SyncClientBase,
+    resolve_base_url,
+)
 
 SERVERS = {
     "production": "https://api.polar.sh",
@@ -28,6 +33,12 @@ class Dog:
 Animal: typing.TypeAlias = Cat | Dog
 
 
+@dataclasses.dataclass(slots=True)
+class ExtensibleModel(AdditionalPropertiesMixin):
+    known: int
+    additional_properties: dict[str, str] = dataclasses.field(default_factory=dict)
+
+
 def test_deserialize_model() -> None:
     cat = deserialize({"type": "cat", "lives": 9}, Cat)
 
@@ -45,6 +56,15 @@ def test_deserialize_union() -> None:
 
     typing.assert_type(animal, Cat | Dog)
     assert animal == Dog(type="dog", breed="Samoyed")
+
+
+def test_deserialize_model_with_additional_properties() -> None:
+    model = deserialize({"known": 1, "custom": "value"}, ExtensibleModel)
+
+    assert model == ExtensibleModel(
+        known=1,
+        additional_properties={"custom": "value"},
+    )
 
 
 @pytest.mark.parametrize(

--- a/sdk/generator/tests/python/test_emitter.py
+++ b/sdk/generator/tests/python/test_emitter.py
@@ -54,3 +54,48 @@ def test_emit_input_model_with_fields_and_additional_properties(
         "class EventMetadataInput(typing_extensions.TypedDict, "
         "extra_items=str | int | float | bool):"
     ) in inputs
+
+
+def test_emit_output_model_with_fields_and_additional_properties(
+    tmp_path: pathlib.Path,
+) -> None:
+    model = Model(
+        name="EventMetadataOutput",
+        fields=[
+            Field(
+                name="_cost",
+                type=ModelRef(kind="model", name="CostMetadataOutput"),
+                required=False,
+            )
+        ],
+        additional_properties=UnionType(
+            kind="union",
+            variants=[
+                PrimitiveType(kind="primitive", type="string"),
+                PrimitiveType(kind="primitive", type="integer"),
+                PrimitiveType(kind="primitive", type="number"),
+                PrimitiveType(kind="primitive", type="boolean"),
+            ],
+        ),
+    )
+    api = APIVersion(
+        version="2026-04",
+        servers=[],
+        services=[],
+        input_models=[],
+        output_models=[model],
+        webhooks=[],
+        enums=[],
+        input_unions=[],
+        output_unions=[],
+    )
+
+    PythonEmitter(APIIR(versions=[api]), "1.0.0").emit(tmp_path)
+
+    outputs = (tmp_path / "polar" / "v2026_04" / "outputs.py").read_text()
+    assert "from polar.base import AdditionalPropertiesMixin" in outputs
+    assert "class EventMetadataOutput(AdditionalPropertiesMixin):" in outputs
+    assert (
+        "additional_properties: dict[str, str | int | float | bool] = "
+        "dataclasses.field(default_factory=dict)"
+    ) in outputs

--- a/sdk/generator/tests/python/test_emitter.py
+++ b/sdk/generator/tests/python/test_emitter.py
@@ -93,9 +93,18 @@ def test_emit_output_model_with_fields_and_additional_properties(
     PythonEmitter(APIIR(versions=[api]), "1.0.0").emit(tmp_path)
 
     outputs = (tmp_path / "polar" / "v2026_04" / "outputs.py").read_text()
-    assert "from polar.base import AdditionalPropertiesMixin" in outputs
-    assert "class EventMetadataOutput(AdditionalPropertiesMixin):" in outputs
+    assert "import typing_extensions" in outputs
+    assert "from polar.base import _register_extra_items_typed_dict" in outputs
     assert (
-        "additional_properties: dict[str, str | int | float | bool] = "
-        "dataclasses.field(default_factory=dict)"
+        "class EventMetadataOutput(\n"
+        "    typing_extensions.TypedDict,\n"
+        "    extra_items=str | int | float | bool,\n"
+        "):"
+    ) in outputs
+    assert "_cost: typing.NotRequired[CostMetadataOutput]" in outputs
+    assert (
+        "_register_extra_items_typed_dict(\n"
+        "    EventMetadataOutput,\n"
+        "    str | int | float | bool,\n"
+        ")"
     ) in outputs

--- a/sdk/generator/tests/python/test_emitter.py
+++ b/sdk/generator/tests/python/test_emitter.py
@@ -1,0 +1,56 @@
+import pathlib
+
+from generator.ir import (
+    APIIR,
+    APIVersion,
+    Field,
+    Model,
+    ModelRef,
+    PrimitiveType,
+    UnionType,
+)
+from python.emitter import PythonEmitter
+
+
+def test_emit_input_model_with_fields_and_additional_properties(
+    tmp_path: pathlib.Path,
+) -> None:
+    model = Model(
+        name="EventMetadataInput",
+        fields=[
+            Field(
+                name="_cost",
+                type=ModelRef(kind="model", name="CostMetadataInput"),
+                required=False,
+            )
+        ],
+        additional_properties=UnionType(
+            kind="union",
+            variants=[
+                PrimitiveType(kind="primitive", type="string"),
+                PrimitiveType(kind="primitive", type="integer"),
+                PrimitiveType(kind="primitive", type="number"),
+                PrimitiveType(kind="primitive", type="boolean"),
+            ],
+        ),
+    )
+    api = APIVersion(
+        version="2026-04",
+        servers=[],
+        services=[],
+        input_models=[model],
+        output_models=[],
+        webhooks=[],
+        enums=[],
+        input_unions=[],
+        output_unions=[],
+    )
+
+    PythonEmitter(APIIR(versions=[api]), "1.0.0").emit(tmp_path)
+
+    inputs = (tmp_path / "polar" / "v2026_04" / "inputs.py").read_text()
+    assert "import typing_extensions" in inputs
+    assert (
+        "class EventMetadataInput(typing_extensions.TypedDict, "
+        "extra_items=str | int | float | bool):"
+    ) in inputs

--- a/sdk/generator/tests/test_ir.py
+++ b/sdk/generator/tests/test_ir.py
@@ -2772,3 +2772,72 @@ def test_ir_generation(
     ir = generate_ir(*(op.OpenAPI.model_validate(spec) for spec in specs))
 
     assert ir.model_dump(mode="json", exclude_none=True) == expected
+
+
+def test_model_preserves_additional_properties_alongside_fields() -> None:
+    spec = op.OpenAPI.model_validate(
+        {
+            "openapi": "3.1.0",
+            "info": {"title": "Test API", "version": "1.0.0"},
+            "paths": {
+                "/events": {
+                    "post": {
+                        "operationId": "events:create",
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/EventMetadataInput"
+                                    }
+                                }
+                            },
+                        },
+                        "responses": {"204": {"description": "Success"}},
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "EventMetadataInput": {
+                        "type": "object",
+                        "title": "EventMetadataInput",
+                        "properties": {"_cost": {"type": "number"}},
+                        "additionalProperties": {
+                            "anyOf": [
+                                {"type": "string"},
+                                {"type": "number"},
+                                {"type": "boolean"},
+                            ]
+                        },
+                    }
+                }
+            },
+        }
+    )
+
+    ir = generate_ir(spec)
+
+    assert ir.versions[0].input_models[0].model_dump(
+        mode="json", exclude_none=True
+    ) == {
+        "name": "EventMetadataInput",
+        "fields": [
+            {
+                "name": "_cost",
+                "type": {"kind": "primitive", "type": "number"},
+                "required": False,
+                "has_default": False,
+                "has_example": False,
+            }
+        ],
+        "additional_properties": {
+            "kind": "union",
+            "variants": [
+                {"kind": "primitive", "type": "string"},
+                {"kind": "primitive", "type": "number"},
+                {"kind": "primitive", "type": "boolean"},
+            ],
+            "composition_kind": "anyOf",
+        },
+    }

--- a/sdk/generator/tests/typescript/test_types.py
+++ b/sdk/generator/tests/typescript/test_types.py
@@ -1,5 +1,8 @@
-from generator.ir import PrimitiveType, UnionType
-from typescript.types import convert_type_to_typescript
+from generator.ir import Field, Model, ModelRef, PrimitiveType, UnionType
+from typescript.types import (
+    convert_additional_properties_to_typescript,
+    convert_type_to_typescript,
+)
 
 
 def test_convert_type_to_typescript_deduplicates_union_members() -> None:
@@ -12,3 +15,34 @@ def test_convert_type_to_typescript_deduplicates_union_members() -> None:
     )
 
     assert convert_type_to_typescript(type_ref) == "number"
+
+
+def test_convert_additional_properties_to_typescript_includes_field_types() -> None:
+    model = Model(
+        name="EventMetadataInput",
+        fields=[
+            Field(
+                name="_cost",
+                type=ModelRef(kind="model", name="CostMetadataInput"),
+                required=False,
+            ),
+            Field(
+                name="_llm",
+                type=ModelRef(kind="model", name="LLMMetadata"),
+                required=False,
+            ),
+        ],
+        additional_properties=UnionType(
+            kind="union",
+            variants=[
+                PrimitiveType(kind="primitive", type="string"),
+                PrimitiveType(kind="primitive", type="integer"),
+                PrimitiveType(kind="primitive", type="number"),
+                PrimitiveType(kind="primitive", type="boolean"),
+            ],
+        ),
+    )
+
+    assert convert_additional_properties_to_typescript(model) == (
+        "string | number | boolean | CostMetadataInput | LLMMetadata | undefined"
+    )

--- a/sdk/generator/typescript/emitter.py
+++ b/sdk/generator/typescript/emitter.py
@@ -21,6 +21,7 @@ from typescript.types import (
     collect_enum_names,
     collect_type_imports,
     collect_union_imports,
+    convert_additional_properties_to_typescript,
     convert_type_to_typescript,
 )
 from typescript.utils import format_default_value_ts, format_description
@@ -157,6 +158,9 @@ class TypeScriptEmitter(EmitterBase):
         super().setup_environment()
         self.env.filters["ts_type"] = lambda type_ref, ref_suffix="": (
             convert_type_to_typescript(type_ref, ref_suffix)
+        )
+        self.env.filters["ts_additional_properties_type"] = (
+            convert_additional_properties_to_typescript
         )
         self.env.filters["camel"] = to_camel_case
         self.env.filters["operation_name"] = operation_name

--- a/sdk/generator/typescript/template/src/version/models.ts
+++ b/sdk/generator/typescript/template/src/version/models.ts
@@ -7,14 +7,15 @@ export type {{ enum.name }} = {% for value in enum.values %}{% if value.value is
 {% for model in models %}/**
  * {{ model.description or model.name }}
  */
-{% if model.additional_properties %}export type {{ model.name }} = Record<string, {{ model.additional_properties | ts_type }}>;
-{% else %}
-export interface {{ model.name }}{% if model.fields %} {
+{% if model.fields %}export interface {{ model.name }} {
   {% for field in model.fields %}  /**
    * {{ field.description or field.name }}
    */
   {{ field.name }}{% if not field.required %}?{% endif %}: {{ field.type | ts_type }};
-  {% endfor %}}{% else %} extends Record<string, never> {}{% endif %}
+  {% endfor %}{% if model.additional_properties %}  [key: string]: {{ model | ts_additional_properties_type }};
+  {% endif %}}
+{% elif model.additional_properties %}export type {{ model.name }} = Record<string, {{ model.additional_properties | ts_type }}>;
+{% else %}export interface {{ model.name }} extends Record<string, never> {}
 {% endif %}
 
 {% endfor %}

--- a/sdk/generator/typescript/types.py
+++ b/sdk/generator/typescript/types.py
@@ -4,6 +4,7 @@ from generator.ir import (
     EnumRef,
     LiteralType,
     MapType,
+    Model,
     ModelRef,
     NullableType,
     PrimitiveType,
@@ -94,6 +95,18 @@ def convert_type_to_typescript(
         return f"Record<string, {value_type}>"
 
     return "unknown"
+
+
+def convert_additional_properties_to_typescript(model: Model) -> str:
+    assert model.additional_properties is not None
+
+    type_refs = [model.additional_properties, *(field.type for field in model.fields)]
+    types = dict.fromkeys(
+        convert_type_to_typescript(type_ref) for type_ref in type_refs
+    )
+    if any(not field.required for field in model.fields):
+        types["undefined"] = None
+    return " | ".join(types)
 
 
 def collect_type_imports(type_ref: TypeRef | None, api: APIVersion) -> set[str]:

--- a/sdk/python/polar/base.py
+++ b/sdk/python/polar/base.py
@@ -224,8 +224,16 @@ def _register_extra_items_typed_dict(
 ) -> None:
     global _retort
 
-    field_types = typing.get_type_hints(model)
-    required_keys = model.__required_keys__
+    field_types = typing.get_type_hints(model, include_extras=True)
+    required_keys = set(model.__required_keys__)
+    for key, field_type in field_types.items():
+        field_origin = typing.get_origin(field_type)
+        if field_origin is typing.Required:
+            required_keys.add(key)
+        elif field_origin is typing.NotRequired:
+            required_keys.discard(key)
+        if field_origin in (typing.Required, typing.NotRequired):
+            field_types[key] = typing.get_args(field_type)[0]
 
     def load_extra_items_typed_dict(data: object) -> dict[str, typing.Any]:
         if not isinstance(data, collections.abc.Mapping):

--- a/sdk/python/polar/base.py
+++ b/sdk/python/polar/base.py
@@ -1,3 +1,4 @@
+import abc
 import builtins
 import collections.abc
 import types
@@ -56,6 +57,20 @@ class PolarRateLimitError(PolarClientError):
     ):
         super().__init__(status_code, "Rate limit exceeded")
         self.retry_after = retry_after
+
+
+class _AdditionalPropertiesModel(abc.ABC):
+    __slots__ = ()
+
+    @abc.abstractmethod
+    def _mark_additional_properties_model(self) -> None: ...
+
+
+class AdditionalPropertiesMixin(_AdditionalPropertiesModel):
+    __slots__ = ()
+
+    def _mark_additional_properties_model(self) -> None:
+        pass
 
 
 def resolve_base_url(

--- a/sdk/python/polar/base.py
+++ b/sdk/python/polar/base.py
@@ -1,4 +1,3 @@
-import abc
 import builtins
 import collections.abc
 import types
@@ -57,20 +56,6 @@ class PolarRateLimitError(PolarClientError):
     ):
         super().__init__(status_code, "Rate limit exceeded")
         self.retry_after = retry_after
-
-
-class _AdditionalPropertiesModel(abc.ABC):
-    __slots__ = ()
-
-    @abc.abstractmethod
-    def _mark_additional_properties_model(self) -> None: ...
-
-
-class AdditionalPropertiesMixin(_AdditionalPropertiesModel):
-    __slots__ = ()
-
-    def _mark_additional_properties_model(self) -> None:
-        pass
 
 
 def resolve_base_url(
@@ -231,6 +216,38 @@ _retort = adaptix.Retort(
         ),
     ]
 )
+
+
+def _register_extra_items_typed_dict(
+    model: typing.Any,
+    extra_items_type: typing_extensions.TypeForm[typing.Any],
+) -> None:
+    global _retort
+
+    field_types = typing.get_type_hints(model)
+    required_keys = model.__required_keys__
+
+    def load_extra_items_typed_dict(data: object) -> dict[str, typing.Any]:
+        if not isinstance(data, collections.abc.Mapping):
+            raise adaptix.load_error.TypeLoadError(collections.abc.Mapping, data)
+
+        missing_keys = required_keys - data.keys()
+        if missing_keys:
+            raise adaptix.load_error.NoRequiredFieldsLoadError(missing_keys, data)
+
+        loaded: dict[str, typing.Any] = {}
+        for key, value in data.items():
+            if not isinstance(key, str):
+                raise adaptix.load_error.TypeLoadError(str, key)
+            if key in field_types:
+                loaded[key] = _retort.load(value, field_types[key])
+            else:
+                loaded[key] = _retort.load(value, extra_items_type)
+        return loaded
+
+    _retort = _retort.extend(
+        recipe=[adaptix.loader(model, load_extra_items_typed_dict)]
+    )
 
 
 def deserialize(data: object, model: typing_extensions.TypeForm[_ModelT]) -> _ModelT:

--- a/sdk/python/polar/v2026_04/inputs.py
+++ b/sdk/python/polar/v2026_04/inputs.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import typing
 
+import typing_extensions
+
 from polar.v2026_04.literals import (
     BenefitVisibility,
     CountryAlpha2Input,
@@ -2086,7 +2088,9 @@ class EventCreateExternalCustomer(typing.TypedDict):
     """ID of the member in your system within the customer's organization who performed the action. Used for member-level attribution in B2B."""
 
 
-class EventMetadataInput(typing.TypedDict):
+class EventMetadataInput(
+    typing_extensions.TypedDict, extra_items=str | int | float | bool
+):
     _cost: typing.NotRequired[CostMetadataInput]
 
     _llm: typing.NotRequired[LLMMetadata]

--- a/sdk/python/polar/v2026_04/outputs.py
+++ b/sdk/python/polar/v2026_04/outputs.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import dataclasses
 import typing
 
-from polar.base import AdditionalPropertiesMixin
+import typing_extensions
+
+from polar.base import _register_extra_items_typed_dict
 from polar.v2026_04.literals import (
     BenefitType,
     BenefitVisibility,
@@ -6210,15 +6212,13 @@ class DownloadableRead:
     file: FileDownload
 
 
-@dataclasses.dataclass(kw_only=True, slots=True)
-class EventMetadataOutput(AdditionalPropertiesMixin):
-    _cost: CostMetadataOutput | None = None
+class EventMetadataOutput(
+    typing_extensions.TypedDict,
+    extra_items=str | int | float | bool,
+):
+    _cost: typing.NotRequired[CostMetadataOutput]
 
-    _llm: LLMMetadata | None = None
-
-    additional_properties: dict[str, str | int | float | bool] = dataclasses.field(
-        default_factory=dict
-    )
+    _llm: typing.NotRequired[LLMMetadata]
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -11050,3 +11050,9 @@ SystemEvent: typing.TypeAlias = (
 )
 
 Event: typing.TypeAlias = SystemEvent | UserEvent
+
+
+_register_extra_items_typed_dict(
+    EventMetadataOutput,
+    str | int | float | bool,
+)

--- a/sdk/python/polar/v2026_04/outputs.py
+++ b/sdk/python/polar/v2026_04/outputs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import typing
 
+from polar.base import AdditionalPropertiesMixin
 from polar.v2026_04.literals import (
     BenefitType,
     BenefitVisibility,
@@ -6210,10 +6211,14 @@ class DownloadableRead:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class EventMetadataOutput:
+class EventMetadataOutput(AdditionalPropertiesMixin):
     _cost: CostMetadataOutput | None = None
 
     _llm: LLMMetadata | None = None
+
+    additional_properties: dict[str, str | int | float | bool] = dataclasses.field(
+        default_factory=dict
+    )
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)

--- a/sdk/python/polar/v2026_10/inputs.py
+++ b/sdk/python/polar/v2026_10/inputs.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import typing
 
+import typing_extensions
+
 from polar.v2026_10.literals import (
     BenefitVisibility,
     CountryAlpha2Input,
@@ -2086,7 +2088,9 @@ class EventCreateExternalCustomer(typing.TypedDict):
     """ID of the member in your system within the customer's organization who performed the action. Used for member-level attribution in B2B."""
 
 
-class EventMetadataInput(typing.TypedDict):
+class EventMetadataInput(
+    typing_extensions.TypedDict, extra_items=str | int | float | bool
+):
     _cost: typing.NotRequired[CostMetadataInput]
 
     _llm: typing.NotRequired[LLMMetadata]

--- a/sdk/python/polar/v2026_10/outputs.py
+++ b/sdk/python/polar/v2026_10/outputs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import typing
 
+from polar.base import AdditionalPropertiesMixin
 from polar.v2026_10.literals import (
     BenefitType,
     BenefitVisibility,
@@ -6210,10 +6211,14 @@ class DownloadableRead:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class EventMetadataOutput:
+class EventMetadataOutput(AdditionalPropertiesMixin):
     _cost: CostMetadataOutput | None = None
 
     _llm: LLMMetadata | None = None
+
+    additional_properties: dict[str, str | int | float | bool] = dataclasses.field(
+        default_factory=dict
+    )
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)

--- a/sdk/python/polar/v2026_10/outputs.py
+++ b/sdk/python/polar/v2026_10/outputs.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import dataclasses
 import typing
 
-from polar.base import AdditionalPropertiesMixin
+import typing_extensions
+
+from polar.base import _register_extra_items_typed_dict
 from polar.v2026_10.literals import (
     BenefitType,
     BenefitVisibility,
@@ -6210,15 +6212,13 @@ class DownloadableRead:
     file: FileDownload
 
 
-@dataclasses.dataclass(kw_only=True, slots=True)
-class EventMetadataOutput(AdditionalPropertiesMixin):
-    _cost: CostMetadataOutput | None = None
+class EventMetadataOutput(
+    typing_extensions.TypedDict,
+    extra_items=str | int | float | bool,
+):
+    _cost: typing.NotRequired[CostMetadataOutput]
 
-    _llm: LLMMetadata | None = None
-
-    additional_properties: dict[str, str | int | float | bool] = dataclasses.field(
-        default_factory=dict
-    )
+    _llm: typing.NotRequired[LLMMetadata]
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -11050,3 +11050,9 @@ SystemEvent: typing.TypeAlias = (
 )
 
 Event: typing.TypeAlias = SystemEvent | UserEvent
+
+
+_register_extra_items_typed_dict(
+    EventMetadataOutput,
+    str | int | float | bool,
+)

--- a/sdk/python/tests/test_base.py
+++ b/sdk/python/tests/test_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import typing
 
@@ -87,6 +89,12 @@ def test_deserialize_model_with_additional_properties() -> None:
         "details": ExtensibleDetails(name="example"),
         "custom": "value",
     }
+
+
+def test_deserialize_model_without_optional_fields() -> None:
+    model = deserialize({"known": 1, "custom": "value"}, ExtensibleModel)
+
+    assert model == {"known": 1, "custom": "value"}
 
 
 def test_deserialize_model_with_invalid_additional_property() -> None:

--- a/sdk/python/tests/test_base.py
+++ b/sdk/python/tests/test_base.py
@@ -78,7 +78,6 @@ def test_deserialize_model_with_additional_properties() -> None:
             "known": 1,
             "details": {"name": "example"},
             "custom": "value",
-            "large_integer": 9007199254740993,
         },
         ExtensibleModel,
     )
@@ -87,9 +86,7 @@ def test_deserialize_model_with_additional_properties() -> None:
         "known": 1,
         "details": ExtensibleDetails(name="example"),
         "custom": "value",
-        "large_integer": 9007199254740993,
     }
-    assert type(typing.cast(dict[str, object], model)["large_integer"]) is int
 
 
 def test_deserialize_model_with_invalid_additional_property() -> None:

--- a/sdk/python/tests/test_base.py
+++ b/sdk/python/tests/test_base.py
@@ -3,12 +3,13 @@ import typing
 
 import httpx
 import pytest
+import typing_extensions
 
 from polar import PolarDeserializationError, deserialize
 from polar.base import (
-    AdditionalPropertiesMixin,
     AsyncClientBase,
     SyncClientBase,
+    _register_extra_items_typed_dict,
     resolve_base_url,
 )
 
@@ -33,10 +34,23 @@ class Dog:
 Animal: typing.TypeAlias = Cat | Dog
 
 
-@dataclasses.dataclass(slots=True)
-class ExtensibleModel(AdditionalPropertiesMixin):
+@dataclasses.dataclass
+class ExtensibleDetails:
+    name: str
+
+
+class ExtensibleModel(
+    typing_extensions.TypedDict,
+    extra_items=str | int | float | bool,
+):
     known: int
-    additional_properties: dict[str, str] = dataclasses.field(default_factory=dict)
+    details: typing.NotRequired[ExtensibleDetails]
+
+
+_register_extra_items_typed_dict(
+    ExtensibleModel,
+    str | int | float | bool,
+)
 
 
 def test_deserialize_model() -> None:
@@ -59,12 +73,28 @@ def test_deserialize_union() -> None:
 
 
 def test_deserialize_model_with_additional_properties() -> None:
-    model = deserialize({"known": 1, "custom": "value"}, ExtensibleModel)
-
-    assert model == ExtensibleModel(
-        known=1,
-        additional_properties={"custom": "value"},
+    model = deserialize(
+        {
+            "known": 1,
+            "details": {"name": "example"},
+            "custom": "value",
+            "large_integer": 9007199254740993,
+        },
+        ExtensibleModel,
     )
+
+    assert model == {
+        "known": 1,
+        "details": ExtensibleDetails(name="example"),
+        "custom": "value",
+        "large_integer": 9007199254740993,
+    }
+    assert type(typing.cast(dict[str, object], model)["large_integer"]) is int
+
+
+def test_deserialize_model_with_invalid_additional_property() -> None:
+    with pytest.raises(PolarDeserializationError):
+        deserialize({"known": 1, "invalid": ["value"]}, ExtensibleModel)
 
 
 @pytest.mark.parametrize(

--- a/sdk/python/tests/test_base.py
+++ b/sdk/python/tests/test_base.py
@@ -5,7 +5,12 @@ import httpx
 import pytest
 
 from polar import PolarDeserializationError, deserialize
-from polar.base import AsyncClientBase, SyncClientBase, resolve_base_url
+from polar.base import (
+    AdditionalPropertiesMixin,
+    AsyncClientBase,
+    SyncClientBase,
+    resolve_base_url,
+)
 
 SERVERS = {
     "production": "https://api.polar.sh",
@@ -28,6 +33,12 @@ class Dog:
 Animal: typing.TypeAlias = Cat | Dog
 
 
+@dataclasses.dataclass(slots=True)
+class ExtensibleModel(AdditionalPropertiesMixin):
+    known: int
+    additional_properties: dict[str, str] = dataclasses.field(default_factory=dict)
+
+
 def test_deserialize_model() -> None:
     cat = deserialize({"type": "cat", "lives": 9}, Cat)
 
@@ -45,6 +56,15 @@ def test_deserialize_union() -> None:
 
     typing.assert_type(animal, Cat | Dog)
     assert animal == Dog(type="dog", breed="Samoyed")
+
+
+def test_deserialize_model_with_additional_properties() -> None:
+    model = deserialize({"known": 1, "custom": "value"}, ExtensibleModel)
+
+    assert model == ExtensibleModel(
+        known=1,
+        additional_properties={"custom": "value"},
+    )
 
 
 @pytest.mark.parametrize(

--- a/sdk/typescript/src/2026-04/models.ts
+++ b/sdk/typescript/src/2026-04/models.ts
@@ -13745,6 +13745,7 @@ export interface EventMetadataInput {
    * _llm
    */
   _llm?: LLMMetadata;
+  [key: string]: string | number | boolean | CostMetadataInput | LLMMetadata | undefined;
 }
 /**
  * EventMetadataOutput
@@ -13758,6 +13759,7 @@ export interface EventMetadataOutput {
    * _llm
    */
   _llm?: LLMMetadata;
+  [key: string]: string | number | boolean | CostMetadataOutput | LLMMetadata | undefined;
 }
 /**
  * EventName

--- a/sdk/typescript/src/2026-10/models.ts
+++ b/sdk/typescript/src/2026-10/models.ts
@@ -13745,6 +13745,7 @@ export interface EventMetadataInput {
    * _llm
    */
   _llm?: LLMMetadata;
+  [key: string]: string | number | boolean | CostMetadataInput | LLMMetadata | undefined;
 }
 /**
  * EventMetadataOutput
@@ -13758,6 +13759,7 @@ export interface EventMetadataOutput {
    * _llm
    */
   _llm?: LLMMetadata;
+  [key: string]: string | number | boolean | CostMetadataOutput | LLMMetadata | undefined;
 }
 /**
  * EventName


### PR DESCRIPTION
## Summary

The generated SDK types did not allow for arbitrary metadata on events, only `_llm` and `_cost`. Modified the generator to properly handle `additionalProperties` and when present, allow arbitrary keys.
