### PR TITLE
Enforce 80% test coverage on checkout package

### DIFF
--- a/clients/packages/checkout/package.json
+++ b/clients/packages/checkout/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "rm -rf dist/ && tsup",
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "typecheck": "tsc --noEmit"
   },
   "exports": {

--- a/clients/packages/checkout/vitest.config.ts
+++ b/clients/packages/checkout/vitest.config.ts
@@ -9,5 +9,17 @@ export default defineConfig({
     env: {
       TZ: 'UTC',
     },
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: ['src/**/*.test.{ts,tsx}', 'src/test-utils/**'],
+      reporter: ['text-summary'],
+      thresholds: {
+        lines: 80,
+        statements: 80,
+        functions: 80,
+        branches: 70,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary

If test coverage goes below 80% for `@polar-sh/checkout` CI will now fail

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

