### PR TITLE
ci: refresh the preview base VM nightly

### DIFF
--- a/.github/workflows/preview-base.yml
+++ b/.github/workflows/preview-base.yml
@@ -1,0 +1,54 @@
+name: Preview Base Refresh
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  refresh:
+    name: Refresh preview base VM
+    if: github.repository == 'polarsource/polar' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    concurrency:
+      group: preview-base-${{ vars.POLAR_PREVIEW_BASE_VM || 'polar-base' }}
+      cancel-in-progress: false
+    env:
+      BASE_VM: ${{ vars.POLAR_PREVIEW_BASE_VM || 'polar-base' }}
+    steps:
+      - name: Set up SSH key
+        env:
+          SSH_KEY: ${{ secrets.POLAR_PREVIEW_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s\n' "$SSH_KEY" > "$RUNNER_TEMP/preview-base-key"
+
+      - name: Refresh from main
+        run: |
+          set -euo pipefail
+          ssh -o BatchMode=yes -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new -o ConnectTimeout=30 \
+            -o ServerAliveInterval=30 -o ServerAliveCountMax=3 \
+            -i "$RUNNER_TEMP/preview-base-key" "vm+${BASE_VM}@vm.exe.xyz" \
+            'sudo -n timeout --kill-after=60s 75m flock --nonblock /run/lock/polar-base-refresh.lock bash -se' <<'REFRESH'
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          export NEEDRESTART_MODE=a
+          cd /srv/polar
+          git fetch origin main:refs/remotes/origin/main
+          git checkout -f origin/main
+          bash infra/preview/setup-base-vm.sh
+          test "$(git rev-parse HEAD)" = "$(cat .deployed_sha)"
+          test -x server/emails/bin/react-email-pkg
+          test -s server/polar/backoffice/static/styles.css
+          test -s server/polar/backoffice/static/scripts.js
+          git log -1 --format='Refreshed preview base to %H (%s)'
+          REFRESH
+
+      - name: Remove SSH key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/preview-base-key"

--- a/infra/preview/README.md
+++ b/infra/preview/README.md
@@ -38,7 +38,20 @@ is installed but not joined (clones would duplicate the node identity), and no s
 are baked in. `polar-backend`/`polar-frontend` are gated on `ConditionPathExists` for
 their env files, so fresh clones boot idle until the first deploy.
 
-Update (after dependency drift or infra/preview changes — do this every few weeks):
+The **Preview Base Refresh** workflow (`.github/workflows/preview-base.yml`) refreshes
+the base nightly at **02:17 UTC**, and can also be run manually with
+`workflow_dispatch` on `main`. It uses the existing `POLAR_PREVIEW_SSH_KEY` secret
+and `POLAR_PREVIEW_BASE_VM` variable (default: `polar-base`). The SSH key must have
+shell access with passwordless sudo on the base VM.
+
+Each run checks out current `origin/main` and runs `setup-base-vm.sh`, updating
+dependencies, prebuilt assets, the local Turbo cache, preview tools, and
+`.deployed_sha`. Refresh jobs are serialized and take an exclusive lock on the VM;
+the remote command has a 75-minute timeout. Failures are reported by the workflow.
+The refresh happens in place, so a preview cloned during the refresh may still
+need to finish dependency installation. Existing preview VMs are unaffected.
+
+To refresh manually over SSH:
 
 ```bash
 ssh polar-base.exe.xyz "cd /srv/polar && sudo git fetch origin main && sudo git checkout -f origin/main && sudo bash infra/preview/setup-base-vm.sh"


### PR DESCRIPTION
PR #14136 spent almost six minutes in pnpm install, even though previews clone a VM that already has dependencies installed. The base VM had fallen behind main, so every new clone had to catch up — including downloading 459 packages and rebuilding the shared packages.

This refreshes polar-base from main every night at 02:17 UTC using the existing setup script, so new previews start with current dependencies, built assets, and a warm Turbo cache. There's also a manual trigger, plus locking and timeouts to keep refreshes from overlapping or hanging forever. The time is just an overnight slot away from the top of the hour.

The refresh happens in place, so a preview cloned while it's running may still need to finish installing dependencies. Existing preview VMs aren't affected.

Validated with Actionlint and mocked SSH checks for quoting, failure propagation, and key cleanup. The underlying setup script was also successfully run on polar-base during the investigation.
