### PR TITLE
feat(adapters): support checkout discount codes

### DIFF
--- a/clients/.changeset/adapter-discount-code.md
+++ b/clients/.changeset/adapter-discount-code.md
@@ -1,0 +1,8 @@
+---
+'@polar-sh/nextjs': minor
+'@polar-sh/nuxt': minor
+'@polar-sh/tanstack-start': minor
+'@polar-sh/better-auth': minor
+---
+
+Support `discount_code` in checkout requests, applying the code before redirecting or opening an embedded checkout. Discount codes must be enabled, and an explicit `discount_id` takes precedence.

--- a/clients/adapters/better-auth/README.md
+++ b/clients/adapters/better-auth/README.md
@@ -316,6 +316,7 @@ Arguments to `authClient.checkout()` and `authClient.checkoutEmbed()` use snake_
 - `products`: a product ID or array of product IDs.
 - `custom_field_data`, `metadata`: objects containing custom field values or metadata.
 - `allow_discount_codes`, `discount_id`: discount settings.
+- `discount_code`: apply a human-readable code before returning the checkout URL, including for `checkoutEmbed()`. Discount codes must be enabled; `discount_id` takes precedence when both are supplied.
 - `seats`, `min_seats`, `max_seats`: seat-based pricing settings.
 - `success_url`, `return_url`: absolute URLs or paths relative to the auth server. These override the plugin's `successUrl` and `returnUrl` configuration.
 - `allow_trial`, `trial_interval`, `trial_interval_count`: trial settings.

--- a/clients/adapters/better-auth/src/__tests__/plugins/checkout.test.ts
+++ b/clients/adapters/better-auth/src/__tests__/plugins/checkout.test.ts
@@ -90,6 +90,72 @@ describe('checkout plugin', () => {
       handler = endpoints.checkout.handler
     })
 
+    it.each([
+      { discount_code: 'SAVE+20%', redirect: true },
+      {
+        discount_code: 'SAVE20',
+        redirect: false,
+        embed_origin: 'https://example.com',
+      },
+      { discount_code: 'SAVE20', discount_id: 'disc_123' },
+      { discount_code: '' },
+    ])('handles discount prefill for %j', async (discountParams) => {
+      const mockCheckout = createMockCheckout()
+      vi.mocked(getSessionFromCtx).mockResolvedValue(null)
+      vi.mocked(mockClient.checkouts.create).mockResolvedValue(mockCheckout)
+      const ctx = {
+        ...mockContext,
+        body: CheckoutParams.parse({
+          products: ['prod-123'],
+          ...discountParams,
+        }),
+        json: vi.fn(),
+      }
+
+      await handler(ctx)
+
+      expect(mockClient.checkouts.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          discount_id: ctx.body.discount_id,
+          embed_origin: ctx.body.embed_origin,
+        }),
+      )
+      if (ctx.body.discount_code && !ctx.body.discount_id) {
+        expect(
+          mockClient.checkouts.clientUpdate,
+        ).toHaveBeenCalledExactlyOnceWith(mockCheckout.client_secret, {
+          discount_code: ctx.body.discount_code,
+        })
+      } else {
+        expect(mockClient.checkouts.clientUpdate).not.toHaveBeenCalled()
+      }
+      expect(ctx.json).toHaveBeenCalledWith({
+        url: `${mockCheckout.url}?theme=dark`,
+        redirect: ctx.body.redirect ?? true,
+      })
+    })
+
+    it('does not return a checkout URL when applying a discount code fails', async () => {
+      vi.mocked(getSessionFromCtx).mockResolvedValue(null)
+      vi.mocked(mockClient.checkouts.create).mockResolvedValue(
+        createMockCheckout(),
+      )
+      vi.mocked(mockClient.checkouts.clientUpdate).mockRejectedValueOnce(
+        new Error('Invalid discount code'),
+      )
+      const ctx = {
+        ...mockContext,
+        body: { products: ['prod-123'], discount_code: 'INVALID' },
+        context: { logger: { error: vi.fn() } },
+        json: vi.fn(),
+      }
+
+      await expect(handler(ctx)).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+      })
+      expect(ctx.json).not.toHaveBeenCalled()
+    })
+
     it('should create checkout with product IDs', async () => {
       const mockCheckout = createMockCheckout()
       vi.mocked(getSessionFromCtx).mockResolvedValue({

--- a/clients/adapters/better-auth/src/__tests__/utils/mocks.ts
+++ b/clients/adapters/better-auth/src/__tests__/utils/mocks.ts
@@ -23,6 +23,7 @@ export const createMockPolarClient = (): MockPolarClient =>
     },
     checkouts: {
       create: vi.fn(),
+      clientUpdate: vi.fn(),
       get: vi.fn(),
     },
     customers: {
@@ -160,6 +161,7 @@ export const createMockProduct = () => ({
 
 export const createMockCheckout = () => ({
   id: 'checkout-123',
+  client_secret: 'checkout_secret',
   url: 'https://polar.sh/checkout/checkout-123',
   customer_id: 'customer-123',
   customer_email: 'test@example.com',

--- a/clients/adapters/better-auth/src/__tests__/utils/sdk.ts
+++ b/clients/adapters/better-auth/src/__tests__/utils/sdk.ts
@@ -5,6 +5,8 @@ type MockPolarClient = ReturnType<typeof createMockPolarClient>
 
 vi.mock('@polar-sh/sdk/2026-04/services/checkouts', () => ({
   createCheckouts: (client: MockPolarClient) => client.checkouts.create,
+  clientUpdateCheckouts: (client: MockPolarClient) =>
+    client.checkouts.clientUpdate,
 }))
 
 vi.mock('@polar-sh/sdk/2026-04/services/customer_sessions', () => ({

--- a/clients/adapters/better-auth/src/plugins/checkout.ts
+++ b/clients/adapters/better-auth/src/plugins/checkout.ts
@@ -1,4 +1,7 @@
-import { createCheckouts } from '@polar-sh/sdk/2026-04/services/checkouts'
+import {
+  clientUpdateCheckouts,
+  createCheckouts,
+} from '@polar-sh/sdk/2026-04/services/checkouts'
 import type { PolarCore } from '@polar-sh/sdk/2026-04'
 import {
   APIError,
@@ -60,6 +63,7 @@ export const CheckoutParams = z.object({
     .optional(),
   allow_discount_codes: z.coerce.boolean().optional(),
   discount_id: z.string().optional(),
+  discount_code: z.string().optional(),
   seats: z.number().int().min(1).max(10_000).optional(),
   min_seats: z.number().int().min(1).max(10_000).optional(),
   max_seats: z.number().int().min(1).max(10_000).optional(),
@@ -267,6 +271,12 @@ export const checkout =
                   ).toString()
                 : undefined,
             })
+
+            if (ctx.body.discount_code && !ctx.body.discount_id) {
+              await clientUpdateCheckouts(polar)(checkout.client_secret, {
+                discount_code: ctx.body.discount_code,
+              })
+            }
 
             const redirectUrl = new URL(checkout.url)
 

--- a/clients/adapters/nextjs/README.md
+++ b/clients/adapters/nextjs/README.md
@@ -30,6 +30,7 @@ Pass query params to this route.
 - external_customer_id (optional) `?products=123&external_customer_id=xxx`
 - customer_email (optional) `?products=123&customer_email=janedoe@gmail.com`
 - customer_name (optional) `?products=123&customer_name=Jane`
+- discount_code (optional) `?products=123&discount_code=SAVE20` - Apply a discount code before redirecting. Discount codes must be enabled; `discount_id` takes precedence when both are supplied.
 - seats (optional) `?products=123&seats=5` - Number of seats for seat-based products
 - metadata (optional) `URL-Encoded JSON string`
 

--- a/clients/adapters/nextjs/src/checkout/checkout.test.ts
+++ b/clients/adapters/nextjs/src/checkout/checkout.test.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockCheckoutCreate = vi.fn()
+const mockCheckoutUpdate = vi.fn()
 
 vi.mock('@polar-sh/sdk/2026-04', () => ({
   createPolarCore: vi.fn(() => ({})),
@@ -9,6 +10,7 @@ vi.mock('@polar-sh/sdk/2026-04', () => ({
 
 vi.mock('@polar-sh/sdk/2026-04/services/checkouts', () => ({
   createCheckouts: vi.fn(() => mockCheckoutCreate),
+  clientUpdateCheckouts: () => mockCheckoutUpdate,
 }))
 
 import { createPolarCore } from '@polar-sh/sdk/2026-04'
@@ -44,6 +46,58 @@ describe('Checkout', () => {
   })
 
   describe('request handling', () => {
+    it.each([
+      ['discount_code=SAVE%2B20%25', 'SAVE+20%', undefined],
+      ['discount_code=SAVE20&discount_id=disc_123', undefined, 'disc_123'],
+      ['discount_code=', undefined, undefined],
+    ])('handles discount prefill for %s', async (query, code, discountId) => {
+      mockCheckoutCreate.mockResolvedValue({
+        url: 'https://polar.sh/checkout/123',
+        client_secret: 'checkout_secret',
+      })
+      const checkout = Checkout({ accessToken: 'test-token', theme: 'dark' })
+      const response = await checkout(
+        new NextRequest(
+          `https://example.com/checkout?products=prod_123&${query}`,
+        ),
+      )
+
+      expect(mockCheckoutCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ discount_id: discountId }),
+      )
+      if (code) {
+        expect(mockCheckoutUpdate).toHaveBeenCalledExactlyOnceWith(
+          'checkout_secret',
+          { discount_code: code },
+        )
+      } else {
+        expect(mockCheckoutUpdate).not.toHaveBeenCalled()
+      }
+      expect(response.headers.get('location')).toBe(
+        'https://polar.sh/checkout/123?theme=dark',
+      )
+    })
+
+    it('does not redirect when applying a discount code fails', async () => {
+      mockCheckoutCreate.mockResolvedValue({
+        url: 'https://polar.sh/checkout/123',
+        client_secret: 'checkout_secret',
+      })
+      mockCheckoutUpdate.mockRejectedValueOnce(
+        new Error('Invalid discount code'),
+      )
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const response = await Checkout({ accessToken: 'test-token' })(
+        new NextRequest(
+          'https://example.com/checkout?products=prod_123&discount_code=INVALID',
+        ),
+      )
+
+      expect(response.ok).toBe(false)
+      expect(response.headers.get('location')).toBeNull()
+      consoleSpy.mockRestore()
+    })
+
     it('should return 400 when no products provided', async () => {
       const checkout = Checkout({ accessToken: 'test-token' })
       const request = new NextRequest('https://example.com/checkout')

--- a/clients/adapters/nextjs/src/checkout/checkout.ts
+++ b/clients/adapters/nextjs/src/checkout/checkout.ts
@@ -1,4 +1,7 @@
-import { createCheckouts } from '@polar-sh/sdk/2026-04/services/checkouts'
+import {
+  clientUpdateCheckouts,
+  createCheckouts,
+} from '@polar-sh/sdk/2026-04/services/checkouts'
 import { createPolarCore, type Environment } from '@polar-sh/sdk/2026-04'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
@@ -80,6 +83,13 @@ export const Checkout = ({
           ? retUrl.toString().replaceAll('%7BCHECKOUT_ID%7D', '{CHECKOUT_ID}')
           : undefined,
       })
+
+      const discountCode = url.searchParams.get('discount_code')
+      if (discountCode && !url.searchParams.get('discount_id')) {
+        await clientUpdateCheckouts(polar)(result.client_secret, {
+          discount_code: discountCode,
+        })
+      }
 
       const redirectUrl = new URL(result.url)
 

--- a/clients/adapters/nuxt/README.md
+++ b/clients/adapters/nuxt/README.md
@@ -52,6 +52,7 @@ Pass query params to this route.
 - external_customer_id (optional) `?products=123&external_customer_id=xxx`
 - customer_email (optional) `?products=123&customer_email=janedoe@gmail.com`
 - customer_name (optional) `?products=123&customer_name=Jane`
+- discount_code (optional) `?products=123&discount_code=SAVE20` - Apply a discount code before redirecting. Discount codes must be enabled; `discount_id` takes precedence when both are supplied.
 - metadata (optional) `URL-Encoded JSON string`
 
 ## Customer Portal

--- a/clients/adapters/nuxt/src/runtime/server/checkoutHandler.ts
+++ b/clients/adapters/nuxt/src/runtime/server/checkoutHandler.ts
@@ -1,4 +1,7 @@
-import { createCheckouts } from '@polar-sh/sdk/2026-04/services/checkouts'
+import {
+  clientUpdateCheckouts,
+  createCheckouts,
+} from '@polar-sh/sdk/2026-04/services/checkouts'
 import { createPolarCore, type Environment } from '@polar-sh/sdk/2026-04'
 import { createError, getValidatedQuery, sendRedirect } from 'h3'
 import type { H3Event } from 'h3'
@@ -33,6 +36,7 @@ const checkoutQuerySchema = z.object({
     .pipe(z.boolean())
     .optional(),
   discount_id: z.string().nonempty().optional(),
+  discount_code: z.string().optional(),
   metadata: z.string().nonempty().optional(),
   seats: z
     .string()
@@ -63,6 +67,7 @@ export const Checkout = ({
       customer_metadata: customerMetadata,
       allow_discount_codes: allowDiscountCodes,
       discount_id: discountId,
+      discount_code: discountCode,
       metadata,
       seats,
     } = await getValidatedQuery(event, checkoutQuerySchema.parse)
@@ -101,6 +106,12 @@ export const Checkout = ({
           ? retUrl.toString().replaceAll('%7BCHECKOUT_ID%7D', '{CHECKOUT_ID}')
           : undefined,
       })
+
+      if (discountCode && !discountId) {
+        await clientUpdateCheckouts(polar)(result.client_secret, {
+          discount_code: discountCode,
+        })
+      }
 
       const redirectUrl = new URL(result.url)
 

--- a/clients/adapters/nuxt/src/runtime/server/checkoutHandler.ts
+++ b/clients/adapters/nuxt/src/runtime/server/checkoutHandler.ts
@@ -36,7 +36,7 @@ const checkoutQuerySchema = z.object({
     .pipe(z.boolean())
     .optional(),
   discount_id: z.string().nonempty().optional(),
-  discount_code: z.string().optional(),
+  discount_code: z.string().trim().optional(),
   metadata: z.string().nonempty().optional(),
   seats: z
     .string()

--- a/clients/adapters/nuxt/test/checkoutHandler.test.ts
+++ b/clients/adapters/nuxt/test/checkoutHandler.test.ts
@@ -3,10 +3,13 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 // `vi.hoisted` makes the mock fns available to the `vi.mock` factories, which
 // vitest hoists above ordinary top-level `const` declarations (so a plain
 // `const` would hit a TDZ ReferenceError when the factory runs at import time).
-const { mockCheckoutCreate, mockSendRedirect } = vi.hoisted(() => ({
-  mockCheckoutCreate: vi.fn(),
-  mockSendRedirect: vi.fn(),
-}))
+const { mockCheckoutCreate, mockCheckoutUpdate, mockSendRedirect } = vi.hoisted(
+  () => ({
+    mockCheckoutCreate: vi.fn(),
+    mockCheckoutUpdate: vi.fn(),
+    mockSendRedirect: vi.fn(),
+  }),
+)
 
 vi.mock('@polar-sh/sdk/2026-04', () => ({
   createPolarCore: vi.fn(() => ({})),
@@ -14,6 +17,7 @@ vi.mock('@polar-sh/sdk/2026-04', () => ({
 
 vi.mock('@polar-sh/sdk/2026-04/services/checkouts', () => ({
   createCheckouts: () => mockCheckoutCreate,
+  clientUpdateCheckouts: () => mockCheckoutUpdate,
 }))
 
 vi.mock('h3', async () => {
@@ -45,6 +49,7 @@ describe('Checkout', () => {
 
   beforeEach(() => {
     mockCheckoutCreate.mockClear()
+    mockCheckoutUpdate.mockClear()
     mockSendRedirect.mockClear()
     mockCheckoutCreate.mockResolvedValue({
       url: 'https://polar.sh/checkout/checkout_123',
@@ -188,6 +193,50 @@ describe('Checkout', () => {
   })
 
   describe('redirect', () => {
+    it.each([
+      ['discount_code=SAVE%2B20%25', 'SAVE+20%', undefined],
+      ['discount_code=SAVE20&discount_id=disc_123', undefined, 'disc_123'],
+      ['discount_code=', undefined, undefined],
+    ])('handles discount prefill for %s', async (query, code, discountId) => {
+      mockCheckoutCreate.mockResolvedValue({
+        url: 'https://polar.sh/checkout/123',
+        client_secret: 'checkout_secret',
+      })
+      const checkout = Checkout({ accessToken: 'test-token', theme: 'dark' })
+      await checkout(makeEvent(`/api/checkout?products=prod_123&${query}`))
+
+      expect(mockCheckoutCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ discount_id: discountId }),
+      )
+      if (code) {
+        expect(mockCheckoutUpdate).toHaveBeenCalledExactlyOnceWith(
+          'checkout_secret',
+          { discount_code: code },
+        )
+      } else {
+        expect(mockCheckoutUpdate).not.toHaveBeenCalled()
+      }
+      expect(mockSendRedirect.mock.calls[0][1]).toBe(
+        'https://polar.sh/checkout/123?theme=dark',
+      )
+    })
+
+    it('does not redirect when applying a discount code fails', async () => {
+      mockCheckoutUpdate.mockRejectedValueOnce(
+        new Error('Invalid discount code'),
+      )
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const checkout = Checkout({ accessToken: 'test-token' })
+
+      await expect(
+        checkout(
+          makeEvent('/api/checkout?products=prod_123&discount_code=INVALID'),
+        ),
+      ).rejects.toThrow('Invalid discount code')
+      expect(mockSendRedirect).not.toHaveBeenCalled()
+      consoleSpy.mockRestore()
+    })
+
     it('redirects to the URL returned by polar.checkouts.create', async () => {
       const checkout = Checkout({ accessToken: 'test-token' })
       const event = makeEvent('/api/checkout?products=prod_123&seats=5')

--- a/clients/adapters/tanstack-start/README.md
+++ b/clients/adapters/tanstack-start/README.md
@@ -33,6 +33,7 @@ Pass query params to this route.
 - external_customer_id (optional) `?products=123&external_customer_id=xxx`
 - customer_email (optional) `?products=123&customer_email=janedoe@gmail.com`
 - customer_name (optional) `?products=123&customer_name=Jane`
+- discount_code (optional) `?products=123&discount_code=SAVE20` - Apply a discount code before redirecting. Discount codes must be enabled; `discount_id` takes precedence when both are supplied.
 - seats (optional) `?products=123&seats=5` - Number of seats for seat-based products
 - metadata (optional) `URL-Encoded JSON string`
 

--- a/clients/adapters/tanstack-start/src/checkout/checkout.test.ts
+++ b/clients/adapters/tanstack-start/src/checkout/checkout.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockCheckoutCreate = vi.fn()
+const mockCheckoutUpdate = vi.fn()
 
 vi.mock('@polar-sh/sdk/2026-04', () => ({
   createPolarCore: vi.fn(() => ({})),
@@ -8,6 +9,7 @@ vi.mock('@polar-sh/sdk/2026-04', () => ({
 
 vi.mock('@polar-sh/sdk/2026-04/services/checkouts', () => ({
   createCheckouts: () => mockCheckoutCreate,
+  clientUpdateCheckouts: () => mockCheckoutUpdate,
 }))
 
 import { Checkout } from './checkout'
@@ -15,6 +17,56 @@ import { Checkout } from './checkout'
 describe('Checkout', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it.each([
+    ['discount_code=SAVE%2B20%25', 'SAVE+20%', undefined],
+    ['discount_code=SAVE20&discount_id=disc_123', undefined, 'disc_123'],
+    ['discount_code=', undefined, undefined],
+  ])('handles discount prefill for %s', async (query, code, discountId) => {
+    mockCheckoutCreate.mockResolvedValue({
+      url: 'https://polar.sh/checkout/123',
+      client_secret: 'checkout_secret',
+    })
+    const checkout = Checkout({ accessToken: 'test-token', theme: 'dark' })
+    const response = await checkout({
+      request: new Request(
+        `https://example.com/checkout?products=prod_123&${query}`,
+      ),
+    })
+
+    expect(mockCheckoutCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ discount_id: discountId }),
+    )
+    if (code) {
+      expect(mockCheckoutUpdate).toHaveBeenCalledExactlyOnceWith(
+        'checkout_secret',
+        { discount_code: code },
+      )
+    } else {
+      expect(mockCheckoutUpdate).not.toHaveBeenCalled()
+    }
+    expect(response.headers.get('location')).toBe(
+      'https://polar.sh/checkout/123?theme=dark',
+    )
+  })
+
+  it('does not redirect when applying a discount code fails', async () => {
+    mockCheckoutCreate.mockResolvedValue({
+      url: 'https://polar.sh/checkout/123',
+      client_secret: 'checkout_secret',
+    })
+    mockCheckoutUpdate.mockRejectedValueOnce(new Error('Invalid discount code'))
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const response = await Checkout({ accessToken: 'test-token' })({
+      request: new Request(
+        'https://example.com/checkout?products=prod_123&discount_code=INVALID',
+      ),
+    })
+
+    expect(response.status).toBe(500)
+    expect(response.headers.get('location')).toBeNull()
+    consoleSpy.mockRestore()
   })
 
   it('should create checkout and redirect when products are provided', async () => {

--- a/clients/adapters/tanstack-start/src/checkout/checkout.ts
+++ b/clients/adapters/tanstack-start/src/checkout/checkout.ts
@@ -84,7 +84,7 @@ export const Checkout = <TPath extends string = string>({
       })
 
       const discountCode = url.searchParams.get('discount_code')
-      if (discountCode && !url.searchParams.get('discount_id')) {
+      if (discountCode?.trim() && !url.searchParams.get('discount_id')) {
         await clientUpdateCheckouts(polar)(result.client_secret, {
           discount_code: discountCode,
         })

--- a/clients/adapters/tanstack-start/src/checkout/checkout.ts
+++ b/clients/adapters/tanstack-start/src/checkout/checkout.ts
@@ -1,4 +1,7 @@
-import { createCheckouts } from '@polar-sh/sdk/2026-04/services/checkouts'
+import {
+  clientUpdateCheckouts,
+  createCheckouts,
+} from '@polar-sh/sdk/2026-04/services/checkouts'
 import { createPolarCore, type Environment } from '@polar-sh/sdk/2026-04'
 import type { StartRouteHandler } from '../types'
 
@@ -79,6 +82,13 @@ export const Checkout = <TPath extends string = string>({
           ? retUrl.toString().replaceAll('%7BCHECKOUT_ID%7D', '{CHECKOUT_ID}')
           : undefined,
       })
+
+      const discountCode = url.searchParams.get('discount_code')
+      if (discountCode && !url.searchParams.get('discount_id')) {
+        await clientUpdateCheckouts(polar)(result.client_secret, {
+          discount_code: discountCode,
+        })
+      }
 
       const redirectUrl = new URL(result.url)
 


### PR DESCRIPTION
## Summary

Support `discount_code` in checkout requests for Next.js, Nuxt, TanStack Start, and Better Auth. For example, `/checkout?products=...&discount_code=SAVE20` now applies the code before redirecting. Better Auth also supports the parameter when returning a URL or opening an embedded checkout.

Fixes polarsource/polar-adapters#411

## What

- Accept `discount_code` alongside the existing `discount_id` parameter.
- Give an explicit `discount_id` precedence and skip empty codes.
- Add regression tests, documentation, and a changeset for all four maintained adapters.

## Why

Checkout creation accepts only discount IDs, and hosted checkout session pages do not consume discount-code query parameters. Codes sent to adapter routes were ignored.

## How

After creating the session, apply the code through the existing public checkout-update operation using its client secret. This uses the backend's normal discount validation and requires no discount-listing permissions. Discount codes must be enabled.

If applying the code fails, the adapter follows its existing error path without redirecting or returning a checkout URL. The newly created, unused session remains because creation and code application are separate API calls.

## Validation

- 297 tests passed: Better Auth 217, Next.js 48, Nuxt 20, TanStack Start 12.
- All four adapter typechecks passed, including the Nuxt playground.
- Full frontend `pnpm lint`, changed-file formatting, and diff checks passed.

## Checklist

- [x] This PR addresses a single concern
- [x] The diff is focused and contains no unrelated fixes
- [x] New behavior is covered by regression tests
- [x] Package linting and type checking pass
