### PR TITLE
docs: update MCP client installation commands

### DIFF
--- a/docs/integrate/mcp.mdx
+++ b/docs/integrate/mcp.mdx
@@ -62,38 +62,23 @@ Choose your client and add the appropriate server.
   </Tab>
 
   <Tab title="Codex">
-    Add the following to `~/.codex/config.toml`, or to `.codex/config.toml` for a trusted project:
-
-    ```toml
-    [mcp_servers.polar]
-    url = "https://mcp.polar.sh/mcp/polar-mcp"
-    ```
-
-    Then authenticate with OAuth:
+    Run:
 
     ```bash
-    codex mcp login polar
+    codex mcp add "polar" --url "https://mcp.polar.sh/mcp/polar-mcp"
     ```
 
-    Use `/mcp` in Codex to confirm that the server is connected.
+    Complete the OAuth authorization when prompted.
   </Tab>
 
   <Tab title="OpenCode">
-    Add the following to `opencode.jsonc`:
+    Run:
 
-    ```jsonc
-    {
-      "$schema": "https://opencode.ai/config.json",
-      "mcp": {
-        "polar": {
-          "type": "remote",
-          "url": "https://mcp.polar.sh/mcp/polar-mcp"
-        }
-      }
-    }
+    ```bash
+    opencode mcp add polar --url https://mcp.polar.sh/mcp/polar-mcp
     ```
 
-    OpenCode will ask you to authorize Polar when it first connects.
+    Complete the OAuth authorization when prompted.
   </Tab>
 
   <Tab title="Other clients">


### PR DESCRIPTION
## Summary
- update Codex MCP setup to use `codex mcp add`
- update OpenCode MCP setup to use `opencode mcp add`
- clarify OAuth authorization steps

## Validation
- `git diff --check`
- Mintlify link check not run: docs dependencies are not installed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

