### PR TITLE
server/webhooks: send version-aware payloads - #14067

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -20632,6 +20632,12 @@ export interface components {
        * @description An optional name for the webhook endpoint to help organize and identify it.
        */
       name?: string | null
+      /**
+       * Api Version
+       * @description The API version that'll be used in event payloads.
+       * @default 2026-04
+       */
+      api_version: string
       /** @description The format of the webhook payload. */
       format: components['schemas']['WebhookFormat']
       /**
@@ -20654,6 +20660,11 @@ export interface components {
        * @description An optional name for the webhook endpoint to help organize and identify it.
        */
       name?: string | null
+      /**
+       * Api Version
+       * @description The API version that'll be used in event payloads.
+       */
+      api_version?: string | null
       format?: components['schemas']['WebhookFormat'] | null
       /** Events */
       events?: components['schemas']['WebhookEventType'][] | null
@@ -38320,6 +38331,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       /** Benefit */
       data: components['schemas']['Benefit']
     }
@@ -38341,6 +38354,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       /** BenefitGrantWebhook */
       data: components['schemas']['BenefitGrantWebhook']
     }
@@ -38363,6 +38378,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       /** BenefitGrantWebhook */
       data: components['schemas']['BenefitGrantWebhook']
     }
@@ -38384,6 +38401,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       /** BenefitGrantWebhook */
       data: components['schemas']['BenefitGrantWebhook']
     }
@@ -38405,6 +38424,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       /** BenefitGrantWebhook */
       data: components['schemas']['BenefitGrantWebhook']
     }
@@ -38426,6 +38447,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       /** Benefit */
       data: components['schemas']['Benefit']
     }
@@ -38447,6 +38470,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Checkout']
     }
     /**
@@ -38470,6 +38495,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Checkout']
     }
     /**
@@ -38490,6 +38517,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Checkout']
     }
     /**
@@ -38515,6 +38544,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Customer']
     }
     /**
@@ -38535,6 +38566,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Customer']
     }
     /**
@@ -38556,6 +38589,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['CustomerSeat']
     }
     /**
@@ -38576,6 +38611,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['CustomerSeat']
     }
     /**
@@ -38596,6 +38633,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['CustomerSeat']
     }
     /**
@@ -38622,6 +38661,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['CustomerState']
     }
     /**
@@ -38646,6 +38687,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Customer']
     }
     /**
@@ -38706,6 +38749,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       /** Discount */
       data: components['schemas']['Discount']
     }
@@ -38727,6 +38772,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       /** Discount */
       data: components['schemas']['Discount']
     }
@@ -38748,6 +38795,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       /** Discount */
       data: components['schemas']['Discount']
     }
@@ -38784,6 +38833,11 @@ export interface components {
        * @description An optional name for the webhook endpoint to help organize and identify it.
        */
       name?: string | null
+      /**
+       * Api Version
+       * @description The API version that'll be used in event payloads.
+       */
+      api_version: string
       /** @description The format of the webhook payload. */
       format: components['schemas']['WebhookFormat']
       /**
@@ -38823,6 +38877,12 @@ export interface components {
        * @description An optional name for the webhook endpoint to help organize and identify it.
        */
       name?: string | null
+      /**
+       * Api Version
+       * @description The API version that'll be used in event payloads.
+       * @default 2026-04
+       */
+      api_version: string
       /** @description The format of the webhook payload. */
       format: components['schemas']['WebhookFormat']
       /**
@@ -38845,6 +38905,11 @@ export interface components {
        * @description An optional name for the webhook endpoint to help organize and identify it.
        */
       name?: string | null
+      /**
+       * Api Version
+       * @description The API version that'll be used in event payloads.
+       */
+      api_version?: string | null
       format?: components['schemas']['WebhookFormat'] | null
       /** Events */
       events?: components['schemas']['WebhookEventType'][] | null
@@ -38897,6 +38962,11 @@ export interface components {
        * @description Whether this event was skipped because the webhook endpoint was disabled.
        */
       skipped: boolean
+      /**
+       * Api Version
+       * @description The API version used in the payload of this event.
+       */
+      api_version: string
       /**
        * Payload
        * @description The payload of the webhook event.
@@ -38984,6 +39054,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Member']
     }
     /**
@@ -39007,6 +39079,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Member']
     }
     /**
@@ -39030,6 +39104,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Member']
     }
     /**
@@ -39060,6 +39136,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Order']
     }
     /**
@@ -39082,6 +39160,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Order']
     }
     /**
@@ -39102,6 +39182,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Order']
     }
     /**
@@ -39127,6 +39209,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Order']
     }
     /**
@@ -39147,6 +39231,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Organization']
     }
     /**
@@ -39167,6 +39253,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Product']
     }
     /**
@@ -39187,6 +39275,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Product']
     }
     /**
@@ -39207,6 +39297,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Refund']
     }
     /**
@@ -39227,6 +39319,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Refund']
     }
     /**
@@ -39248,6 +39342,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Subscription']
     }
     /**
@@ -39269,6 +39365,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Subscription']
     }
     /**
@@ -39291,6 +39389,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Subscription']
     }
     /**
@@ -39319,6 +39419,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Subscription']
     }
     /**
@@ -39344,6 +39446,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Subscription']
     }
     /**
@@ -39367,6 +39471,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Subscription']
     }
     /**
@@ -39389,6 +39495,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Subscription']
     }
     /**
@@ -39412,6 +39520,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Subscription']
     }
     /**
@@ -39436,6 +39546,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Subscription']
     }
     /**
@@ -39460,6 +39572,8 @@ export interface components {
        * Format: date-time
        */
       timestamp: string
+      /** Api Version */
+      api_version: string
       data: components['schemas']['Subscription']
     }
     /** MetadataQuery */

--- a/server/polar/kit/versioning.py
+++ b/server/polar/kit/versioning.py
@@ -14,10 +14,10 @@ from collections.abc import (
 
 from fastapi import APIRouter, FastAPI
 from fastapi.routing import APIRoute, RouteContext, iter_route_contexts
-from pydantic import Field, GetJsonSchemaHandler
+from pydantic import Field, GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic.fields import FieldInfo
 from pydantic.json_schema import JsonSchemaValue
-from pydantic_core import CoreSchema, PydanticOmit
+from pydantic_core import CoreSchema, PydanticOmit, core_schema
 from sqlalchemy import CHAR, Dialect, TypeDecorator
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.responses import JSONResponse
@@ -63,6 +63,27 @@ class APIVersion:
         headers = Headers(scope=scope)
         raw_version = headers.get(VERSION_HEADER)
         return cls.parse(raw_version) if raw_version else default
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        _source_type: typing.Any,
+        _handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        from_string_schema = core_schema.no_info_after_validator_function(
+            cls.parse,
+            core_schema.str_schema(),
+        )
+        return core_schema.json_or_python_schema(
+            json_schema=from_string_schema,
+            python_schema=core_schema.union_schema(
+                [
+                    core_schema.is_instance_schema(cls),
+                    from_string_schema,
+                ]
+            ),
+            serialization=core_schema.to_string_ser_schema(),
+        )
 
 
 class APIVersionType(TypeDecorator[typing.Any]):

--- a/server/polar/webhook/schemas.py
+++ b/server/polar/webhook/schemas.py
@@ -6,8 +6,10 @@ from pydantic import UUID4, AfterValidator, AnyUrl, BeforeValidator, Field
 from pydantic.json_schema import SkipJsonSchema
 
 from polar.kit.schemas import HttpsUrl, IDSchema, Schema, TimestampedSchema
+from polar.kit.versioning import APIVersion
 from polar.models.webhook_endpoint import WebhookEventType, WebhookFormat
 from polar.organization.schemas import OrganizationID
+from polar.version import CURRENT_API_VERSION, VERSIONS
 
 LOCALHOST_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "[::1]"}
 
@@ -76,6 +78,15 @@ EndpointEvents = Annotated[
 ]
 
 
+def _is_available_version(api_version: APIVersion) -> APIVersion:
+    if api_version not in VERSIONS:
+        raise ValueError(f"Invalid API version: {api_version}")
+    return api_version
+
+
+AvailableAPIVersion = Annotated[APIVersion, AfterValidator(_is_available_version)]
+
+
 class WebhookEndpoint(IDSchema, TimestampedSchema):
     """
     A webhook endpoint.
@@ -87,6 +98,9 @@ class WebhookEndpoint(IDSchema, TimestampedSchema):
     name: str | None = Field(
         default=None,
         description="An optional name for the webhook endpoint to help organize and identify it.",
+    )
+    api_version: APIVersion = Field(
+        description="The API version that'll be used in event payloads."
     )
     format: EndpointFormat
     secret: EndpointSecret
@@ -108,6 +122,10 @@ class WebhookEndpointCreate(Schema):
     name: str | None = Field(
         default=None,
         description="An optional name for the webhook endpoint to help organize and identify it.",
+    )
+    api_version: str = Field(
+        default=str(CURRENT_API_VERSION),  # type: ignore
+        description="The API version that'll be used in event payloads.",
     )
     format: EndpointFormat
     events: EndpointEvents
@@ -137,6 +155,9 @@ class WebhookEndpointUpdate(Schema):
     name: str | None = Field(
         default=None,
         description="An optional name for the webhook endpoint to help organize and identify it.",
+    )
+    api_version: AvailableAPIVersion | None = Field(
+        default=None, description="The API version that'll be used in event payloads."
     )
     format: EndpointFormat | None = None
     events: EndpointEvents | None = None
@@ -178,6 +199,9 @@ class WebhookEvent(IDSchema, TimestampedSchema):
     )
     skipped: bool = Field(
         description="Whether this event was skipped because the webhook endpoint was disabled."
+    )
+    api_version: APIVersion = Field(
+        description="The API version used in the payload of this event."
     )
     payload: str | None = Field(description="The payload of the webhook event.")
     type: WebhookEventType = Field(description="The type of the webhook event.")

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -55,6 +55,7 @@ from polar.organization.resolver import get_payload_organization
 from polar.user_organization.service import (
     user_organization as user_organization_service,
 )
+from polar.version import CURRENT_API_VERSION
 from polar.webhook.repository import (
     WebhookDeliveryRepository,
     WebhookEndpointRepository,
@@ -851,7 +852,12 @@ class WebhookService:
     ) -> list[WebhookEvent]:
         now = utc_now()
         payload = WebhookPayloadTypeAdapter.validate_python(
-            {"type": event, "timestamp": now, "data": data}
+            {
+                "type": event,
+                "timestamp": now,
+                "api_version": CURRENT_API_VERSION,
+                "data": data,
+            }
         )
 
         # Publish to eventstream for CLI listeners, regardless of webhook endpoints
@@ -864,13 +870,17 @@ class WebhookService:
         for endpoint in await self._get_event_target_endpoints(
             session, event=event, target=target
         ):
+            endpoint_payload = payload.model_copy(
+                update={"api_version": endpoint.api_version}
+            )
             try:
-                payload_data = payload.get_payload(endpoint.format, target)
+                payload_data = endpoint_payload.get_payload(endpoint.format, target)
                 event_type = WebhookEvent(
-                    created_at=payload.timestamp,
+                    created_at=endpoint_payload.timestamp,
                     webhook_endpoint=endpoint,
                     type=event,
                     payload=payload_data,
+                    api_version=endpoint_payload.api_version,
                 )
                 session.add(event_type)
                 events.append(event_type)

--- a/server/polar/webhook/tasks.py
+++ b/server/polar/webhook/tasks.py
@@ -121,6 +121,7 @@ async def _webhook_event_send(
         "webhook-id": str(event.id),
         "webhook-timestamp": str(int(ts.timestamp())),
         "webhook-signature": signature,
+        "webhook-api-version": str(event.api_version),
     }
 
     delivery = WebhookDelivery(

--- a/server/polar/webhook/webhooks.py
+++ b/server/polar/webhook/webhooks.py
@@ -36,6 +36,7 @@ from polar.integrations.slack.payload import (
     get_branded_slack_payload,
 )
 from polar.kit.schemas import IDSchema, Schema
+from polar.kit.versioning import APIVersion, api_version_context
 from polar.member.schemas import Member as MemberSchema
 from polar.models import (
     Benefit,
@@ -128,6 +129,7 @@ class SkipEvent(PolarError):
 class BaseWebhookPayload(Schema):
     type: WebhookEventType
     timestamp: datetime
+    api_version: APIVersion
     data: IDSchema
 
     def get_payload(self, format: WebhookFormat, target: User | Organization) -> str:
@@ -142,7 +144,8 @@ class BaseWebhookPayload(Schema):
                 assert_never(format)
 
     def get_raw_payload(self) -> str:
-        return self.model_dump_json()
+        with api_version_context(self.api_version):
+            return self.model_dump_json()
 
     def get_discord_payload(self, target: User | Organization) -> str:
         # Generic Discord payload, override in subclasses for more specific payloads

--- a/server/tests/webhooks/conftest.py
+++ b/server/tests/webhooks/conftest.py
@@ -8,6 +8,7 @@ from polar.models import (
     WebhookEvent,
 )
 from polar.models.webhook_endpoint import WebhookEventType, WebhookFormat
+from polar.version import CURRENT_API_VERSION
 from tests.fixtures.database import SaveFixture
 
 
@@ -35,6 +36,7 @@ async def webhook_event_user(
         last_http_code=200,
         succeeded=True,
         type=WebhookEventType.customer_created,
+        api_version=CURRENT_API_VERSION,
         payload='{"foo":"bar"}',
     )
     await save_fixture(event)
@@ -65,6 +67,7 @@ async def webhook_event_organization(
         last_http_code=200,
         succeeded=True,
         type=WebhookEventType.customer_created,
+        api_version=CURRENT_API_VERSION,
         payload='{"foo":"bar"}',
     )
     await save_fixture(event)

--- a/server/tests/webhooks/test_schemas.py
+++ b/server/tests/webhooks/test_schemas.py
@@ -39,3 +39,23 @@ def test_valid_hostname(url: str) -> None:
         organization_id=None,
     )
     assert create.url is not None
+
+
+@pytest.mark.parametrize(
+    "api_version",
+    [
+        pytest.param("v1", id="invalid format"),
+        pytest.param("1991-06", id="not available version"),
+    ],
+)
+def test_invalid_api_version(api_version: str) -> None:
+    with pytest.raises(ValidationError):
+        WebhookEndpointCreate.model_validate(
+            {
+                "url": "https://example.com/hook",
+                "format": WebhookFormat.raw,
+                "api_version": api_version,
+                "events": [],
+                "organization_id": None,
+            }
+        )

--- a/server/tests/webhooks/test_service.py
+++ b/server/tests/webhooks/test_service.py
@@ -20,6 +20,7 @@ from polar.models import (
 )
 from polar.models.webhook_endpoint import WebhookEventType, WebhookFormat
 from polar.postgres import AsyncSession
+from polar.version import CURRENT_API_VERSION
 from polar.webhook.schemas import WebhookEndpointCreate, WebhookEndpointUpdate
 from polar.webhook.service import EventDoesNotExist, EventNotSuccessul
 from polar.webhook.service import webhook as webhook_service
@@ -215,6 +216,7 @@ class TestOnEventSuccess:
             webhook_endpoint=webhook_endpoint_organization,
             succeeded=False,
             type=WebhookEventType.checkout_updated,
+            api_version=CURRENT_API_VERSION,
             payload="{}",
         )
         await save_fixture(event)
@@ -241,8 +243,14 @@ class TestOnEventSuccess:
             succeeded=True,
             last_http_code=200,
             type=WebhookEventType.checkout_updated,
+            api_version=CURRENT_API_VERSION,
             payload=WebhookCheckoutUpdatedPayload.model_validate(
-                {"type": "checkout.updated", "timestamp": timestamp, "data": checkout}
+                {
+                    "type": "checkout.updated",
+                    "timestamp": timestamp,
+                    "api_version": CURRENT_API_VERSION,
+                    "data": checkout,
+                }
             ).model_dump_json(),
         )
         await save_fixture(event)
@@ -268,6 +276,7 @@ class TestCountEarlierPendingEvents:
             webhook_endpoint=webhook_endpoint_organization,
             succeeded=False,
             type=WebhookEventType.checkout_updated,
+            api_version=CURRENT_API_VERSION,
             payload="{}",
         )
         await save_fixture(event)
@@ -285,6 +294,7 @@ class TestCountEarlierPendingEvents:
             succeeded=True,
             last_http_code=200,
             type=WebhookEventType.checkout_updated,
+            api_version=CURRENT_API_VERSION,
             payload="{}",
         )
         await save_fixture(delivered_event)
@@ -301,6 +311,7 @@ class TestCountEarlierPendingEvents:
             webhook_endpoint=webhook_endpoint_organization,
             succeeded=False,
             type=WebhookEventType.checkout_updated,
+            api_version=CURRENT_API_VERSION,
             payload="{}",
         )
         await save_fixture(event)
@@ -318,6 +329,7 @@ class TestCountEarlierPendingEvents:
             succeeded=False,
             last_http_code=None,
             type=WebhookEventType.checkout_updated,
+            api_version=CURRENT_API_VERSION,
             payload="{}",
         )
         await save_fixture(delivered_event)
@@ -334,6 +346,7 @@ class TestCountEarlierPendingEvents:
             webhook_endpoint=webhook_endpoint_organization,
             succeeded=False,
             type=WebhookEventType.checkout_updated,
+            api_version=CURRENT_API_VERSION,
             payload="{}",
         )
         await save_fixture(event)
@@ -351,6 +364,7 @@ class TestCountEarlierPendingEvents:
             succeeded=False,
             last_http_code=None,
             type=WebhookEventType.checkout_updated,
+            api_version=CURRENT_API_VERSION,
             payload="{}",
         )
         await save_fixture(previous_event)
@@ -359,6 +373,7 @@ class TestCountEarlierPendingEvents:
             webhook_endpoint=webhook_endpoint_organization,
             succeeded=False,
             type=WebhookEventType.checkout_updated,
+            api_version=CURRENT_API_VERSION,
             payload="{}",
         )
         await save_fixture(event)
@@ -377,6 +392,7 @@ class TestCountEarlierPendingEvents:
             succeeded=False,
             last_http_code=None,
             type=WebhookEventType.checkout_updated,
+            api_version=CURRENT_API_VERSION,
             payload="{}",
         )
         await save_fixture(previous_event)
@@ -385,6 +401,7 @@ class TestCountEarlierPendingEvents:
             webhook_endpoint=webhook_endpoint_organization,
             succeeded=False,
             type=WebhookEventType.checkout_updated,
+            api_version=CURRENT_API_VERSION,
             payload="{}",
         )
         await save_fixture(event)

--- a/server/tests/webhooks/test_tasks.py
+++ b/server/tests/webhooks/test_tasks.py
@@ -8,6 +8,7 @@ from polar.config import settings
 from polar.models import WebhookEndpoint, WebhookEvent
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.postgres import AsyncSession
+from polar.version import CURRENT_API_VERSION
 from polar.webhook.service import webhook as webhook_service
 from polar.webhook.tasks import (
     _webhook_event_failed_debounce_key,
@@ -37,6 +38,7 @@ class TestWebhookEventSend:
         event = WebhookEvent(
             webhook_endpoint_id=webhook_endpoint_organization.id,
             type=WebhookEventType.customer_created,
+            api_version=CURRENT_API_VERSION,
             payload='{"foo":"bar"}',
         )
         await save_fixture(event)
@@ -63,6 +65,7 @@ class TestOnEventFailed:
             event = WebhookEvent(
                 webhook_endpoint_id=webhook_endpoint_organization.id,
                 type=WebhookEventType.customer_created,
+                api_version=CURRENT_API_VERSION,
                 payload='{"foo":"bar"}',
                 succeeded=False,
             )
@@ -88,6 +91,7 @@ class TestOnEventFailed:
             event = WebhookEvent(
                 webhook_endpoint_id=webhook_endpoint_organization.id,
                 type=WebhookEventType.customer_created,
+                api_version=CURRENT_API_VERSION,
                 payload='{"foo":"bar"}',
                 succeeded=False,
             )
@@ -113,6 +117,7 @@ class TestOnEventFailed:
             event = WebhookEvent(
                 webhook_endpoint_id=webhook_endpoint_organization.id,
                 type=WebhookEventType.customer_created,
+                api_version=CURRENT_API_VERSION,
                 payload='{"foo":"bar"}',
                 succeeded=False,
             )
@@ -123,6 +128,7 @@ class TestOnEventFailed:
         success_event = WebhookEvent(
             webhook_endpoint_id=webhook_endpoint_organization.id,
             type=WebhookEventType.customer_created,
+            api_version=CURRENT_API_VERSION,
             payload='{"foo":"bar"}',
             succeeded=True,
         )
@@ -133,6 +139,7 @@ class TestOnEventFailed:
             event = WebhookEvent(
                 webhook_endpoint_id=webhook_endpoint_organization.id,
                 type=WebhookEventType.customer_created,
+                api_version=CURRENT_API_VERSION,
                 payload='{"foo":"bar"}',
                 succeeded=False,
             )
@@ -160,6 +167,7 @@ class TestOnEventFailed:
         event = WebhookEvent(
             webhook_endpoint_id=webhook_endpoint_organization.id,
             type=WebhookEventType.customer_created,
+            api_version=CURRENT_API_VERSION,
             payload='{"foo":"bar"}',
             succeeded=False,
         )
@@ -184,6 +192,7 @@ class TestOnEventFailed:
             event = WebhookEvent(
                 webhook_endpoint_id=webhook_endpoint_organization.id,
                 type=WebhookEventType.customer_created,
+                api_version=CURRENT_API_VERSION,
                 payload='{"foo":"bar"}',
                 succeeded=False,
             )
@@ -195,6 +204,7 @@ class TestOnEventFailed:
             pending_event = WebhookEvent(
                 webhook_endpoint_id=webhook_endpoint_organization.id,
                 type=WebhookEventType.customer_created,
+                api_version=CURRENT_API_VERSION,
                 payload='{"foo":"bar"}',
                 succeeded=None,
             )
@@ -219,6 +229,7 @@ class TestOnEventFailed:
             event = WebhookEvent(
                 webhook_endpoint_id=webhook_endpoint_organization.id,
                 type=WebhookEventType.customer_created,
+                api_version=CURRENT_API_VERSION,
                 payload='{"foo":"bar"}',
                 succeeded=False,
             )
@@ -231,6 +242,7 @@ class TestOnEventFailed:
             pending_event = WebhookEvent(
                 webhook_endpoint_id=webhook_endpoint_organization.id,
                 type=WebhookEventType.customer_created,
+                api_version=CURRENT_API_VERSION,
                 payload='{"foo":"bar"}',
                 succeeded=None,
                 skipped=False,

--- a/server/tests/webhooks/test_webhooks.py
+++ b/server/tests/webhooks/test_webhooks.py
@@ -1,15 +1,21 @@
-from typing import cast
+import json
+import uuid
+from typing import Annotated, cast
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
 import respx
 from dramatiq import Retry
+from pydantic import Field
 from pytest_mock import MockerFixture
 from standardwebhooks.webhooks import Webhook as StandardWebhook
 
 from polar.config import settings
 from polar.kit.db.postgres import AsyncSession
+from polar.kit.schemas import IDSchema
+from polar.kit.utils import utc_now
+from polar.kit.versioning import Version
 from polar.models.organization import Organization
 from polar.models.subscription import Subscription
 from polar.models.webhook_delivery import WebhookDelivery
@@ -19,15 +25,57 @@ from polar.models.webhook_endpoint import (
     WebhookFormat,
 )
 from polar.models.webhook_event import WebhookEvent
+from polar.version import CURRENT_API_VERSION
 from polar.webhook.repository import WebhookDeliveryRepository
 from polar.webhook.service import webhook as webhook_service
 from polar.webhook.tasks import _webhook_event_send, webhook_event_send
+from polar.webhook.webhooks import BaseWebhookPayload
 from tests.fixtures.database import SaveFixture
+from tests.kit.test_versioning import CURRENT_VERSION, NEXT_VERSION
 
 
 @pytest.fixture
 def enqueue_job_mock(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("polar.webhook.service.enqueue_job")
+
+
+def test_versioned_raw_payload() -> None:
+    class VersionedProduct(IDSchema):
+        name: str
+        shared_field: Annotated[
+            str, Version(starting_from=CURRENT_VERSION, up_to=NEXT_VERSION)
+        ] = "shared"
+        current_field: Annotated[str, Version(up_to=CURRENT_VERSION)] = "current"
+        next_field: Annotated[
+            str,
+            Version(starting_from=NEXT_VERSION),
+            Field(description="Only available in the next API version."),
+        ] = "next"
+
+    class VersionedWebhookPayload(BaseWebhookPayload):
+        data: VersionedProduct
+
+    current_payload = VersionedWebhookPayload(
+        type=WebhookEventType.product_created,
+        timestamp=utc_now(),
+        api_version=CURRENT_VERSION,
+        data=VersionedProduct(id=uuid.uuid4(), name="Test Product"),
+    )
+    current_payload_data = json.loads(current_payload.get_raw_payload())
+    assert "shared_field" in current_payload_data["data"]
+    assert "current_field" in current_payload_data["data"]
+    assert "next_field" not in current_payload_data["data"]
+
+    next_payload = VersionedWebhookPayload(
+        type=WebhookEventType.product_created,
+        timestamp=utc_now(),
+        api_version=NEXT_VERSION,
+        data=VersionedProduct(id=uuid.uuid4(), name="Test Product"),
+    )
+    next_payload_data = json.loads(next_payload.get_raw_payload())
+    assert "shared_field" in next_payload_data["data"]
+    assert "current_field" not in next_payload_data["data"]
+    assert "next_field" in next_payload_data["data"]
 
 
 @pytest.mark.asyncio
@@ -124,6 +172,7 @@ async def test_webhook_delivery_success(
     event = WebhookEvent(
         webhook_endpoint_id=endpoint.id,
         type=WebhookEventType.customer_created,
+        api_version=CURRENT_API_VERSION,
         payload='{"foo":"bar"}',
     )
     await save_fixture(event)
@@ -160,6 +209,7 @@ async def test_webhook_delivery_500(
     event = WebhookEvent(
         webhook_endpoint_id=endpoint.id,
         type=WebhookEventType.customer_created,
+        api_version=CURRENT_API_VERSION,
         payload='{"foo":"bar"}',
     )
     await save_fixture(event)
@@ -213,6 +263,7 @@ async def test_webhook_delivery_http_error(
     event = WebhookEvent(
         webhook_endpoint_id=endpoint.id,
         type=WebhookEventType.customer_created,
+        api_version=CURRENT_API_VERSION,
         payload='{"foo":"bar"}',
     )
     await save_fixture(event)
@@ -264,6 +315,7 @@ async def test_webhook_standard_webhooks_compatible(
     event = WebhookEvent(
         webhook_endpoint_id=endpoint.id,
         type=WebhookEventType.customer_created,
+        api_version=CURRENT_API_VERSION,
         payload='{"foo":"bar"}',
     )
     await save_fixture(event)


### PR DESCRIPTION

Actual logic that will send version-aware webhook payloads. The frontend part is deliberately omitted, and will be added in a follow-up PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

