### PR TITLE
Implement API version monitoring

### DIFF
--- a/handbook/engineering/backend-development/api-versioning.mdx
+++ b/handbook/engineering/backend-development/api-versioning.mdx
@@ -93,6 +93,17 @@ unknown, or removed version returns `404 Not Found`.
   explicitly, either directly or by using a versioned SDK import.
 </Warning>
 
+### Monitoring version usage
+
+Logfire HTTP request spans carry an `api_version` attribute with the resolved
+version, including Current when the request omits `Polar-Version`.
+
+The `polar_http_request_total` counter and
+`polar_http_request_duration_seconds` histogram carry the same `api_version`
+label. The **Request Rate by API Version** panel in the **Polar API** Grafana
+dashboard shows usage with the selected environment, method, and endpoint filters.
+Existing metric exclusions still apply; rejected versions are not counted.
+
 ### OpenAPI schemas and SDKs
 
 An OpenAPI schema is generated for every supported version and exposed at

--- a/server/monitoring/grafana/dashboards/api-slo.json
+++ b/server/monitoring/grafana/dashboards/api-slo.json
@@ -1564,12 +1564,105 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (api_version) (rate(polar_http_request_total{env=\"$env\", endpoint=~\"$endpoint\", method=~\"$method\", api_version!=\"\"}[$__rate_interval]))",
+          "legendFormat": "{{api_version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate by API Version",
+      "type": "timeseries",
+      "description": "Resolved API version for routed requests. Requests without Polar-Version use Current. Rejected versions and existing metric exclusions are not counted."
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 37
       },
       "id": 13,
       "panels": [
@@ -1637,7 +1730,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 38
           },
           "id": 14,
           "options": {
@@ -1744,7 +1837,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 38
           },
           "id": 35,
           "options": {

--- a/server/polar/middlewares.py
+++ b/server/polar/middlewares.py
@@ -40,6 +40,9 @@ class LogCorrelationIdMiddleware:
         root_span = scope.get("logfire.span")
         if root_span is not None and root_span.is_recording():
             root_span.set_attribute("correlation_id", correlation_id)
+            api_version = scope.get("state", {}).get("api_version")
+            if api_version is not None:
+                root_span.set_attribute("api_version", str(api_version))
 
         # Capture client identification headers (sent by the mobile app)
         # so we can correlate API traffic to specific client builds for

--- a/server/polar/observability/http_metrics.py
+++ b/server/polar/observability/http_metrics.py
@@ -5,8 +5,8 @@ These metrics track all HTTP endpoints (except those in METRICS_DENY_LIST
 or belonging to METRICS_EXCLUDED_APPS) for availability and latency SLIs.
 
 Metrics:
-- polar_http_request_total: Counter of total requests by endpoint, method, status_code
-- polar_http_request_duration_seconds: Histogram of request duration by endpoint, method
+- polar_http_request_total: Counter by endpoint, method, status_code, api_version
+- polar_http_request_duration_seconds: Histogram by endpoint, method, api_version
 """
 
 import os
@@ -55,7 +55,7 @@ def exclude_app_from_metrics(app: "ASGIApp") -> None:
 HTTP_REQUEST_TOTAL = Counter(
     "polar_http_request_total",
     "Total number of HTTP requests",
-    ["endpoint", "method", "status_code"],
+    ["endpoint", "method", "status_code", "api_version"],
 )
 
 # HTTP request duration histogram for latency SLI
@@ -68,7 +68,7 @@ HTTP_REQUEST_TOTAL = Counter(
 HTTP_REQUEST_DURATION_SECONDS = Histogram(
     "polar_http_request_duration_seconds",
     "HTTP request duration in seconds",
-    ["endpoint", "method"],
+    ["endpoint", "method", "api_version"],
     buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
 )
 

--- a/server/polar/observability/http_middleware.py
+++ b/server/polar/observability/http_middleware.py
@@ -54,14 +54,17 @@ class HttpMetricsMiddleware:
             if path_template is not None:
                 duration = time.perf_counter() - start_time
                 method = scope.get("method", "UNKNOWN")
+                api_version = str(scope.get("state", {}).get("api_version", ""))
 
                 HTTP_REQUEST_TOTAL.labels(
                     endpoint=path_template,
                     method=method,
                     status_code=status_code,
+                    api_version=api_version,
                 ).inc()
 
                 HTTP_REQUEST_DURATION_SECONDS.labels(
                     endpoint=path_template,
                     method=method,
+                    api_version=api_version,
                 ).observe(duration)


### PR DESCRIPTION
## Summary

Record the resolved API version in Logfire request spans and Prometheus HTTP metrics, and display usage by version in the Polar API Grafana dashboard.

**Related Issue**: [PLR-74](https://linear.app/polarsh/issue/PLR-74/implement-api-version-monitoring)

## What

Add the `api_version` span attribute and metric label, a request-rate panel grouped by version, and handbook documentation.

## Why

Make API version adoption visible so version rotations can be informed by actual usage.

## How

Reuse the version already resolved in request state, including Current for requests without `Polar-Version`. Existing metric exclusions remain in place; rejected versions are not counted. Existing SLO queries continue aggregating across versions.

Validation: 24 existing observability tests pass; Ruff and scoped mypy checks pass; dashboard JSON and panel layout checks pass. The Grafana panel has not been verified against a live deployment.

## Checklist

- [x] This PR addresses a single concern
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass for the changed Python files
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

