### PR TITLE
docs: add fractional seconds to date-time examples in API reference

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -19220,7 +19220,7 @@ export interface components {
        * Granted At
        * Format: date-time
        * @description The timestamp when the benefit was granted.
-       * @example 2025-01-03T13:37:00Z
+       * @example 2025-01-03T13:37:00.123456Z
        */
       granted_at: string
       /**
@@ -19467,26 +19467,26 @@ export interface components {
        * Current Period Start
        * Format: date-time
        * @description The start timestamp of the current billing period.
-       * @example 2025-02-03T13:37:00Z
+       * @example 2025-02-03T13:37:00.123456Z
        */
       current_period_start: string
       /**
        * Current Period End
        * Format: date-time
        * @description The end timestamp of the current billing period.
-       * @example 2025-03-03T13:37:00Z
+       * @example 2025-03-03T13:37:00.123456Z
        */
       current_period_end: string
       /**
        * Trial Start
        * @description The start timestamp of the trial period, if any.
-       * @example 2025-02-03T13:37:00Z
+       * @example 2025-02-03T13:37:00.123456Z
        */
       trial_start: string | null
       /**
        * Trial End
        * @description The end timestamp of the trial period, if any.
-       * @example 2025-03-03T13:37:00Z
+       * @example 2025-03-03T13:37:00.123456Z
        */
       trial_end: string | null
       /**
@@ -19504,7 +19504,7 @@ export interface components {
       /**
        * Started At
        * @description The timestamp when the subscription started.
-       * @example 2025-01-03T13:37:00Z
+       * @example 2025-01-03T13:37:00.123456Z
        */
       started_at: string | null
       /**

--- a/docs/openapi/2026-04.openapi.json
+++ b/docs/openapi/2026-04.openapi.json
@@ -26599,7 +26599,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -26612,7 +26615,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "billing_name": {
             "anyOf": [
@@ -26715,7 +26721,10 @@
           "granted_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "expires_at": {
             "anyOf": [
@@ -26727,7 +26736,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -26739,7 +26751,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -28815,7 +28830,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -29022,7 +29040,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -29252,7 +29273,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -29392,7 +29416,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -29618,7 +29645,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -29852,7 +29882,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -30095,7 +30128,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -30108,7 +30144,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -30326,7 +30365,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -30339,7 +30381,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -30399,7 +30444,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -30412,7 +30460,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -30586,7 +30637,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -30726,7 +30780,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -30739,7 +30796,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -30960,7 +31020,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -30973,7 +31036,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -31033,7 +31099,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -31046,7 +31115,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -31266,7 +31338,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "version": {
             "anyOf": [
@@ -31291,7 +31366,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "flagged_malicious_at": {
             "anyOf": [
@@ -31303,7 +31381,10 @@
                 "type": "null"
               }
             ],
-            "title": "Flagged Malicious At"
+            "title": "Flagged Malicious At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "downloaders": {
             "type": "integer",
@@ -31357,7 +31438,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -31370,7 +31454,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -31588,7 +31675,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -31601,7 +31691,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -31661,7 +31754,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -31674,7 +31770,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -31825,7 +31924,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -31838,7 +31940,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32013,7 +32118,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32026,7 +32134,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32086,7 +32197,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32099,7 +32213,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32250,7 +32367,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32263,7 +32383,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32505,7 +32628,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32518,7 +32644,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32578,7 +32707,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32591,7 +32723,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32746,7 +32881,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32759,7 +32897,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -32778,7 +32919,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -32796,7 +32940,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -32937,7 +33084,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32950,7 +33100,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -32969,7 +33122,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -32987,7 +33143,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -33138,7 +33297,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -33151,7 +33313,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -33170,7 +33335,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -33188,7 +33356,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -33323,7 +33494,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -33336,7 +33510,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -33355,7 +33532,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -33373,7 +33553,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -33523,7 +33706,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -33536,7 +33722,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -33555,7 +33744,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -33573,7 +33765,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -33735,7 +33930,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -33748,7 +33946,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -33767,7 +33968,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -33785,7 +33989,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -33925,7 +34132,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -33938,7 +34148,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -33957,7 +34170,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -33975,7 +34191,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -34141,7 +34360,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -34154,7 +34376,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -34173,7 +34398,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -34191,7 +34419,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -34343,7 +34574,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -34356,7 +34590,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -34375,7 +34612,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -34393,7 +34633,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -34561,7 +34804,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -34764,7 +35010,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -34777,7 +35026,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35043,7 +35295,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -35056,7 +35311,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35116,7 +35374,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -35129,7 +35390,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35328,7 +35592,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -35341,7 +35608,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35557,7 +35827,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -35570,7 +35843,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35655,7 +35931,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -35668,7 +35947,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35879,7 +36161,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -36019,7 +36304,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -36032,7 +36320,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -36300,7 +36591,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -36313,7 +36607,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -36373,7 +36670,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -36386,7 +36686,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -36533,7 +36836,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -36546,7 +36852,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -36625,7 +36934,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -36854,7 +37166,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -36867,7 +37182,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -37277,7 +37595,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -37290,7 +37611,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "custom_field_data": {
             "additionalProperties": {
@@ -37311,6 +37635,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -37339,7 +37666,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Expires At",
-            "description": "Expiration date and time of the checkout session."
+            "description": "Expiration date and time of the checkout session.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "success_url": {
             "type": "string",
@@ -37536,7 +37866,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "End date and time of the trial period, if any."
+            "description": "End date and time of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -38031,6 +38364,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -38265,7 +38601,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -38704,7 +39043,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -38717,7 +39059,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -39453,7 +39798,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -39466,7 +39814,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -39835,7 +40186,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -39848,7 +40202,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -39975,6 +40332,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -40341,7 +40701,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -40354,7 +40717,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -40593,6 +40959,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -41033,6 +41402,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -41468,7 +41840,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -41481,7 +41856,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "custom_field_data": {
             "additionalProperties": {
@@ -41502,6 +41880,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -41530,7 +41911,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Expires At",
-            "description": "Expiration date and time of the checkout session."
+            "description": "Expiration date and time of the checkout session.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "success_url": {
             "type": "string",
@@ -41727,7 +42111,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "End date and time of the trial period, if any."
+            "description": "End date and time of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -42112,7 +42499,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -42125,7 +42515,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "custom_field_data": {
             "additionalProperties": {
@@ -42146,6 +42539,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -42175,7 +42571,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Expires At",
-            "description": "Expiration date and time of the checkout session."
+            "description": "Expiration date and time of the checkout session.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "success_url": {
             "type": "string",
@@ -42372,7 +42771,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "End date and time of the trial period, if any."
+            "description": "End date and time of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -42801,6 +43203,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -43196,6 +43601,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -43420,7 +43828,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -43433,7 +43844,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -43484,7 +43898,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -43497,7 +43914,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -44171,7 +44591,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -44184,7 +44607,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -44689,7 +45115,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -44702,7 +45131,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -44795,7 +45227,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -44808,7 +45243,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -44901,7 +45339,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -44914,7 +45355,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -45040,7 +45484,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -45053,7 +45500,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -45635,7 +46085,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -45648,7 +46101,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -45666,7 +46122,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -45678,7 +46137,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -45793,7 +46255,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -45806,7 +46271,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -45824,7 +46292,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -45836,7 +46307,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -45975,7 +46449,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -45988,7 +46465,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46006,7 +46486,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46018,7 +46501,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -46133,7 +46619,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -46146,7 +46635,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46164,7 +46656,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46176,7 +46671,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -46291,7 +46789,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -46304,7 +46805,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46322,7 +46826,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46334,7 +46841,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -46473,7 +46983,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -46486,7 +46999,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46504,7 +47020,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46516,7 +47035,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -46631,7 +47153,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -46644,7 +47169,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46662,7 +47190,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46674,7 +47205,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -46789,7 +47323,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -46802,7 +47339,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46820,7 +47360,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46832,7 +47375,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -47065,7 +47611,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -47100,7 +47649,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -47289,7 +47841,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -47302,7 +47857,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -47370,7 +47928,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -47383,7 +47944,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -47431,7 +47995,10 @@
           "expires_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "return_url": {
             "anyOf": [
@@ -47464,7 +48031,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -47687,7 +48257,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The start of the period."
+            "description": "The start of the period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "new_customers": {
             "type": "integer",
@@ -47723,7 +48296,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -47736,7 +48312,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -47896,7 +48475,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -47909,7 +48491,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -48109,7 +48694,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -48122,7 +48710,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -48257,7 +48848,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -48270,7 +48864,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/OrderStatus",
@@ -48507,7 +49104,10 @@
               }
             ],
             "title": "Next Payment Attempt At",
-            "description": "When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted."
+            "description": "When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "product": {
             "anyOf": [
@@ -48732,7 +49332,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -48745,7 +49348,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -48950,7 +49556,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -48963,7 +49572,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -49010,13 +49622,19 @@
             "type": "string",
             "format": "date-time",
             "title": "Current Period Start",
-            "description": "The start timestamp of the current billing period."
+            "description": "The start timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_period_end": {
             "type": "string",
             "format": "date-time",
             "title": "Current Period End",
-            "description": "The end timestamp of the current billing period."
+            "description": "The end timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_start": {
             "anyOf": [
@@ -49029,7 +49647,10 @@
               }
             ],
             "title": "Current Meter Period Start",
-            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence."
+            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_end": {
             "anyOf": [
@@ -49042,7 +49663,10 @@
               }
             ],
             "title": "Current Meter Period End",
-            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew."
+            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_start": {
             "anyOf": [
@@ -49055,7 +49679,10 @@
               }
             ],
             "title": "Trial Start",
-            "description": "The start timestamp of the trial period, if any."
+            "description": "The start timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_end": {
             "anyOf": [
@@ -49068,7 +49695,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "The end timestamp of the trial period, if any."
+            "description": "The end timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "cancel_at_period_end": {
             "type": "boolean",
@@ -49086,7 +49716,10 @@
               }
             ],
             "title": "Canceled At",
-            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`."
+            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -49099,7 +49732,10 @@
               }
             ],
             "title": "Started At",
-            "description": "The timestamp when the subscription started."
+            "description": "The timestamp when the subscription started.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -49112,7 +49748,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "The timestamp when the subscription will end."
+            "description": "The timestamp when the subscription will end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ended_at": {
             "anyOf": [
@@ -49125,7 +49764,10 @@
               }
             ],
             "title": "Ended At",
-            "description": "The timestamp when the subscription ended."
+            "description": "The timestamp when the subscription ended.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due_at": {
             "anyOf": [
@@ -49138,7 +49780,10 @@
               }
             ],
             "title": "Past Due At",
-            "description": "The timestamp when the subscription entered `past_due` status."
+            "description": "The timestamp when the subscription entered `past_due` status.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "pause_at_period_end": {
             "type": "boolean",
@@ -49156,7 +49801,10 @@
               }
             ],
             "title": "Paused At",
-            "description": "The timestamp when the subscription was paused."
+            "description": "The timestamp when the subscription was paused.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "resumes_at": {
             "anyOf": [
@@ -49169,7 +49817,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set."
+            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -49324,7 +49975,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49337,7 +49991,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -49464,7 +50121,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49477,7 +50137,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -49625,7 +50288,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49638,7 +50304,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -49685,7 +50354,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49698,7 +50370,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -49744,7 +50419,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49757,7 +50435,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -49965,7 +50646,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49978,7 +50662,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -50172,7 +50859,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -50185,7 +50875,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -50356,7 +51049,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -50369,7 +51065,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -50479,7 +51178,10 @@
               }
             ],
             "title": "Invitation Token Expires At",
-            "description": "When the invitation token expires"
+            "description": "When the invitation token expires",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "claimed_at": {
             "anyOf": [
@@ -50492,7 +51194,10 @@
               }
             ],
             "title": "Claimed At",
-            "description": "When the seat was claimed"
+            "description": "When the seat was claimed",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -50505,7 +51210,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "When the seat was revoked"
+            "description": "When the seat was revoked",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "seat_metadata": {
             "anyOf": [
@@ -50751,7 +51459,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -50764,7 +51475,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -50779,7 +51493,10 @@
           "expires_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "return_url": {
             "anyOf": [
@@ -51144,7 +51861,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51157,7 +51877,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "granted_at": {
             "type": "string",
@@ -51165,7 +51888,7 @@
             "title": "Granted At",
             "description": "The timestamp when the benefit was granted.",
             "examples": [
-              "2025-01-03T13:37:00Z"
+              "2025-01-03T13:37:00.123456Z"
             ]
           },
           "benefit_id": {
@@ -51249,7 +51972,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51262,7 +51988,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -51422,7 +52151,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -51435,7 +52167,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -51512,7 +52247,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51525,7 +52263,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "meter_id": {
             "type": "string",
@@ -51589,7 +52330,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51602,7 +52346,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "custom_field_data": {
             "additionalProperties": {
@@ -51623,6 +52370,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -51670,7 +52420,7 @@
             "title": "Current Period Start",
             "description": "The start timestamp of the current billing period.",
             "examples": [
-              "2025-02-03T13:37:00Z"
+              "2025-02-03T13:37:00.123456Z"
             ]
           },
           "current_period_end": {
@@ -51679,7 +52429,7 @@
             "title": "Current Period End",
             "description": "The end timestamp of the current billing period.",
             "examples": [
-              "2025-03-03T13:37:00Z"
+              "2025-03-03T13:37:00.123456Z"
             ]
           },
           "trial_start": {
@@ -51695,7 +52445,7 @@
             "title": "Trial Start",
             "description": "The start timestamp of the trial period, if any.",
             "examples": [
-              "2025-02-03T13:37:00Z"
+              "2025-02-03T13:37:00.123456Z"
             ]
           },
           "trial_end": {
@@ -51711,7 +52461,7 @@
             "title": "Trial End",
             "description": "The end timestamp of the trial period, if any.",
             "examples": [
-              "2025-03-03T13:37:00Z"
+              "2025-03-03T13:37:00.123456Z"
             ]
           },
           "cancel_at_period_end": {
@@ -51751,7 +52501,7 @@
             "title": "Started At",
             "description": "The timestamp when the subscription started.",
             "examples": [
-              "2025-01-03T13:37:00Z"
+              "2025-01-03T13:37:00.123456Z"
             ]
           },
           "ends_at": {
@@ -51867,7 +52617,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51880,7 +52633,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -51950,7 +52706,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51963,7 +52722,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -52130,7 +52892,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -52143,7 +52908,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -52213,7 +52981,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -52226,7 +52997,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -52273,13 +53047,19 @@
             "type": "string",
             "format": "date-time",
             "title": "Current Period Start",
-            "description": "The start timestamp of the current billing period."
+            "description": "The start timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_period_end": {
             "type": "string",
             "format": "date-time",
             "title": "Current Period End",
-            "description": "The end timestamp of the current billing period."
+            "description": "The end timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_start": {
             "anyOf": [
@@ -52292,7 +53072,10 @@
               }
             ],
             "title": "Current Meter Period Start",
-            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence."
+            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_end": {
             "anyOf": [
@@ -52305,7 +53088,10 @@
               }
             ],
             "title": "Current Meter Period End",
-            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew."
+            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_start": {
             "anyOf": [
@@ -52318,7 +53104,10 @@
               }
             ],
             "title": "Trial Start",
-            "description": "The start timestamp of the trial period, if any."
+            "description": "The start timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_end": {
             "anyOf": [
@@ -52331,7 +53120,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "The end timestamp of the trial period, if any."
+            "description": "The end timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "cancel_at_period_end": {
             "type": "boolean",
@@ -52349,7 +53141,10 @@
               }
             ],
             "title": "Canceled At",
-            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`."
+            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -52362,7 +53157,10 @@
               }
             ],
             "title": "Started At",
-            "description": "The timestamp when the subscription started."
+            "description": "The timestamp when the subscription started.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -52375,7 +53173,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "The timestamp when the subscription will end."
+            "description": "The timestamp when the subscription will end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ended_at": {
             "anyOf": [
@@ -52388,7 +53189,10 @@
               }
             ],
             "title": "Ended At",
-            "description": "The timestamp when the subscription ended."
+            "description": "The timestamp when the subscription ended.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due_at": {
             "anyOf": [
@@ -52401,7 +53205,10 @@
               }
             ],
             "title": "Past Due At",
-            "description": "The timestamp when the subscription entered `past_due` status."
+            "description": "The timestamp when the subscription entered `past_due` status.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "pause_at_period_end": {
             "type": "boolean",
@@ -52419,7 +53226,10 @@
               }
             ],
             "title": "Paused At",
-            "description": "The timestamp when the subscription was paused."
+            "description": "The timestamp when the subscription was paused.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "resumes_at": {
             "anyOf": [
@@ -52432,7 +53242,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set."
+            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -52703,7 +53516,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -52716,7 +53532,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -52780,7 +53599,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -52793,7 +53615,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -52834,7 +53659,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "Date at which the paused subscription should automatically resume. If not set, it stays paused until resumed. Must be after the current period end."
+            "description": "Date at which the paused subscription should automatically resume. If not set, it stays paused until resumed. Must be after the current period end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "additionalProperties": false,
@@ -52856,7 +53684,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -52869,7 +53700,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -53203,7 +54037,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -53216,7 +54053,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -53383,7 +54223,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -53396,7 +54239,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -53848,7 +54694,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -54125,7 +54974,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -54138,7 +54990,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -54596,7 +55451,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Optional timestamp after which the discount is redeemable."
+            "description": "Optional timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -54609,7 +55467,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Optional timestamp after which the discount is no longer redeemable."
+            "description": "Optional timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -54797,7 +55658,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -54810,7 +55674,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -54849,7 +55716,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -54862,7 +55732,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -54976,7 +55849,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -54989,7 +55865,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -55028,7 +55907,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55041,7 +55923,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55150,7 +56035,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -55163,7 +56051,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -55202,7 +56093,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55215,7 +56109,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55334,7 +56231,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -55347,7 +56247,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -55386,7 +56289,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55399,7 +56305,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55522,7 +56431,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Optional timestamp after which the discount is redeemable."
+            "description": "Optional timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55535,7 +56447,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Optional timestamp after which the discount is no longer redeemable."
+            "description": "Optional timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55659,7 +56574,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -55672,7 +56590,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -55711,7 +56632,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55724,7 +56648,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55814,7 +56741,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -55827,7 +56757,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -55866,7 +56799,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55879,7 +56815,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55964,7 +56903,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -55977,7 +56919,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -56016,7 +56961,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -56029,7 +56977,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -56124,7 +57075,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -56137,7 +57091,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -56176,7 +57133,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -56189,7 +57149,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -56266,7 +57229,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -56279,7 +57245,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -56522,7 +57491,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Optional timestamp after which the discount is redeemable."
+            "description": "Optional timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -56535,7 +57507,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Optional timestamp after which the discount is no longer redeemable."
+            "description": "Optional timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -56689,7 +57664,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -56702,7 +57680,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -56784,7 +57765,10 @@
               }
             ],
             "title": "Evidence Due By",
-            "description": "Deadline to submit evidence in response to the dispute. `None` when no response is required."
+            "description": "Deadline to submit evidence in response to the dispute. `None` when no response is required.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due": {
             "type": "boolean",
@@ -56889,7 +57873,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -56902,7 +57889,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -57067,7 +58057,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -57080,7 +58073,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -57166,7 +58162,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -57179,7 +58178,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -57435,7 +58437,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "version": {
             "anyOf": [
@@ -57460,7 +58465,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "flagged_malicious_at": {
             "anyOf": [
@@ -57472,7 +58480,10 @@
                 "type": "null"
               }
             ],
-            "title": "Flagged Malicious At"
+            "title": "Flagged Malicious At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "size_readable": {
             "type": "string",
@@ -57678,7 +58689,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "name": {
             "type": "string",
@@ -57764,7 +58778,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "name": {
             "type": "string",
@@ -57925,13 +58942,19 @@
             "type": "string",
             "format": "date-time",
             "title": "First Seen",
-            "description": "The first time the event occurred."
+            "description": "The first time the event occurred.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "last_seen": {
             "type": "string",
             "format": "date-time",
             "title": "Last Seen",
-            "description": "The last time the event occurred."
+            "description": "The last time the event occurred.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -58084,7 +59107,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -58097,7 +59123,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -58201,7 +59230,10 @@
               }
             ],
             "title": "Created At",
-            "description": "Creation timestamp of the event type. Null for system event types."
+            "description": "Creation timestamp of the event type. Null for system event types.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -58214,7 +59246,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the event type. Null for system event types."
+            "description": "Last modification timestamp of the event type. Null for system event types.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "name": {
             "type": "string",
@@ -58257,13 +59292,19 @@
             "type": "string",
             "format": "date-time",
             "title": "First Seen",
-            "description": "The first time the event occurred."
+            "description": "The first time the event occurred.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "last_seen": {
             "type": "string",
             "format": "date-time",
             "title": "Last Seen",
-            "description": "The last time the event occurred."
+            "description": "The last time the event occurred.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -58381,7 +59422,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -58394,7 +59438,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -58596,7 +59643,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "download": {
             "$ref": "#/components/schemas/S3DownloadURL"
@@ -58792,7 +59842,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "upload": {
             "$ref": "#/components/schemas/S3FileUploadMultipart"
@@ -58958,7 +60011,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -58971,7 +60027,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -59596,7 +60655,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -59609,7 +60671,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -59938,7 +61003,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -59951,7 +61019,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -60068,7 +61139,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -60081,7 +61155,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -60285,7 +61362,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -60297,7 +61377,10 @@
                 "type": "null"
               }
             ],
-            "title": "Modified At"
+            "title": "Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -60350,7 +61433,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -60362,7 +61448,10 @@
                 "type": "null"
               }
             ],
-            "title": "Modified At"
+            "title": "Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "license_key": {
             "$ref": "#/components/schemas/LicenseKeyRead"
@@ -60395,7 +61484,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -60408,7 +61500,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -60573,7 +61668,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -60586,7 +61684,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -60659,7 +61760,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -60672,7 +61776,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -60744,7 +61851,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Validated At"
+            "title": "Last Validated At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "expires_at": {
             "anyOf": [
@@ -60756,7 +61866,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -60846,7 +61959,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -61001,7 +62117,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -61014,7 +62133,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -61086,7 +62208,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Validated At"
+            "title": "Last Validated At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "expires_at": {
             "anyOf": [
@@ -61098,7 +62223,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "activations": {
             "items": {
@@ -62314,7 +63442,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -62373,7 +63504,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -62432,7 +63566,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -62557,7 +63694,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -62763,7 +63903,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -62900,7 +64043,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -62913,7 +64059,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -63278,7 +64427,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -63291,7 +64443,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -63863,7 +65018,10 @@
               }
             ],
             "title": "Renews At",
-            "description": "When the subscription next renews on the source, as staged at import. Null for non-subscription rows or when the source reported none."
+            "description": "When the subscription next renews on the source, as staged at import. Null for non-subscription rows or when the source reported none.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "has_payment_method": {
             "anyOf": [
@@ -64049,7 +65207,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -64062,7 +65223,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -64150,7 +65314,10 @@
               }
             ],
             "title": "Archived At",
-            "description": "Whether the meter is archived and the time it was archived."
+            "description": "Whether the meter is archived and the time it was archived.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -64301,7 +65468,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -64483,7 +65653,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp for the current period."
+            "description": "The timestamp for the current period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "quantity": {
             "type": "number",
@@ -64513,7 +65686,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -64885,7 +66061,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "value": {
             "type": "number",
@@ -64947,7 +66126,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -64960,7 +66142,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -65042,7 +66227,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "Timestamp of this period data."
+            "description": "Timestamp of this period data.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "active_subscriptions": {
             "anyOf": [
@@ -67410,7 +68598,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -67423,7 +68614,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -67643,7 +68837,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -67656,7 +68853,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "client_id": {
             "type": "string",
@@ -67941,7 +69141,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -67954,7 +69157,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "client_id": {
             "type": "string",
@@ -68035,7 +69241,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -68048,7 +69257,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "platform": {
             "$ref": "#/components/schemas/OAuthPlatform"
@@ -68263,7 +69475,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -68276,7 +69491,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/OrderStatus",
@@ -68513,7 +69731,10 @@
               }
             ],
             "title": "Next Payment Attempt At",
-            "description": "When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted."
+            "description": "When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -68537,6 +69758,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -68738,6 +69962,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -68863,7 +70090,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -68876,7 +70106,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -69041,7 +70274,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -69054,7 +70290,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -69153,7 +70392,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -69166,7 +70408,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -69312,7 +70557,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -69521,7 +70769,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -69534,7 +70785,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -69691,7 +70945,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -69887,7 +71144,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -69900,7 +71160,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -69947,13 +71210,19 @@
             "type": "string",
             "format": "date-time",
             "title": "Current Period Start",
-            "description": "The start timestamp of the current billing period."
+            "description": "The start timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_period_end": {
             "type": "string",
             "format": "date-time",
             "title": "Current Period End",
-            "description": "The end timestamp of the current billing period."
+            "description": "The end timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_start": {
             "anyOf": [
@@ -69966,7 +71235,10 @@
               }
             ],
             "title": "Current Meter Period Start",
-            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence."
+            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_end": {
             "anyOf": [
@@ -69979,7 +71251,10 @@
               }
             ],
             "title": "Current Meter Period End",
-            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew."
+            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_start": {
             "anyOf": [
@@ -69992,7 +71267,10 @@
               }
             ],
             "title": "Trial Start",
-            "description": "The start timestamp of the trial period, if any."
+            "description": "The start timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_end": {
             "anyOf": [
@@ -70005,7 +71283,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "The end timestamp of the trial period, if any."
+            "description": "The end timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "cancel_at_period_end": {
             "type": "boolean",
@@ -70023,7 +71304,10 @@
               }
             ],
             "title": "Canceled At",
-            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`."
+            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -70036,7 +71320,10 @@
               }
             ],
             "title": "Started At",
-            "description": "The timestamp when the subscription started."
+            "description": "The timestamp when the subscription started.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -70049,7 +71336,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "The timestamp when the subscription will end."
+            "description": "The timestamp when the subscription will end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ended_at": {
             "anyOf": [
@@ -70062,7 +71352,10 @@
               }
             ],
             "title": "Ended At",
-            "description": "The timestamp when the subscription ended."
+            "description": "The timestamp when the subscription ended.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due_at": {
             "anyOf": [
@@ -70075,7 +71368,10 @@
               }
             ],
             "title": "Past Due At",
-            "description": "The timestamp when the subscription entered `past_due` status."
+            "description": "The timestamp when the subscription entered `past_due` status.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "pause_at_period_end": {
             "type": "boolean",
@@ -70093,7 +71389,10 @@
               }
             ],
             "title": "Paused At",
-            "description": "The timestamp when the subscription was paused."
+            "description": "The timestamp when the subscription was paused.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "resumes_at": {
             "anyOf": [
@@ -70106,7 +71405,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set."
+            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -70238,7 +71540,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -70483,7 +71788,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -70640,7 +71948,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -70653,7 +71964,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -70739,7 +72053,10 @@
               }
             ],
             "title": "Details Submitted At",
-            "description": "When the business details were submitted for review."
+            "description": "When the business details were submitted for review.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "onboarding_resubmission_requested_at": {
             "anyOf": [
@@ -70752,7 +72069,10 @@
               }
             ],
             "title": "Onboarding Resubmission Requested At",
-            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable."
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "sso_enforced": {
             "type": "boolean",
@@ -71385,7 +72705,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -71398,7 +72721,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -71422,7 +72748,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "comment": {
             "type": "string",
@@ -71438,7 +72767,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Used At"
+            "title": "Last Used At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -71602,7 +72934,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Appeal Submitted At",
-            "description": "When the appeal was submitted"
+            "description": "When the appeal was submitted",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -71772,7 +73107,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "version": {
             "anyOf": [
@@ -71797,7 +73135,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "size_readable": {
             "type": "string",
@@ -72108,7 +73449,10 @@
           "expires_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -73325,7 +74669,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -73338,7 +74685,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -73424,7 +74774,10 @@
               }
             ],
             "title": "Details Submitted At",
-            "description": "When the business details were submitted for review."
+            "description": "When the business details were submitted for review.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "onboarding_resubmission_requested_at": {
             "anyOf": [
@@ -73437,7 +74790,10 @@
               }
             ],
             "title": "Onboarding Resubmission Requested At",
-            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable."
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "sso_enforced": {
             "type": "boolean",
@@ -74088,7 +75444,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "The time the OrganizationMember was created."
+            "description": "The time the OrganizationMember was created.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "email": {
             "type": "string",
@@ -74213,7 +75572,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "invoice_number": {
             "anyOf": [
@@ -74391,7 +75753,10 @@
               }
             ],
             "title": "Onboarding Resubmission Requested At",
-            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable. Null for organizations that have never been reset for review."
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable. Null for organizations that have never been reset for review.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -74566,7 +75931,10 @@
           "submitted_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Submitted At"
+            "title": "Submitted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "reviewed_at": {
             "anyOf": [
@@ -74578,7 +75946,10 @@
                 "type": "null"
               }
             ],
-            "title": "Reviewed At"
+            "title": "Reviewed At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "decision": {
             "anyOf": [
@@ -74703,7 +76074,10 @@
                 "type": "null"
               }
             ],
-            "title": "Submitted At"
+            "title": "Submitted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "verdict": {
             "anyOf": [
@@ -74787,7 +76161,10 @@
               }
             ],
             "title": "Appeal Submitted At",
-            "description": "When appeal was submitted"
+            "description": "When appeal was submitted",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "appeal_reason": {
             "anyOf": [
@@ -74823,7 +76200,10 @@
               }
             ],
             "title": "Appeal Reviewed At",
-            "description": "When appeal was reviewed"
+            "description": "When appeal was reviewed",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "appeal_case_id": {
             "anyOf": [
@@ -74928,7 +76308,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -74941,7 +76324,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -75345,7 +76731,10 @@
                 "type": "null"
               }
             ],
-            "title": "Current Period Start"
+            "title": "Current Period Start",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_period_end": {
             "anyOf": [
@@ -75357,7 +76746,10 @@
                 "type": "null"
               }
             ],
-            "title": "Current Period End"
+            "title": "Current Period End",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "cancel_at_period_end": {
             "type": "boolean",
@@ -75374,7 +76766,10 @@
                 "type": "null"
               }
             ],
-            "title": "Canceled At"
+            "title": "Canceled At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -75386,7 +76781,10 @@
                 "type": "null"
               }
             ],
-            "title": "Started At"
+            "title": "Started At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -75398,7 +76796,10 @@
                 "type": "null"
               }
             ],
-            "title": "Ends At"
+            "title": "Ends At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "pending_change": {
             "anyOf": [
@@ -75524,7 +76925,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Estimated date the discount stops applying. Computed for 'repeating' discounts from the subscription's started_at + duration_in_months; null for 'once' and 'forever' durations."
+            "description": "Estimated date the discount stops applying. Computed for 'repeating' discounts from the subscription's started_at + duration_in_months; null for 'once' and 'forever' durations.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -75546,7 +76950,10 @@
           "applies_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Applies At"
+            "title": "Applies At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -75629,7 +77036,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Last Seen At",
-            "description": "When it last opened one."
+            "description": "When it last opened one.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -76398,7 +77808,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -76411,7 +77824,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -76497,7 +77913,10 @@
               }
             ],
             "title": "Details Submitted At",
-            "description": "When the business details were submitted for review."
+            "description": "When the business details were submitted for review.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "onboarding_resubmission_requested_at": {
             "anyOf": [
@@ -76510,7 +77929,10 @@
               }
             ],
             "title": "Onboarding Resubmission Requested At",
-            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable."
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "sso_enforced": {
             "type": "boolean",
@@ -77457,7 +78879,10 @@
               }
             ],
             "title": "Expected At",
-            "description": "When Ops expects this step to land."
+            "description": "When Ops expects this step to land.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -77470,7 +78895,10 @@
               }
             ],
             "title": "Started At",
-            "description": "When the step became actionable."
+            "description": "When the step became actionable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "completed_at": {
             "anyOf": [
@@ -77483,7 +78911,10 @@
               }
             ],
             "title": "Completed At",
-            "description": "When the step was completed."
+            "description": "When the step was completed.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "completed_by": {
             "anyOf": [
@@ -77719,7 +79150,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -77732,7 +79166,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -77814,7 +79251,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -77827,7 +79267,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -77887,7 +79330,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -77900,7 +79346,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -78077,7 +79526,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -78090,7 +79542,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -78114,7 +79569,10 @@
                 "type": "null"
               }
             ],
-            "title": "Paid At"
+            "title": "Paid At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "currency": {
             "type": "string",
@@ -78214,7 +79672,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -78227,7 +79688,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "$ref": "#/components/schemas/PayoutAccountType"
@@ -78401,7 +79865,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -78414,7 +79881,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -78473,7 +79943,10 @@
                 "type": "null"
               }
             ],
-            "title": "Paid At"
+            "title": "Paid At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -78615,7 +80088,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -78628,7 +80104,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -78640,7 +80119,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Applies At",
-            "description": "The date and time when the subscription update will be applied."
+            "description": "The date and time when the subscription update will be applied.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "product_id": {
             "anyOf": [
@@ -78699,7 +80181,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -78712,7 +80197,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -78736,7 +80224,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "comment": {
             "type": "string",
@@ -78752,7 +80243,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Used At"
+            "title": "Last Used At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -79211,7 +80705,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -79224,7 +80721,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -79956,7 +81456,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "version": {
             "anyOf": [
@@ -79981,7 +81484,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "size_readable": {
             "type": "string",
@@ -80056,7 +81562,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -80069,7 +81578,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -80233,7 +81745,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -80246,7 +81761,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -80409,7 +81927,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -80422,7 +81943,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -80575,7 +82099,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -80588,7 +82115,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -80753,7 +82283,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -80766,7 +82299,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -80995,7 +82531,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -81008,7 +82547,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -81520,7 +83062,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -81533,7 +83078,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -81711,7 +83259,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -81724,7 +83275,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -81806,7 +83360,10 @@
               }
             ],
             "title": "Evidence Due By",
-            "description": "Deadline to submit evidence in response to the dispute. `None` when no response is required."
+            "description": "Deadline to submit evidence in response to the dispute. `None` when no response is required.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due": {
             "type": "boolean",
@@ -81938,7 +83495,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -81951,7 +83511,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -82077,7 +83640,10 @@
           "expires_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -82226,7 +83792,10 @@
           "expires_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "headers": {
             "additionalProperties": {
@@ -82930,7 +84499,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -82943,7 +84515,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -83061,7 +84636,10 @@
               }
             ],
             "title": "Installed At",
-            "description": "Timestamp when the Slack app was installed."
+            "description": "Timestamp when the Slack app was installed.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -83074,7 +84652,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "Timestamp when the Slack app was revoked or uninstalled."
+            "description": "Timestamp when the Slack app was revoked or uninstalled.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -83376,19 +84957,28 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "Period timestamp"
+            "description": "Period timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "period_start": {
             "type": "string",
             "format": "date-time",
             "title": "Period Start",
-            "description": "Period start (inclusive)"
+            "description": "Period start (inclusive)",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "period_end": {
             "type": "string",
             "format": "date-time",
             "title": "Period End",
-            "description": "Period end (exclusive)"
+            "description": "Period end (exclusive)",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "stats": {
             "items": {
@@ -83548,7 +85138,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -83561,7 +85154,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -83608,13 +85204,19 @@
             "type": "string",
             "format": "date-time",
             "title": "Current Period Start",
-            "description": "The start timestamp of the current billing period."
+            "description": "The start timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_period_end": {
             "type": "string",
             "format": "date-time",
             "title": "Current Period End",
-            "description": "The end timestamp of the current billing period."
+            "description": "The end timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_start": {
             "anyOf": [
@@ -83627,7 +85229,10 @@
               }
             ],
             "title": "Current Meter Period Start",
-            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence."
+            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_end": {
             "anyOf": [
@@ -83640,7 +85245,10 @@
               }
             ],
             "title": "Current Meter Period End",
-            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew."
+            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_start": {
             "anyOf": [
@@ -83653,7 +85261,10 @@
               }
             ],
             "title": "Trial Start",
-            "description": "The start timestamp of the trial period, if any."
+            "description": "The start timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_end": {
             "anyOf": [
@@ -83666,7 +85277,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "The end timestamp of the trial period, if any."
+            "description": "The end timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "cancel_at_period_end": {
             "type": "boolean",
@@ -83684,7 +85298,10 @@
               }
             ],
             "title": "Canceled At",
-            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`."
+            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -83697,7 +85314,10 @@
               }
             ],
             "title": "Started At",
-            "description": "The timestamp when the subscription started."
+            "description": "The timestamp when the subscription started.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -83710,7 +85330,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "The timestamp when the subscription will end."
+            "description": "The timestamp when the subscription will end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ended_at": {
             "anyOf": [
@@ -83723,7 +85346,10 @@
               }
             ],
             "title": "Ended At",
-            "description": "The timestamp when the subscription ended."
+            "description": "The timestamp when the subscription ended.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due_at": {
             "anyOf": [
@@ -83736,7 +85362,10 @@
               }
             ],
             "title": "Past Due At",
-            "description": "The timestamp when the subscription entered `past_due` status."
+            "description": "The timestamp when the subscription entered `past_due` status.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "pause_at_period_end": {
             "type": "boolean",
@@ -83754,7 +85383,10 @@
               }
             ],
             "title": "Paused At",
-            "description": "The timestamp when the subscription was paused."
+            "description": "The timestamp when the subscription was paused.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "resumes_at": {
             "anyOf": [
@@ -83767,7 +85399,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set."
+            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -83873,6 +85508,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -83998,7 +85636,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -84227,7 +85868,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -84733,7 +86377,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -84919,7 +86566,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -84932,7 +86582,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -85097,7 +86750,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -85110,7 +86766,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -85158,7 +86817,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -85375,7 +87037,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -85388,7 +87053,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -85460,7 +87128,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -85644,7 +87315,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "Date at which the paused subscription should automatically resume.\n\nIf not set, the subscription stays paused until it is resumed manually.\nMust be after the current period end."
+            "description": "Date at which the paused subscription should automatically resume.\n\nIf not set, the subscription stays paused until it is resumed manually.\nMust be after the current period end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "additionalProperties": false,
@@ -85666,7 +87340,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -85848,7 +87525,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -86021,7 +87701,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -86194,7 +87877,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -86383,7 +88069,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -86595,7 +88284,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -86768,7 +88460,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -86974,7 +88669,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -87152,7 +88850,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -87424,7 +89125,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "Set or extend the trial period of the subscription. If set to `now`, the trial will end immediately."
+            "description": "Set or extend the trial period of the subscription. If set to `now`, the trial will end immediately.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "additionalProperties": false,
@@ -87437,7 +89141,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Current Billing Period End",
-            "description": "Set a new date for the end of the current billing period. The subscription will renew on this date. The new date can be earlier or later than the current period end, as long as it's in the future.\n\nIt is not possible to update the current billing period on a canceled subscription."
+            "description": "Set a new date for the end of the current billing period. The subscription will renew on this date. The new date can be earlier or later than the current period end, as long as it's in the future.\n\nIt is not possible to update the current billing period on a canceled subscription.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "additionalProperties": false,
@@ -87474,7 +89181,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -87683,7 +89393,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -87916,7 +89629,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -87929,7 +89645,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -87956,7 +89675,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -87969,7 +89691,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -88185,7 +89910,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "version": {
             "anyOf": [
@@ -88210,7 +89938,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "size_readable": {
             "type": "string",
@@ -88263,7 +89994,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -88276,7 +90010,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89125,7 +90862,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89138,7 +90878,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89392,7 +91135,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89405,7 +91151,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89610,7 +91359,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89623,7 +91375,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89656,7 +91411,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89669,7 +91427,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89716,7 +91477,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89729,7 +91493,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89774,7 +91541,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89787,7 +91557,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89819,7 +91592,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89832,7 +91608,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89972,7 +91751,10 @@
               }
             ],
             "title": "Next Release At",
-            "description": "When the next chunk of the held balance becomes available for payout."
+            "description": "When the next chunk of the held balance becomes available for payout.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "next_release_amount": {
             "type": "integer",
@@ -89995,7 +91777,10 @@
               }
             ],
             "title": "Fully Available At",
-            "description": "When the whole held balance has become available for payout."
+            "description": "When the whole held balance has become available for payout.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -90247,7 +92032,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -90494,7 +92282,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -90507,7 +92298,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "email": {
             "type": "string",
@@ -91247,7 +93041,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -91260,7 +93057,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -91332,7 +93132,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Validated At"
+            "title": "Last Validated At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "expires_at": {
             "anyOf": [
@@ -91344,7 +93147,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "activation": {
             "anyOf": [
@@ -91460,7 +93266,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "Timestamp of the root event."
+            "description": "Timestamp of the root event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "values": {
             "additionalProperties": {
@@ -91584,7 +93393,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -91597,7 +93409,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -91693,7 +93508,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Benefit",
@@ -91722,7 +93540,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/BenefitGrantWebhook",
@@ -91751,7 +93572,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/BenefitGrantWebhook",
@@ -91780,7 +93604,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/BenefitGrantWebhook",
@@ -91809,7 +93636,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/BenefitGrantWebhook",
@@ -91838,7 +93668,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Benefit",
@@ -91867,7 +93700,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Checkout"
@@ -91895,7 +93731,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Checkout"
@@ -91923,7 +93762,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Checkout"
@@ -91951,7 +93793,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Customer"
@@ -91979,7 +93824,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Customer"
@@ -92007,7 +93855,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/CustomerSeat"
@@ -92035,7 +93886,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/CustomerSeat"
@@ -92063,7 +93917,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/CustomerSeat"
@@ -92091,7 +93948,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/CustomerState"
@@ -92119,7 +93979,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Customer"
@@ -92140,7 +94003,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -92153,7 +94019,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -92221,7 +94090,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Discount",
@@ -92250,7 +94122,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Discount",
@@ -92279,7 +94154,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Discount",
@@ -92301,7 +94179,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -92314,7 +94195,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -92532,7 +94416,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -92545,7 +94432,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -92686,7 +94576,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Member"
@@ -92714,7 +94607,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Member"
@@ -92742,7 +94638,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Member"
@@ -92770,7 +94669,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Order"
@@ -92798,7 +94700,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Order"
@@ -92826,7 +94731,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Order"
@@ -92854,7 +94762,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Order"
@@ -92882,7 +94793,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Organization"
@@ -92910,7 +94824,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Product"
@@ -92938,7 +94855,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Product"
@@ -92966,7 +94886,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Refund"
@@ -92994,7 +94917,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Refund"
@@ -93022,7 +94948,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93050,7 +94979,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93078,7 +95010,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93106,7 +95041,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93134,7 +95072,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93162,7 +95103,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93190,7 +95134,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93218,7 +95165,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93246,7 +95196,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93274,7 +95227,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"

--- a/docs/openapi/2026-10.openapi.json
+++ b/docs/openapi/2026-10.openapi.json
@@ -26599,7 +26599,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -26612,7 +26615,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "billing_name": {
             "anyOf": [
@@ -26715,7 +26721,10 @@
           "granted_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "expires_at": {
             "anyOf": [
@@ -26727,7 +26736,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -26739,7 +26751,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -28815,7 +28830,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -29022,7 +29040,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -29252,7 +29273,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -29392,7 +29416,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -29618,7 +29645,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -29852,7 +29882,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -30095,7 +30128,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -30108,7 +30144,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -30326,7 +30365,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -30339,7 +30381,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -30399,7 +30444,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -30412,7 +30460,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -30586,7 +30637,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -30726,7 +30780,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -30739,7 +30796,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -30960,7 +31020,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -30973,7 +31036,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -31033,7 +31099,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -31046,7 +31115,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -31266,7 +31338,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "version": {
             "anyOf": [
@@ -31291,7 +31366,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "flagged_malicious_at": {
             "anyOf": [
@@ -31303,7 +31381,10 @@
                 "type": "null"
               }
             ],
-            "title": "Flagged Malicious At"
+            "title": "Flagged Malicious At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "downloaders": {
             "type": "integer",
@@ -31357,7 +31438,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -31370,7 +31454,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -31588,7 +31675,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -31601,7 +31691,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -31661,7 +31754,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -31674,7 +31770,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -31825,7 +31924,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -31838,7 +31940,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32013,7 +32118,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32026,7 +32134,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32086,7 +32197,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32099,7 +32213,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32250,7 +32367,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32263,7 +32383,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32505,7 +32628,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32518,7 +32644,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32578,7 +32707,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32591,7 +32723,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -32746,7 +32881,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32759,7 +32897,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -32778,7 +32919,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -32796,7 +32940,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -32937,7 +33084,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -32950,7 +33100,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -32969,7 +33122,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -32987,7 +33143,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -33138,7 +33297,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -33151,7 +33313,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -33170,7 +33335,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -33188,7 +33356,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -33323,7 +33494,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -33336,7 +33510,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -33355,7 +33532,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -33373,7 +33553,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -33523,7 +33706,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -33536,7 +33722,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -33555,7 +33744,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -33573,7 +33765,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -33735,7 +33930,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -33748,7 +33946,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -33767,7 +33968,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -33785,7 +33989,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -33925,7 +34132,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -33938,7 +34148,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -33957,7 +34170,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -33975,7 +34191,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -34141,7 +34360,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -34154,7 +34376,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -34173,7 +34398,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -34191,7 +34419,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -34343,7 +34574,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -34356,7 +34590,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -34375,7 +34612,10 @@
               }
             ],
             "title": "Granted At",
-            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted."
+            "description": "The timestamp when the benefit was granted. If `None`, the benefit is not granted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_granted": {
             "type": "boolean",
@@ -34393,7 +34633,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked."
+            "description": "The timestamp when the benefit was revoked. If `None`, the benefit is not revoked.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "is_revoked": {
             "type": "boolean",
@@ -34561,7 +34804,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -34764,7 +35010,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -34777,7 +35026,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35043,7 +35295,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -35056,7 +35311,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35116,7 +35374,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -35129,7 +35390,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35328,7 +35592,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -35341,7 +35608,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35557,7 +35827,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -35570,7 +35843,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35655,7 +35931,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -35668,7 +35947,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -35879,7 +36161,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -36019,7 +36304,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -36032,7 +36320,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -36300,7 +36591,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -36313,7 +36607,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -36373,7 +36670,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -36386,7 +36686,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -36533,7 +36836,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -36546,7 +36852,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -36625,7 +36934,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -36854,7 +37166,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -36867,7 +37182,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -37277,7 +37595,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -37290,7 +37611,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "custom_field_data": {
             "additionalProperties": {
@@ -37311,6 +37635,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -37339,7 +37666,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Expires At",
-            "description": "Expiration date and time of the checkout session."
+            "description": "Expiration date and time of the checkout session.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "success_url": {
             "type": "string",
@@ -37536,7 +37866,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "End date and time of the trial period, if any."
+            "description": "End date and time of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -38031,6 +38364,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -38265,7 +38601,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -38704,7 +39043,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -38717,7 +39059,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -39453,7 +39798,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -39466,7 +39814,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -39835,7 +40186,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -39848,7 +40202,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -39975,6 +40332,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -40341,7 +40701,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -40354,7 +40717,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -40593,6 +40959,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -41033,6 +41402,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -41468,7 +41840,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -41481,7 +41856,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "custom_field_data": {
             "additionalProperties": {
@@ -41502,6 +41880,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -41530,7 +41911,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Expires At",
-            "description": "Expiration date and time of the checkout session."
+            "description": "Expiration date and time of the checkout session.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "success_url": {
             "type": "string",
@@ -41727,7 +42111,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "End date and time of the trial period, if any."
+            "description": "End date and time of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -42112,7 +42499,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -42125,7 +42515,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "custom_field_data": {
             "additionalProperties": {
@@ -42146,6 +42539,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -42175,7 +42571,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Expires At",
-            "description": "Expiration date and time of the checkout session."
+            "description": "Expiration date and time of the checkout session.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "success_url": {
             "type": "string",
@@ -42372,7 +42771,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "End date and time of the trial period, if any."
+            "description": "End date and time of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -42801,6 +43203,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -43196,6 +43601,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -43420,7 +43828,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -43433,7 +43844,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -43484,7 +43898,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -43497,7 +43914,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -44171,7 +44591,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -44184,7 +44607,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -44689,7 +45115,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -44702,7 +45131,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -44795,7 +45227,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -44808,7 +45243,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -44901,7 +45339,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -44914,7 +45355,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -45040,7 +45484,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -45053,7 +45500,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -45635,7 +46085,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -45648,7 +46101,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -45666,7 +46122,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -45678,7 +46137,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -45793,7 +46255,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -45806,7 +46271,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -45824,7 +46292,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -45836,7 +46307,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -45975,7 +46449,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -45988,7 +46465,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46006,7 +46486,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46018,7 +46501,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -46133,7 +46619,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -46146,7 +46635,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46164,7 +46656,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46176,7 +46671,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -46291,7 +46789,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -46304,7 +46805,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46322,7 +46826,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46334,7 +46841,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -46473,7 +46983,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -46486,7 +46999,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46504,7 +47020,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46516,7 +47035,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -46631,7 +47153,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -46644,7 +47169,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46662,7 +47190,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46674,7 +47205,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -46789,7 +47323,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -46802,7 +47339,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -46820,7 +47360,10 @@
                 "type": "null"
               }
             ],
-            "title": "Granted At"
+            "title": "Granted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -46832,7 +47375,10 @@
                 "type": "null"
               }
             ],
-            "title": "Revoked At"
+            "title": "Revoked At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -47065,7 +47611,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -47100,7 +47649,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -47289,7 +47841,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -47302,7 +47857,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -47370,7 +47928,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -47383,7 +47944,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -47431,7 +47995,10 @@
           "expires_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "return_url": {
             "anyOf": [
@@ -47464,7 +48031,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -47687,7 +48257,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The start of the period."
+            "description": "The start of the period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "new_customers": {
             "type": "integer",
@@ -47723,7 +48296,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -47736,7 +48312,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -47896,7 +48475,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -47909,7 +48491,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -48109,7 +48694,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -48122,7 +48710,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -48257,7 +48848,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -48270,7 +48864,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/OrderStatus",
@@ -48507,7 +49104,10 @@
               }
             ],
             "title": "Next Payment Attempt At",
-            "description": "When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted."
+            "description": "When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "product": {
             "anyOf": [
@@ -48732,7 +49332,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -48745,7 +49348,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -48950,7 +49556,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -48963,7 +49572,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -49010,13 +49622,19 @@
             "type": "string",
             "format": "date-time",
             "title": "Current Period Start",
-            "description": "The start timestamp of the current billing period."
+            "description": "The start timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_period_end": {
             "type": "string",
             "format": "date-time",
             "title": "Current Period End",
-            "description": "The end timestamp of the current billing period."
+            "description": "The end timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_start": {
             "anyOf": [
@@ -49029,7 +49647,10 @@
               }
             ],
             "title": "Current Meter Period Start",
-            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence."
+            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_end": {
             "anyOf": [
@@ -49042,7 +49663,10 @@
               }
             ],
             "title": "Current Meter Period End",
-            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew."
+            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_start": {
             "anyOf": [
@@ -49055,7 +49679,10 @@
               }
             ],
             "title": "Trial Start",
-            "description": "The start timestamp of the trial period, if any."
+            "description": "The start timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_end": {
             "anyOf": [
@@ -49068,7 +49695,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "The end timestamp of the trial period, if any."
+            "description": "The end timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "cancel_at_period_end": {
             "type": "boolean",
@@ -49086,7 +49716,10 @@
               }
             ],
             "title": "Canceled At",
-            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`."
+            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -49099,7 +49732,10 @@
               }
             ],
             "title": "Started At",
-            "description": "The timestamp when the subscription started."
+            "description": "The timestamp when the subscription started.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -49112,7 +49748,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "The timestamp when the subscription will end."
+            "description": "The timestamp when the subscription will end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ended_at": {
             "anyOf": [
@@ -49125,7 +49764,10 @@
               }
             ],
             "title": "Ended At",
-            "description": "The timestamp when the subscription ended."
+            "description": "The timestamp when the subscription ended.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due_at": {
             "anyOf": [
@@ -49138,7 +49780,10 @@
               }
             ],
             "title": "Past Due At",
-            "description": "The timestamp when the subscription entered `past_due` status."
+            "description": "The timestamp when the subscription entered `past_due` status.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "pause_at_period_end": {
             "type": "boolean",
@@ -49156,7 +49801,10 @@
               }
             ],
             "title": "Paused At",
-            "description": "The timestamp when the subscription was paused."
+            "description": "The timestamp when the subscription was paused.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "resumes_at": {
             "anyOf": [
@@ -49169,7 +49817,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set."
+            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -49324,7 +49975,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49337,7 +49991,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -49464,7 +50121,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49477,7 +50137,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -49625,7 +50288,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49638,7 +50304,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -49685,7 +50354,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49698,7 +50370,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -49744,7 +50419,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49757,7 +50435,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -49965,7 +50646,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -49978,7 +50662,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -50172,7 +50859,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -50185,7 +50875,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -50356,7 +51049,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -50369,7 +51065,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -50479,7 +51178,10 @@
               }
             ],
             "title": "Invitation Token Expires At",
-            "description": "When the invitation token expires"
+            "description": "When the invitation token expires",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "claimed_at": {
             "anyOf": [
@@ -50492,7 +51194,10 @@
               }
             ],
             "title": "Claimed At",
-            "description": "When the seat was claimed"
+            "description": "When the seat was claimed",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -50505,7 +51210,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "When the seat was revoked"
+            "description": "When the seat was revoked",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "seat_metadata": {
             "anyOf": [
@@ -50751,7 +51459,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -50764,7 +51475,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -50779,7 +51493,10 @@
           "expires_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "return_url": {
             "anyOf": [
@@ -51144,7 +51861,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51157,7 +51877,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "granted_at": {
             "type": "string",
@@ -51165,7 +51888,7 @@
             "title": "Granted At",
             "description": "The timestamp when the benefit was granted.",
             "examples": [
-              "2025-01-03T13:37:00Z"
+              "2025-01-03T13:37:00.123456Z"
             ]
           },
           "benefit_id": {
@@ -51249,7 +51972,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51262,7 +51988,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -51422,7 +52151,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -51435,7 +52167,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -51512,7 +52247,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51525,7 +52263,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "meter_id": {
             "type": "string",
@@ -51589,7 +52330,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51602,7 +52346,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "custom_field_data": {
             "additionalProperties": {
@@ -51623,6 +52370,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -51670,7 +52420,7 @@
             "title": "Current Period Start",
             "description": "The start timestamp of the current billing period.",
             "examples": [
-              "2025-02-03T13:37:00Z"
+              "2025-02-03T13:37:00.123456Z"
             ]
           },
           "current_period_end": {
@@ -51679,7 +52429,7 @@
             "title": "Current Period End",
             "description": "The end timestamp of the current billing period.",
             "examples": [
-              "2025-03-03T13:37:00Z"
+              "2025-03-03T13:37:00.123456Z"
             ]
           },
           "trial_start": {
@@ -51695,7 +52445,7 @@
             "title": "Trial Start",
             "description": "The start timestamp of the trial period, if any.",
             "examples": [
-              "2025-02-03T13:37:00Z"
+              "2025-02-03T13:37:00.123456Z"
             ]
           },
           "trial_end": {
@@ -51711,7 +52461,7 @@
             "title": "Trial End",
             "description": "The end timestamp of the trial period, if any.",
             "examples": [
-              "2025-03-03T13:37:00Z"
+              "2025-03-03T13:37:00.123456Z"
             ]
           },
           "cancel_at_period_end": {
@@ -51751,7 +52501,7 @@
             "title": "Started At",
             "description": "The timestamp when the subscription started.",
             "examples": [
-              "2025-01-03T13:37:00Z"
+              "2025-01-03T13:37:00.123456Z"
             ]
           },
           "ends_at": {
@@ -51867,7 +52617,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51880,7 +52633,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -51950,7 +52706,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -51963,7 +52722,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -52130,7 +52892,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -52143,7 +52908,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -52213,7 +52981,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -52226,7 +52997,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -52273,13 +53047,19 @@
             "type": "string",
             "format": "date-time",
             "title": "Current Period Start",
-            "description": "The start timestamp of the current billing period."
+            "description": "The start timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_period_end": {
             "type": "string",
             "format": "date-time",
             "title": "Current Period End",
-            "description": "The end timestamp of the current billing period."
+            "description": "The end timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_start": {
             "anyOf": [
@@ -52292,7 +53072,10 @@
               }
             ],
             "title": "Current Meter Period Start",
-            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence."
+            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_end": {
             "anyOf": [
@@ -52305,7 +53088,10 @@
               }
             ],
             "title": "Current Meter Period End",
-            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew."
+            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_start": {
             "anyOf": [
@@ -52318,7 +53104,10 @@
               }
             ],
             "title": "Trial Start",
-            "description": "The start timestamp of the trial period, if any."
+            "description": "The start timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_end": {
             "anyOf": [
@@ -52331,7 +53120,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "The end timestamp of the trial period, if any."
+            "description": "The end timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "cancel_at_period_end": {
             "type": "boolean",
@@ -52349,7 +53141,10 @@
               }
             ],
             "title": "Canceled At",
-            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`."
+            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -52362,7 +53157,10 @@
               }
             ],
             "title": "Started At",
-            "description": "The timestamp when the subscription started."
+            "description": "The timestamp when the subscription started.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -52375,7 +53173,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "The timestamp when the subscription will end."
+            "description": "The timestamp when the subscription will end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ended_at": {
             "anyOf": [
@@ -52388,7 +53189,10 @@
               }
             ],
             "title": "Ended At",
-            "description": "The timestamp when the subscription ended."
+            "description": "The timestamp when the subscription ended.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due_at": {
             "anyOf": [
@@ -52401,7 +53205,10 @@
               }
             ],
             "title": "Past Due At",
-            "description": "The timestamp when the subscription entered `past_due` status."
+            "description": "The timestamp when the subscription entered `past_due` status.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "pause_at_period_end": {
             "type": "boolean",
@@ -52419,7 +53226,10 @@
               }
             ],
             "title": "Paused At",
-            "description": "The timestamp when the subscription was paused."
+            "description": "The timestamp when the subscription was paused.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "resumes_at": {
             "anyOf": [
@@ -52432,7 +53242,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set."
+            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -52703,7 +53516,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -52716,7 +53532,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -52780,7 +53599,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -52793,7 +53615,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -52834,7 +53659,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "Date at which the paused subscription should automatically resume. If not set, it stays paused until resumed. Must be after the current period end."
+            "description": "Date at which the paused subscription should automatically resume. If not set, it stays paused until resumed. Must be after the current period end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "additionalProperties": false,
@@ -52856,7 +53684,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -52869,7 +53700,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -53203,7 +54037,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -53216,7 +54053,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -53383,7 +54223,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -53396,7 +54239,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -53848,7 +54694,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -54125,7 +54974,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -54138,7 +54990,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -54459,7 +55314,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Optional timestamp after which the discount is redeemable."
+            "description": "Optional timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -54472,7 +55330,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Optional timestamp after which the discount is no longer redeemable."
+            "description": "Optional timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -54660,7 +55521,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -54673,7 +55537,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -54712,7 +55579,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -54725,7 +55595,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -54839,7 +55712,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -54852,7 +55728,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -54891,7 +55770,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -54904,7 +55786,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55013,7 +55898,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -55026,7 +55914,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -55065,7 +55956,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55078,7 +55972,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55197,7 +56094,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -55210,7 +56110,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -55249,7 +56152,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55262,7 +56168,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55385,7 +56294,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Optional timestamp after which the discount is redeemable."
+            "description": "Optional timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55398,7 +56310,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Optional timestamp after which the discount is no longer redeemable."
+            "description": "Optional timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55522,7 +56437,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -55535,7 +56453,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -55574,7 +56495,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55587,7 +56511,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55677,7 +56604,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -55690,7 +56620,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -55729,7 +56662,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55742,7 +56678,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55827,7 +56766,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -55840,7 +56782,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -55879,7 +56824,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -55892,7 +56840,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -55987,7 +56938,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -56000,7 +56954,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -56039,7 +56996,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Timestamp after which the discount is redeemable."
+            "description": "Timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -56052,7 +57012,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Timestamp after which the discount is no longer redeemable."
+            "description": "Timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -56129,7 +57092,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -56142,7 +57108,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -56385,7 +57354,10 @@
               }
             ],
             "title": "Starts At",
-            "description": "Optional timestamp after which the discount is redeemable."
+            "description": "Optional timestamp after which the discount is redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -56398,7 +57370,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Optional timestamp after which the discount is no longer redeemable."
+            "description": "Optional timestamp after which the discount is no longer redeemable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "max_redemptions": {
             "anyOf": [
@@ -56552,7 +57527,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -56565,7 +57543,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -56647,7 +57628,10 @@
               }
             ],
             "title": "Evidence Due By",
-            "description": "Deadline to submit evidence in response to the dispute. `None` when no response is required."
+            "description": "Deadline to submit evidence in response to the dispute. `None` when no response is required.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due": {
             "type": "boolean",
@@ -56752,7 +57736,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -56765,7 +57752,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -56930,7 +57920,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -56943,7 +57936,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -57029,7 +58025,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -57042,7 +58041,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -57298,7 +58300,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "version": {
             "anyOf": [
@@ -57323,7 +58328,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "flagged_malicious_at": {
             "anyOf": [
@@ -57335,7 +58343,10 @@
                 "type": "null"
               }
             ],
-            "title": "Flagged Malicious At"
+            "title": "Flagged Malicious At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "size_readable": {
             "type": "string",
@@ -57541,7 +58552,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "name": {
             "type": "string",
@@ -57627,7 +58641,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "name": {
             "type": "string",
@@ -57788,13 +58805,19 @@
             "type": "string",
             "format": "date-time",
             "title": "First Seen",
-            "description": "The first time the event occurred."
+            "description": "The first time the event occurred.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "last_seen": {
             "type": "string",
             "format": "date-time",
             "title": "Last Seen",
-            "description": "The last time the event occurred."
+            "description": "The last time the event occurred.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -57947,7 +58970,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -57960,7 +58986,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -58064,7 +59093,10 @@
               }
             ],
             "title": "Created At",
-            "description": "Creation timestamp of the event type. Null for system event types."
+            "description": "Creation timestamp of the event type. Null for system event types.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -58077,7 +59109,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the event type. Null for system event types."
+            "description": "Last modification timestamp of the event type. Null for system event types.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "name": {
             "type": "string",
@@ -58120,13 +59155,19 @@
             "type": "string",
             "format": "date-time",
             "title": "First Seen",
-            "description": "The first time the event occurred."
+            "description": "The first time the event occurred.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "last_seen": {
             "type": "string",
             "format": "date-time",
             "title": "Last Seen",
-            "description": "The last time the event occurred."
+            "description": "The last time the event occurred.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -58244,7 +59285,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -58257,7 +59301,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -58459,7 +59506,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "download": {
             "$ref": "#/components/schemas/S3DownloadURL"
@@ -58655,7 +59705,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "upload": {
             "$ref": "#/components/schemas/S3FileUploadMultipart"
@@ -58821,7 +59874,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -58834,7 +59890,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -59459,7 +60518,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -59472,7 +60534,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -59801,7 +60866,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -59814,7 +60882,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -59931,7 +61002,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -59944,7 +61018,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -60148,7 +61225,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -60160,7 +61240,10 @@
                 "type": "null"
               }
             ],
-            "title": "Modified At"
+            "title": "Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -60213,7 +61296,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -60225,7 +61311,10 @@
                 "type": "null"
               }
             ],
-            "title": "Modified At"
+            "title": "Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "license_key": {
             "$ref": "#/components/schemas/LicenseKeyRead"
@@ -60258,7 +61347,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -60271,7 +61363,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -60436,7 +61531,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -60449,7 +61547,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -60522,7 +61623,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -60535,7 +61639,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -60607,7 +61714,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Validated At"
+            "title": "Last Validated At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "expires_at": {
             "anyOf": [
@@ -60619,7 +61729,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -60709,7 +61822,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -60864,7 +61980,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -60877,7 +61996,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -60949,7 +62071,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Validated At"
+            "title": "Last Validated At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "expires_at": {
             "anyOf": [
@@ -60961,7 +62086,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "activations": {
             "items": {
@@ -62177,7 +63305,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -62236,7 +63367,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -62295,7 +63429,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -62420,7 +63557,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -62626,7 +63766,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "type": "string",
@@ -62763,7 +63906,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -62776,7 +63922,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -63141,7 +64290,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -63154,7 +64306,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -63726,7 +64881,10 @@
               }
             ],
             "title": "Renews At",
-            "description": "When the subscription next renews on the source, as staged at import. Null for non-subscription rows or when the source reported none."
+            "description": "When the subscription next renews on the source, as staged at import. Null for non-subscription rows or when the source reported none.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "has_payment_method": {
             "anyOf": [
@@ -63912,7 +65070,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -63925,7 +65086,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -64013,7 +65177,10 @@
               }
             ],
             "title": "Archived At",
-            "description": "Whether the meter is archived and the time it was archived."
+            "description": "Whether the meter is archived and the time it was archived.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -64164,7 +65331,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -64346,7 +65516,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp for the current period."
+            "description": "The timestamp for the current period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "quantity": {
             "type": "number",
@@ -64376,7 +65549,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -64748,7 +65924,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "value": {
             "type": "number",
@@ -64810,7 +65989,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -64823,7 +66005,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -64905,7 +66090,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "Timestamp of this period data."
+            "description": "Timestamp of this period data.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "active_subscriptions": {
             "anyOf": [
@@ -67273,7 +68461,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -67286,7 +68477,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -67506,7 +68700,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -67519,7 +68716,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "client_id": {
             "type": "string",
@@ -67804,7 +69004,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -67817,7 +69020,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "client_id": {
             "type": "string",
@@ -67898,7 +69104,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -67911,7 +69120,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "platform": {
             "$ref": "#/components/schemas/OAuthPlatform"
@@ -68126,7 +69338,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -68139,7 +69354,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/OrderStatus",
@@ -68376,7 +69594,10 @@
               }
             ],
             "title": "Next Payment Attempt At",
-            "description": "When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted."
+            "description": "When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -68400,6 +69621,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -68601,6 +69825,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -68726,7 +69953,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -68739,7 +69969,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -68904,7 +70137,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -68917,7 +70153,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -69016,7 +70255,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -69029,7 +70271,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -69175,7 +70420,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -69384,7 +70632,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -69397,7 +70648,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -69554,7 +70808,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -69750,7 +71007,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -69763,7 +71023,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -69810,13 +71073,19 @@
             "type": "string",
             "format": "date-time",
             "title": "Current Period Start",
-            "description": "The start timestamp of the current billing period."
+            "description": "The start timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_period_end": {
             "type": "string",
             "format": "date-time",
             "title": "Current Period End",
-            "description": "The end timestamp of the current billing period."
+            "description": "The end timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_start": {
             "anyOf": [
@@ -69829,7 +71098,10 @@
               }
             ],
             "title": "Current Meter Period Start",
-            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence."
+            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_end": {
             "anyOf": [
@@ -69842,7 +71114,10 @@
               }
             ],
             "title": "Current Meter Period End",
-            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew."
+            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_start": {
             "anyOf": [
@@ -69855,7 +71130,10 @@
               }
             ],
             "title": "Trial Start",
-            "description": "The start timestamp of the trial period, if any."
+            "description": "The start timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_end": {
             "anyOf": [
@@ -69868,7 +71146,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "The end timestamp of the trial period, if any."
+            "description": "The end timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "cancel_at_period_end": {
             "type": "boolean",
@@ -69886,7 +71167,10 @@
               }
             ],
             "title": "Canceled At",
-            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`."
+            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -69899,7 +71183,10 @@
               }
             ],
             "title": "Started At",
-            "description": "The timestamp when the subscription started."
+            "description": "The timestamp when the subscription started.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -69912,7 +71199,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "The timestamp when the subscription will end."
+            "description": "The timestamp when the subscription will end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ended_at": {
             "anyOf": [
@@ -69925,7 +71215,10 @@
               }
             ],
             "title": "Ended At",
-            "description": "The timestamp when the subscription ended."
+            "description": "The timestamp when the subscription ended.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due_at": {
             "anyOf": [
@@ -69938,7 +71231,10 @@
               }
             ],
             "title": "Past Due At",
-            "description": "The timestamp when the subscription entered `past_due` status."
+            "description": "The timestamp when the subscription entered `past_due` status.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "pause_at_period_end": {
             "type": "boolean",
@@ -69956,7 +71252,10 @@
               }
             ],
             "title": "Paused At",
-            "description": "The timestamp when the subscription was paused."
+            "description": "The timestamp when the subscription was paused.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "resumes_at": {
             "anyOf": [
@@ -69969,7 +71268,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set."
+            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -70101,7 +71403,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -70346,7 +71651,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -70503,7 +71811,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -70516,7 +71827,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -70602,7 +71916,10 @@
               }
             ],
             "title": "Details Submitted At",
-            "description": "When the business details were submitted for review."
+            "description": "When the business details were submitted for review.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "onboarding_resubmission_requested_at": {
             "anyOf": [
@@ -70615,7 +71932,10 @@
               }
             ],
             "title": "Onboarding Resubmission Requested At",
-            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable."
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "sso_enforced": {
             "type": "boolean",
@@ -71248,7 +72568,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -71261,7 +72584,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -71285,7 +72611,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "comment": {
             "type": "string",
@@ -71301,7 +72630,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Used At"
+            "title": "Last Used At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -71465,7 +72797,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Appeal Submitted At",
-            "description": "When the appeal was submitted"
+            "description": "When the appeal was submitted",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -71635,7 +72970,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "version": {
             "anyOf": [
@@ -71660,7 +72998,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "size_readable": {
             "type": "string",
@@ -71971,7 +73312,10 @@
           "expires_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -73188,7 +74532,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -73201,7 +74548,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -73287,7 +74637,10 @@
               }
             ],
             "title": "Details Submitted At",
-            "description": "When the business details were submitted for review."
+            "description": "When the business details were submitted for review.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "onboarding_resubmission_requested_at": {
             "anyOf": [
@@ -73300,7 +74653,10 @@
               }
             ],
             "title": "Onboarding Resubmission Requested At",
-            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable."
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "sso_enforced": {
             "type": "boolean",
@@ -73951,7 +75307,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "The time the OrganizationMember was created."
+            "description": "The time the OrganizationMember was created.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "email": {
             "type": "string",
@@ -74076,7 +75435,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "invoice_number": {
             "anyOf": [
@@ -74254,7 +75616,10 @@
               }
             ],
             "title": "Onboarding Resubmission Requested At",
-            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable. Null for organizations that have never been reset for review."
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable. Null for organizations that have never been reset for review.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -74429,7 +75794,10 @@
           "submitted_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Submitted At"
+            "title": "Submitted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "reviewed_at": {
             "anyOf": [
@@ -74441,7 +75809,10 @@
                 "type": "null"
               }
             ],
-            "title": "Reviewed At"
+            "title": "Reviewed At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "decision": {
             "anyOf": [
@@ -74566,7 +75937,10 @@
                 "type": "null"
               }
             ],
-            "title": "Submitted At"
+            "title": "Submitted At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "verdict": {
             "anyOf": [
@@ -74650,7 +76024,10 @@
               }
             ],
             "title": "Appeal Submitted At",
-            "description": "When appeal was submitted"
+            "description": "When appeal was submitted",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "appeal_reason": {
             "anyOf": [
@@ -74686,7 +76063,10 @@
               }
             ],
             "title": "Appeal Reviewed At",
-            "description": "When appeal was reviewed"
+            "description": "When appeal was reviewed",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "appeal_case_id": {
             "anyOf": [
@@ -74791,7 +76171,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -74804,7 +76187,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -75208,7 +76594,10 @@
                 "type": "null"
               }
             ],
-            "title": "Current Period Start"
+            "title": "Current Period Start",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_period_end": {
             "anyOf": [
@@ -75220,7 +76609,10 @@
                 "type": "null"
               }
             ],
-            "title": "Current Period End"
+            "title": "Current Period End",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "cancel_at_period_end": {
             "type": "boolean",
@@ -75237,7 +76629,10 @@
                 "type": "null"
               }
             ],
-            "title": "Canceled At"
+            "title": "Canceled At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -75249,7 +76644,10 @@
                 "type": "null"
               }
             ],
-            "title": "Started At"
+            "title": "Started At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -75261,7 +76659,10 @@
                 "type": "null"
               }
             ],
-            "title": "Ends At"
+            "title": "Ends At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "pending_change": {
             "anyOf": [
@@ -75387,7 +76788,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "Estimated date the discount stops applying. Computed for 'repeating' discounts from the subscription's started_at + duration_in_months; null for 'once' and 'forever' durations."
+            "description": "Estimated date the discount stops applying. Computed for 'repeating' discounts from the subscription's started_at + duration_in_months; null for 'once' and 'forever' durations.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -75409,7 +76813,10 @@
           "applies_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Applies At"
+            "title": "Applies At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -75492,7 +76899,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Last Seen At",
-            "description": "When it last opened one."
+            "description": "When it last opened one.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -76261,7 +77671,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -76274,7 +77687,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -76360,7 +77776,10 @@
               }
             ],
             "title": "Details Submitted At",
-            "description": "When the business details were submitted for review."
+            "description": "When the business details were submitted for review.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "onboarding_resubmission_requested_at": {
             "anyOf": [
@@ -76373,7 +77792,10 @@
               }
             ],
             "title": "Onboarding Resubmission Requested At",
-            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable."
+            "description": "When Polar requested that the organization review and resubmit its onboarding information, if applicable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "sso_enforced": {
             "type": "boolean",
@@ -77320,7 +78742,10 @@
               }
             ],
             "title": "Expected At",
-            "description": "When Ops expects this step to land."
+            "description": "When Ops expects this step to land.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -77333,7 +78758,10 @@
               }
             ],
             "title": "Started At",
-            "description": "When the step became actionable."
+            "description": "When the step became actionable.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "completed_at": {
             "anyOf": [
@@ -77346,7 +78774,10 @@
               }
             ],
             "title": "Completed At",
-            "description": "When the step was completed."
+            "description": "When the step was completed.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "completed_by": {
             "anyOf": [
@@ -77582,7 +79013,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -77595,7 +79029,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -77677,7 +79114,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -77690,7 +79130,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -77750,7 +79193,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -77763,7 +79209,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "processor": {
             "$ref": "#/components/schemas/PaymentProcessor"
@@ -77940,7 +79389,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -77953,7 +79405,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -77977,7 +79432,10 @@
                 "type": "null"
               }
             ],
-            "title": "Paid At"
+            "title": "Paid At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "currency": {
             "type": "string",
@@ -78077,7 +79535,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -78090,7 +79551,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "type": {
             "$ref": "#/components/schemas/PayoutAccountType"
@@ -78264,7 +79728,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -78277,7 +79744,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -78336,7 +79806,10 @@
                 "type": "null"
               }
             ],
-            "title": "Paid At"
+            "title": "Paid At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -78478,7 +79951,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -78491,7 +79967,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -78503,7 +79982,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Applies At",
-            "description": "The date and time when the subscription update will be applied."
+            "description": "The date and time when the subscription update will be applied.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "product_id": {
             "anyOf": [
@@ -78562,7 +80044,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -78575,7 +80060,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -78599,7 +80087,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "comment": {
             "type": "string",
@@ -78615,7 +80106,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Used At"
+            "title": "Last Used At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -79074,7 +80568,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -79087,7 +80584,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_interval": {
             "anyOf": [
@@ -79819,7 +81319,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "version": {
             "anyOf": [
@@ -79844,7 +81347,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "size_readable": {
             "type": "string",
@@ -79919,7 +81425,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -79932,7 +81441,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -80096,7 +81608,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -80109,7 +81624,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -80272,7 +81790,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -80285,7 +81806,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -80438,7 +81962,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -80451,7 +81978,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -80616,7 +82146,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -80629,7 +82162,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -80858,7 +82394,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -80871,7 +82410,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -81383,7 +82925,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -81396,7 +82941,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -81574,7 +83122,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -81587,7 +83138,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -81669,7 +83223,10 @@
               }
             ],
             "title": "Evidence Due By",
-            "description": "Deadline to submit evidence in response to the dispute. `None` when no response is required."
+            "description": "Deadline to submit evidence in response to the dispute. `None` when no response is required.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due": {
             "type": "boolean",
@@ -81801,7 +83358,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -81814,7 +83374,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -81940,7 +83503,10 @@
           "expires_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -82089,7 +83655,10 @@
           "expires_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "headers": {
             "additionalProperties": {
@@ -82793,7 +84362,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -82806,7 +84378,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -82924,7 +84499,10 @@
               }
             ],
             "title": "Installed At",
-            "description": "Timestamp when the Slack app was installed."
+            "description": "Timestamp when the Slack app was installed.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "revoked_at": {
             "anyOf": [
@@ -82937,7 +84515,10 @@
               }
             ],
             "title": "Revoked At",
-            "description": "Timestamp when the Slack app was revoked or uninstalled."
+            "description": "Timestamp when the Slack app was revoked or uninstalled.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -83239,19 +84820,28 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "Period timestamp"
+            "description": "Period timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "period_start": {
             "type": "string",
             "format": "date-time",
             "title": "Period Start",
-            "description": "Period start (inclusive)"
+            "description": "Period start (inclusive)",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "period_end": {
             "type": "string",
             "format": "date-time",
             "title": "Period End",
-            "description": "Period end (exclusive)"
+            "description": "Period end (exclusive)",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "stats": {
             "items": {
@@ -83411,7 +85001,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -83424,7 +85017,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -83471,13 +85067,19 @@
             "type": "string",
             "format": "date-time",
             "title": "Current Period Start",
-            "description": "The start timestamp of the current billing period."
+            "description": "The start timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_period_end": {
             "type": "string",
             "format": "date-time",
             "title": "Current Period End",
-            "description": "The end timestamp of the current billing period."
+            "description": "The end timestamp of the current billing period.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_start": {
             "anyOf": [
@@ -83490,7 +85092,10 @@
               }
             ],
             "title": "Current Meter Period Start",
-            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence."
+            "description": "The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "current_meter_period_end": {
             "anyOf": [
@@ -83503,7 +85108,10 @@
               }
             ],
             "title": "Current Meter Period End",
-            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew."
+            "description": "The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_start": {
             "anyOf": [
@@ -83516,7 +85124,10 @@
               }
             ],
             "title": "Trial Start",
-            "description": "The start timestamp of the trial period, if any."
+            "description": "The start timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "trial_end": {
             "anyOf": [
@@ -83529,7 +85140,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "The end timestamp of the trial period, if any."
+            "description": "The end timestamp of the trial period, if any.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "cancel_at_period_end": {
             "type": "boolean",
@@ -83547,7 +85161,10 @@
               }
             ],
             "title": "Canceled At",
-            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`."
+            "description": "The timestamp when the subscription was canceled. The subscription might still be active if `cancel_at_period_end` is `true`.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "started_at": {
             "anyOf": [
@@ -83560,7 +85177,10 @@
               }
             ],
             "title": "Started At",
-            "description": "The timestamp when the subscription started."
+            "description": "The timestamp when the subscription started.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ends_at": {
             "anyOf": [
@@ -83573,7 +85193,10 @@
               }
             ],
             "title": "Ends At",
-            "description": "The timestamp when the subscription will end."
+            "description": "The timestamp when the subscription will end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "ended_at": {
             "anyOf": [
@@ -83586,7 +85209,10 @@
               }
             ],
             "title": "Ended At",
-            "description": "The timestamp when the subscription ended."
+            "description": "The timestamp when the subscription ended.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "past_due_at": {
             "anyOf": [
@@ -83599,7 +85225,10 @@
               }
             ],
             "title": "Past Due At",
-            "description": "The timestamp when the subscription entered `past_due` status."
+            "description": "The timestamp when the subscription entered `past_due` status.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "pause_at_period_end": {
             "type": "boolean",
@@ -83617,7 +85246,10 @@
               }
             ],
             "title": "Paused At",
-            "description": "The timestamp when the subscription was paused."
+            "description": "The timestamp when the subscription was paused.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "resumes_at": {
             "anyOf": [
@@ -83630,7 +85262,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set."
+            "description": "The timestamp when a paused subscription is scheduled to automatically resume, if set.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -83736,6 +85371,9 @@
                 {
                   "type": "null"
                 }
+              ],
+              "examples": [
+                "2025-01-03T13:37:00.123456Z"
               ]
             },
             "type": "object",
@@ -83861,7 +85499,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -84090,7 +85731,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -84596,7 +86240,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -84782,7 +86429,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -84795,7 +86445,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "metadata": {
             "$ref": "#/components/schemas/MetadataOutputType"
@@ -84960,7 +86613,10 @@
               }
             ],
             "title": "Deleted At",
-            "description": "Timestamp for when the customer was soft deleted."
+            "description": "Timestamp for when the customer was soft deleted.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "first_user_event_at": {
             "anyOf": [
@@ -84973,7 +86629,10 @@
               }
             ],
             "title": "First User Event At",
-            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested."
+            "description": "Timestamp of the first event ingested for this customer. Can predate `created_at`, and is null if no event was ever ingested.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "avatar_url": {
             "anyOf": [
@@ -85021,7 +86680,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -85238,7 +86900,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -85251,7 +86916,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -85323,7 +86991,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -85507,7 +87178,10 @@
               }
             ],
             "title": "Resumes At",
-            "description": "Date at which the paused subscription should automatically resume.\n\nIf not set, the subscription stays paused until it is resumed manually.\nMust be after the current period end."
+            "description": "Date at which the paused subscription should automatically resume.\n\nIf not set, the subscription stays paused until it is resumed manually.\nMust be after the current period end.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "additionalProperties": false,
@@ -85529,7 +87203,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -85711,7 +87388,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -85884,7 +87564,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -86057,7 +87740,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -86246,7 +87932,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -86458,7 +88147,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -86631,7 +88323,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -86837,7 +88532,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -87015,7 +88713,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -87287,7 +88988,10 @@
               }
             ],
             "title": "Trial End",
-            "description": "Set or extend the trial period of the subscription. If set to `now`, the trial will end immediately."
+            "description": "Set or extend the trial period of the subscription. If set to `now`, the trial will end immediately.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "additionalProperties": false,
@@ -87300,7 +89004,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Current Billing Period End",
-            "description": "Set a new date for the end of the current billing period. The subscription will renew on this date. The new date can be earlier or later than the current period end, as long as it's in the future.\n\nIt is not possible to update the current billing period on a canceled subscription."
+            "description": "Set a new date for the end of the current billing period. The subscription will renew on this date. The new date can be earlier or later than the current period end, as long as it's in the future.\n\nIt is not possible to update the current billing period on a canceled subscription.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "additionalProperties": false,
@@ -87337,7 +89044,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -87546,7 +89256,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -87779,7 +89492,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -87792,7 +89508,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -87819,7 +89538,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -87832,7 +89554,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -88048,7 +89773,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Modified At"
+            "title": "Last Modified At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "version": {
             "anyOf": [
@@ -88073,7 +89801,10 @@
           "created_at": {
             "type": "string",
             "format": "date-time",
-            "title": "Created At"
+            "title": "Created At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "size_readable": {
             "type": "string",
@@ -88126,7 +89857,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -88139,7 +89873,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -88988,7 +90725,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89001,7 +90741,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89255,7 +90998,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89268,7 +91014,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89473,7 +91222,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89486,7 +91238,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89519,7 +91274,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89532,7 +91290,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89579,7 +91340,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89592,7 +91356,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89637,7 +91404,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89650,7 +91420,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89682,7 +91455,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -89695,7 +91471,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -89835,7 +91614,10 @@
               }
             ],
             "title": "Next Release At",
-            "description": "When the next chunk of the held balance becomes available for payout."
+            "description": "When the next chunk of the held balance becomes available for payout.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "next_release_amount": {
             "type": "integer",
@@ -89858,7 +91640,10 @@
               }
             ],
             "title": "Fully Available At",
-            "description": "When the whole held balance has become available for payout."
+            "description": "When the whole held balance has become available for payout.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           }
         },
         "type": "object",
@@ -90110,7 +91895,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "The timestamp of the event."
+            "description": "The timestamp of the event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -90357,7 +92145,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -90370,7 +92161,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "email": {
             "type": "string",
@@ -91110,7 +92904,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -91123,7 +92920,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "organization_id": {
             "type": "string",
@@ -91195,7 +92995,10 @@
                 "type": "null"
               }
             ],
-            "title": "Last Validated At"
+            "title": "Last Validated At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "expires_at": {
             "anyOf": [
@@ -91207,7 +93010,10 @@
                 "type": "null"
               }
             ],
-            "title": "Expires At"
+            "title": "Expires At",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "activation": {
             "anyOf": [
@@ -91323,7 +93129,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Timestamp",
-            "description": "Timestamp of the root event."
+            "description": "Timestamp of the root event.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "values": {
             "additionalProperties": {
@@ -91447,7 +93256,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -91460,7 +93272,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "customer_id": {
             "type": "string",
@@ -91556,7 +93371,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Benefit",
@@ -91585,7 +93403,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/BenefitGrantWebhook",
@@ -91614,7 +93435,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/BenefitGrantWebhook",
@@ -91643,7 +93467,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/BenefitGrantWebhook",
@@ -91672,7 +93499,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/BenefitGrantWebhook",
@@ -91701,7 +93531,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Benefit",
@@ -91730,7 +93563,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Checkout"
@@ -91758,7 +93594,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Checkout"
@@ -91786,7 +93625,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Checkout"
@@ -91814,7 +93656,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Customer"
@@ -91842,7 +93687,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Customer"
@@ -91870,7 +93718,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/CustomerSeat"
@@ -91898,7 +93749,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/CustomerSeat"
@@ -91926,7 +93780,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/CustomerSeat"
@@ -91954,7 +93811,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/CustomerState"
@@ -91982,7 +93842,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Customer"
@@ -92003,7 +93866,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -92016,7 +93882,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -92084,7 +93953,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Discount",
@@ -92113,7 +93985,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Discount",
@@ -92142,7 +94017,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Discount",
@@ -92164,7 +94042,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -92177,7 +94058,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -92397,7 +94281,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Created At",
-            "description": "Creation timestamp of the object."
+            "description": "Creation timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "modified_at": {
             "anyOf": [
@@ -92410,7 +94297,10 @@
               }
             ],
             "title": "Modified At",
-            "description": "Last modification timestamp of the object."
+            "description": "Last modification timestamp of the object.",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "id": {
             "type": "string",
@@ -92551,7 +94441,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Member"
@@ -92579,7 +94472,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Member"
@@ -92607,7 +94503,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Member"
@@ -92635,7 +94534,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Order"
@@ -92663,7 +94565,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Order"
@@ -92691,7 +94596,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Order"
@@ -92719,7 +94627,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Order"
@@ -92747,7 +94658,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Organization"
@@ -92775,7 +94689,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Product"
@@ -92803,7 +94720,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Product"
@@ -92831,7 +94751,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Refund"
@@ -92859,7 +94782,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Refund"
@@ -92887,7 +94813,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -92915,7 +94844,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -92943,7 +94875,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -92971,7 +94906,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -92999,7 +94937,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93027,7 +94968,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93055,7 +94999,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93083,7 +95030,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93111,7 +95061,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"
@@ -93139,7 +95092,10 @@
           "timestamp": {
             "type": "string",
             "format": "date-time",
-            "title": "Timestamp"
+            "title": "Timestamp",
+            "examples": [
+              "2025-01-03T13:37:00.123456Z"
+            ]
           },
           "data": {
             "$ref": "#/components/schemas/Subscription"

--- a/sdk/generator/generator/docs_openapi.py
+++ b/sdk/generator/generator/docs_openapi.py
@@ -14,6 +14,7 @@ HTTP_METHODS = frozenset(
     {"delete", "get", "head", "options", "patch", "post", "put", "trace"}
 )
 DOCS_OPENAPI_PATH = ROOT / "docs" / "openapi"
+DATETIME_EXAMPLE = "2025-01-03T13:37:00.123456Z"
 
 
 def generate_private_operations_overlay(
@@ -62,6 +63,29 @@ def generate_private_operations_overlay(
     }
 
 
+def generate_datetime_examples_overlay(
+    schema: dict[str, typing.Any],
+) -> dict[str, typing.Any]:
+    schemas = schema.get("components", {}).get("schemas", {})
+    actions = [
+        {
+            "target": _json_path(["components", "schemas", *path]),
+            "update": {"examples": [DATETIME_EXAMPLE]},
+        }
+        for path in _iter_datetime_schemas_without_examples(schemas)
+    ]
+
+    version = schema.get("info", {}).get("version", "0.0.0")
+    return {
+        "overlay": "1.1.0",
+        "info": {
+            "title": "Add examples with fractional seconds to date-time schemas",
+            "version": version,
+        },
+        "actions": actions,
+    }
+
+
 def apply_overlay(
     openapi_path: pathlib.Path,
     overlay_path: pathlib.Path,
@@ -98,6 +122,8 @@ def generate_docs_openapi(
             samples_overlay_path = temporary_path / "samples.overlay.json"
             samples_path = temporary_path / "samples.json"
             private_overlay_path = temporary_path / "private.overlay.json"
+            private_path = temporary_path / "private.json"
+            datetime_overlay_path = temporary_path / "datetime.overlay.json"
             final_path = temporary_path / "openapi.json"
 
             samples_overlay = generate_code_samples_overlay(
@@ -114,6 +140,47 @@ def generate_docs_openapi(
                 json.dumps(private_overlay, indent=2, ensure_ascii=False) + "\n",
                 encoding="utf-8",
             )
-            apply_overlay(samples_path, private_overlay_path, final_path)
+            apply_overlay(samples_path, private_overlay_path, private_path)
+
+            datetime_overlay = generate_datetime_examples_overlay(openapi_spec_dict)
+            datetime_overlay_path.write_text(
+                json.dumps(datetime_overlay, indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            apply_overlay(private_path, datetime_overlay_path, final_path)
 
             final_path.replace(output_path / openapi_file.name)
+
+
+def _iter_datetime_schemas_without_examples(
+    node: typing.Any, path: tuple[str | int, ...] = ()
+) -> typing.Iterator[tuple[str | int, ...]]:
+    if isinstance(node, list):
+        for index, item in enumerate(node):
+            yield from _iter_datetime_schemas_without_examples(item, (*path, index))
+        return
+    if not isinstance(node, dict):
+        return
+    if _is_datetime_schema(node):
+        if "examples" not in node and "example" not in node:
+            yield path
+        return
+    for key, value in node.items():
+        yield from _iter_datetime_schemas_without_examples(value, (*path, key))
+
+
+def _is_datetime_schema(schema: dict[str, typing.Any]) -> bool:
+    if schema.get("format") == "date-time":
+        return True
+    return any(
+        isinstance(member, dict) and member.get("format") == "date-time"
+        for keyword in ("anyOf", "oneOf")
+        for member in schema.get(keyword, [])
+    )
+
+
+def _json_path(path: typing.Sequence[str | int]) -> str:
+    return "$" + "".join(
+        f"[{segment}]" if isinstance(segment, int) else f"[{json.dumps(segment)}]"
+        for segment in path
+    )

--- a/sdk/generator/tests/test_docs_openapi.py
+++ b/sdk/generator/tests/test_docs_openapi.py
@@ -2,7 +2,12 @@ import json
 import pathlib
 import typing
 
-from generator.docs_openapi import apply_overlay, generate_private_operations_overlay
+from generator.docs_openapi import (
+    DATETIME_EXAMPLE,
+    apply_overlay,
+    generate_datetime_examples_overlay,
+    generate_private_operations_overlay,
+)
 
 
 def test_private_operations_overlay_removes_private_operations(
@@ -55,3 +60,100 @@ def test_private_operations_overlay_ignores_path_metadata() -> None:
     overlay = generate_private_operations_overlay(schema)
 
     assert overlay["actions"] == [{"target": '$["paths"]["/private"]', "remove": True}]
+
+
+def test_datetime_examples_overlay_adds_examples_with_fractional_seconds(
+    tmp_path: pathlib.Path,
+) -> None:
+    schema: dict[str, typing.Any] = {
+        "openapi": "3.1.0",
+        "info": {"title": "Test", "version": "2026-04"},
+        "components": {
+            "schemas": {
+                "Order": {
+                    "properties": {
+                        "created_at": {"type": "string", "format": "date-time"},
+                        "modified_at": {
+                            "anyOf": [
+                                {"type": "string", "format": "date-time"},
+                                {"type": "null"},
+                            ]
+                        },
+                        "started_at": {
+                            "type": "string",
+                            "format": "date-time",
+                            "examples": ["2025-01-03T13:37:00Z"],
+                        },
+                        "amount": {"type": "integer"},
+                        "items": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "period_end": {
+                                        "type": "string",
+                                        "format": "date-time",
+                                    }
+                                }
+                            },
+                        },
+                    }
+                }
+            }
+        },
+    }
+    overlay = generate_datetime_examples_overlay(schema)
+    source_path = tmp_path / "source.json"
+    overlay_path = tmp_path / "overlay.json"
+    output_path = tmp_path / "output.json"
+    source_path.write_text(json.dumps(schema), encoding="utf-8")
+    overlay_path.write_text(json.dumps(overlay), encoding="utf-8")
+
+    apply_overlay(source_path, overlay_path, output_path)
+
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    properties = output["components"]["schemas"]["Order"]["properties"]
+    assert properties["created_at"]["examples"] == [DATETIME_EXAMPLE]
+    assert properties["modified_at"]["examples"] == [DATETIME_EXAMPLE]
+    assert "examples" not in properties["modified_at"]["anyOf"][0]
+    assert properties["started_at"]["examples"] == ["2025-01-03T13:37:00Z"]
+    assert "examples" not in properties["amount"]
+    assert properties["items"]["items"]["properties"]["period_end"]["examples"] == [
+        DATETIME_EXAMPLE
+    ]
+
+
+def test_datetime_examples_overlay_targets_component_schemas_only() -> None:
+    schema = {
+        "info": {"version": "2026-04"},
+        "paths": {
+            "/orders": {
+                "get": {
+                    "parameters": [
+                        {
+                            "name": "since",
+                            "in": "query",
+                            "schema": {"type": "string", "format": "date-time"},
+                        }
+                    ]
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Order": {
+                    "properties": {
+                        "created_at": {"type": "string", "format": "date-time"}
+                    }
+                }
+            }
+        },
+    }
+
+    overlay = generate_datetime_examples_overlay(schema)
+
+    assert overlay["actions"] == [
+        {
+            "target": '$["components"]["schemas"]["Order"]["properties"]["created_at"]',
+            "update": {"examples": [DATETIME_EXAMPLE]},
+        }
+    ]

--- a/server/polar/customer/schemas/state.py
+++ b/server/polar/customer/schemas/state.py
@@ -57,19 +57,19 @@ class CustomerStateSubscription(
     )
     current_period_start: datetime = Field(
         description="The start timestamp of the current billing period.",
-        examples=["2025-02-03T13:37:00Z"],
+        examples=["2025-02-03T13:37:00.123456Z"],
     )
     current_period_end: datetime = Field(
         description="The end timestamp of the current billing period.",
-        examples=["2025-03-03T13:37:00Z"],
+        examples=["2025-03-03T13:37:00.123456Z"],
     )
     trial_start: datetime | None = Field(
         description="The start timestamp of the trial period, if any.",
-        examples=["2025-02-03T13:37:00Z"],
+        examples=["2025-02-03T13:37:00.123456Z"],
     )
     trial_end: datetime | None = Field(
         description="The end timestamp of the trial period, if any.",
-        examples=["2025-03-03T13:37:00Z"],
+        examples=["2025-03-03T13:37:00.123456Z"],
     )
     cancel_at_period_end: bool = Field(
         description=(
@@ -87,7 +87,7 @@ class CustomerStateSubscription(
     )
     started_at: datetime | None = Field(
         description="The timestamp when the subscription started.",
-        examples=["2025-01-03T13:37:00Z"],
+        examples=["2025-01-03T13:37:00.123456Z"],
     )
     ends_at: datetime | None = Field(
         description="The timestamp when the subscription will end.",
@@ -138,7 +138,7 @@ class CustomerStateBenefitGrant(TimestampedSchema, IDSchema):
     )
     granted_at: datetime = Field(
         description="The timestamp when the benefit was granted.",
-        examples=["2025-01-03T13:37:00Z"],
+        examples=["2025-01-03T13:37:00.123456Z"],
     )
     benefit_id: UUID4 = Field(
         description="The ID of the benefit concerned by this grant.",


### PR DESCRIPTION
Mintlify generated date-time examples without fractional seconds, while the
API serializes timestamps with microsecond precision. The docs OpenAPI
generator now applies an overlay adding an example with fractional seconds to
every date-time schema in components that has none, and the explicit examples
in the customer state schemas follow the same format.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BTJPWcTZdi8HrH8kghK8Px

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

