### PR TITLE
Secrets encryption: stop dual-writing Slack secrets

### DIFF
--- a/clients/apps/web/src/components/Benefit/SlackSharedChannelBenefitForm.tsx
+++ b/clients/apps/web/src/components/Benefit/SlackSharedChannelBenefitForm.tsx
@@ -86,7 +86,8 @@ export const SlackSharedChannelBenefitForm = ({
     selectedIntegrationId === CREATE_NEW_SLACK_APP ||
     (!showIntegrationSelect && !selectedIntegration)
 
-  const connected = !!selectedIntegration?.team_id && !selectedIntegration.revoked_at
+  const connected =
+    !!selectedIntegration?.team_id && !selectedIntegration.revoked_at
   const integrationId = selectedIntegration?.id
 
   useEffect(() => {
@@ -170,10 +171,14 @@ export const SlackSharedChannelBenefitForm = ({
       ) : (
         <>
           <SlackIntegrationSetupPanel
-            key={setupNewIntegration ? 'new' : (resolvedIntegration?.id ?? 'new')}
+            key={
+              setupNewIntegration ? 'new' : (resolvedIntegration?.id ?? 'new')
+            }
             organizationId={organization.id}
             defaultDisplayName={organization.name}
-            integration={setupNewIntegration ? null : (resolvedIntegration ?? null)}
+            integration={
+              setupNewIntegration ? null : (resolvedIntegration ?? null)
+            }
             returnTo={returnTo}
           />
           <FormDescription>

--- a/clients/apps/web/src/components/Benefit/SlackSharedChannelBenefitForm.tsx
+++ b/clients/apps/web/src/components/Benefit/SlackSharedChannelBenefitForm.tsx
@@ -26,7 +26,7 @@ import {
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
 import { usePathname, useSearchParams } from 'next/navigation'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { ConfirmModal } from '../Modal/ConfirmModal'
 import { toast } from '../Toast/use-toast'
@@ -76,21 +76,18 @@ export const SlackSharedChannelBenefitForm = ({
     !!resolvedIntegrationId &&
     resolvedIntegration === undefined &&
     selectedIntegrationFromList === undefined
-  const selectedIntegration = useMemo(() => {
-    if (selectedIntegrationId === CREATE_NEW_SLACK_APP) {
-      return null
-    }
-    return resolvedIntegration ?? selectedIntegrationFromList ?? null
-  }, [resolvedIntegration, selectedIntegrationFromList, selectedIntegrationId])
+  const selectedIntegration =
+    selectedIntegrationId === CREATE_NEW_SLACK_APP
+      ? null
+      : (resolvedIntegration ?? selectedIntegrationFromList ?? null)
 
   const showIntegrationSelect = !update && (integrations?.length ?? 0) > 0
   const setupNewIntegration =
     selectedIntegrationId === CREATE_NEW_SLACK_APP ||
     (!showIntegrationSelect && !selectedIntegration)
-  const integration = selectedIntegration ?? null
 
-  const connected = !!integration?.team_id && !integration.revoked_at
-  const integrationId = integration?.id
+  const connected = !!selectedIntegration?.team_id && !selectedIntegration.revoked_at
+  const integrationId = selectedIntegration?.id
 
   useEffect(() => {
     if (!connected || !integrationId || linkedIntegrationId === integrationId) {
@@ -164,8 +161,8 @@ export const SlackSharedChannelBenefitForm = ({
         />
       )}
 
-      {connected && integration ? (
-        <SlackConnectedBanner integration={integration} />
+      {connected && selectedIntegration ? (
+        <SlackConnectedBanner integration={selectedIntegration} />
       ) : !selectedIntegrationId && !setupNewIntegration ? (
         <FormDescription>
           Select an existing Slack app or create a new one.
@@ -173,10 +170,10 @@ export const SlackSharedChannelBenefitForm = ({
       ) : (
         <>
           <SlackIntegrationSetupPanel
-            key={setupNewIntegration ? 'new' : (integration?.id ?? 'new')}
+            key={setupNewIntegration ? 'new' : (resolvedIntegration?.id ?? 'new')}
             organizationId={organization.id}
             defaultDisplayName={organization.name}
-            integration={setupNewIntegration ? null : integration}
+            integration={setupNewIntegration ? null : (resolvedIntegration ?? null)}
             returnTo={returnTo}
           />
           <FormDescription>
@@ -186,7 +183,7 @@ export const SlackSharedChannelBenefitForm = ({
         </>
       )}
 
-      {!connected || !integration ? null : (
+      {!connected || !selectedIntegration ? null : (
         <>
           <FormField
             control={control}
@@ -326,7 +323,7 @@ const SlackIntegrationSelect = ({
   value,
   onChange,
 }: {
-  integrations: schemas['SlackIntegration'][]
+  integrations: schemas['SlackIntegrationListItem'][]
   value?: string
   onChange: (value: string) => void
 }) => {
@@ -365,7 +362,7 @@ const SlackIntegrationSelect = ({
 const SlackConnectedBanner = ({
   integration,
 }: {
-  integration: schemas['SlackIntegration']
+  integration: schemas['SlackIntegrationListItem']
 }) => {
   const disconnect = useDeleteSlackIntegration()
   const [showConfirm, setShowConfirm] = useState(false)

--- a/clients/apps/web/src/hooks/queries/slack.ts
+++ b/clients/apps/web/src/hooks/queries/slack.ts
@@ -32,7 +32,7 @@ export const useSlackIntegrations = (
 ) =>
   useQuery({
     queryKey: ['slackIntegrations', organizationId],
-    queryFn: async (): Promise<schemas['SlackIntegration'][]> => {
+    queryFn: async (): Promise<schemas['SlackIntegrationListItem'][]> => {
       const response = await api.GET('/v1/integrations/slack', {
         params: { query: { organization_id: organizationId ?? '' } },
       })

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -34302,6 +34302,7 @@ export interface components {
        * Created At
        * Format: date-time
        * @description Creation timestamp of the object.
+       * @example 2026-01-01T00:00:00.000000Z
        */
       created_at: string
       /**

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -34217,6 +34217,41 @@ export interface components {
        */
       client_id_last_4: string
       /**
+       * Team Id
+       * @description Slack workspace ID, if installed.
+       */
+      team_id: string | null
+      /**
+       * Team Name
+       * @description Slack workspace name, if installed.
+       */
+      team_name: string | null
+      /**
+       * Bot User Id
+       * @description Installed bot user ID, if any.
+       */
+      bot_user_id: string | null
+      /**
+       * Authed User Id
+       * @description Slack user ID that authorized the app, if installed.
+       */
+      authed_user_id: string | null
+      /**
+       * Scopes
+       * @description Granted Slack bot scopes, if any.
+       */
+      scopes: string[] | null
+      /**
+       * Installed At
+       * @description Timestamp when the Slack app was installed.
+       */
+      installed_at: string | null
+      /**
+       * Revoked At
+       * @description Timestamp when the Slack app was revoked or uninstalled.
+       */
+      revoked_at: string | null
+      /**
        * Client Secret Last 4
        * @description Last four characters of the client secret (display only).
        */
@@ -34226,6 +34261,86 @@ export interface components {
        * @description Last four characters of the signing secret (display only).
        */
       signing_secret_last_4: string
+    }
+    /** SlackIntegrationCredentialsUpdate */
+    SlackIntegrationCredentialsUpdate: {
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description Organization the integration belongs to.
+       */
+      organization_id: string
+      /**
+       * Display Name
+       * @description Display name used by the bot user in your Slack workspace. Reflected in the manifest.
+       */
+      display_name: string
+      /**
+       * Slack App Id
+       * @description App ID from your Slack app's Basic Information page.
+       */
+      slack_app_id: string
+      /**
+       * Client Id
+       * @description Client ID from your Slack app's Basic Information page.
+       */
+      client_id: string
+      /**
+       * Client Secret
+       * @description Client Secret from your Slack app's Basic Information page. Omit to keep the existing value when updating other fields.
+       */
+      client_secret?: string | null
+      /**
+       * Signing Secret
+       * @description Signing Secret from your Slack app's Basic Information page. Omit to keep the existing value when updating other fields.
+       */
+      signing_secret?: string | null
+    }
+    /** SlackIntegrationListItem */
+    SlackIntegrationListItem: {
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Id
+       * Format: uuid4
+       * @description ID of the Slack integration.
+       */
+      id: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description Organization that owns the Slack integration.
+       */
+      organization_id: string
+      /**
+       * Display Name
+       * @description Display name used by the Slack app.
+       */
+      display_name: string
+      /**
+       * Slack App Id
+       * @description Slack app ID.
+       */
+      slack_app_id: string
+      /**
+       * Client Id
+       * @description Slack client ID.
+       */
+      client_id: string
+      /**
+       * Client Id Last 4
+       * @description Last four characters of the Client ID (display only).
+       */
+      client_id_last_4: string
       /**
        * Team Id
        * @description Slack workspace ID, if installed.
@@ -34262,40 +34377,6 @@ export interface components {
        */
       revoked_at: string | null
     }
-    /** SlackIntegrationCredentialsUpdate */
-    SlackIntegrationCredentialsUpdate: {
-      /**
-       * Organization Id
-       * Format: uuid4
-       * @description Organization the integration belongs to.
-       */
-      organization_id: string
-      /**
-       * Display Name
-       * @description Display name used by the bot user in your Slack workspace. Reflected in the manifest.
-       */
-      display_name: string
-      /**
-       * Slack App Id
-       * @description App ID from your Slack app's Basic Information page.
-       */
-      slack_app_id: string
-      /**
-       * Client Id
-       * @description Client ID from your Slack app's Basic Information page.
-       */
-      client_id: string
-      /**
-       * Client Secret
-       * @description Client Secret from your Slack app's Basic Information page. Omit to keep the existing value when updating other fields.
-       */
-      client_secret?: string | null
-      /**
-       * Signing Secret
-       * @description Signing Secret from your Slack app's Basic Information page. Omit to keep the existing value when updating other fields.
-       */
-      signing_secret?: string | null
-    }
     /** SlackIntegrationManifest */
     SlackIntegrationManifest: {
       /**
@@ -34318,7 +34399,7 @@ export interface components {
        * Integrations
        * @description Slack apps configured for the organization.
        */
-      integrations: components['schemas']['SlackIntegration'][]
+      integrations: components['schemas']['SlackIntegrationListItem'][]
     }
     /** SlackWorkspaceUser */
     SlackWorkspaceUser: {

--- a/server/polar/integrations/slack/endpoints.py
+++ b/server/polar/integrations/slack/endpoints.py
@@ -104,11 +104,7 @@ async def list_integrations(
 
     repository = SlackAppRepository.from_session(session)
     integrations = await repository.list_by_organization_id(organization_id)
-    return SlackIntegrationsResponse(
-        integrations=[
-            SlackIntegration.model_validate(integration) for integration in integrations
-        ]
-    )
+    return SlackIntegrationsResponse.model_validate({"integrations": integrations})
 
 
 @router.get(
@@ -158,7 +154,7 @@ async def post_credentials(
     integration = await slack_app_service.set_credentials(
         session, payload.organization_id, payload, redirect_uri=redirect_uri
     )
-    return SlackIntegration.model_validate(integration)
+    return await SlackIntegration.from_slack_app(integration)
 
 
 @router.get(
@@ -233,7 +229,7 @@ async def get_integration(
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> SlackIntegration:
     integration = await _get_writable_integration(session, auth_subject, id)
-    return SlackIntegration.model_validate(integration)
+    return await SlackIntegration.from_slack_app(integration)
 
 
 @router.delete(

--- a/server/polar/integrations/slack/schemas.py
+++ b/server/polar/integrations/slack/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Self
 
 from pydantic import (
     UUID4,
@@ -12,6 +12,7 @@ from pydantic import (
 )
 
 from polar.kit.schemas import Schema, TimestampedSchema
+from polar.models import SlackApp
 
 # Slack app IDs look like A0XXXXXXXXX (11 chars). Client IDs are numeric.dot.numeric.
 # Signing secrets and client secrets are 32-char hex blobs in practice but Slack
@@ -116,7 +117,7 @@ class SlackWorkspaceUsersResponse(Schema):
     )
 
 
-class SlackIntegration(TimestampedSchema):
+class SlackIntegrationListItem(TimestampedSchema):
     id: UUID4 = Field(description="ID of the Slack integration.")
     organization_id: UUID4 = Field(
         description="Organization that owns the Slack integration."
@@ -128,14 +129,6 @@ class SlackIntegration(TimestampedSchema):
     client_id_last_4: SecretLast4 = Field(
         validation_alias=AliasPath("client_id"),
         description="Last four characters of the Client ID (display only).",
-    )
-    client_secret_last_4: SecretLast4 = Field(
-        validation_alias=AliasPath("client_secret"),
-        description="Last four characters of the client secret (display only).",
-    )
-    signing_secret_last_4: SecretLast4 = Field(
-        validation_alias=AliasPath("signing_secret"),
-        description="Last four characters of the signing secret (display only).",
     )
 
     team_id: str | None = Field(description="Slack workspace ID, if installed.")
@@ -158,7 +151,28 @@ class SlackIntegration(TimestampedSchema):
         return _empty_if_none(value)
 
 
+class SlackIntegration(SlackIntegrationListItem):
+    client_secret_last_4: SecretLast4 = Field(
+        validation_alias=AliasPath("client_secret"),
+        description="Last four characters of the client secret (display only).",
+    )
+    signing_secret_last_4: SecretLast4 = Field(
+        validation_alias=AliasPath("signing_secret"),
+        description="Last four characters of the signing secret (display only).",
+    )
+
+    @classmethod
+    async def from_slack_app(cls, slack_app: SlackApp) -> Self:
+        return cls.model_validate(
+            {
+                **SlackIntegrationListItem.model_validate(slack_app).model_dump(),
+                "client_secret": await slack_app.get_client_secret() or "",
+                "signing_secret": await slack_app.get_signing_secret() or "",
+            }
+        )
+
+
 class SlackIntegrationsResponse(Schema):
-    integrations: list[SlackIntegration] = Field(
+    integrations: list[SlackIntegrationListItem] = Field(
         description="Slack apps configured for the organization."
     )

--- a/server/polar/integrations/slack/service.py
+++ b/server/polar/integrations/slack/service.py
@@ -118,8 +118,6 @@ class SlackAppService:
                 display_name=update.display_name,
                 slack_app_id=update.slack_app_id,
                 client_id=update.client_id,
-                client_secret=client_secret,
-                signing_secret=signing_secret,
             )
             integration.id = SlackApp.generate_id()
             integration.client_secret_encrypted = await SlackApp.encrypt_client_secret(
@@ -133,11 +131,9 @@ class SlackAppService:
         update_dict: dict[str, Any] = {
             "display_name": update.display_name,
             "client_id": update.client_id,
-            "client_secret": client_secret,
             "client_secret_encrypted": await SlackApp.encrypt_client_secret(
                 existing.id, client_secret
             ),
-            "signing_secret": signing_secret,
             "signing_secret_encrypted": await SlackApp.encrypt_signing_secret(
                 existing.id, signing_secret
             ),
@@ -152,7 +148,6 @@ class SlackAppService:
                     "team_id": None,
                     "team_name": None,
                     "bot_user_id": None,
-                    "bot_token": None,
                     "bot_token_encrypted": None,
                     "authed_user_id": None,
                     "scopes": None,
@@ -284,7 +279,6 @@ class SlackAppService:
                 "team_id": team.get("id"),
                 "team_name": team.get("name"),
                 "bot_user_id": result.get("bot_user_id"),
-                "bot_token": bot_token,
                 "bot_token_encrypted": await SlackApp.encrypt_bot_token(
                     integration.id, bot_token
                 ),
@@ -317,7 +311,6 @@ class SlackAppService:
             await repository.update(
                 integration,
                 update_dict={
-                    "bot_token": None,
                     "bot_token_encrypted": None,
                     "revoked_at": utc_now(),
                 },

--- a/server/tests/integrations/slack/test_endpoints.py
+++ b/server/tests/integrations/slack/test_endpoints.py
@@ -217,8 +217,9 @@ class TestListIntegrations:
             "T1",
             None,
         }
-        assert all("bot_token" not in integration for integration in integrations)
-        assert all("client_secret" not in integration for integration in integrations)
+        assert all(
+            integration["client_id_last_4"] == ".200" for integration in integrations
+        )
 
     @pytest.mark.auth(
         AuthSubjectFixture(scopes={Scope.organizations_read}),
@@ -702,7 +703,7 @@ class TestEvents:
         repo = SlackAppRepository.from_session(session)
         integration = await repo.get_by_app_id("A0TESTAPPID")
         assert integration is not None
-        assert integration.bot_token is None
+        assert await integration.get_bot_token() is None
         assert integration.revoked_at is not None
 
     async def test_event_callback_verifies_when_plaintext_signing_secret_absent(

--- a/server/tests/integrations/slack/test_schemas.py
+++ b/server/tests/integrations/slack/test_schemas.py
@@ -47,8 +47,11 @@ class TestSlackIntegrationCredentialsUpdate:
             )
 
 
+@pytest.mark.asyncio
 class TestSlackIntegration:
-    def test_computes_secret_suffixes_without_serializing_raw_secrets(self) -> None:
+    async def test_computes_secret_suffixes_without_serializing_raw_secrets(
+        self,
+    ) -> None:
         slack_app = SlackApp(
             id=uuid4(),
             created_at=datetime.now(UTC),
@@ -57,8 +60,6 @@ class TestSlackIntegration:
             display_name="Test",
             slack_app_id="A0TESTAPPID",
             client_id="100.200",
-            client_secret="cs-test-secret",
-            signing_secret="ss-test-secret",
             team_id=None,
             team_name=None,
             bot_user_id=None,
@@ -67,8 +68,14 @@ class TestSlackIntegration:
             installed_at=None,
             revoked_at=None,
         )
+        slack_app.client_secret_encrypted = await SlackApp.encrypt_client_secret(
+            slack_app.id, "cs-test-secret"
+        )
+        slack_app.signing_secret_encrypted = await SlackApp.encrypt_signing_secret(
+            slack_app.id, "ss-test-secret"
+        )
 
-        integration = SlackIntegration.model_validate(slack_app)
+        integration = await SlackIntegration.from_slack_app(slack_app)
 
         assert integration.client_id_last_4 == ".200"
         assert integration.client_secret_last_4 == "cret"
@@ -78,7 +85,7 @@ class TestSlackIntegration:
         assert "client_secret" not in dumped
         assert "signing_secret" not in dumped
 
-    def test_normalizes_missing_display_fields(self) -> None:
+    async def test_normalizes_missing_display_fields(self) -> None:
         slack_app = SlackApp(
             id=uuid4(),
             created_at=datetime.now(UTC),
@@ -87,8 +94,6 @@ class TestSlackIntegration:
             display_name="Test",
             slack_app_id=None,
             client_id=None,
-            client_secret=None,
-            signing_secret=None,
             team_id=None,
             team_name=None,
             bot_user_id=None,
@@ -98,7 +103,7 @@ class TestSlackIntegration:
             revoked_at=None,
         )
 
-        integration = SlackIntegration.model_validate(slack_app)
+        integration = await SlackIntegration.from_slack_app(slack_app)
 
         assert integration.slack_app_id == ""
         assert integration.client_id == ""

--- a/server/tests/integrations/slack/test_service.py
+++ b/server/tests/integrations/slack/test_service.py
@@ -143,6 +143,8 @@ class TestSetCredentials:
         assert integration.slack_app_id == "A0NEWAPPID0"
         assert integration.bot_token is None
         assert integration.team_id is None
+        assert await integration.get_client_secret() == "cs-test-secret"
+        assert await integration.get_signing_secret() == "ss-test-secret"
 
     async def test_rotating_secrets_preserves_oauth_state(
         self,
@@ -170,10 +172,10 @@ class TestSetCredentials:
         )
 
         # Same client_id and slack_app_id, only secrets rotated: keep install.
-        assert integration.bot_token == "xoxb-test-token"
+        assert await integration.get_bot_token() == "xoxb-test-token"
         assert integration.team_id == "T1"
-        assert integration.client_secret == "cs-new-secret"
-        assert integration.signing_secret == "ss-new-secret"
+        assert await integration.get_client_secret() == "cs-new-secret"
+        assert await integration.get_signing_secret() == "ss-new-secret"
 
     async def test_changing_client_id_resets_oauth_state(
         self,
@@ -200,7 +202,7 @@ class TestSetCredentials:
             session, organization.id, update, redirect_uri=_REDIRECT_URI
         )
 
-        assert integration.bot_token is None
+        assert await integration.get_bot_token() is None
         assert integration.team_id is None
         assert integration.client_id == "999.888"
 
@@ -307,7 +309,7 @@ class TestCompleteInstall:
             session, created.id, code="abc", redirect_uri=_REDIRECT_URI
         )
 
-        assert integration.bot_token == "xoxb-new-token"
+        assert await integration.get_bot_token() == "xoxb-new-token"
         assert integration.team_id == "T1"
         assert integration.team_name == "Test team"
         assert integration.scopes == ["channels:manage", "chat:write"]
@@ -395,7 +397,7 @@ class TestHandleEvent:
         repo = SlackAppRepository.from_session(session)
         integration = await repo.get_by_app_id("A0TESTAPPID")
         assert integration is not None
-        assert integration.bot_token is None
+        assert await integration.get_bot_token() is None
         assert integration.revoked_at is not None
 
     async def test_app_uninstalled_clears_bot_token(
@@ -417,7 +419,7 @@ class TestHandleEvent:
         repo = SlackAppRepository.from_session(session)
         integration = await repo.get_by_app_id("A0TESTAPPID")
         assert integration is not None
-        assert integration.bot_token is None
+        assert await integration.get_bot_token() is None
 
     async def test_unknown_app_is_noop(
         self,

--- a/server/tests/models/test_slack_app.py
+++ b/server/tests/models/test_slack_app.py
@@ -125,15 +125,12 @@ class TestPersistence:
     ) -> None:
         integration = _build(organization)
         integration.id = SlackApp.generate_id()
-        integration.client_secret = "cs-test"
         integration.client_secret_encrypted = await SlackApp.encrypt_client_secret(
             integration.id, "cs-test"
         )
-        integration.signing_secret = "ss-test"
         integration.signing_secret_encrypted = await SlackApp.encrypt_signing_secret(
             integration.id, "ss-test"
         )
-        integration.bot_token = "xoxb-test"
         integration.bot_token_encrypted = await SlackApp.encrypt_bot_token(
             integration.id, "xoxb-test"
         )


### PR DESCRIPTION
## Summary

**Related Issue**: https://linear.app/polarsh/issue/PLR-35/roll-out-secrets-encryption

Stop writing plaintext slack app secrets as they're not read anymore since #14114 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

