### PR TITLE
fix(subscription): re-anchor a scheduled update when a sub resumes

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1119,6 +1119,11 @@ class SubscriptionService:
             subscription.status = SubscriptionStatus.paused
             subscription.paused_at = utc_now()
             subscription.pause_at_period_end = False
+            # A scheduled change targets the next cycle, which never begins.
+            if subscription.pending_update is not None:
+                subscription = await self.clear_pending_update(
+                    session, ctx, subscription
+                )
             await self.enqueue_benefits_grants(session, subscription)
             repository = SubscriptionRepository.from_session(session)
             return await repository.update(
@@ -2745,6 +2750,11 @@ class SubscriptionService:
             )
         )
         subscription.initialize_meter_period(now)
+
+        # Scheduling a change on a paused subscription is still allowed; it
+        # snapshots the pre-pause period, which this fresh one supersedes.
+        if subscription.pending_update is not None:
+            subscription = await self.clear_pending_update(session, ctx, subscription)
 
         self._clear_expired_discount(subscription)
 

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -3739,6 +3739,41 @@ class TestPause:
         assert order_calls == []
         assert_hooks_called_once(subscription_hooks, {"updated", "paused"})
 
+    async def test_cycle_drops_pending_update_when_pausing(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_job_mock: MagicMock,
+        enqueue_benefits_grants_mock: MagicMock,
+        product: Product,
+        product_second: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+        )
+        subscription_update, _ = generate_subscription_update(
+            subscription,
+            SubscriptionProrationBehavior.next_period,
+            product=product_second,
+        )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        subscription.pause_at_period_end = True
+        await save_fixture(subscription)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.cycle(session, ctx, subscription)
+
+        assert updated.status == SubscriptionStatus.paused
+        assert updated.pending_update is None
+        assert updated.product == product
+
 
 @pytest.mark.asyncio
 class TestCancelScheduledPause:
@@ -3938,6 +3973,53 @@ class TestResume:
         ]
         assert len(cycle_entries) == 1
         assert cycle_entries[0].discount is None
+
+    async def test_drops_pending_update_scheduled_while_paused(
+        self,
+        frozen_time: datetime,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_job_mock: MagicMock,
+        enqueue_benefits_grants_mock: MagicMock,
+        product: Product,
+        product_second: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        subscription_update, _ = generate_subscription_update(
+            subscription,
+            SubscriptionProrationBehavior.next_period,
+            product=product_second,
+        )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        subscription.paused_at = frozen_time - timedelta(days=10)
+        await save_fixture(subscription)
+        mocker.patch.object(subscription_service, "reset_meters")
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.resume(session, ctx, subscription)
+
+        assert updated.pending_update is None
+        assert updated.product == product
+
+        billing_entry_repository = BillingEntryRepository.from_session(session)
+        billing_entries = await billing_entry_repository.get_pending_by_subscription(
+            subscription.id
+        )
+        cycle_entries = [
+            entry for entry in billing_entries if entry.type == BillingEntryType.cycle
+        ]
+        assert len(cycle_entries) == 1
+        assert cycle_entries[0].start_timestamp == frozen_time
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Better attempt at fixing this detail bug: https://github.com/polarsource/polar/pull/14165


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

