### PR TITLE
events: Increase Tinybird timeout

### DIFF
--- a/server/polar/integrations/tinybird/client.py
+++ b/server/polar/integrations/tinybird/client.py
@@ -129,7 +129,7 @@ class TinybirdClient:
         self._read_client = httpx.AsyncClient(
             base_url=api_url,
             headers={"Authorization": f"Bearer {read_token}"} if read_token else {},
-            timeout=httpx.Timeout(25.0, connect=10.0),
+            timeout=httpx.Timeout(60.0, connect=10.0),
             transport=(
                 httpx.MockTransport(lambda _: httpx.Response(200, json={"data": []}))
                 if read_token is None


### PR DESCRIPTION
Since Tinybird has a 25s flush on their side, we might need more than 25s to ensure that the request got safely stored.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

