### PR TITLE
Clean up CTA color experiment

### DIFF
--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -101,11 +101,6 @@ const Checkout = ({
   })
   const trialDueTodayExperiment = hasActiveTrial && isTreatment
 
-  const { isTreatment: ctaColorExperiment } = useExperiment(
-    'checkout_cta_primary_color',
-    { trackExposure: !embed },
-  )
-
   const isMobileViewport = useIsMobileViewport()
   const collapsibleOrderSummary =
     hasProductCheckout(checkout) && isOrderSummaryCollapsible(checkout)
@@ -398,7 +393,6 @@ const Checkout = ({
             loadingLabel={label}
             theme={theme}
             themePreset={themePreset}
-            ctaColorExperiment={ctaColorExperiment}
             disabled={disableCheckout}
             isUpdatePending={isUpdatePending}
             locale={locale}

--- a/clients/apps/web/src/experiments/experiments.ts
+++ b/clients/apps/web/src/experiments/experiments.ts
@@ -24,12 +24,6 @@ export const experiments = {
     variants: ['control', 'treatment'] as const,
     defaultVariant: 'control',
   },
-  checkout_cta_primary_color: {
-    description:
-      'Alternative primary color for the checkout CTA button instead of the default black/white',
-    variants: ['control', 'treatment'] as const,
-    defaultVariant: 'control',
-  },
   checkout_collapsed_order_summary: {
     description:
       'Collapse the order summary on mobile hosted checkouts so the CTA moves above the fold',

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -76,7 +76,6 @@ interface BaseCheckoutFormProps {
   isWalletPayment?: boolean
   beforeSubmit?: React.ReactNode
   embed?: boolean
-  ctaColorExperiment?: boolean
 }
 
 const BaseCheckoutForm = ({
@@ -93,7 +92,6 @@ const BaseCheckoutForm = ({
   isWalletPayment,
   beforeSubmit,
   embed,
-  ctaColorExperiment,
 }: React.PropsWithChildren<BaseCheckoutFormProps>) => {
   const interval = hasProductCheckout(checkout)
     ? isLegacyRecurringProductPrice(checkout.product_price)
@@ -721,7 +719,6 @@ const BaseCheckoutForm = ({
             <div className="flex w-full flex-col items-center justify-center gap-y-2">
               <Button
                 type="submit"
-                variant={ctaColorExperiment ? 'primary' : 'default'}
                 size="lg"
                 wrapperClassNames="text-base"
                 className="w-full"
@@ -792,7 +789,6 @@ interface CheckoutFormProps {
   locale?: AcceptedLocale
   beforeSubmit?: React.ReactNode
   embed?: boolean
-  ctaColorExperiment?: boolean
 }
 
 const StripeCheckoutForm = (props: CheckoutFormProps) => {

--- a/clients/packages/checkout/src/components/ui/Button.tsx
+++ b/clients/packages/checkout/src/components/ui/Button.tsx
@@ -7,8 +7,6 @@ const baseClasses =
 const variantClasses = {
   default:
     'bg-black dark:bg-white dark:text-black text-white hover:opacity-85 transition-opacity duration-100',
-  primary:
-    'bg-[#0570de] text-white hover:opacity-85 transition-opacity duration-100',
   secondary:
     'text-black dark:text-white hover:bg-gray-200 dark:bg-polar-700 dark:hover:bg-polar-600 bg-gray-100 border dark:border-white/5 border-black/4',
   ghost:


### PR DESCRIPTION
## Summary

The [control group](https://us.posthog.com/project/27829/experiments/460482) won (womp womp) so this PR will clean up the experiment

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

