### PR TITLE
test(checkout): use fake timers for CheckoutForm debounce waits

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutForm.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.test.tsx
@@ -62,6 +62,7 @@ beforeAll(() => {
 afterEach(() => {
   captureOptions.mockClear()
   mockLoadStripe.mockClear()
+  vi.useRealTimers()
 })
 
 function FormWrapper({
@@ -304,63 +305,8 @@ describe('CheckoutForm', () => {
     })
   })
 
-  it('displays validation error on billing address state field', async () => {
-    let form: UseFormReturn<schemas['CheckoutUpdatePublic']> | null = null
-    const checkout = createCheckout({
-      // oxlint-disable-next-line typescript/no-explicit-any
-      payment_processor: 'dummy' as any,
-      billing_address_fields: {
-        country: 'required',
-        state: 'required',
-        city: 'optional',
-        postal_code: 'optional',
-        line1: 'optional',
-        line2: 'disabled',
-      },
-    })
-
-    render(
-      <FormWrapper
-        checkout={checkout}
-        {...defaultProps}
-        onForm={(f) => {
-          form = f
-        }}
-        defaultValues={{
-          customer_billing_address: {
-            country: 'US',
-            state: 'California',
-          },
-        }}
-        locale="en"
-      />,
-    )
-
-    await act(async () => {
-      form!.setError('customer_billing_address.state', {
-        type: 'value_error',
-        message: 'Invalid US state',
-      })
-    })
-
-    expect(screen.getByText('Invalid US state')).toBeInTheDocument()
-  })
-
-  describe('debounced country changes', () => {
-    beforeEach(() => {
-      vi.useFakeTimers({ shouldAdvanceTime: true })
-    })
-
-    afterEach(() => {
-      vi.useRealTimers()
-    })
-
-    const waitForDebounce = () =>
-      act(async () => {
-        await vi.advanceTimersByTimeAsync(600)
-      })
-
-    it('resets state field when country changes', async () => {
+  it('resets state field when country changes', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
     let form: UseFormReturn<schemas['CheckoutUpdatePublic']> | null = null
     const update = vi.fn(async () => createCheckout())
     const checkout = createCheckout({
@@ -408,7 +354,9 @@ describe('CheckoutForm', () => {
       form!.setValue('customer_billing_address.country', 'US')
     })
 
-    await waitForDebounce()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600)
+    })
 
     // Only state should be reset
     expect(form!.getValues('customer_billing_address.state')).toBe('')
@@ -419,7 +367,50 @@ describe('CheckoutForm', () => {
     expect(form!.getValues('customer_billing_address.line1')).toBe('Foo St')
   })
 
+  it('displays validation error on billing address state field', async () => {
+    let form: UseFormReturn<schemas['CheckoutUpdatePublic']> | null = null
+    const checkout = createCheckout({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      payment_processor: 'dummy' as any,
+      billing_address_fields: {
+        country: 'required',
+        state: 'required',
+        city: 'optional',
+        postal_code: 'optional',
+        line1: 'optional',
+        line2: 'disabled',
+      },
+    })
+
+    render(
+      <FormWrapper
+        checkout={checkout}
+        {...defaultProps}
+        onForm={(f) => {
+          form = f
+        }}
+        defaultValues={{
+          customer_billing_address: {
+            country: 'US',
+            state: 'California',
+          },
+        }}
+        locale="en"
+      />,
+    )
+
+    await act(async () => {
+      form!.setError('customer_billing_address.state', {
+        type: 'value_error',
+        message: 'Invalid US state',
+      })
+    })
+
+    expect(screen.getByText('Invalid US state')).toBeInTheDocument()
+  })
+
   it('clears billing address errors when country changes', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
     let form: UseFormReturn<schemas['CheckoutUpdatePublic']> | null = null
     const checkout = createCheckout({
       // oxlint-disable-next-line typescript/no-explicit-any
@@ -464,12 +455,18 @@ describe('CheckoutForm', () => {
       form!.setValue('customer_billing_address.country', 'CA')
     })
 
-    await waitForDebounce()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600)
+    })
 
     expect(screen.queryByText('Invalid US state')).not.toBeInTheDocument()
   })
 
   describe('tax ID handling on country change', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+    })
+
     const businessCheckout = (
       overrides: Partial<ProductCheckoutPublic> = {},
     ): ProductCheckoutPublic =>
@@ -511,6 +508,11 @@ describe('CheckoutForm', () => {
       )
       return { form, update }
     }
+
+    const waitForDebounce = () =>
+      act(async () => {
+        await vi.advanceTimersByTimeAsync(600)
+      })
 
     it('clears an applied tax ID on the server and form when the country changes', async () => {
       const update = vi.fn(async () => createCheckout())
@@ -641,7 +643,6 @@ describe('CheckoutForm', () => {
         customer_billing_address: { country: 'US' },
         customer_tax_id: null,
       })
-    })
     })
   })
 

--- a/clients/packages/checkout/src/components/CheckoutForm.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.test.tsx
@@ -4,7 +4,15 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import { useEffect } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { useForm } from 'react-hook-form'
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 import type { ProductCheckoutPublic } from '../guards'
 import {
   CheckoutFormContext,

--- a/clients/packages/checkout/src/components/CheckoutForm.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.test.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import { useEffect } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { useForm } from 'react-hook-form'
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ProductCheckoutPublic } from '../guards'
 import {
   CheckoutFormContext,
@@ -304,7 +304,63 @@ describe('CheckoutForm', () => {
     })
   })
 
-  it('resets state field when country changes', async () => {
+  it('displays validation error on billing address state field', async () => {
+    let form: UseFormReturn<schemas['CheckoutUpdatePublic']> | null = null
+    const checkout = createCheckout({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      payment_processor: 'dummy' as any,
+      billing_address_fields: {
+        country: 'required',
+        state: 'required',
+        city: 'optional',
+        postal_code: 'optional',
+        line1: 'optional',
+        line2: 'disabled',
+      },
+    })
+
+    render(
+      <FormWrapper
+        checkout={checkout}
+        {...defaultProps}
+        onForm={(f) => {
+          form = f
+        }}
+        defaultValues={{
+          customer_billing_address: {
+            country: 'US',
+            state: 'California',
+          },
+        }}
+        locale="en"
+      />,
+    )
+
+    await act(async () => {
+      form!.setError('customer_billing_address.state', {
+        type: 'value_error',
+        message: 'Invalid US state',
+      })
+    })
+
+    expect(screen.getByText('Invalid US state')).toBeInTheDocument()
+  })
+
+  describe('debounced country changes', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    const waitForDebounce = () =>
+      act(async () => {
+        await vi.advanceTimersByTimeAsync(600)
+      })
+
+    it('resets state field when country changes', async () => {
     let form: UseFormReturn<schemas['CheckoutUpdatePublic']> | null = null
     const update = vi.fn(async () => createCheckout())
     const checkout = createCheckout({
@@ -352,9 +408,7 @@ describe('CheckoutForm', () => {
       form!.setValue('customer_billing_address.country', 'US')
     })
 
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 600))
-    })
+    await waitForDebounce()
 
     // Only state should be reset
     expect(form!.getValues('customer_billing_address.state')).toBe('')
@@ -363,48 +417,6 @@ describe('CheckoutForm', () => {
     )
     expect(form!.getValues('customer_billing_address.city')).toBe('Stockholm')
     expect(form!.getValues('customer_billing_address.line1')).toBe('Foo St')
-  })
-
-  it('displays validation error on billing address state field', async () => {
-    let form: UseFormReturn<schemas['CheckoutUpdatePublic']> | null = null
-    const checkout = createCheckout({
-      // oxlint-disable-next-line typescript/no-explicit-any
-      payment_processor: 'dummy' as any,
-      billing_address_fields: {
-        country: 'required',
-        state: 'required',
-        city: 'optional',
-        postal_code: 'optional',
-        line1: 'optional',
-        line2: 'disabled',
-      },
-    })
-
-    render(
-      <FormWrapper
-        checkout={checkout}
-        {...defaultProps}
-        onForm={(f) => {
-          form = f
-        }}
-        defaultValues={{
-          customer_billing_address: {
-            country: 'US',
-            state: 'California',
-          },
-        }}
-        locale="en"
-      />,
-    )
-
-    await act(async () => {
-      form!.setError('customer_billing_address.state', {
-        type: 'value_error',
-        message: 'Invalid US state',
-      })
-    })
-
-    expect(screen.getByText('Invalid US state')).toBeInTheDocument()
   })
 
   it('clears billing address errors when country changes', async () => {
@@ -452,9 +464,7 @@ describe('CheckoutForm', () => {
       form!.setValue('customer_billing_address.country', 'CA')
     })
 
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 600))
-    })
+    await waitForDebounce()
 
     expect(screen.queryByText('Invalid US state')).not.toBeInTheDocument()
   })
@@ -501,11 +511,6 @@ describe('CheckoutForm', () => {
       )
       return { form, update }
     }
-
-    const waitForDebounce = () =>
-      act(async () => {
-        await new Promise((r) => setTimeout(r, 600))
-      })
 
     it('clears an applied tax ID on the server and form when the country changes', async () => {
       const update = vi.fn(async () => createCheckout())
@@ -636,6 +641,7 @@ describe('CheckoutForm', () => {
         customer_billing_address: { country: 'US' },
         customer_tax_id: null,
       })
+    })
     })
   })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Some checkout tests were unnecessarily so because they used `setTimeout` with real timers. Modified them to use fake timers and shaved off 6 seconds from execution.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e98ca59-fc49-446b-9b1d-aafc4a7e25b5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e98ca59-fc49-446b-9b1d-aafc4a7e25b5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

