### PR TITLE
End "Due today" experiment

### DIFF
--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -93,14 +93,6 @@ const Checkout = ({
   const locale: AcceptedLocale = _locale || 'en'
   const posthog = usePostHog()
 
-  const hasActiveTrial = Boolean(
-    checkout.active_trial_interval && checkout.active_trial_interval_count,
-  )
-  const { isTreatment } = useExperiment('checkout_trial_due_today', {
-    trackExposure: hasActiveTrial,
-  })
-  const trialDueTodayExperiment = hasActiveTrial && isTreatment
-
   const isMobileViewport = useIsMobileViewport()
   const collapsibleOrderSummary =
     hasProductCheckout(checkout) && isOrderSummaryCollapsible(checkout)
@@ -305,11 +297,7 @@ const Checkout = ({
                       <hr className="dark:border-polar-700 border-gray-200" />
                     </>
                   )}
-                <CheckoutPricingBreakdown
-                  checkout={checkout}
-                  locale={locale}
-                  trialDueTodayExperiment={trialDueTodayExperiment}
-                />
+                <CheckoutPricingBreakdown checkout={checkout} locale={locale} />
                 <CheckoutDiscountInput
                   checkout={checkout}
                   update={update}
@@ -359,7 +347,6 @@ const Checkout = ({
               update={update}
               themePreset={themePreset}
               locale={locale}
-              trialDueTodayExperiment={trialDueTodayExperiment}
             />
           ) : (
             <div className="flex flex-col gap-y-8 md:sticky md:top-8">
@@ -369,7 +356,6 @@ const Checkout = ({
                   update={update}
                   themePreset={themePreset}
                   locale={locale}
-                  trialDueTodayExperiment={trialDueTodayExperiment}
                 />
               )}
             </div>

--- a/clients/apps/web/src/components/Checkout/CheckoutCollapsibleOrderSummary.test.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutCollapsibleOrderSummary.test.tsx
@@ -50,7 +50,6 @@ const renderSummary = (checkout = createCheckout()) =>
       update={vi.fn()}
       themePreset={{} as never}
       locale="en"
-      trialDueTodayExperiment={false}
     />,
   )
 

--- a/clients/apps/web/src/components/Checkout/CheckoutOrderSummary.tsx
+++ b/clients/apps/web/src/components/Checkout/CheckoutOrderSummary.tsx
@@ -37,7 +37,6 @@ export interface CheckoutOrderSummaryProps {
   ) => Promise<schemas['CheckoutPublic']>
   themePreset: ThemingPresetProps
   locale: AcceptedLocale
-  trialDueTodayExperiment: boolean
 }
 
 export const CheckoutOrderSummary = ({
@@ -45,7 +44,6 @@ export const CheckoutOrderSummary = ({
   update,
   themePreset,
   locale,
-  trialDueTodayExperiment,
 }: CheckoutOrderSummaryProps) => {
   const hasMedia = checkout.product.medias.length > 0
 
@@ -134,11 +132,7 @@ export const CheckoutOrderSummary = ({
               locale={locale}
             />
           )}
-          <CheckoutPricingBreakdown
-            checkout={checkout}
-            locale={locale}
-            trialDueTodayExperiment={trialDueTodayExperiment}
-          />
+          <CheckoutPricingBreakdown checkout={checkout} locale={locale} />
           <CheckoutDiscountInput
             checkout={checkout}
             update={update}

--- a/clients/apps/web/src/experiments/experiments.ts
+++ b/clients/apps/web/src/experiments/experiments.ts
@@ -6,19 +6,14 @@
  * 2. Add it here with variants and default
  * 3. Use useExperiment() or <Experiment> in your components
  *
+ * Below is an example of a experiment definition:
+ * test_experiment: {
+ *   description: 'Brief description of what the experiment does',
+ *   variants: ['control', 'treatment'] as const,
+ *   defaultVariant: 'control',
+ * }
  */
 export const experiments = {
-  test_experiment: {
-    description: 'Test experiment',
-    variants: ['control', 'treatment'] as const,
-    defaultVariant: 'control',
-  },
-  checkout_trial_due_today: {
-    description:
-      'Show an emphasized "Due today $0" total on trial checkouts, with the recurring price de-emphasized',
-    variants: ['control', 'treatment'] as const,
-    defaultVariant: 'control',
-  },
   checkout_collapsed_order_summary: {
     description:
       'Collapse the order summary on mobile hosted checkouts so the CTA moves above the fold',

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.test.tsx
@@ -506,20 +506,14 @@ describe('CheckoutPricingBreakdown', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('composes with the due-today experiment like a dated total after trial plus due today', () => {
+    it('shows a dated total after trial plus due today', () => {
       const checkout = createDiscountedCheckout({
         interval: 'month',
         discount: onceDiscount,
         trial: true,
       })
 
-      render(
-        <CheckoutPricingBreakdown
-          checkout={checkout}
-          locale="en"
-          trialDueTodayExperiment
-        />,
-      )
+      render(<CheckoutPricingBreakdown checkout={checkout} locale="en" />)
 
       expect(screen.getByTestId('detail-row-Due today')).toHaveTextContent('$0')
       const afterTrial = screen.getByTestId('detail-row-Total after trial')
@@ -850,28 +844,38 @@ describe('CheckoutPricingBreakdown', () => {
         trial_end: new Date('2026-04-05T00:00:00Z').toISOString(),
       })
 
-    it('shows a due-today row alongside the recurring total', () => {
-      render(
-        <CheckoutPricingBreakdown
-          checkout={trialCheckout()}
-          locale="en"
-          trialDueTodayExperiment
-        />,
-      )
-
-      expect(screen.getByTestId('detail-row-Due today')).toHaveTextContent('$0')
-      expect(screen.getByTestId('detail-row-Monthly')).toBeInTheDocument()
-    })
-
-    it('keeps only the recurring total by default', () => {
+    it('shows an emphasized due-today row and mutes the recurring total', () => {
       render(
         <CheckoutPricingBreakdown checkout={trialCheckout()} locale="en" />,
+      )
+
+      const dueTodayRow = screen.getByTestId('detail-row-Due today')
+      expect(dueTodayRow).toHaveTextContent('$0')
+      expect(dueTodayRow).toHaveClass('font-medium')
+      expect(screen.getByTestId('detail-row-Monthly')).not.toHaveClass(
+        'font-medium',
+      )
+    })
+
+    it('keeps the emphasized recurring total without a trial', () => {
+      render(
+        <CheckoutPricingBreakdown
+          checkout={createCheckout({
+            ...trialCheckout(),
+            active_trial_interval: null,
+            active_trial_interval_count: null,
+            trial_end: null,
+          })}
+          locale="en"
+        />,
       )
 
       expect(
         screen.queryByTestId('detail-row-Due today'),
       ).not.toBeInTheDocument()
-      expect(screen.getByTestId('detail-row-Monthly')).toBeInTheDocument()
+      expect(screen.getByTestId('detail-row-Monthly')).toHaveClass(
+        'font-medium',
+      )
     })
   })
 

--- a/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
+++ b/clients/packages/checkout/src/components/CheckoutPricingBreakdown.tsx
@@ -44,15 +44,17 @@ function formatShortDate(date: Date, locale: AcceptedLocale): string {
 export interface CheckoutPricingBreakdownProps {
   checkout: schemas['CheckoutPublic']
   locale?: AcceptedLocale
-  trialDueTodayExperiment?: boolean
 }
 
 const CheckoutPricingBreakdown = ({
   checkout,
   locale = DEFAULT_LOCALE,
-  trialDueTodayExperiment = false,
 }: CheckoutPricingBreakdownProps) => {
   const t = useTranslations(locale)
+
+  const hasActiveTrial = Boolean(
+    checkout.active_trial_interval && checkout.active_trial_interval_count,
+  )
 
   const temporaryDiscount = isTemporaryDiscount(checkout.discount)
 
@@ -261,7 +263,7 @@ const CheckoutPricingBreakdown = ({
                 ? formatShortDate(new Date(checkout.trial_end), locale)
                 : undefined
             }
-            emphasis={!trialDueTodayExperiment}
+            emphasis={!hasActiveTrial}
           >
             <AmountLabel
               amount={checkout.total_amount}
@@ -272,7 +274,7 @@ const CheckoutPricingBreakdown = ({
               locale={locale}
             />
           </DetailRow>
-          {trialDueTodayExperiment && (
+          {hasActiveTrial && (
             <DetailRow title={t('checkout.pricing.dueToday')} emphasis>
               {formatCurrency('standard', locale)(0, checkout.currency)}
             </DetailRow>


### PR DESCRIPTION
## Summary

The "Due today" experiment proved very successful, improving conversion rate by almost 9%. This PR will clean up the experiment and ship treatment to everyone

<img width="95" height="37" alt="Screenshot 2026-09-07 at 15 23 43" src="https://github.com/user-attachments/assets/efd24801-1545-4525-a458-2199149f7f9e" />

| Control | Treatment  |
|--------|--------|
| <img width="512" height="451" alt="Screenshot 2026-09-04 at 14 07 06" src="https://github.com/user-attachments/assets/8af264b1-32a8-4f46-8a95-d22ac278b485" /> | <img width="507" height="447" alt="Screenshot 2026-09-04 at 14 06 47" src="https://github.com/user-attachments/assets/3ecf4af6-d264-4ef0-af0f-cd6f638f32fd" /> |








<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

