### PR TITLE
feat(checkout): serve the frame-ancestors policy for a checkout session

### DIFF
--- a/server/polar/checkout/endpoints.py
+++ b/server/polar/checkout/endpoints.py
@@ -1,7 +1,9 @@
 from typing import Annotated
 
-from fastapi import Depends, Path, Query, Request
+import structlog
+from fastapi import Depends, Header, Path, Query, Request
 from pydantic import UUID4
+from sqlalchemy.orm import joinedload
 from sse_starlette.sse import EventSourceResponse
 
 from polar.auth.permission import OrganizationPermission
@@ -18,6 +20,11 @@ from polar.kit.schemas import (
 from polar.models import Checkout
 from polar.models.checkout import CheckoutStatus
 from polar.openapi import APITag
+from polar.organization.embed_hosts import (
+    csp_frame_ancestors,
+    match_origin,
+    parse_origin,
+)
 from polar.organization.schemas import OrganizationID
 from polar.postgres import (
     AsyncReadSession,
@@ -30,10 +37,12 @@ from polar.redis import Redis, get_redis
 from polar.routing import APIRouter
 
 from . import auth, ip_geolocation, sorting
+from .repository import CheckoutRepository
 from .schemas import Checkout as CheckoutSchema
 from .schemas import (
     CheckoutConfirm,
     CheckoutCreate,
+    CheckoutEmbedPolicy,
     CheckoutOpened,
     CheckoutPublic,
     CheckoutPublicConfirmed,
@@ -49,6 +58,8 @@ from .service import (
     TrialAlreadyRedeemed,
 )
 from .service import checkout as checkout_service
+
+log = structlog.get_logger()
 
 inner_router = APIRouter(tags=["checkouts", APITag.public])
 
@@ -302,6 +313,48 @@ async def client_opened(
     return await checkout_service.mark_opened(
         session, checkout, checkout_opened.distinct_id
     )
+
+
+@inner_router.get(
+    "/client/{client_secret}/embed-policy",
+    response_model=CheckoutEmbedPolicy,
+    summary="Get Checkout Session Embed Policy from Client",
+    responses={404: CheckoutNotFound},
+    tags=[APITag.private],
+    include_in_schema=False,
+)
+async def client_embed_policy(
+    client_secret: CheckoutClientSecret,
+    referer: Annotated[str | None, Header()] = None,
+    sec_fetch_dest: Annotated[str | None, Header()] = None,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> CheckoutEmbedPolicy:
+    """Get the hosts allowed to embed a checkout session, as CSP sources."""
+    repository = CheckoutRepository.from_session(session)
+    checkout = await repository.get_by_client_secret(
+        client_secret, options=(joinedload(Checkout.organization),)
+    )
+    if checkout is None:
+        raise ResourceNotFound()
+
+    hosts = checkout.organization.embed_hosts
+    parsed = parse_origin(referer) if referer is not None else None
+    frame_origin = str(parsed) if parsed is not None else None
+    allowed = (
+        match_origin(frame_origin, hosts) is not None
+        if frame_origin is not None
+        else None
+    )
+    log.info(
+        "Embedded checkout framing policy resolved",
+        organization_id=str(checkout.organization_id),
+        frame_origin=frame_origin,
+        fetch_dest=sec_fetch_dest,
+        allowed=allowed,
+        embed_hosts=hosts,
+    )
+
+    return CheckoutEmbedPolicy(frame_ancestors=csp_frame_ancestors(hosts))
 
 
 @inner_router.get("/client/{client_secret}/stream", include_in_schema=False)

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -819,3 +819,9 @@ class CheckoutPublicConfirmed(CheckoutPublic):
 
     status: Literal[CheckoutStatus.confirmed]
     customer_session_token: str | None
+
+
+class CheckoutEmbedPolicy(Schema):
+    """The `frame-ancestors` sources admitting the hosts allowed to embed."""
+
+    frame_ancestors: list[str]

--- a/server/polar/organization/embed_hosts.py
+++ b/server/polar/organization/embed_hosts.py
@@ -257,6 +257,31 @@ def host_for_origin(origin: ParsedOrigin) -> str | None:
     return str(HostPattern(scheme, origin.host, port, False))
 
 
+def csp_frame_ancestors(hosts: list[str]) -> list[str]:
+    """The `frame-ancestors` source list admitting the same origins as `matches`."""
+    sources: list[str] = []
+    for entry in hosts:
+        pattern = parse_host_pattern(entry)
+        if pattern is None or pattern.host.startswith("["):
+            continue
+
+        host = f"{WILDCARD_PREFIX}{pattern.host}" if pattern.wildcard else pattern.host
+        port = f":{pattern.port}" if pattern.port is not None else ""
+
+        if pattern.scheme is not None:
+            sources.append(f"{pattern.scheme}://{host}{port}")
+            continue
+
+        sources.append(f"https://{host}{port}")
+        probe = (
+            f"{_WILDCARD_LABEL}.{pattern.host}" if pattern.wildcard else pattern.host
+        )
+        if is_local_host(probe):
+            sources.append(f"http://{host}{port}")
+
+    return sources or ["'none'"]
+
+
 def uncovered_hosts(
     observed: Iterable[tuple[str, int, datetime]], hosts: list[str]
 ) -> list[ObservedHost]:

--- a/server/tests/checkout/test_endpoints.py
+++ b/server/tests/checkout/test_endpoints.py
@@ -1105,3 +1105,70 @@ class TestClientOpened:
             updated_checkout.analytics_metadata.get("opened_at") == original_opened_at
         )
         assert updated_checkout.analytics_metadata.get("distinct_id") == "original-id"
+
+
+@pytest.mark.asyncio
+class TestClientEmbedPolicy:
+    async def test_not_existing(self, api_prefix: str, client: AsyncClient) -> None:
+        response = await client.get(f"{api_prefix}/client/123/embed-policy")
+
+        assert response.status_code == 404
+
+    async def test_configured(
+        self,
+        api_prefix: str,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        checkout_open: Checkout,
+    ) -> None:
+        organization.embed_hosts = ["example.com", "*.shop.example.com"]
+        await save_fixture(organization)
+
+        response = await client.get(
+            f"{api_prefix}/client/{checkout_open.client_secret}/embed-policy",
+            headers={
+                "Referer": "https://example.com/pricing",
+                "Sec-Fetch-Dest": "iframe",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["frame_ancestors"] == [
+            "https://example.com",
+            "https://*.shop.example.com",
+        ]
+
+    async def test_not_configured(
+        self, api_prefix: str, client: AsyncClient, checkout_open: Checkout
+    ) -> None:
+        response = await client.get(
+            f"{api_prefix}/client/{checkout_open.client_secret}/embed-policy"
+        )
+
+        assert response.status_code == 200
+        assert response.json()["frame_ancestors"] == ["'none'"]
+
+    async def test_expired_checkout_keeps_its_policy(
+        self,
+        api_prefix: str,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        organization.embed_hosts = ["example.com"]
+        await save_fixture(organization)
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            status=CheckoutStatus.expired,
+            expires_at=utc_now() - timedelta(days=1),
+        )
+
+        response = await client.get(
+            f"{api_prefix}/client/{checkout.client_secret}/embed-policy"
+        )
+
+        assert response.status_code == 200
+        assert response.json()["frame_ancestors"] == ["https://example.com"]

--- a/server/tests/organization/test_embed_hosts.py
+++ b/server/tests/organization/test_embed_hosts.py
@@ -4,6 +4,7 @@ import pytest
 
 from polar.organization.embed_hosts import (
     InvalidEmbedHost,
+    csp_frame_ancestors,
     is_shared_host,
     match_origin,
     parse_origin,
@@ -345,3 +346,48 @@ class TestIsSharedHost:
     )
     def test_everything_else(self, entry: str) -> None:
         assert is_shared_host(entry) is False
+
+
+class TestCspFrameAncestors:
+    @pytest.mark.parametrize(
+        ("entry", "expected"),
+        [
+            ("example.com", ["https://example.com"]),
+            ("*.example.com", ["https://*.example.com"]),
+            ("example.com:8443", ["https://example.com:8443"]),
+            ("chrome-extension://abcdef", ["chrome-extension://abcdef"]),
+        ],
+    )
+    def test_source(self, entry: str, expected: list[str]) -> None:
+        assert csp_frame_ancestors([entry]) == expected
+
+    @pytest.mark.parametrize(
+        ("entry", "expected"),
+        [
+            ("localhost", ["https://localhost", "http://localhost"]),
+            ("localhost:3000", ["https://localhost:3000", "http://localhost:3000"]),
+            ("app.localhost", ["https://app.localhost", "http://app.localhost"]),
+            ("192.168.1.10", ["https://192.168.1.10", "http://192.168.1.10"]),
+            ("*.local", ["https://*.local", "http://*.local"]),
+        ],
+    )
+    def test_local_host_carries_both_schemes(
+        self, entry: str, expected: list[str]
+    ) -> None:
+        """`HostPattern.matches` admits HTTP on a local host, so the header must too."""
+        assert csp_frame_ancestors([entry]) == expected
+
+    def test_entries_keep_their_order(self) -> None:
+        assert csp_frame_ancestors(["example.com", "*.myshop.com"]) == [
+            "https://example.com",
+            "https://*.myshop.com",
+        ]
+
+    @pytest.mark.parametrize("entry", ["[::1]:3000", "[2001:db8::1]"])
+    def test_ipv6_literal_dropped(self, entry: str) -> None:
+        """CSP's host-source grammar has no form for an IPv6 literal."""
+        assert csp_frame_ancestors([entry]) == ["'none'"]
+
+    @pytest.mark.parametrize("hosts", [[], ["not a host"]])
+    def test_nothing_to_admit(self, hosts: list[str]) -> None:
+        assert csp_frame_ancestors(hosts) == ["'none'"]


### PR DESCRIPTION
## Summary

Groundwork for [ENG-12](https://linear.app/polarsh/issue/ENG-12/enforce-embed-hosts-through-frame-ancestors-csp). Translates an organization's embed hosts into a CSP `frame-ancestors` source list and serves it for a checkout client secret.

Nothing calls the endpoint yet. It logs the framing origin it is asked about, which will be used by used to measure the blast radius before anything is enforced.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

