### PR TITLE
feat(checkout): resolve a framed checkout's embed policy in the proxy

### DIFF
--- a/clients/apps/web/src/proxy.test.ts
+++ b/clients/apps/web/src/proxy.test.ts
@@ -1,6 +1,6 @@
 import { unstable_doesMiddlewareMatch } from 'next/experimental/testing/server'
 import { NextRequest } from 'next/server'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { config, proxy } from './proxy'
 
 vi.mock('./utils/client', () => ({
@@ -424,5 +424,87 @@ describe('the /to/ dance', () => {
 
     expect(response.status).toBe(307)
     expect(response.headers.get('location')).toContain('/auth')
+  })
+})
+
+describe('checkout frame ancestors', () => {
+  let mockFetch: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ frame_ancestors: ['https://example.com'] }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const framedRequest = (url: string) =>
+    new NextRequest(url, {
+      headers: {
+        'Sec-Fetch-Dest': 'iframe',
+        Referer: 'https://example.com/pricing',
+      },
+    })
+
+  it('asks for the policy of a framed checkout', async () => {
+    const response = await proxy(
+      framedRequest('https://polar.sh/checkout/polar_c_123'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockFetch).toHaveBeenCalledOnce()
+
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toContain('/v1/checkouts/client/polar_c_123/embed-policy')
+    expect(init.headers).toMatchObject({
+      Referer: 'https://example.com/pricing',
+      'Sec-Fetch-Dest': 'iframe',
+    })
+  })
+
+  it('resolves the same secret on the confirmation page', async () => {
+    await proxy(
+      framedRequest('https://polar.sh/checkout/polar_c_123/confirmation'),
+    )
+
+    expect(mockFetch.mock.calls[0][0]).toContain(
+      '/v1/checkouts/client/polar_c_123/embed-policy',
+    )
+  })
+
+  it('asks nothing on a top-level navigation', async () => {
+    const request = new NextRequest('https://polar.sh/checkout/polar_c_123', {
+      headers: { 'Sec-Fetch-Dest': 'document' },
+    })
+
+    await proxy(request)
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('asks when the browser sends no fetch destination', async () => {
+    await proxy(new NextRequest('https://polar.sh/checkout/polar_c_123'))
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+  })
+
+  it('asks nothing outside checkout', async () => {
+    await proxy(framedRequest('https://polar.sh/embed/payment-method'))
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('swallows a failed call', async () => {
+    mockFetch.mockRejectedValue(new Error('unreachable'))
+
+    const response = await proxy(
+      framedRequest('https://polar.sh/checkout/polar_c_123'),
+    )
+
+    expect(response.status).toBe(200)
   })
 })

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -8,6 +8,7 @@ import {
   DISTINCT_ID_COOKIE,
   DISTINCT_ID_HEADER,
 } from './experiments/constants'
+import { getServerURL } from './utils/api'
 import { createServerSideAPI } from './utils/client'
 import { CONFIG } from './utils/config'
 import { POLAR_ENV_COOKIE } from './utils/cookies'
@@ -91,6 +92,45 @@ const requiresAuthentication = (request: NextRequest): boolean => {
   return AUTHENTICATED_ROUTES.some((route) =>
     route.test(request.nextUrl.pathname),
   )
+}
+
+const CHECKOUT_CLIENT_SECRET = /^\/checkout\/([^/]+)/
+const NO_FRAME_ANCESTORS = ["'none'"]
+
+const isFramed = (request: NextRequest): boolean => {
+  const destination = request.headers.get('Sec-Fetch-Dest')
+  return (
+    destination === null || destination === 'iframe' || destination === 'frame'
+  )
+}
+
+const getFrameAncestors = async (
+  request: NextRequest,
+  clientSecret: string,
+): Promise<string[]> => {
+  const headers: Record<string, string> = {}
+  for (const header of ['Referer', 'Sec-Fetch-Dest']) {
+    const value = request.headers.get(header)
+    if (value) {
+      headers[header] = value
+    }
+  }
+
+  try {
+    const response = await fetch(
+      getServerURL(
+        `/v1/checkouts/client/${encodeURIComponent(clientSecret)}/embed-policy`,
+      ),
+      { headers, cache: 'no-store' },
+    )
+    if (!response.ok) {
+      return NO_FRAME_ANCESTORS
+    }
+    const { frame_ancestors } = await response.json()
+    return frame_ancestors
+  } catch {
+    return NO_FRAME_ANCESTORS
+  }
 }
 
 const getLoginResponse = (request: NextRequest): NextResponse => {
@@ -286,6 +326,11 @@ export async function proxy(request: NextRequest) {
       POLAR_USER_HEADER,
       Buffer.from(JSON.stringify(user)).toString('base64'),
     )
+  }
+
+  const checkout = request.nextUrl.pathname.match(CHECKOUT_CLIENT_SECRET)
+  if (checkout && isFramed(request)) {
+    await getFrameAncestors(request, checkout[1])
   }
 
   const response = NextResponse.next({


### PR DESCRIPTION
## Summary

This is a "dry run" for [ENG-12](https://linear.app/polarsh/issue/ENG-12/enforce-embed-hosts-through-frame-ancestors-csp) : The return value is not yet used to write the header, but calling the function will trigger the log so we'll be able to monitor if some framed checkouts will be broken when enforced.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

