### PR TITLE
Exclude docs/openapi from docs code ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,6 +28,7 @@ clients/packages/orbit/** @emilwidlund @sebastianekstrom
 
 # Docs
 /docs/ @pieterbeulque
+/docs/openapi/**
 
 # ADR
 handbook/engineering/decisions/** @frankie567


### PR DESCRIPTION
The generated OpenAPI snapshots under `docs/openapi/` change on every API update and don't need docs review.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

