### PR TITLE
Add common datetime example to OpenAPI schema

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -7313,6 +7313,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -7359,6 +7360,7 @@ export interface components {
       /**
        * Granted At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       granted_at: string
       /** Expires At */
@@ -8461,6 +8463,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -8559,6 +8562,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -8667,6 +8671,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -8742,6 +8747,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -8848,6 +8854,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -8958,6 +8965,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -9067,6 +9075,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -9181,6 +9190,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -9232,6 +9242,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -9329,6 +9340,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -9406,6 +9418,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -9542,6 +9555,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -9593,6 +9607,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -9721,6 +9736,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /** Flagged Malicious At */
@@ -9750,6 +9766,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -9866,6 +9883,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -9917,6 +9935,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10014,6 +10033,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10122,6 +10142,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10173,6 +10194,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10269,6 +10291,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10412,6 +10435,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10463,6 +10487,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10561,6 +10586,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10645,6 +10671,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10732,6 +10759,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10813,6 +10841,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10900,6 +10929,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -10992,6 +11022,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -11077,6 +11108,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -11172,6 +11204,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -11263,6 +11296,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -11368,6 +11402,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -11464,6 +11499,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -11585,6 +11621,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -11636,6 +11673,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -11742,6 +11780,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -11875,6 +11914,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -11940,6 +11980,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -12055,6 +12096,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -12127,6 +12169,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -12283,6 +12326,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -12334,6 +12378,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -12429,6 +12474,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -12493,6 +12539,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -12611,6 +12658,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -12823,6 +12871,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -12863,6 +12912,7 @@ export interface components {
        * Expires At
        * Format: date-time
        * @description Expiration date and time of the checkout session.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       expires_at: string
       /**
@@ -13208,6 +13258,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -13434,6 +13485,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -13790,6 +13842,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -13956,6 +14009,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -14176,6 +14230,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -14618,6 +14673,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -14658,6 +14714,7 @@ export interface components {
        * Expires At
        * Format: date-time
        * @description Expiration date and time of the checkout session.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       expires_at: string
       /**
@@ -14909,6 +14966,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -14944,6 +15002,7 @@ export interface components {
        * Expires At
        * Format: date-time
        * @description Expiration date and time of the checkout session.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       expires_at: string
       /**
@@ -15401,6 +15460,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -15431,6 +15491,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -16023,6 +16084,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -16305,6 +16367,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -16365,6 +16428,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -16425,6 +16489,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -16503,6 +16568,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -16750,6 +16816,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -16806,6 +16873,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -16868,6 +16936,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -16924,6 +16993,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -16980,6 +17050,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -17042,6 +17113,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -17098,6 +17170,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -17154,6 +17227,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -17267,6 +17341,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
     }
@@ -17288,6 +17363,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -17371,6 +17447,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -17418,6 +17495,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -17461,6 +17539,7 @@ export interface components {
       /**
        * Expires At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       expires_at: string
       /** Return Url */
@@ -17481,6 +17560,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -17576,6 +17656,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The start of the period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -17605,6 +17686,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -17749,6 +17831,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -17844,6 +17927,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -18075,6 +18159,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -18183,6 +18268,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -18227,12 +18313,14 @@ export interface components {
        * Current Period Start
        * Format: date-time
        * @description The start timestamp of the current billing period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       current_period_start: string
       /**
        * Current Period End
        * Format: date-time
        * @description The end timestamp of the current billing period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       current_period_end: string
       /**
@@ -18354,6 +18442,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -18437,6 +18526,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -18514,6 +18604,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -18548,6 +18639,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -18580,6 +18672,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -18638,6 +18731,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -18743,6 +18837,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -18824,6 +18919,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -19010,6 +19106,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -19028,6 +19125,7 @@ export interface components {
       /**
        * Expires At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       expires_at: string
       /** Return Url */
@@ -19209,6 +19307,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -19272,6 +19371,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -19378,6 +19478,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -19427,6 +19528,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -19553,6 +19655,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -19612,6 +19715,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -19709,6 +19813,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -19753,12 +19858,14 @@ export interface components {
        * Current Period Start
        * Format: date-time
        * @description The start timestamp of the current billing period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       current_period_start: string
       /**
        * Current Period End
        * Format: date-time
        * @description The end timestamp of the current billing period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       current_period_end: string
       /**
@@ -19942,6 +20049,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -19988,6 +20096,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -20035,6 +20144,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -20204,6 +20314,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -20428,6 +20539,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -20533,6 +20645,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -20836,6 +20949,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -20926,6 +21040,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -21020,6 +21135,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -21112,6 +21228,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -21271,6 +21388,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -21344,6 +21462,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -21421,6 +21540,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -21496,6 +21616,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -21569,6 +21690,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -21737,6 +21859,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -21849,6 +21972,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -21958,6 +22082,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -22084,6 +22209,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /** Flagged Malicious At */
@@ -22169,6 +22295,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp?: string
       /**
@@ -22223,6 +22350,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp?: string
       /**
@@ -22307,12 +22435,14 @@ export interface components {
        * First Seen
        * Format: date-time
        * @description The first time the event occurred.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       first_seen: string
       /**
        * Last Seen
        * Format: date-time
        * @description The last time the event occurred.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       last_seen: string
     }
@@ -22429,6 +22559,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -22526,12 +22657,14 @@ export interface components {
        * First Seen
        * Format: date-time
        * @description The first time the event occurred.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       first_seen: string
       /**
        * Last Seen
        * Format: date-time
        * @description The last time the event occurred.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       last_seen: string
     }
@@ -22605,6 +22738,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -22823,6 +22957,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -23147,6 +23282,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -23329,6 +23465,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -23407,6 +23544,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -23531,6 +23669,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /** Modified At */
@@ -23557,6 +23696,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /** Modified At */
@@ -23576,6 +23716,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -23679,6 +23820,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -23802,6 +23944,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -24232,6 +24375,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -24265,6 +24409,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -24293,6 +24438,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -24345,6 +24491,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -24413,6 +24560,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -24482,6 +24630,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -24656,6 +24805,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -25039,6 +25189,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -25161,6 +25312,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -25247,6 +25399,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp for the current period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -25271,6 +25424,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -25452,6 +25606,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Value */
@@ -25487,6 +25642,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -25539,6 +25695,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description Timestamp of this period data.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Active Subscriptions */
@@ -25983,6 +26140,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -26079,6 +26237,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -26195,6 +26354,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -26221,6 +26381,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -26348,6 +26509,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -26631,6 +26793,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -26759,6 +26922,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -26850,6 +27014,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -26954,6 +27119,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -27037,6 +27203,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -27147,6 +27314,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -27191,12 +27359,14 @@ export interface components {
        * Current Period Start
        * Format: date-time
        * @description The start timestamp of the current billing period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       current_period_start: string
       /**
        * Current Period End
        * Format: date-time
        * @description The end timestamp of the current billing period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       current_period_end: string
       /**
@@ -27314,6 +27484,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -27427,6 +27598,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -27502,6 +27674,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -27866,6 +28039,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -27955,6 +28129,7 @@ export interface components {
        * Appeal Submitted At
        * Format: date-time
        * @description When the appeal was submitted
+       * @example 2026-01-01T00:00:00.123456Z
        */
       appeal_submitted_at: string
     }
@@ -28034,6 +28209,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /** Size Readable */
@@ -28163,6 +28339,7 @@ export interface components {
       /**
        * Expires At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       expires_at: string
     }
@@ -28797,6 +28974,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -29169,6 +29347,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description The time the OrganizationMember was created.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /** Email */
@@ -29225,6 +29404,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /** Invoice Number */
@@ -29389,6 +29569,7 @@ export interface components {
       /**
        * Submitted At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       submitted_at: string
       /** Reviewed At */
@@ -29565,6 +29746,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -29856,6 +30038,7 @@ export interface components {
       /**
        * Applies At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       applies_at: string
     }
@@ -29904,6 +30087,7 @@ export interface components {
        * Last Seen At
        * Format: date-time
        * @description When it last opened one.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       last_seen_at: string
     }
@@ -30245,6 +30429,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -30896,6 +31081,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -30941,6 +31127,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -30980,6 +31167,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -31080,6 +31268,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -31140,6 +31329,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -31227,6 +31417,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -31335,6 +31526,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -31352,6 +31544,7 @@ export interface components {
        * Applies At
        * Format: date-time
        * @description The date and time when the subscription update will be applied.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       applies_at: string
       /**
@@ -31376,6 +31569,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -31709,6 +31903,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -32041,6 +32236,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /** Size Readable */
@@ -32064,6 +32260,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -32431,6 +32628,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -32664,6 +32862,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -32758,6 +32957,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -32858,6 +33058,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -33010,6 +33211,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -33249,6 +33451,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -33360,6 +33563,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -33491,6 +33695,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -33563,6 +33768,7 @@ export interface components {
       /**
        * Expires At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       expires_at: string
     }
@@ -33615,6 +33821,7 @@ export interface components {
       /**
        * Expires At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       expires_at: string
       /**
@@ -33958,6 +34165,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -34191,18 +34399,21 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description Period timestamp
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
        * Period Start
        * Format: date-time
        * @description Period start (inclusive)
+       * @example 2026-01-01T00:00:00.123456Z
        */
       period_start: string
       /**
        * Period End
        * Format: date-time
        * @description Period end (exclusive)
+       * @example 2026-01-01T00:00:00.123456Z
        */
       period_end: string
       /**
@@ -34346,6 +34557,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -34390,12 +34602,14 @@ export interface components {
        * Current Period Start
        * Format: date-time
        * @description The start timestamp of the current billing period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       current_period_start: string
       /**
        * Current Period End
        * Format: date-time
        * @description The end timestamp of the current billing period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       current_period_end: string
       /**
@@ -34547,6 +34761,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -34692,6 +34907,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -34983,6 +35199,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -35073,6 +35290,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -35164,6 +35382,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -35286,6 +35505,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -35342,6 +35562,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -35453,6 +35674,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -35547,6 +35769,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -35640,6 +35863,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -35730,6 +35954,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -35829,6 +36054,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -35963,6 +36189,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -36053,6 +36280,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -36175,6 +36403,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -36265,6 +36494,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -36394,6 +36624,7 @@ export interface components {
        * @description Set a new date for the end of the current billing period. The subscription will renew on this date. The new date can be earlier or later than the current period end, as long as it's in the future.
        *
        *     It is not possible to update the current billing period on a canceled subscription.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       current_billing_period_end: string
     }
@@ -36420,6 +36651,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -36524,6 +36756,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -36624,6 +36857,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -36645,6 +36879,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -36747,6 +36982,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /** Size Readable */
@@ -36761,6 +36997,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -37214,6 +37451,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -37277,6 +37515,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -37345,6 +37584,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -37369,6 +37609,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -37392,6 +37633,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -37418,6 +37660,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -37441,6 +37684,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -37653,6 +37897,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -37753,6 +37998,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -38086,6 +38332,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -38172,6 +38419,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description Timestamp of the root event.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /**
@@ -38265,6 +38513,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -38335,6 +38584,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38358,6 +38608,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38382,6 +38633,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38405,6 +38657,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38428,6 +38681,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38451,6 +38705,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38474,6 +38729,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38499,6 +38755,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38521,6 +38778,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38548,6 +38806,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38570,6 +38829,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38593,6 +38853,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38615,6 +38876,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38637,6 +38899,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38665,6 +38928,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38691,6 +38955,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38706,6 +38971,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -38753,6 +39019,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38776,6 +39043,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38799,6 +39067,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -38815,6 +39084,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -38946,6 +39216,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -39064,6 +39335,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39089,6 +39361,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39114,6 +39387,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39146,6 +39420,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39170,6 +39445,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39192,6 +39468,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39219,6 +39496,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39241,6 +39519,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39263,6 +39542,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39285,6 +39565,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39307,6 +39588,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39329,6 +39611,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39352,6 +39635,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39375,6 +39659,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39399,6 +39684,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39429,6 +39715,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39456,6 +39743,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39481,6 +39769,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39505,6 +39794,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39530,6 +39820,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39556,6 +39847,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */
@@ -39582,6 +39874,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
+       * @example 2026-01-01T00:00:00.123456Z
        */
       timestamp: string
       /** Api Version */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -7313,7 +7313,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -7360,7 +7360,7 @@ export interface components {
       /**
        * Granted At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       granted_at: string
       /** Expires At */
@@ -8463,7 +8463,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -8562,7 +8562,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -8671,7 +8671,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -8747,7 +8747,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -8854,7 +8854,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -8965,7 +8965,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -9075,7 +9075,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -9190,7 +9190,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -9242,7 +9242,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -9340,7 +9340,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -9418,7 +9418,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -9555,7 +9555,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -9607,7 +9607,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -9736,7 +9736,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /** Flagged Malicious At */
@@ -9766,7 +9766,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -9883,7 +9883,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -9935,7 +9935,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -10033,7 +10033,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -10142,7 +10142,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -10194,7 +10194,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -10291,7 +10291,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -10435,7 +10435,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -10487,7 +10487,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -10586,7 +10586,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -10671,7 +10671,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -10759,7 +10759,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -10841,7 +10841,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -10929,7 +10929,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -11022,7 +11022,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -11108,7 +11108,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -11204,7 +11204,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -11296,7 +11296,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -11402,7 +11402,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -11499,7 +11499,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -11621,7 +11621,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -11673,7 +11673,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -11780,7 +11780,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -11914,7 +11914,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -11980,7 +11980,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -12096,7 +12096,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -12169,7 +12169,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -12326,7 +12326,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -12378,7 +12378,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -12474,7 +12474,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -12539,7 +12539,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -12658,7 +12658,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -12871,7 +12871,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -12912,7 +12912,7 @@ export interface components {
        * Expires At
        * Format: date-time
        * @description Expiration date and time of the checkout session.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       expires_at: string
       /**
@@ -13258,7 +13258,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -13485,7 +13485,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -13842,7 +13842,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -14009,7 +14009,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -14230,7 +14230,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -14673,7 +14673,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -14714,7 +14714,7 @@ export interface components {
        * Expires At
        * Format: date-time
        * @description Expiration date and time of the checkout session.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       expires_at: string
       /**
@@ -14966,7 +14966,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -15002,7 +15002,7 @@ export interface components {
        * Expires At
        * Format: date-time
        * @description Expiration date and time of the checkout session.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       expires_at: string
       /**
@@ -15460,7 +15460,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -15491,7 +15491,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -16084,7 +16084,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -16367,7 +16367,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -16428,7 +16428,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -16489,7 +16489,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -16568,7 +16568,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -16816,7 +16816,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -16873,7 +16873,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -16936,7 +16936,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -16993,7 +16993,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -17050,7 +17050,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -17113,7 +17113,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -17170,7 +17170,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -17227,7 +17227,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -17341,7 +17341,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
     }
@@ -17363,7 +17363,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -17447,7 +17447,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -17495,7 +17495,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -17539,7 +17539,7 @@ export interface components {
       /**
        * Expires At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       expires_at: string
       /** Return Url */
@@ -17560,7 +17560,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -17656,7 +17656,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The start of the period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -17686,7 +17686,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -17831,7 +17831,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -17927,7 +17927,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -18159,7 +18159,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -18268,7 +18268,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -18313,14 +18313,14 @@ export interface components {
        * Current Period Start
        * Format: date-time
        * @description The start timestamp of the current billing period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       current_period_start: string
       /**
        * Current Period End
        * Format: date-time
        * @description The end timestamp of the current billing period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       current_period_end: string
       /**
@@ -18442,7 +18442,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -18526,7 +18526,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -18604,7 +18604,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -18639,7 +18639,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -18672,7 +18672,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -18731,7 +18731,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -18837,7 +18837,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -18919,7 +18919,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -19106,7 +19106,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -19125,7 +19125,7 @@ export interface components {
       /**
        * Expires At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       expires_at: string
       /** Return Url */
@@ -19307,7 +19307,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -19371,7 +19371,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -19478,7 +19478,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -19528,7 +19528,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -19655,7 +19655,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -19715,7 +19715,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -19813,7 +19813,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -19858,14 +19858,14 @@ export interface components {
        * Current Period Start
        * Format: date-time
        * @description The start timestamp of the current billing period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       current_period_start: string
       /**
        * Current Period End
        * Format: date-time
        * @description The end timestamp of the current billing period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       current_period_end: string
       /**
@@ -20049,7 +20049,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -20096,7 +20096,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -20144,7 +20144,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -20314,7 +20314,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -20539,7 +20539,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -20645,7 +20645,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -20949,7 +20949,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -21040,7 +21040,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -21135,7 +21135,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -21228,7 +21228,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -21388,7 +21388,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -21462,7 +21462,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -21540,7 +21540,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -21616,7 +21616,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -21690,7 +21690,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -21859,7 +21859,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -21972,7 +21972,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -22082,7 +22082,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -22209,7 +22209,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /** Flagged Malicious At */
@@ -22295,7 +22295,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp?: string
       /**
@@ -22350,7 +22350,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp?: string
       /**
@@ -22435,14 +22435,14 @@ export interface components {
        * First Seen
        * Format: date-time
        * @description The first time the event occurred.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       first_seen: string
       /**
        * Last Seen
        * Format: date-time
        * @description The last time the event occurred.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       last_seen: string
     }
@@ -22559,7 +22559,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -22657,14 +22657,14 @@ export interface components {
        * First Seen
        * Format: date-time
        * @description The first time the event occurred.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       first_seen: string
       /**
        * Last Seen
        * Format: date-time
        * @description The last time the event occurred.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       last_seen: string
     }
@@ -22738,7 +22738,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -22957,7 +22957,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -23282,7 +23282,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -23465,7 +23465,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -23544,7 +23544,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -23669,7 +23669,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /** Modified At */
@@ -23696,7 +23696,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /** Modified At */
@@ -23716,7 +23716,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -23820,7 +23820,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -23944,7 +23944,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -24375,7 +24375,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -24409,7 +24409,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -24438,7 +24438,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -24491,7 +24491,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -24560,7 +24560,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -24630,7 +24630,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -24805,7 +24805,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -25189,7 +25189,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -25312,7 +25312,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -25399,7 +25399,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp for the current period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -25424,7 +25424,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -25606,7 +25606,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Value */
@@ -25642,7 +25642,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -25695,7 +25695,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description Timestamp of this period data.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Active Subscriptions */
@@ -26140,7 +26140,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -26237,7 +26237,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -26354,7 +26354,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -26381,7 +26381,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -26509,7 +26509,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -26793,7 +26793,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -26922,7 +26922,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -27014,7 +27014,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -27119,7 +27119,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -27203,7 +27203,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -27314,7 +27314,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -27359,14 +27359,14 @@ export interface components {
        * Current Period Start
        * Format: date-time
        * @description The start timestamp of the current billing period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       current_period_start: string
       /**
        * Current Period End
        * Format: date-time
        * @description The end timestamp of the current billing period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       current_period_end: string
       /**
@@ -27484,7 +27484,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -27598,7 +27598,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -27674,7 +27674,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -28039,7 +28039,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -28129,7 +28129,7 @@ export interface components {
        * Appeal Submitted At
        * Format: date-time
        * @description When the appeal was submitted
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       appeal_submitted_at: string
     }
@@ -28209,7 +28209,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /** Size Readable */
@@ -28339,7 +28339,7 @@ export interface components {
       /**
        * Expires At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       expires_at: string
     }
@@ -28974,7 +28974,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -29347,7 +29347,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description The time the OrganizationMember was created.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /** Email */
@@ -29404,7 +29404,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /** Invoice Number */
@@ -29569,7 +29569,7 @@ export interface components {
       /**
        * Submitted At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       submitted_at: string
       /** Reviewed At */
@@ -29746,7 +29746,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -30038,7 +30038,7 @@ export interface components {
       /**
        * Applies At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       applies_at: string
     }
@@ -30087,7 +30087,7 @@ export interface components {
        * Last Seen At
        * Format: date-time
        * @description When it last opened one.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       last_seen_at: string
     }
@@ -30429,7 +30429,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -31081,7 +31081,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -31127,7 +31127,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -31167,7 +31167,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -31268,7 +31268,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -31329,7 +31329,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -31417,7 +31417,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -31526,7 +31526,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -31544,7 +31544,7 @@ export interface components {
        * Applies At
        * Format: date-time
        * @description The date and time when the subscription update will be applied.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       applies_at: string
       /**
@@ -31569,7 +31569,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -31903,7 +31903,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -32236,7 +32236,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /** Size Readable */
@@ -32260,7 +32260,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -32628,7 +32628,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -32862,7 +32862,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -32957,7 +32957,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -33058,7 +33058,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -33211,7 +33211,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -33451,7 +33451,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -33563,7 +33563,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -33695,7 +33695,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -33768,7 +33768,7 @@ export interface components {
       /**
        * Expires At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       expires_at: string
     }
@@ -33821,7 +33821,7 @@ export interface components {
       /**
        * Expires At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       expires_at: string
       /**
@@ -34165,7 +34165,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -34399,21 +34399,21 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description Period timestamp
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
        * Period Start
        * Format: date-time
        * @description Period start (inclusive)
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       period_start: string
       /**
        * Period End
        * Format: date-time
        * @description Period end (exclusive)
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       period_end: string
       /**
@@ -34557,7 +34557,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -34602,14 +34602,14 @@ export interface components {
        * Current Period Start
        * Format: date-time
        * @description The start timestamp of the current billing period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       current_period_start: string
       /**
        * Current Period End
        * Format: date-time
        * @description The end timestamp of the current billing period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       current_period_end: string
       /**
@@ -34761,7 +34761,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -34907,7 +34907,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -35199,7 +35199,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -35290,7 +35290,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -35382,7 +35382,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -35505,7 +35505,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -35562,7 +35562,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -35674,7 +35674,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -35769,7 +35769,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -35863,7 +35863,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -35954,7 +35954,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -36054,7 +36054,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -36189,7 +36189,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -36280,7 +36280,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -36403,7 +36403,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -36494,7 +36494,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -36624,7 +36624,7 @@ export interface components {
        * @description Set a new date for the end of the current billing period. The subscription will renew on this date. The new date can be earlier or later than the current period end, as long as it's in the future.
        *
        *     It is not possible to update the current billing period on a canceled subscription.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       current_billing_period_end: string
     }
@@ -36651,7 +36651,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -36756,7 +36756,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -36857,7 +36857,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -36879,7 +36879,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -36982,7 +36982,7 @@ export interface components {
       /**
        * Created At
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /** Size Readable */
@@ -36997,7 +36997,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -37451,7 +37451,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -37515,7 +37515,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -37584,7 +37584,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -37609,7 +37609,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -37633,7 +37633,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -37660,7 +37660,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -37684,7 +37684,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -37897,7 +37897,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description The timestamp of the event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -37998,7 +37998,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -38332,7 +38332,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -38419,7 +38419,7 @@ export interface components {
        * Timestamp
        * Format: date-time
        * @description Timestamp of the root event.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /**
@@ -38513,7 +38513,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -38584,7 +38584,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38608,7 +38608,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38633,7 +38633,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38657,7 +38657,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38681,7 +38681,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38705,7 +38705,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38729,7 +38729,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38755,7 +38755,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38778,7 +38778,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38806,7 +38806,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38829,7 +38829,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38853,7 +38853,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38876,7 +38876,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38899,7 +38899,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38928,7 +38928,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38955,7 +38955,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -38971,7 +38971,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -39019,7 +39019,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39043,7 +39043,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39067,7 +39067,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39084,7 +39084,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -39216,7 +39216,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -39335,7 +39335,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39361,7 +39361,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39387,7 +39387,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39420,7 +39420,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39445,7 +39445,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39468,7 +39468,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39496,7 +39496,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39519,7 +39519,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39542,7 +39542,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39565,7 +39565,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39588,7 +39588,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39611,7 +39611,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39635,7 +39635,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39659,7 +39659,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39684,7 +39684,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39715,7 +39715,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39743,7 +39743,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39769,7 +39769,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39794,7 +39794,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39820,7 +39820,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39847,7 +39847,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */
@@ -39874,7 +39874,7 @@ export interface components {
       /**
        * Timestamp
        * Format: date-time
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       timestamp: string
       /** Api Version */

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -318,6 +318,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -388,6 +389,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -468,6 +470,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -540,6 +543,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -607,6 +611,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -705,6 +710,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -780,6 +786,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -852,6 +859,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -1442,6 +1450,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -1594,6 +1603,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -1654,6 +1664,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -2320,6 +2331,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -2526,6 +2538,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -2709,6 +2722,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       created_at: string
       /**
@@ -2753,12 +2767,14 @@ export interface components {
        * Current Period Start
        * Format: date-time
        * @description The start timestamp of the current billing period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       current_period_start: string
       /**
        * Current Period End
        * Format: date-time
        * @description The end timestamp of the current billing period.
+       * @example 2026-01-01T00:00:00.123456Z
        */
       current_period_end: string
       /**

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -318,7 +318,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -389,7 +389,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -470,7 +470,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -543,7 +543,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -611,7 +611,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -710,7 +710,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -786,7 +786,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -859,7 +859,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -1450,7 +1450,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -1603,7 +1603,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -1664,7 +1664,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -2331,7 +2331,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -2538,7 +2538,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -2722,7 +2722,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**
@@ -2767,14 +2767,14 @@ export interface components {
        * Current Period Start
        * Format: date-time
        * @description The start timestamp of the current billing period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       current_period_start: string
       /**
        * Current Period End
        * Format: date-time
        * @description The end timestamp of the current billing period.
-       * @example 2026-01-01T00:00:00.123456Z
+       * @example 2026-01-01T00:00:00.000000Z
        */
       current_period_end: string
       /**

--- a/server/polar/kit/schemas.py
+++ b/server/polar/kit/schemas.py
@@ -26,6 +26,27 @@ from slugify import slugify
 class Schema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        schema = handler.resolve_ref_schema(handler(core_schema))
+        # Add a common datetime example to all inherited JSON schemas.
+        pending: list[Any] = [schema]
+        while pending:
+            node = pending.pop()
+            if isinstance(node, dict):
+                if node.get("format") == "date-time":
+                    node.setdefault("examples", ["2026-01-01T00:00:00.123456Z"])
+                for key, value in node.items():
+                    if key in {"properties", "patternProperties", "$defs"}:
+                        pending.extend(value.values())
+                    elif key not in {"examples", "example", "default", "enum", "const"}:
+                        pending.append(value)
+            elif isinstance(node, list):
+                pending.extend(node)
+        return schema
+
     @field_validator("*", mode="after")
     @classmethod
     def _reject_nul_characters(cls, value: Any) -> Any:

--- a/server/polar/kit/schemas.py
+++ b/server/polar/kit/schemas.py
@@ -37,7 +37,7 @@ class Schema(BaseModel):
             node = pending.pop()
             if isinstance(node, dict):
                 if node.get("format") == "date-time":
-                    node.setdefault("examples", ["2026-01-01T00:00:00.123456Z"])
+                    node.setdefault("examples", ["2026-01-01T00:00:00.000000Z"])
                 for key, value in node.items():
                     if key in {"properties", "patternProperties", "$defs"}:
                         pending.extend(value.values())

--- a/server/polar/webhook/webhooks.py
+++ b/server/polar/webhook/webhooks.py
@@ -204,8 +204,7 @@ class BaseWebhookPayload(Schema):
     def __get_pydantic_json_schema__(
         cls, core_schema: cs.CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
-        json_schema = handler(core_schema)
-        json_schema = handler.resolve_ref_schema(json_schema)
+        json_schema = super().__get_pydantic_json_schema__(core_schema, handler)
 
         # Force the example of the `type` field to be the event type literal value
         type_field_annotation = cls.model_fields["type"].annotation

--- a/server/tests/kit/test_schemas.py
+++ b/server/tests/kit/test_schemas.py
@@ -1,9 +1,11 @@
+from datetime import datetime
 from typing import Any
 
 import pytest
-from pydantic import ValidationError
+from pydantic import Field, ValidationError
+from pydantic.json_schema import JsonSchemaMode
 
-from polar.kit.schemas import Schema
+from polar.kit.schemas import Schema, TimestampedSchema
 
 
 class StringSchema(Schema):
@@ -26,6 +28,31 @@ class NonStringSchema(Schema):
 
 class AnySchema(Schema):
     value: Any
+
+
+class TestJsonSchema:
+    @pytest.mark.parametrize("mode", ["validation", "serialization"])
+    def test_common_datetime_examples(self, mode: JsonSchemaMode) -> None:
+        class DatetimeSchema(TimestampedSchema):
+            timestamps: list[datetime]
+            nested: TimestampedSchema
+            example: datetime
+            custom: datetime = Field(examples=["2025-01-01T00:00:00Z"])
+            data: dict[str, str] = Field(examples=[{"format": "date-time"}])
+
+        schema = DatetimeSchema.model_json_schema(mode=mode)
+        properties = schema["properties"]
+
+        for field in (
+            properties["created_at"],
+            properties["modified_at"]["anyOf"][0],
+            properties["timestamps"]["items"],
+            properties["example"],
+            schema["$defs"]["TimestampedSchema"]["properties"]["created_at"],
+        ):
+            assert field["examples"] == ["2026-01-01T00:00:00.123456Z"]
+        assert properties["custom"]["examples"] == ["2025-01-01T00:00:00Z"]
+        assert properties["data"]["examples"] == [{"format": "date-time"}]
 
 
 def test_rejects_nul_character_in_string() -> None:

--- a/server/tests/kit/test_schemas.py
+++ b/server/tests/kit/test_schemas.py
@@ -50,7 +50,7 @@ class TestJsonSchema:
             properties["example"],
             schema["$defs"]["TimestampedSchema"]["properties"]["created_at"],
         ):
-            assert field["examples"] == ["2026-01-01T00:00:00.123456Z"]
+            assert field["examples"] == ["2026-01-01T00:00:00.000000Z"]
         assert properties["custom"]["examples"] == ["2025-01-01T00:00:00Z"]
         assert properties["data"]["examples"] == [{"format": "date-time"}]
 

--- a/server/tests/webhooks/test_webhooks.py
+++ b/server/tests/webhooks/test_webhooks.py
@@ -12,6 +12,7 @@ import pytest
 import respx
 from dramatiq import Retry
 from pydantic import Field
+from pydantic.json_schema import JsonSchemaMode
 from pytest_mock import MockerFixture
 from standardwebhooks.webhooks import Webhook as StandardWebhook
 
@@ -45,7 +46,7 @@ from polar.webhook.tasks import (
     sign_webhook,
     webhook_event_send,
 )
-from polar.webhook.webhooks import BaseWebhookPayload
+from polar.webhook.webhooks import BaseWebhookPayload, WebhookCustomerCreatedPayload
 from tests.fixtures.database import SaveFixture
 from tests.kit.test_versioning import CURRENT_VERSION, NEXT_VERSION
 
@@ -53,6 +54,17 @@ from tests.kit.test_versioning import CURRENT_VERSION, NEXT_VERSION
 @pytest.fixture
 def enqueue_job_mock(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("polar.webhook.service.enqueue_job")
+
+
+class TestWebhookJsonSchema:
+    @pytest.mark.parametrize("mode", ["validation", "serialization"])
+    def test_datetime_and_event_type_examples(self, mode: JsonSchemaMode) -> None:
+        schema = WebhookCustomerCreatedPayload.model_json_schema(mode=mode)
+
+        assert schema["properties"]["timestamp"]["examples"] == [
+            "2026-01-01T00:00:00.123456Z"
+        ]
+        assert schema["properties"]["type"]["examples"] == ["customer.created"]
 
 
 def test_versioned_raw_payload() -> None:

--- a/server/tests/webhooks/test_webhooks.py
+++ b/server/tests/webhooks/test_webhooks.py
@@ -62,7 +62,7 @@ class TestWebhookJsonSchema:
         schema = WebhookCustomerCreatedPayload.model_json_schema(mode=mode)
 
         assert schema["properties"]["timestamp"]["examples"] == [
-            "2026-01-01T00:00:00.123456Z"
+            "2026-01-01T00:00:00.000000Z"
         ]
         assert schema["properties"]["type"]["examples"] == ["customer.created"]
 


### PR DESCRIPTION

Some people complained that our docs advertise the wrong datetime format in examples (no microseconds). This PR forces our own example so we show the correct format, including microseconds.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

