### PR TITLE
Serialize client checkout updates

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutForm.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.test.tsx
@@ -619,6 +619,33 @@ describe('CheckoutForm', () => {
   })
 
   describe('contact capture', () => {
+    it('accepts checkbox toggles while a contact update is pending', async () => {
+      const update = vi.fn(async () => createCheckout())
+      render(
+        <FormWrapper
+          checkout={createCheckout()}
+          {...defaultProps}
+          update={update}
+          isUpdatePending
+          themePreset={{ stripe: {} } as ThemingPresetProps}
+          locale="en"
+        />,
+      )
+
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole('checkbox', { name: /purchasing as a business/i }),
+        )
+      })
+      expect(update).toHaveBeenLastCalledWith({ is_business_customer: true })
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole('checkbox', { name: /purchasing as a business/i }),
+        )
+      })
+      expect(update).toHaveBeenLastCalledWith({ is_business_customer: false })
+    })
+
     const rejectingUpdate = () =>
       vi.fn(async () => {
         throw new Error('rejected')

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -594,7 +594,6 @@ const BaseCheckoutForm = ({
                               )}
                               checked={field.value ? field.value : false}
                               onCheckedChange={(checked) => {
-                                if (isUpdatePending) return
                                 field.onChange(checked)
                                 updateBusinessCustomer(!!checked)
                               }}

--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.test.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.test.tsx
@@ -2,7 +2,10 @@ import { act } from '@testing-library/react'
 import type { Stripe, StripeElements } from '@stripe/stripe-js'
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithCheckout } from '../test-utils/renderWithCheckout'
+import type { CheckoutFormContextProps } from './CheckoutFormProvider'
 import type { CheckoutContextProps } from './CheckoutProvider'
+
+type CheckoutResult = Awaited<ReturnType<CheckoutFormContextProps['update']>>
 
 type UpdateResult = Awaited<ReturnType<CheckoutContextProps['update']>>
 type ConfirmResult = Awaited<ReturnType<CheckoutContextProps['confirm']>>
@@ -205,6 +208,95 @@ describe('CheckoutFormProvider', () => {
         expect(getCtx().form.formState.errors).toEqual({})
       },
     )
+  })
+
+  describe('update (single-flight)', () => {
+    interface Deferred<T> {
+      promise: Promise<T>
+      resolve: (value: T) => void
+    }
+
+    const createDeferred = <T,>(): Deferred<T> => {
+      let resolve!: (value: T) => void
+      const promise = new Promise<T>((res) => {
+        resolve = res
+      })
+      return { promise, resolve }
+    }
+
+    it('never overlaps requests and coalesces pending calls into one trailing request', async () => {
+      const outer: Deferred<UpdateResult>[] = []
+      const update = vi.fn<CheckoutContextProps['update']>(() => {
+        const deferred = createDeferred<UpdateResult>()
+        outer.push(deferred)
+        return deferred.promise
+      })
+
+      const getCtx = renderWithCheckout({ update })
+
+      // First call starts immediately.
+      await act(async () => {
+        void getCtx().update({ customer_email: 'a@example.com' })
+      })
+      expect(update).toHaveBeenCalledTimes(1)
+
+      // Two calls made while the first is in flight must not fire a request yet.
+      let bResult: CheckoutResult | undefined
+      let cResult: CheckoutResult | undefined
+      await act(async () => {
+        void getCtx()
+          .update({ customer_name: 'B' })
+          .then((value) => {
+            bResult = value
+          })
+        void getCtx()
+          .update({ customer_tax_id: 'C' })
+          .then((value) => {
+            cResult = value
+          })
+      })
+      expect(update).toHaveBeenCalledTimes(1)
+
+      // Resolving the first flushes a single coalesced request with both fields.
+      await act(async () => {
+        outer[0].resolve({ ok: true, value: { id: 'ch_1' } } as UpdateResult)
+      })
+      expect(update).toHaveBeenCalledTimes(2)
+      expect(update).toHaveBeenLastCalledWith({
+        customer_name: 'B',
+        customer_tax_id: 'C',
+      })
+
+      // Both coalesced callers resolve with the trailing request's result.
+      await act(async () => {
+        outer[1].resolve({ ok: true, value: { id: 'ch_2' } } as UpdateResult)
+      })
+      expect(bResult).toMatchObject({ id: 'ch_2' })
+      expect(cResult).toMatchObject({ id: 'ch_2' })
+    })
+
+    it('re-arms the fast path once the queue drains', async () => {
+      const outer: Deferred<UpdateResult>[] = []
+      const update = vi.fn<CheckoutContextProps['update']>(() => {
+        const deferred = createDeferred<UpdateResult>()
+        outer.push(deferred)
+        return deferred.promise
+      })
+
+      const getCtx = renderWithCheckout({ update })
+
+      await act(async () => {
+        void getCtx().update({ customer_email: 'a@example.com' })
+        outer[0].resolve({ ok: true, value: { id: 'ch_1' } } as UpdateResult)
+      })
+      expect(update).toHaveBeenCalledTimes(1)
+
+      // A later call, after the first settled, fires immediately rather than queueing.
+      await act(async () => {
+        void getCtx().update({ customer_name: 'B' })
+      })
+      expect(update).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe('confirm (free checkout path)', () => {

--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.test.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.test.tsx
@@ -1,6 +1,6 @@
 import { act } from '@testing-library/react'
 import type { Stripe, StripeElements } from '@stripe/stripe-js'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderWithCheckout } from '../test-utils/renderWithCheckout'
 import type { CheckoutFormContextProps } from './CheckoutFormProvider'
 import type { CheckoutContextProps } from './CheckoutProvider'
@@ -211,6 +211,9 @@ describe('CheckoutFormProvider', () => {
   })
 
   describe('update (single-flight)', () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
     interface Deferred<T> {
       promise: Promise<T>
       resolve: (value: T) => void
@@ -234,9 +237,9 @@ describe('CheckoutFormProvider', () => {
 
       const getCtx = renderWithCheckout({ update })
 
-      // First call starts immediately.
       await act(async () => {
         void getCtx().update({ customer_email: 'a@example.com' })
+        await vi.advanceTimersByTimeAsync(100)
       })
       expect(update).toHaveBeenCalledTimes(1)
 
@@ -254,6 +257,7 @@ describe('CheckoutFormProvider', () => {
           .then((value) => {
             cResult = value
           })
+        await vi.advanceTimersByTimeAsync(100)
       })
       expect(update).toHaveBeenCalledTimes(1)
 
@@ -275,7 +279,7 @@ describe('CheckoutFormProvider', () => {
       expect(cResult).toMatchObject({ id: 'ch_2' })
     })
 
-    it('re-arms the fast path once the queue drains', async () => {
+    it('debounces again once the queue drains', async () => {
       const outer: Deferred<UpdateResult>[] = []
       const update = vi.fn<CheckoutContextProps['update']>(() => {
         const deferred = createDeferred<UpdateResult>()
@@ -287,15 +291,81 @@ describe('CheckoutFormProvider', () => {
 
       await act(async () => {
         void getCtx().update({ customer_email: 'a@example.com' })
+        await vi.advanceTimersByTimeAsync(100)
         outer[0].resolve({ ok: true, value: { id: 'ch_1' } } as UpdateResult)
       })
       expect(update).toHaveBeenCalledTimes(1)
 
-      // A later call, after the first settled, fires immediately rather than queueing.
       await act(async () => {
         void getCtx().update({ customer_name: 'B' })
       })
+      expect(update).toHaveBeenCalledTimes(1)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100)
+      })
       expect(update).toHaveBeenCalledTimes(2)
+      await act(async () => {
+        outer[1].resolve({ ok: true, value: { id: 'ch_2' } } as UpdateResult)
+      })
+      expect(getCtx().isUpdatePending).toBe(false)
+    })
+
+    it('combines name blur and rapid checkbox toggles using the final value', async () => {
+      const update = vi.fn<CheckoutContextProps['update']>(
+        async () => ({ ok: true, value: { id: 'ch_1' } }) as UpdateResult,
+      )
+      const getCtx = renderWithCheckout({ update })
+      const results: CheckoutResult[] = []
+
+      await act(async () => {
+        void getCtx()
+          .update({ customer_name: 'Buyer' })
+          .then((v) => results.push(v))
+        void getCtx()
+          .update({ is_business_customer: true })
+          .then((v) => results.push(v))
+        await vi.advanceTimersByTimeAsync(50)
+        void getCtx()
+          .update({ is_business_customer: false })
+          .then((v) => results.push(v))
+        await vi.advanceTimersByTimeAsync(99)
+      })
+      expect(update).not.toHaveBeenCalled()
+      expect(getCtx().isUpdatePending).toBe(true)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1)
+      })
+      expect(update).toHaveBeenCalledExactlyOnceWith({
+        customer_name: 'Buyer',
+        is_business_customer: false,
+      })
+      expect(results).toEqual([{ id: 'ch_1' }, { id: 'ch_1' }, { id: 'ch_1' }])
+      expect(getCtx().isUpdatePending).toBe(false)
+    })
+
+    it('waits for the remaining debounce when an in-flight request finishes', async () => {
+      const first = createDeferred<UpdateResult>()
+      const update = vi
+        .fn<CheckoutContextProps['update']>()
+        .mockReturnValueOnce(first.promise)
+        .mockResolvedValue({ ok: true, value: { id: 'ch_2' } } as UpdateResult)
+      const getCtx = renderWithCheckout({ update })
+
+      await act(async () => {
+        void getCtx().update({ customer_name: 'Buyer' })
+        await vi.advanceTimersByTimeAsync(100)
+        void getCtx().update({ is_business_customer: true })
+        await vi.advanceTimersByTimeAsync(50)
+        first.resolve({ ok: true, value: { id: 'ch_1' } } as UpdateResult)
+      })
+      expect(update).toHaveBeenCalledTimes(1)
+      expect(getCtx().isUpdatePending).toBe(true)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50)
+      })
+      expect(update).toHaveBeenCalledTimes(2)
+      expect(getCtx().isUpdatePending).toBe(false)
     })
   })
 

--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
@@ -13,7 +13,7 @@ import type {
   StripeElements,
   StripeError,
 } from '@stripe/stripe-js'
-import { createContext, useCallback, useContext, useState } from 'react'
+import { createContext, useCallback, useContext, useRef, useState } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { useForm } from 'react-hook-form'
 import { setValidationErrors } from '../utils/form'
@@ -23,6 +23,22 @@ const stub = (): never => {
   throw new Error(
     'You forgot to wrap your component in <CheckoutFormProvider>.',
   )
+}
+
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason: unknown) => void
+}
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
 }
 
 export interface CheckoutFormContextProps {
@@ -80,16 +96,11 @@ export const CheckoutFormProvider = ({
     [checkout, setError],
   )
 
-  const update = useCallback(
+  const performUpdate = useCallback(
     async (
       checkoutUpdatePublic: schemas['CheckoutUpdatePublic'],
     ): Promise<schemas['CheckoutPublic']> => {
-      setIsUpdatePending(true)
-      const { ok, value, error } = await updateOuter(
-        checkoutUpdatePublic,
-      ).finally(() => {
-        setIsUpdatePending(false)
-      })
+      const { ok, value, error } = await updateOuter(checkoutUpdatePublic)
       if (ok) {
         return value
       } else {
@@ -116,6 +127,62 @@ export const CheckoutFormProvider = ({
       }
     },
     [updateOuter, setError, setDiscountError],
+  )
+
+  // Keep at most one checkout update PATCH in flight at a time. The backend
+  // locks the checkout row with `FOR UPDATE NOWAIT` and returns a 409
+  // (CheckoutLocked) if a second update overlaps the first, so we serialize
+  // here. Calls made while a request is in flight are coalesced into a single
+  // trailing request (last write wins per field) that flushes once the current
+  // one settles; all coalesced callers resolve with that request's result.
+  const inFlightRef = useRef(false)
+  const pendingRef = useRef<{
+    payload: schemas['CheckoutUpdatePublic']
+    deferred: Deferred<schemas['CheckoutPublic']>
+  } | null>(null)
+
+  const pump = useCallback(async (): Promise<void> => {
+    if (inFlightRef.current) {
+      return
+    }
+    const batch = pendingRef.current
+    if (!batch) {
+      setIsUpdatePending(false)
+      return
+    }
+    pendingRef.current = null
+    inFlightRef.current = true
+    try {
+      batch.deferred.resolve(await performUpdate(batch.payload))
+    } catch (error) {
+      batch.deferred.reject(error)
+    } finally {
+      inFlightRef.current = false
+      void pump()
+    }
+  }, [performUpdate])
+
+  const update = useCallback(
+    (
+      checkoutUpdatePublic: schemas['CheckoutUpdatePublic'],
+    ): Promise<schemas['CheckoutPublic']> => {
+      if (pendingRef.current) {
+        pendingRef.current.payload = {
+          ...pendingRef.current.payload,
+          ...checkoutUpdatePublic,
+        }
+      } else {
+        pendingRef.current = {
+          payload: checkoutUpdatePublic,
+          deferred: createDeferred<schemas['CheckoutPublic']>(),
+        }
+      }
+      setIsUpdatePending(true)
+      const { promise } = pendingRef.current.deferred
+      void pump()
+      return promise
+    },
+    [pump],
   )
 
   const _confirm = useCallback(

--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
@@ -129,38 +129,37 @@ export const CheckoutFormProvider = ({
     [updateOuter, setError, setDiscountError],
   )
 
-  // Keep at most one checkout update PATCH in flight at a time. The backend
-  // locks the checkout row with `FOR UPDATE NOWAIT` and returns a 409
-  // (CheckoutLocked) if a second update overlaps the first, so we serialize
-  // here. Calls made while a request is in flight are coalesced into a single
-  // trailing request (last write wins per field) that flushes once the current
-  // one settles; all coalesced callers resolve with that request's result.
+  // Debounce edits and serialize PATCHes to avoid CheckoutLocked responses.
   const inFlightRef = useRef(false)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingRef = useRef<{
     payload: schemas['CheckoutUpdatePublic']
     deferred: Deferred<schemas['CheckoutPublic']>
   } | null>(null)
 
-  const pump = useCallback(async (): Promise<void> => {
-    if (inFlightRef.current) {
-      return
-    }
-    const batch = pendingRef.current
-    if (!batch) {
-      setIsUpdatePending(false)
-      return
-    }
-    pendingRef.current = null
-    inFlightRef.current = true
-    try {
-      batch.deferred.resolve(await performUpdate(batch.payload))
-    } catch (error) {
-      batch.deferred.reject(error)
-    } finally {
-      inFlightRef.current = false
-      void pump()
-    }
-  }, [performUpdate])
+  const pump = useCallback(
+    async function pump(): Promise<void> {
+      if (inFlightRef.current || debounceRef.current !== null) {
+        return
+      }
+      const batch = pendingRef.current
+      if (!batch) {
+        setIsUpdatePending(false)
+        return
+      }
+      pendingRef.current = null
+      inFlightRef.current = true
+      try {
+        batch.deferred.resolve(await performUpdate(batch.payload))
+      } catch (error) {
+        batch.deferred.reject(error)
+      } finally {
+        inFlightRef.current = false
+        void pump()
+      }
+    },
+    [performUpdate],
+  )
 
   const update = useCallback(
     (
@@ -179,7 +178,13 @@ export const CheckoutFormProvider = ({
       }
       setIsUpdatePending(true)
       const { promise } = pendingRef.current.deferred
-      void pump()
+      if (debounceRef.current !== null) {
+        clearTimeout(debounceRef.current)
+      }
+      debounceRef.current = setTimeout(() => {
+        debounceRef.current = null
+        void pump()
+      }, 100)
       return promise
     },
     [pump],


### PR DESCRIPTION
The checkout form fires overlapping `PATCH /v1/checkouts/client/{client_secret}` requests. Most notably, Stripe's `PaymentElement` can emit several change events on hydration. The backend locks the checkout row with and returns 409 CheckoutLocked when a second update triggers while the first is still ongoing, causing (harmless) 409's when checkout renders.

This change makes sure we queue consecutive `update` and merges the payloads so that there's always only a single `PATCH` in flight, and all other ones are bundled in a single trailing request.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

