### PR TITLE
clients/web: scope AI assistant MCP token to the current organization

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/mcpSessionCookie.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/mcpSessionCookie.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseMCPSessionCookie,
+  serializeMCPSessionCookie,
+} from './mcpSessionCookie'
+
+const ORGANIZATION_ID = 'e2c8a9d0-1234-4f56-8a9b-0c1d2e3f4a5b'
+const OTHER_ORGANIZATION_ID = 'f3d9b0e1-5678-4a9b-8c0d-1e2f3a4b5c6d'
+const TOKEN = 'polar_oat_test'
+
+describe('parseMCPSessionCookie', () => {
+  it('returns the token when the cookie was minted for the same organization', () => {
+    const value = serializeMCPSessionCookie(ORGANIZATION_ID, TOKEN)
+    expect(parseMCPSessionCookie(value, ORGANIZATION_ID)).toBe(TOKEN)
+  })
+
+  it('returns null when the cookie was minted for another organization', () => {
+    const value = serializeMCPSessionCookie(OTHER_ORGANIZATION_ID, TOKEN)
+    expect(parseMCPSessionCookie(value, ORGANIZATION_ID)).toBeNull()
+  })
+
+  it('returns null for a legacy bare-token cookie value', () => {
+    expect(parseMCPSessionCookie(TOKEN, ORGANIZATION_ID)).toBeNull()
+  })
+
+  it('returns null for malformed JSON payloads', () => {
+    expect(
+      parseMCPSessionCookie('{"organizationId":', ORGANIZATION_ID),
+    ).toBeNull()
+    expect(
+      parseMCPSessionCookie(
+        JSON.stringify({ organizationId: ORGANIZATION_ID }),
+        ORGANIZATION_ID,
+      ),
+    ).toBeNull()
+    expect(
+      parseMCPSessionCookie(
+        JSON.stringify({ organizationId: ORGANIZATION_ID, token: 42 }),
+        ORGANIZATION_ID,
+      ),
+    ).toBeNull()
+  })
+})

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/mcpSessionCookie.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/mcpSessionCookie.ts
@@ -1,0 +1,27 @@
+export const serializeMCPSessionCookie = (
+  organizationId: string,
+  token: string,
+): string => JSON.stringify({ organizationId, token })
+
+export const parseMCPSessionCookie = (
+  value: string,
+  organizationId: string,
+): string | null => {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'organizationId' in parsed &&
+      parsed.organizationId === organizationId &&
+      'token' in parsed &&
+      typeof parsed.token === 'string'
+    ) {
+      return parsed.token
+    }
+  } catch {
+    // Legacy cookie values stored the bare token without organization scoping;
+    // treat them as a miss so a properly scoped token is minted.
+  }
+  return null
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/route.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/route.ts
@@ -20,6 +20,10 @@ import {
 import { cookies } from 'next/headers'
 import { PostHog } from 'posthog-node'
 import { z } from 'zod'
+import {
+  parseMCPSessionCookie,
+  serializeMCPSessionCookie,
+} from './mcpSessionCookie'
 
 const phClient = process.env.NEXT_PUBLIC_POSTHOG_TOKEN
   ? new PostHog(process.env.NEXT_PUBLIC_POSTHOG_TOKEN!, {
@@ -242,8 +246,15 @@ async function generateOAT(
 ): Promise<string> {
   const requestCookies = await cookies()
 
-  if (requestCookies.has(CONFIG.AUTH_MCP_COOKIE_KEY)) {
-    return requestCookies.get(CONFIG.AUTH_MCP_COOKIE_KEY)!.value
+  const cachedSession = requestCookies.get(CONFIG.AUTH_MCP_COOKIE_KEY)
+  if (cachedSession) {
+    const cachedToken = parseMCPSessionCookie(
+      cachedSession.value,
+      organizationId,
+    )
+    if (cachedToken) {
+      return cachedToken
+    }
   }
 
   const userSessionToken = requestCookies.get(CONFIG.AUTH_COOKIE_KEY)
@@ -283,11 +294,15 @@ async function generateOAT(
     throw new Error('Failed to generate OAT')
   }
 
-  requestCookies.set(CONFIG.AUTH_MCP_COOKIE_KEY, accessToken, {
-    httpOnly: true,
-    secure: true,
-    expires: new Date(Date.now() + data.expires_in * 1000),
-  })
+  requestCookies.set(
+    CONFIG.AUTH_MCP_COOKIE_KEY,
+    serializeMCPSessionCookie(organizationId, accessToken),
+    {
+      httpOnly: true,
+      secure: true,
+      expires: new Date(Date.now() + data.expires_in * 1000),
+    },
+  )
 
   return accessToken
 }
@@ -329,7 +344,10 @@ export async function POST(req: Request) {
   }: { messages: UIMessage[]; organizationId: string; conversationId: string } =
     await req.json()
 
-  const hasToolAccess = (await cookies()).has(CONFIG.AUTH_MCP_COOKIE_KEY)
+  const mcpSessionCookie = (await cookies()).get(CONFIG.AUTH_MCP_COOKIE_KEY)
+  const hasToolAccess =
+    mcpSessionCookie !== undefined &&
+    parseMCPSessionCookie(mcpSessionCookie.value, organizationId) !== null
   let requiresToolAccess = false
   let requiresManualSetup = false
   let isRelevant = true


### PR DESCRIPTION
## Bug

The AI product-creation assistant creates products under the **wrong organization**.

`generateOAT()` in `clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/route.ts` cached the MCP access token in the `polar_mcp_session` cookie and returned it **unconditionally** whenever the cookie existed. The token is minted with `sub_type: 'organization', sub: organizationId` — i.e. bound to whichever org was open the first time the assistant was used — and the cookie name is a fixed constant, not per-org.

Server-side, an organization-scoped token always resolves to its own org (and 422s if a different `organization_id` is passed), so after switching organizations in the dashboard, the assistant kept reusing org A's token and deterministically created products in org A.

## Fix

Minimal, value-scoped cache:

- New colocated helper `mcpSessionCookie.ts` with `serializeMCPSessionCookie` / `parseMCPSessionCookie` — the cookie value now stores `{ organizationId, token }` as JSON.
- `generateOAT()` only reuses the cached token when its `organizationId` matches the organization the user currently has open; on mismatch (or any unparseable value) it mints a fresh org-scoped token and overwrites the cookie.
- The `hasToolAccess` heuristic in `POST` now also checks the cached token's org instead of mere cookie presence, so a stale token from another org no longer counts as tool access.
- Legacy bare-token cookie values fail JSON parsing and are treated as a cache miss, so existing sessions transparently migrate to the scoped format.

## Verification

- New unit tests `mcpSessionCookie.test.ts` (4 tests: same-org hit, cross-org miss, legacy bare-token miss, malformed/incomplete payload miss) — `pnpm vitest run` passes.
- `pnpm typecheck` in `clients/apps/web` — clean.
- `oxlint --type-aware` on the touched files and `oxfmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

