### PR TITLE
fix(sdk): preserve integers in `int | float` union deserialization

### DIFF
--- a/sdk/generator/python/template/polar/base.py
+++ b/sdk/generator/python/template/polar/base.py
@@ -194,7 +194,22 @@ class AsyncServiceBase:
         return cls(service.client)
 
 
-_retort = adaptix.Retort()
+def _load_exact_float(data: object) -> float:
+    if type(data) is float:
+        return data
+    raise adaptix.load_error.TypeLoadError(float, data)
+
+
+_retort = adaptix.Retort(
+    recipe=[
+        adaptix.loader(
+            adaptix.P[int | float][float]
+            | adaptix.P[int | float | None][float]
+            | adaptix.P[str | int | float | bool][float],
+            _load_exact_float,
+        ),
+    ]
+)
 
 
 def deserialize(

--- a/sdk/generator/python/template/polar/base.py
+++ b/sdk/generator/python/template/polar/base.py
@@ -200,6 +200,10 @@ def _load_exact_float(data: object) -> float:
     raise adaptix.load_error.TypeLoadError(float, data)
 
 
+# Adaptix's float loader also accepts int, and union cases are tried in an
+# order that puts float first, so int | float would always coerce to float.
+# P[Union][float] targets float only as a member of that union (not standalone
+# float fields, which should still coerce JSON ints).
 _retort = adaptix.Retort(
     recipe=[
         adaptix.loader(

--- a/sdk/generator/python/template/tests/test_base.py
+++ b/sdk/generator/python/template/tests/test_base.py
@@ -48,6 +48,52 @@ def test_deserialize_union() -> None:
 
 
 @pytest.mark.parametrize(
+    ("value", "expected_type"),
+    [
+        (42, int),
+        (99.5, float),
+    ],
+)
+def test_deserialize_int_float_union_preserves_json_type(
+    value: int | float, expected_type: type[int] | type[float]
+) -> None:
+    result = deserialize(value, int | float)
+    assert type(result) is expected_type
+    assert result == value
+
+
+def test_deserialize_int_float_optional_field() -> None:
+    @dataclasses.dataclass
+    class Metric:
+        orders: int | float | None = None
+        revenue: int | float | None = None
+
+    result = deserialize({"orders": 42, "revenue": 99.5}, Metric)
+    assert type(result.orders) is int
+    assert result.orders == 42
+    assert type(result.revenue) is float
+    assert result.revenue == 99.5
+
+
+def test_deserialize_json_scalar_union_preserves_int() -> None:
+    result = deserialize(
+        {"count": 1, "ratio": 1.5, "name": "x", "ok": True},
+        dict[str, str | int | float | bool],
+    )
+    assert type(result["count"]) is int
+    assert result["count"] == 1
+    assert type(result["ratio"]) is float
+    assert type(result["name"]) is str
+    assert type(result["ok"]) is bool
+
+
+def test_deserialize_float_still_coerces_int() -> None:
+    result = deserialize(7, float)
+    assert type(result) is float
+    assert result == 7.0
+
+
+@pytest.mark.parametrize(
     ("environment", "base_url", "expected"),
     [
         ("production", None, "https://api.polar.sh"),

--- a/sdk/generator/python/template/tests/test_base.py
+++ b/sdk/generator/python/template/tests/test_base.py
@@ -55,7 +55,7 @@ def test_deserialize_union() -> None:
     ],
 )
 def test_deserialize_int_float_union_preserves_json_type(
-    value: int | float, expected_type: type[int] | type[float]
+    value: object, expected_type: type
 ) -> None:
     result = deserialize(value, int | float)
     assert type(result) is expected_type

--- a/sdk/python/polar/base.py
+++ b/sdk/python/polar/base.py
@@ -202,6 +202,10 @@ def _load_exact_float(data: object) -> float:
     raise adaptix.load_error.TypeLoadError(float, data)
 
 
+# Adaptix's float loader also accepts int, and union cases are tried in an
+# order that puts float first, so int | float would always coerce to float.
+# P[Union][float] targets float only as a member of that union (not standalone
+# float fields, which should still coerce JSON ints).
 _retort = adaptix.Retort(
     recipe=[
         adaptix.loader(

--- a/sdk/python/polar/base.py
+++ b/sdk/python/polar/base.py
@@ -196,7 +196,22 @@ class AsyncServiceBase:
         return cls(service.client)
 
 
-_retort = adaptix.Retort()
+def _load_exact_float(data: object) -> float:
+    if type(data) is float:
+        return data
+    raise adaptix.load_error.TypeLoadError(float, data)
+
+
+_retort = adaptix.Retort(
+    recipe=[
+        adaptix.loader(
+            adaptix.P[int | float][float]
+            | adaptix.P[int | float | None][float]
+            | adaptix.P[str | int | float | bool][float],
+            _load_exact_float,
+        ),
+    ]
+)
 
 
 def deserialize(data: object, model: typing_extensions.TypeForm[_ModelT]) -> _ModelT:

--- a/sdk/python/tests/test_base.py
+++ b/sdk/python/tests/test_base.py
@@ -48,6 +48,52 @@ def test_deserialize_union() -> None:
 
 
 @pytest.mark.parametrize(
+    ("value", "expected_type"),
+    [
+        (42, int),
+        (99.5, float),
+    ],
+)
+def test_deserialize_int_float_union_preserves_json_type(
+    value: int | float, expected_type: type[int] | type[float]
+) -> None:
+    result = deserialize(value, int | float)
+    assert type(result) is expected_type
+    assert result == value
+
+
+def test_deserialize_int_float_optional_field() -> None:
+    @dataclasses.dataclass
+    class Metric:
+        orders: int | float | None = None
+        revenue: int | float | None = None
+
+    result = deserialize({"orders": 42, "revenue": 99.5}, Metric)
+    assert type(result.orders) is int
+    assert result.orders == 42
+    assert type(result.revenue) is float
+    assert result.revenue == 99.5
+
+
+def test_deserialize_json_scalar_union_preserves_int() -> None:
+    result = deserialize(
+        {"count": 1, "ratio": 1.5, "name": "x", "ok": True},
+        dict[str, str | int | float | bool],
+    )
+    assert type(result["count"]) is int
+    assert result["count"] == 1
+    assert type(result["ratio"]) is float
+    assert type(result["name"]) is str
+    assert type(result["ok"]) is bool
+
+
+def test_deserialize_float_still_coerces_int() -> None:
+    result = deserialize(7, float)
+    assert type(result) is float
+    assert result == 7.0
+
+
+@pytest.mark.parametrize(
     ("environment", "base_url", "expected"),
     [
         ("production", None, "https://api.polar.sh"),

--- a/sdk/python/tests/test_base.py
+++ b/sdk/python/tests/test_base.py
@@ -55,7 +55,7 @@ def test_deserialize_union() -> None:
     ],
 )
 def test_deserialize_int_float_union_preserves_json_type(
-    value: int | float, expected_type: type[int] | type[float]
+    value: object, expected_type: type
 ) -> None:
     result = deserialize(value, int | float)
     assert type(result) is expected_type


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adaptix’s default `float` loader also accepts `int`, and it tries the `float` case first in `int | float` unions. JSON integers from the API were therefore always coerced to `float`.

This Retort recipe makes the `float` union case accept only actual floats, so integers stay integers. Standalone `float` fields still coerce JSON ints as before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f83b537-e053-4e31-9c47-58d3a308402e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f83b537-e053-4e31-9c47-58d3a308402e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

