### PR TITLE
Require successful charge on manual early trial conversion

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -36365,7 +36365,7 @@ export interface components {
       discount_id?: string | null
       /**
        * Trial End
-       * @description Set or extend the trial period of the subscription. If set to `now`, the trial will end immediately.
+       * @description Set or extend the trial period of the subscription. If set to `now`, the trial will end immediately and the first billing cycle will be charged synchronously. The subscription remains trialing if the payment fails.
        */
       trial_end?: string | 'now' | null
     }
@@ -43030,13 +43030,15 @@ export interface operations {
           'application/json': components['schemas']['Subscription']
         }
       }
-      /** @description Payment required to apply the subscription update. */
+      /** @description The charge failed, or requires customer authentication that can't be completed off-session. */
       402: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['PaymentFailed']
+          'application/json':
+            | components['schemas']['PaymentFailed']
+            | components['schemas']['PaymentActionRequired']
         }
       }
       /** @description Subscription is already canceled or will be at the end of the period, or is not active. */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -43041,7 +43041,7 @@ export interface operations {
             | components['schemas']['PaymentActionRequired']
         }
       }
-      /** @description Subscription is already canceled or will be at the end of the period, or is not active. */
+      /** @description Subscription is already canceled or will be at the end of the period, is not active, or the organization is not ready to renew subscriptions. */
       403: {
         headers: {
           [name: string]: unknown
@@ -43050,6 +43050,7 @@ export interface operations {
           'application/json':
             | components['schemas']['AlreadyCanceledSubscription']
             | components['schemas']['InactiveSubscription']
+            | components['schemas']['PaymentNotReady']
         }
       }
       /** @description Subscription not found. */

--- a/docs/features/subscriptions/manage.mdx
+++ b/docs/features/subscriptions/manage.mdx
@@ -75,7 +75,7 @@ curl --request PATCH \
 You can add, extend, or end a [trial](/features/subscriptions/trials) on any subscription:
 
 - **Add or extend** a trial by setting `trial_end` to a future date. If the subscription is currently active, its status switches to `trialing` and the next charge is postponed to the new date.
-- **End a trial immediately** by setting `trial_end` to `"now"`. The subscription becomes `active` and a new billing cycle — and charge — starts on the spot.
+- **End a trial immediately** by setting `trial_end` to `"now"`. Polar charges the first billing cycle synchronously and only changes the subscription to `active` if payment succeeds. If payment fails, the request returns `402` and the subscription remains `trialing` with its original trial end.
 
 ```bash cURL
 curl --request PATCH \

--- a/docs/features/subscriptions/trials.mdx
+++ b/docs/features/subscriptions/trials.mdx
@@ -52,7 +52,7 @@ For existing subscriptions, you can add, extend or cancel a customer's trial per
 
 To add or extend a trial, set a new trial end date in the future. If the subscription was active, its status will be changed to **trialing**, and the billing will be postponed until the end of the trial.
 
-To cancel a trial, click on the **End trial** button. The subscription will become active immediately, and the customer will be charged immediately for a new billing cycle.
+To cancel a trial, click on the **End trial** button. Polar charges the customer immediately for a new billing cycle and only changes the subscription to **active** if payment succeeds. If payment fails, the subscription remains **trialing** with its original trial end.
 
 <img
   className="block dark:hidden"

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -18,7 +18,7 @@ from polar.kit.schemas import MultipleQueryFilter
 from polar.models import Subscription
 from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
 from polar.openapi import APITag
-from polar.order.service import PaymentFailed
+from polar.order.service import PaymentActionRequired, PaymentFailed
 from polar.organization.schemas import OrganizationID
 from polar.postgres import (
     AsyncReadSession,
@@ -404,8 +404,11 @@ async def create(
     responses={
         200: {"description": "Subscription updated."},
         402: {
-            "description": "Payment required to apply the subscription update.",
-            "model": PaymentFailed.schema(),
+            "description": (
+                "The charge failed, or requires customer authentication "
+                "that can't be completed off-session."
+            ),
+            "model": PaymentFailed.schema() | PaymentActionRequired.schema(),
         },
         403: {
             "description": (

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -10,7 +10,7 @@ from polar.auth.permission import OrganizationPermission
 from polar.authz.service import assert_resource_permission
 from polar.customer.schemas.customer import CustomerID, ExternalCustomerID
 from polar.discount.schemas import DiscountID
-from polar.exceptions import ResourceNotFound
+from polar.exceptions import PaymentNotReady, ResourceNotFound
 from polar.kit.csv import CSVStreamingResponse
 from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
 from polar.kit.pagination import ListResource, PaginationParamsQuery
@@ -413,10 +413,12 @@ async def create(
         403: {
             "description": (
                 "Subscription is already canceled or will be at the end of the "
-                "period, or is not active."
+                "period, is not active, or the organization is not ready to renew "
+                "subscriptions."
             ),
             "model": AlreadyCanceledSubscription.schema()
-            | InactiveSubscription.schema(),
+            | InactiveSubscription.schema()
+            | PaymentNotReady.schema(),
         },
         404: SubscriptionNotFound,
         409: {

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -341,7 +341,9 @@ class SubscriptionUpdateBase(MetadataInputMixin, Schema):
         default=None,
         description=(
             "Set or extend the trial period of the subscription. "
-            "If set to `now`, the trial will end immediately."
+            "If set to `now`, the trial will end immediately and the first "
+            "billing cycle will be charged synchronously. The subscription "
+            "remains trialing if the payment fails."
         ),
     )
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -56,6 +56,7 @@ from polar.event.system import (
 )
 from polar.exceptions import (
     BadRequest,
+    PaymentNotReady,
     PolarError,
     PolarRequestValidationError,
     ResourceUnavailable,
@@ -505,12 +506,7 @@ class SubscriptionUpdateContext:
     def set_billing_effect(
         self, effect: Literal["invoice", "cycle", "cycle_sync"]
     ) -> None:
-        if effect == "cycle_sync":
-            self._billing_effect = "cycle_sync"
-        elif effect == "cycle" and self._billing_effect != "cycle_sync":
-            self._billing_effect = "cycle"
-        elif effect == "invoice" and self._billing_effect is None:
-            self._billing_effect = "invoice"
+        self._billing_effect = effect
 
     def add_event_metadata(
         self, **metadata: Unpack[SubscriptionUpdatedMetadataFields]
@@ -1249,7 +1245,7 @@ class SubscriptionService:
             billing_reason = OrderBillingReasonInternal.subscription_cycle
 
         if payment_mode == PaymentMode.sync:
-            await self._create_subscription_cycle_order(
+            await self._create_subscription_update_order(
                 session, subscription, billing_reason, cutoff=cycle_at
             )
         else:
@@ -2210,6 +2206,10 @@ class SubscriptionService:
         if subscription.trialing:
             # End trial immediately
             if trial_end == "now":
+                if not subscription.organization.can_renew_subscriptions:
+                    raise PaymentNotReady(
+                        "Organization is not ready to renew subscriptions"
+                    )
                 subscription.trial_end = subscription.current_period_end = utc_now()
                 ctx.set_billing_effect("cycle_sync")
             # Set new trial end date
@@ -4331,24 +4331,14 @@ class SubscriptionService:
             await repository.update(subscription)
 
     async def _create_subscription_update_order(
-        self, session: AsyncSession, subscription: Subscription
-    ) -> Order:
-        from polar.order.service import order as order_service
-
-        return await order_service.create_subscription_order(
-            session,
-            subscription,
-            OrderBillingReasonInternal.subscription_update,
-            payment_mode=PaymentMode.sync,
-        )
-
-    async def _create_subscription_cycle_order(
         self,
         session: AsyncSession,
         subscription: Subscription,
-        billing_reason: OrderBillingReasonInternal,
+        billing_reason: OrderBillingReasonInternal = (
+            OrderBillingReasonInternal.subscription_update
+        ),
         *,
-        cutoff: datetime,
+        cutoff: datetime | None = None,
     ) -> Order:
         from polar.order.service import order as order_service
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -444,7 +444,7 @@ class SubscriptionUpdateContext:
         self._previous_is_canceled = subscription.canceled
         self._notify_customer = notify_customer
 
-        self._billing_effect: Literal["invoice", "cycle"] | None = None
+        self._billing_effect: Literal["invoice", "cycle", "cycle_sync"] | None = None
         self._event_metadata: SubscriptionUpdatedMetadataFields = {}
         self._has_changes = True
 
@@ -464,6 +464,13 @@ class SubscriptionUpdateContext:
         match self._billing_effect:
             case "cycle":
                 await self.service.cycle(self.session, self, self.subscription)
+            case "cycle_sync":
+                await self.service.cycle(
+                    self.session,
+                    self,
+                    self.subscription,
+                    payment_mode=PaymentMode.sync,
+                )
             case "invoice":
                 await self.service._create_subscription_update_order(
                     self.session, self.subscription
@@ -495,10 +502,14 @@ class SubscriptionUpdateContext:
     def mark_unchanged(self) -> None:
         self._has_changes = False
 
-    def set_billing_effect(self, effect: Literal["invoice", "cycle"]) -> None:
-        if effect == "cycle":
+    def set_billing_effect(
+        self, effect: Literal["invoice", "cycle", "cycle_sync"]
+    ) -> None:
+        if effect == "cycle_sync":
+            self._billing_effect = "cycle_sync"
+        elif effect == "cycle" and self._billing_effect != "cycle_sync":
             self._billing_effect = "cycle"
-        elif effect == "invoice" and self._billing_effect != "cycle":
+        elif effect == "invoice" and self._billing_effect is None:
             self._billing_effect = "invoice"
 
     def add_event_metadata(
@@ -1085,6 +1096,8 @@ class SubscriptionService:
         ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         update_cycle_dates: bool = True,
+        *,
+        payment_mode: PaymentMode = PaymentMode.background,
     ) -> Subscription:
         if not subscription.billable:
             raise NotBillableSubscription(subscription)
@@ -1235,12 +1248,17 @@ class SubscriptionService:
         else:
             billing_reason = OrderBillingReasonInternal.subscription_cycle
 
-        enqueue_job(
-            "order.create_subscription_order",
-            subscription.id,
-            billing_reason,
-            cutoff=cycle_at.isoformat(),
-        )
+        if payment_mode == PaymentMode.sync:
+            await self._create_subscription_cycle_order(
+                session, subscription, billing_reason, cutoff=cycle_at
+            )
+        else:
+            enqueue_job(
+                "order.create_subscription_order",
+                subscription.id,
+                billing_reason,
+                cutoff=cycle_at.isoformat(),
+            )
 
         return subscription
 
@@ -2193,8 +2211,7 @@ class SubscriptionService:
             # End trial immediately
             if trial_end == "now":
                 subscription.trial_end = subscription.current_period_end = utc_now()
-                # Make sure to cycle the subscription immediately to update status and trigger order
-                ctx.set_billing_effect("cycle")
+                ctx.set_billing_effect("cycle_sync")
             # Set new trial end date
             else:
                 subscription.trial_end = subscription.current_period_end = trial_end
@@ -4322,6 +4339,24 @@ class SubscriptionService:
             session,
             subscription,
             OrderBillingReasonInternal.subscription_update,
+            payment_mode=PaymentMode.sync,
+        )
+
+    async def _create_subscription_cycle_order(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        billing_reason: OrderBillingReasonInternal,
+        *,
+        cutoff: datetime,
+    ) -> Order:
+        from polar.order.service import order as order_service
+
+        return await order_service.create_subscription_order(
+            session,
+            subscription,
+            billing_reason,
+            cutoff=cutoff,
             payment_mode=PaymentMode.sync,
         )
 

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -23,6 +23,7 @@ from polar.models.order import OrderStatus
 from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
 from polar.order.service import PaymentFailed, PaymentFailedReason
 from polar.postgres import AsyncSession
+from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.service import subscription as subscription_service
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
@@ -1239,6 +1240,7 @@ class TestSubscriptionUpdateTrial:
     async def test_end_trial_payment_failure_returns_402(
         self,
         client: AsyncClient,
+        session: AsyncSession,
         save_fixture: SaveFixture,
         mocker: MockerFixture,
         user_organization: UserOrganization,
@@ -1247,7 +1249,7 @@ class TestSubscriptionUpdateTrial:
     ) -> None:
         mocker.patch.object(
             subscription_service,
-            "_create_subscription_cycle_order",
+            "_create_subscription_update_order",
             new=AsyncMock(side_effect=PaymentFailed(PaymentFailedReason.card_error)),
         )
         subscription = await create_subscription(
@@ -1259,11 +1261,21 @@ class TestSubscriptionUpdateTrial:
             trial_start=utc_now(),
             trial_end=utc_now() + timedelta(days=14),
         )
+        original_trial_end = subscription.trial_end
+        original_period_end = subscription.current_period_end
+        nested = await session.begin_nested()
         response = await client.patch(
             f"/v1/subscriptions/{subscription.id}", json={"trial_end": "now"}
         )
 
         assert response.status_code == 402
+        await nested.rollback()
+        repository = SubscriptionRepository.from_session(session)
+        persisted_subscription = await repository.get_by_id(subscription.id)
+        assert persisted_subscription is not None
+        assert persisted_subscription.status == SubscriptionStatus.trialing
+        assert persisted_subscription.trial_end == original_trial_end
+        assert persisted_subscription.current_period_end == original_period_end
 
     @pytest.mark.auth
     async def test_extend_trial_seat_based_subscription(

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -1,9 +1,11 @@
 import uuid
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
+from pytest_mock import MockerFixture
 
 from polar.auth.scope import Scope
 from polar.enums import SubscriptionRecurringInterval
@@ -19,7 +21,9 @@ from polar.models import (
 from polar.models.customer_seat import SeatStatus
 from polar.models.order import OrderStatus
 from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
+from polar.order.service import PaymentFailed, PaymentFailedReason
 from polar.postgres import AsyncSession
+from polar.subscription.service import subscription as subscription_service
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -1231,6 +1235,36 @@ class TestSubscriptionUpdateSeats:
 
 @pytest.mark.asyncio
 class TestSubscriptionUpdateTrial:
+    @pytest.mark.auth
+    async def test_end_trial_payment_failure_returns_402(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        mocker.patch.object(
+            subscription_service,
+            "_create_subscription_cycle_order",
+            new=AsyncMock(side_effect=PaymentFailed(PaymentFailedReason.card_error)),
+        )
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.trialing,
+            started_at=utc_now(),
+            trial_start=utc_now(),
+            trial_end=utc_now() + timedelta(days=14),
+        )
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}", json={"trial_end": "now"}
+        )
+
+        assert response.status_code == 402
+
     @pytest.mark.auth
     async def test_extend_trial_seat_based_subscription(
         self,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -4779,12 +4779,18 @@ class TestUpdate:
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
+        mocker: MockerFixture,
         customer: Customer,
         organization: Organization,
         product: Product,
         webhook_service_send_mock: MagicMock,
         enqueue_job_mock: MagicMock,
     ) -> None:
+        create_subscription_cycle_order_mock = mocker.patch.object(
+            subscription_service,
+            "_create_subscription_cycle_order",
+            new_callable=AsyncMock,
+        )
         subscription = await create_trialing_subscription(
             save_fixture,
             product=product,
@@ -4816,11 +4822,15 @@ class TestUpdate:
             organization,
             updated,
         )
-        enqueue_job_mock.assert_any_call(
-            "order.create_subscription_order",
-            updated.id,
+        create_subscription_cycle_order_mock.assert_awaited_once_with(
+            session,
+            updated,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
-            cutoff=ANY,
+            cutoff=updated.current_period_start,
+        )
+        assert not any(
+            call.args and call.args[0] == "order.create_subscription_order"
+            for call in enqueue_job_mock.call_args_list
         )
 
     async def test_seats_update(
@@ -5057,12 +5067,18 @@ class TestUpdate:
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
+        mocker: MockerFixture,
         customer: Customer,
         organization: Organization,
         product: Product,
         webhook_service_send_mock: MagicMock,
         enqueue_job_mock: MagicMock,
     ) -> None:
+        create_subscription_cycle_order_mock = mocker.patch.object(
+            subscription_service,
+            "_create_subscription_cycle_order",
+            new_callable=AsyncMock,
+        )
 
         subscription = await create_trialing_subscription(
             save_fixture,
@@ -5091,11 +5107,15 @@ class TestUpdate:
         assert updated.product == new_product
         assert updated.active
 
-        enqueue_job_mock.assert_any_call(
-            "order.create_subscription_order",
-            updated.id,
+        create_subscription_cycle_order_mock.assert_awaited_once_with(
+            session,
+            updated,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
-            cutoff=ANY,
+            cutoff=updated.current_period_start,
+        )
+        assert not any(
+            call.args and call.args[0] == "order.create_subscription_order"
+            for call in enqueue_job_mock.call_args_list
         )
 
         assert_webhook_sent_once(
@@ -6678,15 +6698,59 @@ class TestUpdateDiscount:
 
 @pytest.mark.asyncio
 class TestUpdateTrial:
+    async def test_trialing_subscription_ending_now_payment_failure_preserves_trial(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        mocker.patch.object(
+            subscription_service,
+            "_create_subscription_cycle_order",
+            side_effect=PaymentFailed(PaymentFailedReason.card_error),
+        )
+        subscription = await create_trialing_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        original_trial_end = subscription.trial_end
+        original_period_end = subscription.current_period_end
+
+        nested = await session.begin_nested()
+
+        with pytest.raises(PaymentFailed):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_trial(
+                    session, ctx, subscription, trial_end="now"
+                )
+
+        await nested.rollback()
+        await session.refresh(subscription)
+        assert subscription.status == SubscriptionStatus.trialing
+        assert subscription.trial_end == original_trial_end
+        assert subscription.current_period_end == original_period_end
+
     async def test_trialing_subscription_ending_now(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
+        mocker: MockerFixture,
         product: Product,
         customer: Customer,
     ) -> None:
+        payment_method = await create_payment_method(save_fixture, customer=customer)
         subscription = await create_trialing_subscription(
-            save_fixture, product=product, customer=customer
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+        subscription.payment_method = payment_method
+        await save_fixture(subscription)
+        trigger_payment_mock = mocker.patch.object(
+            order_service, "trigger_payment", new_callable=AsyncMock
         )
 
         assert subscription.trial_end is not None
@@ -6705,6 +6769,8 @@ class TestUpdateTrial:
             updated_subscription.trial_end == updated_subscription.current_period_start
         )
         assert updated_subscription.trial_end < original_trial_end
+        await assert_order_exists(session, subscription)
+        trigger_payment_mock.assert_awaited_once()
 
     async def test_trialing_subscription_extending(
         self,
@@ -6892,10 +6958,16 @@ class TestUpdateTrial:
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
+        mocker: MockerFixture,
         product: Product,
         product_second: Product,
         customer: Customer,
     ) -> None:
+        mocker.patch.object(
+            subscription_service,
+            "_create_subscription_cycle_order",
+            new_callable=AsyncMock,
+        )
         subscription = await create_trialing_subscription(
             save_fixture, product=product, customer=customer
         )

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -28,6 +28,7 @@ from polar.event.repository import EventRepository
 from polar.event.system import SystemEvent
 from polar.exceptions import (
     BadRequest,
+    PaymentNotReady,
     PolarRequestValidationError,
     ResourceUnavailable,
 )
@@ -4786,9 +4787,9 @@ class TestUpdate:
         webhook_service_send_mock: MagicMock,
         enqueue_job_mock: MagicMock,
     ) -> None:
-        create_subscription_cycle_order_mock = mocker.patch.object(
+        create_subscription_update_order_mock = mocker.patch.object(
             subscription_service,
-            "_create_subscription_cycle_order",
+            "_create_subscription_update_order",
             new_callable=AsyncMock,
         )
         subscription = await create_trialing_subscription(
@@ -4822,7 +4823,7 @@ class TestUpdate:
             organization,
             updated,
         )
-        create_subscription_cycle_order_mock.assert_awaited_once_with(
+        create_subscription_update_order_mock.assert_awaited_once_with(
             session,
             updated,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
@@ -5074,9 +5075,9 @@ class TestUpdate:
         webhook_service_send_mock: MagicMock,
         enqueue_job_mock: MagicMock,
     ) -> None:
-        create_subscription_cycle_order_mock = mocker.patch.object(
+        create_subscription_update_order_mock = mocker.patch.object(
             subscription_service,
-            "_create_subscription_cycle_order",
+            "_create_subscription_update_order",
             new_callable=AsyncMock,
         )
 
@@ -5107,7 +5108,7 @@ class TestUpdate:
         assert updated.product == new_product
         assert updated.active
 
-        create_subscription_cycle_order_mock.assert_awaited_once_with(
+        create_subscription_update_order_mock.assert_awaited_once_with(
             session,
             updated,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
@@ -6698,6 +6699,37 @@ class TestUpdateDiscount:
 
 @pytest.mark.asyncio
 class TestUpdateTrial:
+    async def test_trialing_subscription_ending_now_with_renewals_disabled(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        organization.capabilities = {
+            **organization.capabilities,
+            "subscription_renewals": False,
+        }
+        await save_fixture(organization)
+        subscription = await create_trialing_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        original_trial_end = subscription.trial_end
+        original_period_end = subscription.current_period_end
+
+        with pytest.raises(PaymentNotReady):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_trial(
+                    session, ctx, subscription, trial_end="now"
+                )
+
+        assert subscription.status == SubscriptionStatus.trialing
+        assert subscription.trial_end == original_trial_end
+        assert subscription.current_period_end == original_period_end
+
     async def test_trialing_subscription_ending_now_payment_failure_preserves_trial(
         self,
         session: AsyncSession,
@@ -6708,7 +6740,7 @@ class TestUpdateTrial:
     ) -> None:
         mocker.patch.object(
             subscription_service,
-            "_create_subscription_cycle_order",
+            "_create_subscription_update_order",
             side_effect=PaymentFailed(PaymentFailedReason.card_error),
         )
         subscription = await create_trialing_subscription(
@@ -6965,7 +6997,7 @@ class TestUpdateTrial:
     ) -> None:
         mocker.patch.object(
             subscription_service,
-            "_create_subscription_cycle_order",
+            "_create_subscription_update_order",
             new_callable=AsyncMock,
         )
         subscription = await create_trialing_subscription(


### PR DESCRIPTION
Similar to how we attempt the charge before updating a subscription, attempt the charge before converting a trial early.

We do this only for explicit early conversions by setting `trial_end` to `now`, the automatic trial conversion still will flip trialing → active, then a failed payment will mark it as past due. TBD if we also want to change that, it may make sense to change from trialing → canceled instead of trialing → past due, but I think that's a different discussion. Since this focuses only on the manual trial-conversion path, the merchant has control, so we don't have to think about that.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

