### PR TITLE
Fix scroll on payment method pages

### DIFF
--- a/clients/packages/checkout/src/payment-method.test.ts
+++ b/clients/packages/checkout/src/payment-method.test.ts
@@ -160,6 +160,20 @@ describe('PolarEmbedPaymentMethod', () => {
       embed.close()
     })
 
+    it('opts the overlay out of Lenis smooth scrolling', async () => {
+      const promise = PolarEmbedPaymentMethod.create({
+        sessionToken: CUSTOMER_SESSION_TOKEN,
+      })
+
+      expect(
+        document.querySelector('iframe')!.getAttribute('data-lenis-prevent'),
+      ).toBe('')
+
+      dispatchLoaded()
+      const embed = await promise
+      embed.close()
+    })
+
     it('calls onLoaded callback when the embed loads', async () => {
       const onLoaded = vi.fn()
 

--- a/clients/packages/checkout/src/payment-method.ts
+++ b/clients/packages/checkout/src/payment-method.ts
@@ -320,6 +320,10 @@ class EmbedPaymentMethod {
     iframe.style.backgroundColor = 'rgba(0, 0, 0, 0.5)'
     iframe.style.colorScheme = 'normal'
 
+    // Opt the overlay out of smooth-scroll libraries (Lenis) on the embedding
+    // page, which would otherwise swallow the scroll inside the modal.
+    iframe.setAttribute('data-lenis-prevent', '')
+
     iframe.allow = buildIframeAllow()
 
     document.body.appendChild(iframe)


### PR DESCRIPTION
## Summary

Similar to what we do on embedded checkouts, this PR will fix a scrolling issue if the payment method is embedded on a page using [Lenis](https://lenis.dev/).

Fixes: https://github.com/polarsource/feedback/issues/440

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

