### PR TITLE
Checkout: Compact mobile view

### DIFF
--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { UploadImage } from '@/components/Image/Image'
 import { useExperiment } from '@/experiments/client'
 import { DISTINCT_ID_COOKIE } from '@/experiments/constants'
 import { useCheckoutConfirmedRedirect } from '@/hooks/checkout'
 import { usePostHog } from '@/hooks/posthog'
+import { useIsMobileViewport } from '@/hooks/useIsMobileViewport'
 import { useOrganizationPaymentStatus } from '@/hooks/queries/org'
 import { getServerURL } from '@/utils/api'
+import { isOrderSummaryCollapsible } from '@/utils/checkout'
 import { getResizedImage } from '@/utils/getResizedImage'
 import { ArrowLeft } from 'lucide-react'
 import {
@@ -30,22 +31,14 @@ import { ClientResponseError, type schemas } from '@polar-sh/client'
 import { AcceptedLocale } from '@polar-sh/i18n'
 import { Alert, Avatar } from '@polar-sh/orbit'
 import ShadowBox from '@polar-sh/ui/components/atoms/ShadowBox'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@polar-sh/ui/components/ui/dialog'
 import { getThemePreset } from '@polar-sh/ui/hooks/theming'
 import type { Stripe, StripeElements } from '@stripe/stripe-js'
 import { useTheme } from 'next-themes'
 import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Slideshow } from '../Products/Slideshow'
+import { CheckoutCollapsibleOrderSummary } from './CheckoutCollapsibleOrderSummary'
 import { CheckoutDiscountInput } from './CheckoutDiscountInput'
-import { CheckoutProductDescription } from './CheckoutProductDescription'
+import { CheckoutOrderSummary } from './CheckoutOrderSummary'
 
 const PaymentNotReadyBanner = ({
   organizationStatus,
@@ -112,6 +105,16 @@ const Checkout = ({
     'checkout_cta_primary_color',
     { trackExposure: !embed },
   )
+
+  const isMobileViewport = useIsMobileViewport()
+  const collapsibleOrderSummary =
+    hasProductCheckout(checkout) && isOrderSummaryCollapsible(checkout)
+  const { isTreatment: collapsedOrderSummaryExperiment } = useExperiment(
+    'checkout_collapsed_order_summary',
+    { trackExposure: !embed && isMobileViewport && collapsibleOrderSummary },
+  )
+  const collapsedOrderSummary =
+    collapsibleOrderSummary && collapsedOrderSummaryExperiment
 
   const openedTrackedRef = useRef(false)
   useEffect(() => {
@@ -324,9 +327,6 @@ const Checkout = ({
     )
   }
 
-  const hasMedia =
-    hasProductCheckout(checkout) && checkout.product.medias.length > 0
-
   const orgHeader = (
     <div className="flex flex-row items-center gap-x-4">
       {checkout.return_url && (
@@ -355,119 +355,29 @@ const Checkout = ({
   return (
     <div className="md:grid md:min-h-screen md:grid-cols-2">
       <div className="md:flex md:justify-end">
-        <div className="mx-auto flex w-full max-w-[480px] flex-col gap-y-8 px-4 py-6 md:mx-0 md:py-12 md:pr-12 md:pl-4">
+        <div className="mx-auto flex w-full max-w-[480px] flex-col gap-y-6 px-4 py-6 pb-2 md:mx-0 md:py-12 md:pr-12 md:pl-4">
           {orgHeader}
-          <div className="flex flex-col gap-y-8 md:sticky md:top-8">
-            {hasProductCheckout(checkout) && (
-              <>
-                <div className="flex flex-col gap-y-2">
-                  <div className="flex flex-row items-center gap-x-3">
-                    {hasMedia && checkout.product.medias[0]?.public_url && (
-                      <Dialog>
-                        <DialogTrigger
-                          asChild
-                          disabled={checkout.product.medias.length <= 1}
-                        >
-                          <button
-                            className={`relative h-10 w-10 shrink-0 ${checkout.product.medias.length > 1 ? 'cursor-pointer' : 'cursor-default'}`}
-                          >
-                            <UploadImage
-                              src={checkout.product.medias[0].public_url}
-                              approximateWidth={40}
-                              alt={checkout.product.name}
-                              className="h-10 w-10 rounded-lg object-cover"
-                            />
-                            {checkout.product.medias.length > 1 && (
-                              <span className="absolute right-0 bottom-0 rounded bg-black/60 px-1 py-0.5 text-[10px] leading-none font-medium text-white">
-                                +{checkout.product.medias.length - 1}
-                              </span>
-                            )}
-                          </button>
-                        </DialogTrigger>
-                        <DialogContent className="dark:bg-polar-900 max-w-2xl">
-                          <DialogHeader>
-                            <DialogTitle>{checkout.product.name}</DialogTitle>
-                            <DialogDescription className="sr-only">
-                              Product images
-                            </DialogDescription>
-                          </DialogHeader>
-                          <Slideshow
-                            images={checkout.product.medias.map((m) =>
-                              getResizedImage(m.public_url, 672),
-                            )}
-                          />
-                        </DialogContent>
-                      </Dialog>
-                    )}
-                    <div className="flex min-w-0 flex-col gap-y-1">
-                      <span className="text-sm font-medium text-gray-900 dark:text-white">
-                        {checkout.product.name}
-                      </span>
-                    </div>
-                  </div>
-                  <span className="text-3xl font-medium">
-                    <CheckoutHeroPrice checkout={checkout} locale={locale} />
-                  </span>
-                </div>
-                <CheckoutProductSwitcher
+          {collapsedOrderSummary && hasProductCheckout(checkout) ? (
+            <CheckoutCollapsibleOrderSummary
+              checkout={checkout}
+              update={update}
+              themePreset={themePreset}
+              locale={locale}
+              trialDueTodayExperiment={trialDueTodayExperiment}
+            />
+          ) : (
+            <div className="flex flex-col gap-y-8 md:sticky md:top-8">
+              {hasProductCheckout(checkout) && (
+                <CheckoutOrderSummary
                   checkout={checkout}
-                  update={
-                    update as (
-                      data: schemas['CheckoutUpdatePublic'],
-                    ) => Promise<ProductCheckoutPublic>
-                  }
+                  update={update}
                   themePreset={themePreset}
                   locale={locale}
+                  trialDueTodayExperiment={trialDueTodayExperiment}
                 />
-                {checkout.product_price.amount_type === 'custom' && (
-                  <CheckoutPWYWForm
-                    checkout={checkout}
-                    update={update}
-                    productPrice={
-                      checkout.product_price as schemas['ProductPriceCustom']
-                    }
-                    locale={locale}
-                  />
-                )}
-                {!checkout.is_free_product_price && (
-                  <div className="flex flex-col gap-4 text-sm">
-                    {!!getSeatPrice(checkout) && (
-                      <CheckoutSeatSelector
-                        checkout={checkout}
-                        updateCheckout={update}
-                        locale={locale}
-                      />
-                    )}
-                    {!!getUnitPrice(checkout) && (
-                      <CheckoutUnitSelector
-                        checkout={checkout}
-                        updateCheckout={update}
-                        locale={locale}
-                      />
-                    )}
-                    <CheckoutPricingBreakdown
-                      checkout={checkout}
-                      locale={locale}
-                      trialDueTodayExperiment={trialDueTodayExperiment}
-                    />
-                    <CheckoutDiscountInput
-                      checkout={checkout}
-                      update={update}
-                      locale={locale}
-                      collapsible
-                    />
-                  </div>
-                )}
-                {checkout.product.description && (
-                  <CheckoutProductDescription
-                    description={checkout.product.description}
-                    productName={checkout.product.name}
-                    locale={locale}
-                  />
-                )}
-              </>
-            )}
-          </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
       <div className="dark:md:bg-polar-900 md:bg-white">

--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -113,6 +113,7 @@ const Checkout = ({
     'checkout_collapsed_order_summary',
     { trackExposure: !embed && isMobileViewport && collapsibleOrderSummary },
   )
+
   const collapsedOrderSummary =
     collapsibleOrderSummary && collapsedOrderSummaryExperiment
 
@@ -355,7 +356,7 @@ const Checkout = ({
   return (
     <div className="md:grid md:min-h-screen md:grid-cols-2">
       <div className="md:flex md:justify-end">
-        <div className="mx-auto flex w-full max-w-[480px] flex-col gap-y-6 px-4 py-6 pb-2 md:mx-0 md:py-12 md:pr-12 md:pl-4">
+        <div className="mx-auto flex w-full max-w-[480px] flex-col gap-y-6 px-4 py-6 pb-0 md:mx-0 md:py-12 md:pr-12 md:pl-4">
           {orgHeader}
           {collapsedOrderSummary && hasProductCheckout(checkout) ? (
             <CheckoutCollapsibleOrderSummary

--- a/clients/apps/web/src/components/Checkout/CheckoutCollapsibleOrderSummary.test.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutCollapsibleOrderSummary.test.tsx
@@ -1,0 +1,90 @@
+import type { ProductCheckoutPublic } from '@polar-sh/checkout/guards'
+import type { schemas } from '@polar-sh/client'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CheckoutCollapsibleOrderSummary } from './CheckoutCollapsibleOrderSummary'
+
+afterEach(cleanup)
+
+vi.mock('./CheckoutOrderSummary', () => ({
+  CheckoutOrderSummary: () => <div data-testid="order-summary" />,
+}))
+
+vi.mock('@polar-sh/checkout/components', () => ({
+  CheckoutHeroPrice: ({ compact }: { compact?: boolean }) => (
+    <span>{compact ? 'compact price' : 'hero price'}</span>
+  ),
+}))
+
+const createPrice = (
+  overrides: Record<string, unknown> = {},
+): schemas['ProductPrice'] =>
+  ({
+    id: 'price_1',
+    amount_type: 'fixed',
+    type: 'recurring',
+    price_amount: 999,
+    price_currency: 'usd',
+    ...overrides,
+  }) as unknown as schemas['ProductPrice']
+
+const createCheckout = (
+  overrides: Partial<ProductCheckoutPublic> = {},
+): ProductCheckoutPublic => {
+  const price = createPrice()
+  return {
+    currency: 'usd',
+    product_id: 'prod_1',
+    product: { id: 'prod_1', name: 'Pro', medias: [] },
+    product_price: price,
+    products: [{ id: 'prod_1' }],
+    prices: { prod_1: [price] },
+    ...overrides,
+  } as unknown as ProductCheckoutPublic
+}
+
+const renderSummary = (checkout = createCheckout()) =>
+  render(
+    <CheckoutCollapsibleOrderSummary
+      checkout={checkout}
+      update={vi.fn()}
+      themePreset={{} as never}
+      locale="en"
+      trialDueTodayExperiment={false}
+    />,
+  )
+
+describe('CheckoutCollapsibleOrderSummary', () => {
+  it('starts collapsed with the compact price in the bar', () => {
+    renderSummary()
+
+    const toggle = screen.getByRole('button', { name: /Order summary/ })
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(toggle.textContent).toContain('compact price')
+
+    const summary = document.getElementById(
+      toggle.getAttribute('aria-controls')!,
+    )!
+    expect(summary.className).toContain('hidden')
+    expect(
+      summary.querySelector('[data-testid="order-summary"]'),
+    ).not.toBeNull()
+  })
+
+  it('expands and collapses on click', () => {
+    renderSummary()
+
+    const toggle = screen.getByRole('button', { name: /Order summary/ })
+    const summary = document.getElementById(
+      toggle.getAttribute('aria-controls')!,
+    )!
+
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    expect(summary.className).not.toContain('hidden')
+
+    fireEvent.click(toggle)
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(summary.className).toContain('hidden')
+  })
+})

--- a/clients/apps/web/src/components/Checkout/CheckoutCollapsibleOrderSummary.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutCollapsibleOrderSummary.tsx
@@ -25,13 +25,16 @@ export const CheckoutCollapsibleOrderSummary = (
         aria-expanded={expanded}
         aria-controls={summaryId}
         onClick={() => setExpanded((value) => !value)}
-        className="dark:border-polar-700 dark:bg-polar-950 -mx-4 flex cursor-pointer flex-row items-center justify-between gap-x-4 border-y border-gray-200 bg-gray-50 px-4 py-4 text-left md:hidden"
+        className="dark:border-polar-700 dark:bg-polar-950 -mx-4 flex cursor-pointer flex-row items-center justify-between gap-x-4 border-y border-gray-200 bg-gray-50 px-4 py-4 text-left min-[480px]:mx-0 min-[480px]:rounded-2xl min-[480px]:border-x md:hidden"
       >
-        <span className="flex flex-row items-center gap-x-2 font-medium">
+        <span className="flex flex-row items-center gap-x-1 font-medium">
           {t('checkout.orderSummary')}
           <ChevronDown
             size={16}
-            className={cn('transition-transform', expanded && 'rotate-180')}
+            className={cn(
+              'translate-y-px transition-transform',
+              expanded && 'rotate-180',
+            )}
           />
         </span>
         <span className="shrink-0 text-right font-medium">

--- a/clients/apps/web/src/components/Checkout/CheckoutCollapsibleOrderSummary.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutCollapsibleOrderSummary.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { CheckoutHeroPrice } from '@polar-sh/checkout/components'
+import { useTranslations } from '@polar-sh/i18n'
+import { cn } from '@polar-sh/ui/lib/utils'
+import { ChevronDown } from 'lucide-react'
+import { useId, useState } from 'react'
+import {
+  CheckoutOrderSummary,
+  type CheckoutOrderSummaryProps,
+} from './CheckoutOrderSummary'
+
+export const CheckoutCollapsibleOrderSummary = (
+  props: CheckoutOrderSummaryProps,
+) => {
+  const { checkout, locale } = props
+  const t = useTranslations(locale)
+  const [expanded, setExpanded] = useState(false)
+  const summaryId = useId()
+
+  return (
+    <div className="flex flex-col gap-y-8 md:sticky md:top-8">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={summaryId}
+        onClick={() => setExpanded((value) => !value)}
+        className="dark:border-polar-700 dark:bg-polar-950 -mx-4 flex cursor-pointer flex-row items-center justify-between gap-x-4 border-y border-gray-200 bg-gray-50 px-4 py-4 text-left md:hidden"
+      >
+        <span className="flex flex-row items-center gap-x-2 font-medium">
+          {t('checkout.orderSummary')}
+          <ChevronDown
+            size={16}
+            className={cn('transition-transform', expanded && 'rotate-180')}
+          />
+        </span>
+        <span className="shrink-0 text-right font-medium">
+          <CheckoutHeroPrice checkout={checkout} locale={locale} compact />
+        </span>
+      </button>
+      <div
+        id={summaryId}
+        className={cn('flex-col gap-y-8', expanded ? 'flex' : 'hidden md:flex')}
+      >
+        <CheckoutOrderSummary {...props} />
+      </div>
+    </div>
+  )
+}

--- a/clients/apps/web/src/components/Checkout/CheckoutOrderSummary.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutOrderSummary.tsx
@@ -1,0 +1,159 @@
+'use client'
+
+import { UploadImage } from '@/components/Image/Image'
+import { getResizedImage } from '@/utils/getResizedImage'
+import {
+  CheckoutHeroPrice,
+  CheckoutPricingBreakdown,
+  CheckoutProductSwitcher,
+  CheckoutPWYWForm,
+  CheckoutSeatSelector,
+  CheckoutUnitSelector,
+} from '@polar-sh/checkout/components'
+import {
+  getSeatPrice,
+  getUnitPrice,
+  type ProductCheckoutPublic,
+} from '@polar-sh/checkout/guards'
+import type { schemas } from '@polar-sh/client'
+import type { AcceptedLocale } from '@polar-sh/i18n'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@polar-sh/ui/components/ui/dialog'
+import type { ThemingPresetProps } from '@polar-sh/ui/hooks/theming'
+import { Slideshow } from '../Products/Slideshow'
+import { CheckoutDiscountInput } from './CheckoutDiscountInput'
+import { CheckoutProductDescription } from './CheckoutProductDescription'
+
+export interface CheckoutOrderSummaryProps {
+  checkout: ProductCheckoutPublic
+  update: (
+    data: schemas['CheckoutUpdatePublic'],
+  ) => Promise<schemas['CheckoutPublic']>
+  themePreset: ThemingPresetProps
+  locale: AcceptedLocale
+  trialDueTodayExperiment: boolean
+}
+
+export const CheckoutOrderSummary = ({
+  checkout,
+  update,
+  themePreset,
+  locale,
+  trialDueTodayExperiment,
+}: CheckoutOrderSummaryProps) => {
+  const hasMedia = checkout.product.medias.length > 0
+
+  return (
+    <>
+      <div className="flex flex-col gap-y-2">
+        <div className="flex flex-row items-center gap-x-3">
+          {hasMedia && checkout.product.medias[0]?.public_url && (
+            <Dialog>
+              <DialogTrigger
+                asChild
+                disabled={checkout.product.medias.length <= 1}
+              >
+                <button
+                  className={`relative h-10 w-10 shrink-0 ${checkout.product.medias.length > 1 ? 'cursor-pointer' : 'cursor-default'}`}
+                >
+                  <UploadImage
+                    src={checkout.product.medias[0].public_url}
+                    approximateWidth={40}
+                    alt={checkout.product.name}
+                    className="h-10 w-10 rounded-lg object-cover"
+                  />
+                  {checkout.product.medias.length > 1 && (
+                    <span className="absolute right-0 bottom-0 rounded bg-black/60 px-1 py-0.5 text-[10px] leading-none font-medium text-white">
+                      +{checkout.product.medias.length - 1}
+                    </span>
+                  )}
+                </button>
+              </DialogTrigger>
+              <DialogContent className="dark:bg-polar-900 max-w-2xl">
+                <DialogHeader>
+                  <DialogTitle>{checkout.product.name}</DialogTitle>
+                  <DialogDescription className="sr-only">
+                    Product images
+                  </DialogDescription>
+                </DialogHeader>
+                <Slideshow
+                  images={checkout.product.medias.map((m) =>
+                    getResizedImage(m.public_url, 672),
+                  )}
+                />
+              </DialogContent>
+            </Dialog>
+          )}
+          <div className="flex min-w-0 flex-col gap-y-1">
+            <span className="text-sm font-medium text-gray-900 dark:text-white">
+              {checkout.product.name}
+            </span>
+          </div>
+        </div>
+        <span className="text-3xl font-medium">
+          <CheckoutHeroPrice checkout={checkout} locale={locale} />
+        </span>
+      </div>
+      <CheckoutProductSwitcher
+        checkout={checkout}
+        update={
+          update as (
+            data: schemas['CheckoutUpdatePublic'],
+          ) => Promise<ProductCheckoutPublic>
+        }
+        themePreset={themePreset}
+        locale={locale}
+      />
+      {checkout.product_price.amount_type === 'custom' && (
+        <CheckoutPWYWForm
+          checkout={checkout}
+          update={update}
+          productPrice={checkout.product_price as schemas['ProductPriceCustom']}
+          locale={locale}
+        />
+      )}
+      {!checkout.is_free_product_price && (
+        <div className="flex flex-col gap-4 text-sm">
+          {!!getSeatPrice(checkout) && (
+            <CheckoutSeatSelector
+              checkout={checkout}
+              updateCheckout={update}
+              locale={locale}
+            />
+          )}
+          {!!getUnitPrice(checkout) && (
+            <CheckoutUnitSelector
+              checkout={checkout}
+              updateCheckout={update}
+              locale={locale}
+            />
+          )}
+          <CheckoutPricingBreakdown
+            checkout={checkout}
+            locale={locale}
+            trialDueTodayExperiment={trialDueTodayExperiment}
+          />
+          <CheckoutDiscountInput
+            checkout={checkout}
+            update={update}
+            locale={locale}
+            collapsible
+          />
+        </div>
+      )}
+      {checkout.product.description && (
+        <CheckoutProductDescription
+          description={checkout.product.description}
+          productName={checkout.product.name}
+          locale={locale}
+        />
+      )}
+    </>
+  )
+}

--- a/clients/apps/web/src/components/Checkout/CheckoutProductDescription.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutProductDescription.tsx
@@ -27,15 +27,11 @@ export const CheckoutProductDescription = ({
     const el = textRef.current
     if (!el) return
 
-    const checkClamped = () => {
-      requestAnimationFrame(() => {
-        setIsClamped(el.scrollHeight > el.clientHeight + 1)
-      })
-    }
-
-    checkClamped()
-    window.addEventListener('resize', checkClamped)
-    return () => window.removeEventListener('resize', checkClamped)
+    const observer = new ResizeObserver(() => {
+      setIsClamped(el.scrollHeight > el.clientHeight + 1)
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
   }, [description])
 
   return (

--- a/clients/apps/web/src/experiments/experiments.ts
+++ b/clients/apps/web/src/experiments/experiments.ts
@@ -30,4 +30,10 @@ export const experiments = {
     variants: ['control', 'treatment'] as const,
     defaultVariant: 'control',
   },
+  checkout_collapsed_order_summary: {
+    description:
+      'Collapse the order summary on mobile hosted checkouts so the CTA moves above the fold',
+    variants: ['control', 'treatment'] as const,
+    defaultVariant: 'control',
+  },
 } as const

--- a/clients/apps/web/src/hooks/useIsMobileViewport.ts
+++ b/clients/apps/web/src/hooks/useIsMobileViewport.ts
@@ -1,0 +1,16 @@
+import { useSyncExternalStore } from 'react'
+
+const MD_BREAKPOINT_MEDIA_QUERY = '(min-width: 768px)'
+
+const subscribe = (onChange: () => void) => {
+  const mediaQueryList = window.matchMedia(MD_BREAKPOINT_MEDIA_QUERY)
+  mediaQueryList.addEventListener('change', onChange)
+  return () => mediaQueryList.removeEventListener('change', onChange)
+}
+
+const getSnapshot = () => !window.matchMedia(MD_BREAKPOINT_MEDIA_QUERY).matches
+
+const getServerSnapshot = () => false
+
+export const useIsMobileViewport = (): boolean =>
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)

--- a/clients/apps/web/src/utils/checkout.test.ts
+++ b/clients/apps/web/src/utils/checkout.test.ts
@@ -1,0 +1,112 @@
+import type { ProductCheckoutPublic } from '@polar-sh/checkout/guards'
+import type { schemas } from '@polar-sh/client'
+import { describe, expect, it } from 'vitest'
+import { isOrderSummaryCollapsible } from './checkout'
+
+const createPrice = (
+  overrides: Record<string, unknown> = {},
+): schemas['ProductPrice'] =>
+  ({
+    id: 'price_1',
+    amount_type: 'fixed',
+    type: 'recurring',
+    price_amount: 999,
+    price_currency: 'usd',
+    ...overrides,
+  }) as unknown as schemas['ProductPrice']
+
+const createCheckout = (
+  overrides: Partial<ProductCheckoutPublic> = {},
+): ProductCheckoutPublic => {
+  const price = createPrice()
+  return {
+    currency: 'usd',
+    product_id: 'prod_1',
+    product: { id: 'prod_1', name: 'Pro', medias: [] },
+    product_price: price,
+    products: [{ id: 'prod_1' }],
+    prices: { prod_1: [price] },
+    ...overrides,
+  } as unknown as ProductCheckoutPublic
+}
+
+describe('isOrderSummaryCollapsible', () => {
+  it('collapses a fixed one-time price', () => {
+    const checkout = createCheckout({
+      product_price: createPrice({ type: 'one_time' }),
+    })
+    expect(isOrderSummaryCollapsible(checkout)).toBe(true)
+  })
+
+  it('collapses a subscription', () => {
+    expect(isOrderSummaryCollapsible(createCheckout())).toBe(true)
+  })
+
+  it('keeps a free product open', () => {
+    const freePrice = createPrice({ price_amount: 0 })
+    const checkout = createCheckout({
+      product_price: freePrice,
+      prices: { prod_1: [freePrice] },
+      is_free_product_price: true,
+    })
+    expect(isOrderSummaryCollapsible(checkout)).toBe(false)
+  })
+
+  it('keeps pay-what-you-want open', () => {
+    const customPrice = createPrice({ amount_type: 'custom' })
+    const checkout = createCheckout({
+      product_price: customPrice,
+      prices: { prod_1: [customPrice] },
+    })
+    expect(isOrderSummaryCollapsible(checkout)).toBe(false)
+  })
+
+  it('keeps seat-based pricing open', () => {
+    const seatPrice = createPrice({ amount_type: 'seat_based' })
+    const checkout = createCheckout({
+      product_price: seatPrice,
+      prices: { prod_1: [seatPrice] },
+    })
+    expect(isOrderSummaryCollapsible(checkout)).toBe(false)
+  })
+
+  it('keeps unit-based pricing open', () => {
+    const unitPrice = createPrice({ amount_type: 'unit_based' })
+    const checkout = createCheckout({
+      product_price: unitPrice,
+      prices: { prod_1: [unitPrice] },
+    })
+    expect(isOrderSummaryCollapsible(checkout)).toBe(false)
+  })
+
+  it('keeps metered pricing open', () => {
+    const checkout = createCheckout({
+      prices: {
+        prod_1: [
+          createPrice(),
+          createPrice({ id: 'price_2', amount_type: 'metered_unit' }),
+        ],
+      },
+    })
+    expect(isOrderSummaryCollapsible(checkout)).toBe(false)
+  })
+
+  it('keeps a product choice open', () => {
+    const checkout = createCheckout({
+      products: [{ id: 'prod_1' }, { id: 'prod_2' }] as never,
+    })
+    expect(isOrderSummaryCollapsible(checkout)).toBe(false)
+  })
+
+  it('keeps legacy recurring prices open', () => {
+    const legacyPrice = createPrice({
+      legacy: true,
+      recurring_interval: 'month',
+    })
+    const checkout = createCheckout({
+      product_price: legacyPrice,
+      prices: { prod_1: [legacyPrice] },
+    })
+    expect(isOrderSummaryCollapsible(checkout)).toBe(false)
+  })
+})

--- a/clients/apps/web/src/utils/checkout.ts
+++ b/clients/apps/web/src/utils/checkout.ts
@@ -1,3 +1,4 @@
+import type { ProductCheckoutPublic } from '@polar-sh/checkout/guards'
 import { Client, schemas, unwrap } from '@polar-sh/client'
 import type { StatusColor } from '@polar-sh/orbit'
 import { notFound } from 'next/navigation'
@@ -45,3 +46,12 @@ export const CheckoutStatusDisplayColor: Record<
   expired: 'gray',
   failed: 'red',
 }
+
+export const isOrderSummaryCollapsible = (
+  checkout: ProductCheckoutPublic,
+): boolean =>
+  checkout.products.length === 1 &&
+  !checkout.is_free_product_price &&
+  (checkout.prices[checkout.product.id] ?? []).every(
+    (price) => price.amount_type === 'fixed' && !('legacy' in price),
+  )

--- a/clients/packages/checkout/src/components/CheckoutHeroPrice.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutHeroPrice.test.tsx
@@ -171,4 +171,32 @@ describe('CheckoutHeroPrice', () => {
       expect(screen.getByText('1 month free')).toBeInTheDocument()
     })
   })
+
+  describe('compact', () => {
+    it('forwards compact to the trial hero price', () => {
+      const checkout = createCheckout({
+        amount: 999,
+        net_amount: 999,
+        total_amount: 999,
+        active_trial_interval: 'day',
+        active_trial_interval_count: 7,
+        trial_end: '2026-04-05T00:00:00Z',
+        product: {
+          ...createCheckout().product,
+          recurring_interval: 'month',
+          is_recurring: true,
+          trial_interval: 'day',
+          trial_interval_count: 7,
+        },
+      })
+
+      const { container } = render(
+        <CheckoutHeroPrice checkout={checkout} locale="en" compact />,
+      )
+
+      expect(screen.getByText('7 days free')).toBeInTheDocument()
+      expect(container.textContent).toContain('$9.99 / mo')
+      expect(container.textContent).not.toContain('starting')
+    })
+  })
 })

--- a/clients/packages/checkout/src/components/CheckoutHeroPrice.tsx
+++ b/clients/packages/checkout/src/components/CheckoutHeroPrice.tsx
@@ -9,16 +9,27 @@ import CheckoutTrialHeroPrice from './CheckoutTrialHeroPrice'
 export interface CheckoutHeroPriceProps {
   checkout: ProductCheckoutPublic
   locale?: AcceptedLocale
+  compact?: boolean
 }
 
-const CheckoutHeroPrice = ({ checkout, locale }: CheckoutHeroPriceProps) => {
+const CheckoutHeroPrice = ({
+  checkout,
+  locale,
+  compact,
+}: CheckoutHeroPriceProps) => {
   const { product, product_price } = checkout
 
   const hasTrial =
     checkout.active_trial_interval && checkout.active_trial_interval_count
 
   if (hasTrial) {
-    return <CheckoutTrialHeroPrice checkout={checkout} locale={locale} />
+    return (
+      <CheckoutTrialHeroPrice
+        checkout={checkout}
+        locale={locale}
+        compact={compact}
+      />
+    )
   }
 
   return (

--- a/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.test.tsx
@@ -326,4 +326,68 @@ describe('CheckoutTrialHeroPrice', () => {
       expect(container.textContent).toContain('$199.99 / 2 yr')
     })
   })
+
+  describe('compact', () => {
+    it('drops the starting date and uses the short interval', () => {
+      const checkout = createTrialCheckout({
+        amount: 999,
+        net_amount: 999,
+        total_amount: 999,
+        product: { ...trialProduct, recurring_interval: 'month' },
+      })
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" compact />,
+      )
+
+      expect(screen.getByText('1 month free')).toBeInTheDocument()
+      expect(container.textContent).toContain('Then')
+      expect(container.textContent).toContain('$9.99 / mo')
+      expect(container.textContent).not.toContain('starting')
+    })
+
+    it('keeps the interval count in the short interval', () => {
+      const checkout = createTrialCheckout({
+        amount: 4106,
+        net_amount: 4106,
+        total_amount: 4106,
+        product: {
+          ...trialProduct,
+          recurring_interval: 'month',
+          recurring_interval_count: 3,
+        },
+      })
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" compact />,
+      )
+
+      expect(container.textContent).toContain('$41.06 / 3 mo')
+    })
+
+    it('shows only the trial label with a limited-time discount', () => {
+      const checkout = createTrialCheckout({
+        amount: 9999,
+        discount_amount: 5000,
+        net_amount: 4999,
+        total_amount: 4999,
+        discount: {
+          id: 'disc_1',
+          name: '50% off',
+          type: 'percentage',
+          duration: 'once',
+          code: null,
+          basis_points: 5000,
+        } as ProductCheckoutPublic['discount'],
+      })
+
+      const { container } = render(
+        <CheckoutTrialHeroPrice checkout={checkout} locale="en" compact />,
+      )
+
+      expect(screen.getByText('1 month free')).toBeInTheDocument()
+      expect(container.textContent).not.toContain('Free until')
+      expect(container.textContent).not.toContain('$')
+    })
+  })
 })

--- a/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.tsx
+++ b/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.tsx
@@ -11,6 +11,7 @@ import { isLegacyRecurringPrice } from '../utils/product'
 export interface CheckoutTrialHeroPriceProps {
   checkout: ProductCheckoutPublic
   locale?: AcceptedLocale
+  compact?: boolean
 }
 
 const TRIAL_FREE_KEYS = {
@@ -29,6 +30,7 @@ const INTERVAL_SUFFIX_KEYS = {
 const CheckoutTrialHeroPrice = ({
   checkout,
   locale,
+  compact = false,
 }: CheckoutTrialHeroPriceProps) => {
   const { product, product_price } = checkout
   const effectiveLocale = locale ?? DEFAULT_LOCALE
@@ -52,7 +54,7 @@ const CheckoutTrialHeroPrice = ({
     return (
       <div className="flex flex-col gap-y-1">
         <span>{trialLabel}</span>
-        {checkout.trial_end && (
+        {!compact && checkout.trial_end && (
           <span className="dark:text-polar-500 text-sm text-gray-500">
             {t('checkout.trial.hero.freeUntil', {
               date: formatDate(checkout.trial_end, effectiveLocale, {
@@ -73,21 +75,22 @@ const CheckoutTrialHeroPrice = ({
   const intervalSuffix = (() => {
     if (!interval || !(interval in INTERVAL_SUFFIX_KEYS)) return ''
     const intervalKey = interval as keyof typeof INTERVAL_SUFFIX_KEYS
-    if (intervalCount && intervalCount > 1) {
-      return ` / ${t(`intervals.short.${intervalKey}`, { count: intervalCount })}`
+    if (compact || (intervalCount && intervalCount > 1)) {
+      return ` / ${t(`intervals.short.${intervalKey}`, { count: intervalCount ?? 1 })}`
     }
     return t(INTERVAL_SUFFIX_KEYS[intervalKey])
   })()
   const format = formatCurrency('standard', effectiveLocale)
   const priceStr = `${format(recurringAmount, currency)}${intervalSuffix}`
 
-  const dateStr = checkout.trial_end
-    ? formatDate(checkout.trial_end, effectiveLocale, {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      })
-    : null
+  const dateStr =
+    !compact && checkout.trial_end
+      ? formatDate(checkout.trial_end, effectiveLocale, {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        })
+      : null
 
   return (
     <div className="flex flex-col gap-y-1">

--- a/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.tsx
+++ b/clients/packages/checkout/src/components/CheckoutTrialHeroPrice.tsx
@@ -4,6 +4,7 @@ import { formatCurrency } from '@polar-sh/currency'
 import type { AcceptedLocale } from '@polar-sh/i18n'
 import { DEFAULT_LOCALE, useTranslations } from '@polar-sh/i18n'
 import { formatDate } from '@polar-sh/i18n/formatters/date'
+import { cn } from '@polar-sh/ui/lib/utils'
 import type { ProductCheckoutPublic } from '../guards'
 import { isTemporaryDiscount } from '../utils/discount'
 import { isLegacyRecurringPrice } from '../utils/product'
@@ -52,7 +53,7 @@ const CheckoutTrialHeroPrice = ({
 
   if (isTemporaryDiscount(checkout.discount)) {
     return (
-      <div className="flex flex-col gap-y-1">
+      <div className={cn('flex flex-col', !compact && 'gap-y-1')}>
         <span>{trialLabel}</span>
         {!compact && checkout.trial_end && (
           <span className="dark:text-polar-500 text-sm text-gray-500">
@@ -93,9 +94,14 @@ const CheckoutTrialHeroPrice = ({
       : null
 
   return (
-    <div className="flex flex-col gap-y-1">
+    <div className={cn('flex flex-col', !compact && 'gap-y-1')}>
       <span>{trialLabel}</span>
-      <span className="dark:text-polar-500 text-sm text-gray-500">
+      <span
+        className={cn(
+          'dark:text-polar-500 text-gray-500',
+          compact ? 'text-xs' : 'text-sm',
+        )}
+      >
         {t('checkout.trial.hero.then')}{' '}
         <strong className="font-semibold">{priceStr}</strong>
         {dateStr

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -201,7 +201,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -402,7 +403,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -603,7 +605,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -807,7 +810,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1011,7 +1015,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1204,7 +1209,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1400,7 +1406,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1593,7 +1600,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1786,7 +1794,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1979,7 +1988,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2175,7 +2185,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "tr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2371,7 +2382,8 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   },
   "pl": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2567,6 +2579,7 @@
     "checkout.pricing.tiers.from": "From",
     "checkout.pricing.tiers.range": "{from}–{to}",
     "checkout.pricing.tiers.andAbove": "{from}+",
-    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in"
+    "checkout.pricing.tiers.volumeExplainer": "All usage is billed at the rate for the range it falls in",
+    "checkout.orderSummary": "Order summary"
   }
 }

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -266,6 +266,7 @@ export default {
       description:
         'Sie haben bereits eine kostenlose Testversion für dieses Produkt genutzt, daher wird Ihnen heute der Preis berechnet. Fahren Sie unten fort, um Ihren Kauf abzuschließen.',
     },
+    orderSummary: 'Bestellübersicht',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -59,6 +59,11 @@ export default {
       },
       fieldRequired: 'This field is required',
     },
+    orderSummary: {
+      value: 'Order summary',
+      _llmContext:
+        'Label of the collapsed order summary bar on mobile checkouts. Tapping it expands the product, price breakdown and discount code field.',
+    },
     pricing: {
       subtotal: 'Subtotal',
       taxableAmount: 'Taxable amount',

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -261,6 +261,7 @@ export default {
       description:
         'Ya has usado una prueba gratis para este producto, así que se te cobrará hoy. Continúa abajo para completar tu compra.',
     },
+    orderSummary: 'Resumen del pedido',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -264,6 +264,7 @@ export default {
       description:
         "Vous avez déjà utilisé un essai gratuit pour ce produit, vous serez donc facturé aujourd'hui. Continuez ci-dessous pour finaliser votre achat.",
     },
+    orderSummary: 'Récapitulatif de commande',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -260,6 +260,7 @@ export default {
       description:
         'Ehhez a termékhez már felhasznált egy ingyenes próbaidőszakot, így ma kiszámlázzuk az összeget. A vásárlás befejezéséhez folytassa lent.',
     },
+    orderSummary: 'Rendelés összegzése',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -263,6 +263,7 @@ export default {
       description:
         "Hai già utilizzato una prova gratuita per questo prodotto, quindi ti verrà addebitato oggi. Continua qui sotto per completare l'acquisto.",
     },
+    orderSummary: 'Riepilogo ordine',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -262,6 +262,7 @@ export default {
       description:
         'この商品ではすでに無料トライアルを利用済みのため、本日ご請求されます。以下から続行して購入を完了してください。',
     },
+    orderSummary: '注文概要',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -257,6 +257,7 @@ export default {
       description:
         '이 제품의 무료 체험을 이미 사용하셨으므로 오늘 결제가 진행됩니다. 아래에서 계속하여 구매를 완료하세요.',
     },
+    orderSummary: '주문 요약',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -263,6 +263,7 @@ export default {
       description:
         'Je hebt al een gratis proefperiode voor dit product gebruikt, dus er wordt vandaag kosten in rekening gebracht. Ga hieronder verder om je aankoop af te ronden.',
     },
+    orderSummary: 'Besteloverzicht',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/pl.ts
+++ b/clients/packages/i18n/src/locales/pl.ts
@@ -263,6 +263,7 @@ export default {
       description:
         'Już skorzystano z bezpłatnego okresu próbnego tego produktu, więc opłata zostanie naliczona dzisiaj. Kontynuuj poniżej, aby dokończyć zakup.',
     },
+    orderSummary: 'Podsumowanie zamówienia',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -261,6 +261,7 @@ export default {
       description:
         'Já utilizou uma avaliação gratuita para este produto, por isso será cobrado hoje. Continue abaixo para concluir a compra.',
     },
+    orderSummary: 'Resumo da encomenda',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -261,6 +261,7 @@ export default {
       description:
         'Você já usou um teste grátis para este produto, então a cobrança será feita hoje. Continue abaixo para concluir sua compra.',
     },
+    orderSummary: 'Resumo do pedido',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -259,6 +259,7 @@ export default {
       description:
         'Du har redan använt en gratis provperiod för den här produkten, så du debiteras idag. Fortsätt nedan för att slutföra köpet.',
     },
+    orderSummary: 'Ordersammanfattning',
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/tr.ts
+++ b/clients/packages/i18n/src/locales/tr.ts
@@ -260,6 +260,7 @@ export default {
       description:
         'Bu ürün için ücretsiz denemeyi zaten kullandınız, bu yüzden bugün ücretlendirileceksiniz. Satın alma işleminizi tamamlamak için aşağıdan devam edin.',
     },
+    orderSummary: 'Sipariş özeti',
   },
   intervals: {
     short: {


### PR DESCRIPTION
## Summary

In the mobile view of the checkout we throw a lot of numbers at the user, this is most certainly bad for conversion. To mitigate this I've created an experiment that hides all order details behind a `Order summary` accordion.

However there are a few types of products where this doesn't make sense, because user input is needed (PWYW, seats, etc.) so this feature will only be available for products that's either a one-time purchase or a subscription.

Everything is hidden behind and experiment (`checkout_collapsed_order_summary`).

## Screenshots

| Control | Treatment  |
|--------|--------|
| <img width="594" height="1135" alt="Screenshot 2026-09-04 at 16 49 41" src="https://github.com/user-attachments/assets/d4182ded-0b8c-48c5-8d84-1970c78efed7" /> | <img width="594" height="1135" alt="Screenshot 2026-09-04 at 16 49 34" src="https://github.com/user-attachments/assets/a339e13d-96da-4c65-8eef-9ce9509ef41e" /> |






<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

