### PR TITLE
clients/web: view and set webhook API version

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
@@ -18,9 +18,8 @@ import {
 import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import { operations, schemas } from '@polar-sh/client'
-import { Button } from '@polar-sh/orbit'
+import { Button, Switch, Text } from '@polar-sh/orbit'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
-import { Switch } from '@polar-sh/orbit'
 import { useParams, useRouter } from 'next/navigation'
 import { parseAsArrayOf, parseAsString, useQueryStates } from 'nuqs'
 import { useCallback, useState } from 'react'
@@ -172,6 +171,7 @@ export default function ClientPage({
             ) : (
               <h3 className="text-lg break-words">{endpoint.url}</h3>
             )}
+            <Text color="muted">API version {endpoint.api_version}</Text>
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <span className="text-sm text-gray-500" id="webhook-status-label">

--- a/clients/apps/web/src/components/Settings/Webhook/NewWebhookModal.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/NewWebhookModal.tsx
@@ -10,7 +10,13 @@ import { Form } from '@polar-sh/ui/components/ui/form'
 import { useRouter } from 'next/navigation'
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
-import { FieldEvents, FieldFormat, FieldName, FieldUrl } from './WebhookForm'
+import {
+  FieldApiVersion,
+  FieldEvents,
+  FieldFormat,
+  FieldName,
+  FieldUrl,
+} from './WebhookForm'
 
 export default function NewWebhookModal({
   organization,
@@ -73,6 +79,7 @@ export default function NewWebhookModal({
             <FieldName />
             <FieldUrl />
             <FieldFormat />
+            <FieldApiVersion />
             <FieldEvents />
 
             <Button

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookContextView.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookContextView.tsx
@@ -2,6 +2,7 @@
 
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import {
+  FieldApiVersion,
   FieldEvents,
   FieldFormat,
   FieldName,
@@ -10,7 +11,7 @@ import {
 import { toast } from '@/components/Toast/use-toast'
 import { useEditWebhookEndpoint } from '@/hooks/queries'
 import { extractApiErrorMessage } from '@/utils/api/errors'
-import { schemas } from '@polar-sh/client'
+import { enums, schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
@@ -21,10 +22,18 @@ export default function WebhookContextView({
 }: {
   endpoint: schemas['WebhookEndpoint']
 }) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { secret, ...endpointWithoutSecret } = endpoint
+  const apiVersion = enums.webhookEndpointCreateApi_versionValues.find(
+    (version) => version === endpoint.api_version,
+  )
   const form = useForm<schemas['WebhookEndpointUpdate']>({
-    defaultValues: endpointWithoutSecret,
+    defaultValues: {
+      url: endpoint.url,
+      name: endpoint.name,
+      api_version: apiVersion,
+      format: endpoint.format,
+      events: endpoint.events,
+      enabled: endpoint.enabled,
+    },
   })
 
   const { handleSubmit } = form
@@ -62,6 +71,7 @@ export default function WebhookContextView({
             <FieldName />
             <FieldUrl />
             <FieldFormat />
+            <FieldApiVersion />
             <FieldEvents />
 
             <Button

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookDeliveriesTable.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookDeliveriesTable.tsx
@@ -287,6 +287,9 @@ const ExpandedRow = (props: DataTableCellContext<DeliveryRow, unknown>) => {
         <div>Event Timestamp</div>
         <code className="text-xs">{delivery.webhook_event.created_at}</code>
 
+        <div>Event API Version</div>
+        <code className="text-xs">{delivery.webhook_event.api_version}</code>
+
         <div>Delivery ID</div>
         <code className="text-xs">{delivery.id}</code>
 

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
@@ -169,6 +169,46 @@ export const FieldFormat = () => {
   )
 }
 
+export const FieldApiVersion = () => {
+  const { control } = useFormContext<CreateOrUpdate>()
+
+  return (
+    <FormField
+      control={control}
+      name="api_version"
+      rules={{
+        required: 'This field is required',
+      }}
+      render={({ field }) => (
+        <FormItem className="flex flex-col gap-1">
+          <div className="flex flex-row items-center justify-between">
+            <FormLabel>API Version</FormLabel>
+          </div>
+          <FormControl>
+            <Select
+              {...field}
+              value={field.value || undefined}
+              onValueChange={field.onChange}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select an API version" />
+              </SelectTrigger>
+              <SelectContent>
+                {enums.webhookEndpointCreateApi_versionValues.map((version) => (
+                  <SelectItem key={version} value={version}>
+                    {version}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  )
+}
+
 export const FieldEvents = () => {
   const { control } = useFormContext<CreateOrUpdate>()
 

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookSettings.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookSettings.tsx
@@ -112,6 +112,7 @@ const Endpoint = ({
         <p className="dark:text-polar-400 pl-4 text-sm text-gray-500">
           Added on{' '}
           <FormattedDateTime datetime={endpoint.created_at} dateStyle="long" />
+          {' · '}API version {endpoint.api_version}
         </p>
       </div>
       <div className="dark:text-polar-400 text-gray-500">

--- a/clients/packages/client/src/enums.ts
+++ b/clients/packages/client/src/enums.ts
@@ -21,4 +21,5 @@ export {
   trialIntervalValues,
   uniqueAggregationFuncValues,
   webhookEventTypeValues,
+  webhookEndpointCreateApi_versionValues,
 } from './v1'

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -20636,8 +20636,9 @@ export interface components {
        * Api Version
        * @description The API version that'll be used in event payloads.
        * @default 2026-04
+       * @enum {string}
        */
-      api_version: string
+      api_version: '2026-04' | '2026-10'
       /** @description The format of the webhook payload. */
       format: components['schemas']['WebhookFormat']
       /**
@@ -20664,7 +20665,7 @@ export interface components {
        * Api Version
        * @description The API version that'll be used in event payloads.
        */
-      api_version?: string | null
+      api_version?: ('2026-04' | '2026-10') | null
       format?: components['schemas']['WebhookFormat'] | null
       /** Events */
       events?: components['schemas']['WebhookEventType'][] | null
@@ -38881,8 +38882,9 @@ export interface components {
        * Api Version
        * @description The API version that'll be used in event payloads.
        * @default 2026-04
+       * @enum {string}
        */
-      api_version: string
+      api_version: '2026-04' | '2026-10'
       /** @description The format of the webhook payload. */
       format: components['schemas']['WebhookFormat']
       /**
@@ -38909,7 +38911,7 @@ export interface components {
        * Api Version
        * @description The API version that'll be used in event payloads.
        */
-      api_version?: string | null
+      api_version?: ('2026-04' | '2026-10') | null
       format?: components['schemas']['WebhookFormat'] | null
       /** Events */
       events?: components['schemas']['WebhookEventType'][] | null
@@ -68973,6 +68975,12 @@ export const customerWalletSortPropertyValues: ReadonlyArray<
 export const dataTableBlockTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['DataTableBlock']['type']
 > = ['data_table']
+export const deprecatedWebhookEndpointCreateWithSecretApi_versionValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['DeprecatedWebhookEndpointCreateWithSecret']['api_version']
+> = ['2026-04', '2026-10']
+export const deprecatedWebhookEndpointUpdateWithSecretApi_versionAnyOf0Values: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['DeprecatedWebhookEndpointUpdateWithSecret']['api_version']
+> = ['2026-04', '2026-10']
 export const discountDurationValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['DiscountDuration']
 > = ['once', 'forever', 'repeating']
@@ -71822,6 +71830,12 @@ export const walletSortPropertyValues: ReadonlyArray<
 export const walletTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['WalletType']
 > = ['usage', 'billing']
+export const webhookEndpointCreateApi_versionValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['WebhookEndpointCreate']['api_version']
+> = ['2026-04', '2026-10']
+export const webhookEndpointUpdateApi_versionAnyOf0Values: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['WebhookEndpointUpdate']['api_version']
+> = ['2026-04', '2026-10']
 export const webhookEventTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['WebhookEventType']
 > = [

--- a/server/polar/webhook/schemas.py
+++ b/server/polar/webhook/schemas.py
@@ -5,7 +5,13 @@ import idna
 from pydantic import UUID4, AfterValidator, AnyUrl, BeforeValidator, Field
 from pydantic.json_schema import SkipJsonSchema
 
-from polar.kit.schemas import HttpsUrl, IDSchema, Schema, TimestampedSchema
+from polar.kit.schemas import (
+    HttpsUrl,
+    IDSchema,
+    MergeJSONSchema,
+    Schema,
+    TimestampedSchema,
+)
 from polar.kit.versioning import APIVersion
 from polar.models.webhook_endpoint import WebhookEventType, WebhookFormat
 from polar.organization.schemas import OrganizationID
@@ -84,7 +90,11 @@ def _is_available_version(api_version: APIVersion) -> APIVersion:
     return api_version
 
 
-AvailableAPIVersion = Annotated[APIVersion, AfterValidator(_is_available_version)]
+AvailableAPIVersion = Annotated[
+    APIVersion,
+    MergeJSONSchema({"enum": [str(version) for version in sorted(VERSIONS)]}),
+    AfterValidator(_is_available_version),
+]
 
 
 class WebhookEndpoint(IDSchema, TimestampedSchema):


### PR DESCRIPTION

Surface the API version set on a Webhook Endpoint and on a Webhook Event. Also add the API Version selector in the Webhook Endpoint form.

<img width="460" height="505" alt="Capture d’écran 2026-09-04 à 14 24 48" src="https://github.com/user-attachments/assets/47e24043-03c1-4180-993e-408c68a26f5f" />

<img width="1030" height="706" alt="Capture d’écran 2026-09-04 à 14 24 55" src="https://github.com/user-attachments/assets/9fe285bc-dab4-42ad-8110-b0a11d59d5cf" />
