### PR TITLE
feat(checkout): enforce embed hosts through frame-ancestors

### DIFF
--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -2,6 +2,13 @@
 import createMDX from '@next/mdx'
 import { withSentryConfig } from '@sentry/nextjs'
 import { themeConfig } from './shiki.config.mjs'
+import {
+  docsCSP,
+  embeddedCSP,
+  ENVIRONMENT,
+  nonEmbeddedCSP,
+  oauth2CSP,
+} from './src/csp.mjs'
 
 const PREVIEW_BUILD = process.env.POLAR_PREVIEW_BUILD === '1'
 
@@ -32,60 +39,9 @@ if (
 
 const POLAR_AUTH_COOKIE_KEY =
   process.env.POLAR_AUTH_COOKIE_KEY || 'polar_session'
-const ENVIRONMENT =
-  process.env.VERCEL_ENV || process.env.NEXT_PUBLIC_VERCEL_ENV || 'development'
-
 const defaultFrontendHostname = process.env.NEXT_PUBLIC_FRONTEND_BASE_URL
   ? new URL(process.env.NEXT_PUBLIC_FRONTEND_BASE_URL).hostname
   : 'polar.sh'
-
-const S3_PUBLIC_IMAGES_BUCKET_ORIGIN = process.env
-  .S3_PUBLIC_IMAGES_BUCKET_HOSTNAME
-  ? `${process.env.S3_PUBLIC_IMAGES_BUCKET_PROTOCOL || 'https'}://${process.env.S3_PUBLIC_IMAGES_BUCKET_HOSTNAME}${process.env.S3_PUBLIC_IMAGES_BUCKET_PORT ? `:${process.env.S3_PUBLIC_IMAGES_BUCKET_PORT}` : ''}`
-  : ''
-const baseCSP = `
-    default-src 'self';
-    connect-src 'self' ${process.env.NEXT_PUBLIC_API_URL} ${process.env.S3_UPLOAD_ORIGINS} https://api.stripe.com https://maps.googleapis.com https://*.google-analytics.com https://chat.uk.plain.com https://prod-uk-services-attachm-attachmentsuploadbucket2-1l2e4906o2asm.s3.eu-west-2.amazonaws.com;
-    frame-src 'self' https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://hooks.stripe.com https://customer-wl21dabnj6qtvcai.cloudflarestream.com videodelivery.net *.cloudflarestream.com;
-    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://maps.googleapis.com https://www.googletagmanager.com https://chat.cdn-plain.com https://embed.cloudflarestream.com;
-    style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
-    img-src 'self' blob: data: https://www.gravatar.com https://img.logo.dev https://lh3.googleusercontent.com https://avatars.githubusercontent.com ${S3_PUBLIC_IMAGES_BUCKET_ORIGIN} https://uploads.polar.sh https://prod-uk-services-workspac-workspacefilespublicbuck-vs4gjqpqjkh6.s3.amazonaws.com https://prod-uk-services-attachm-attachmentsbucket28b3ccf-uwfssb4vt2us.s3.eu-west-2.amazonaws.com https://i0.wp.com;
-    font-src 'self';
-    object-src 'none';
-    base-uri 'self';
-    ${ENVIRONMENT !== 'development' ? 'upgrade-insecure-requests;' : ''}
-`
-const nonEmbeddedCSP = `
-  ${baseCSP}
-  form-action 'self' ${process.env.NEXT_PUBLIC_API_URL} polar:;
-  frame-ancestors 'none';
-`
-const embeddedCSP = `
-  ${baseCSP}
-  form-action 'self' ${process.env.NEXT_PUBLIC_API_URL} polar:;
-  frame-ancestors *;
-`
-// Don't add form-action to the OAuth2 authorize page, as it blocks the OAuth2 redirection
-// 10-years old debate about whether to block redirects with form-action or not: https://github.com/w3c/webappsec-csp/issues/8
-const oauth2CSP = `
-  ${baseCSP}
-  frame-ancestors 'none';
-`
-
-// We rewrite Mintlify docs to polar.sh/docs, so we need a specific CSP for them
-// Ref: https://www.mintlify.com/docs/guides/csp-configuration#content-security-policy-csp-configuration
-const docsCSP = `
-  default-src 'self';
-  script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.jsdelivr.net www.googletagmanager.com cdn.segment.com plausible.io
-  us.posthog.com tag.clearbitscripts.com cdn.heapanalytics.com chat.cdn-plain.com chat-assets.frontapp.com
-  browser.sentry-cdn.com js.sentry-cdn.com;
-  style-src 'self' 'unsafe-inline' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com;
-  font-src 'self' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com;
-  img-src 'self' data: blob: d3gk2c5xim1je2.cloudfront.net mintcdn.com *.mintcdn.com cdn.jsdelivr.net mintlify.s3.us-west-1.amazonaws.com;
-  connect-src 'self' *.mintlify.dev *.mintlify.com d1ctpt7j8wusba.cloudfront.net mintcdn.com *.mintcdn.com
-  api.mintlifytrieve.com www.googletagmanager.com cdn.segment.com plausible.io us.posthog.com browser.sentry-cdn.com;
-  frame-src 'self' *.mintlify.dev https://polar-public-assets.s3.us-east-2.amazonaws.com;
-`
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -426,7 +382,7 @@ const nextConfig = {
     const baseHeaders = [
       {
         key: 'Content-Security-Policy',
-        value: nonEmbeddedCSP.replace(/\n/g, ''),
+        value: nonEmbeddedCSP(),
       },
       {
         key: 'Permissions-Policy',
@@ -457,7 +413,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Content-Security-Policy',
-            value: oauth2CSP.replace(/\n/g, ''),
+            value: oauth2CSP(),
           },
           {
             key: 'Permissions-Policy',
@@ -484,7 +440,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Content-Security-Policy',
-            value: embeddedCSP.replace(/\n/g, ''),
+            value: embeddedCSP(),
           },
           {
             key: 'Permissions-Policy',
@@ -506,7 +462,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Content-Security-Policy',
-            value: embeddedCSP.replace(/\n/g, ''),
+            value: embeddedCSP(),
           },
           {
             key: 'Permissions-Policy',
@@ -528,7 +484,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Content-Security-Policy',
-            value: docsCSP.replace(/\n/g, ''),
+            value: docsCSP(),
           },
           {
             key: 'Permissions-Policy',

--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -439,10 +439,6 @@ const nextConfig = {
         source: '/checkout/:path*',
         headers: [
           {
-            key: 'Content-Security-Policy',
-            value: embeddedCSP(),
-          },
-          {
             key: 'Permissions-Policy',
             value: `payment=*, publickey-credentials-get=*, camera=(), microphone=(), geolocation=()`,
           },

--- a/clients/apps/web/src/csp.mjs
+++ b/clients/apps/web/src/csp.mjs
@@ -1,0 +1,57 @@
+/* global process */
+export const ENVIRONMENT =
+  process.env.VERCEL_ENV || process.env.NEXT_PUBLIC_VERCEL_ENV || 'development'
+
+const flatten = (policy) => policy.replace(/\n/g, '')
+
+const S3_PUBLIC_IMAGES_BUCKET_ORIGIN = process.env
+  .S3_PUBLIC_IMAGES_BUCKET_HOSTNAME
+  ? `${process.env.S3_PUBLIC_IMAGES_BUCKET_PROTOCOL || 'https'}://${process.env.S3_PUBLIC_IMAGES_BUCKET_HOSTNAME}${process.env.S3_PUBLIC_IMAGES_BUCKET_PORT ? `:${process.env.S3_PUBLIC_IMAGES_BUCKET_PORT}` : ''}`
+  : ''
+const baseCSP = () => `
+    default-src 'self';
+    connect-src 'self' ${process.env.NEXT_PUBLIC_API_URL} ${process.env.S3_UPLOAD_ORIGINS} https://api.stripe.com https://maps.googleapis.com https://*.google-analytics.com https://chat.uk.plain.com https://prod-uk-services-attachm-attachmentsuploadbucket2-1l2e4906o2asm.s3.eu-west-2.amazonaws.com;
+    frame-src 'self' https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://hooks.stripe.com https://customer-wl21dabnj6qtvcai.cloudflarestream.com videodelivery.net *.cloudflarestream.com;
+    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://maps.googleapis.com https://www.googletagmanager.com https://chat.cdn-plain.com https://embed.cloudflarestream.com;
+    style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+    img-src 'self' blob: data: https://www.gravatar.com https://img.logo.dev https://lh3.googleusercontent.com https://avatars.githubusercontent.com ${S3_PUBLIC_IMAGES_BUCKET_ORIGIN} https://uploads.polar.sh https://prod-uk-services-workspac-workspacefilespublicbuck-vs4gjqpqjkh6.s3.amazonaws.com https://prod-uk-services-attachm-attachmentsbucket28b3ccf-uwfssb4vt2us.s3.eu-west-2.amazonaws.com https://i0.wp.com;
+    font-src 'self';
+    object-src 'none';
+    base-uri 'self';
+    ${ENVIRONMENT !== 'development' ? 'upgrade-insecure-requests;' : ''}
+`
+export const nonEmbeddedCSP = () =>
+  flatten(`
+  ${baseCSP()}
+  form-action 'self' ${process.env.NEXT_PUBLIC_API_URL} polar:;
+  frame-ancestors 'none';
+`)
+export const embeddedCSP = () =>
+  flatten(`
+  ${baseCSP()}
+  form-action 'self' ${process.env.NEXT_PUBLIC_API_URL} polar:;
+  frame-ancestors *;
+`)
+// Don't add form-action to the OAuth2 authorize page, as it blocks the OAuth2 redirection
+// 10-years old debate about whether to block redirects with form-action or not: https://github.com/w3c/webappsec-csp/issues/8
+export const oauth2CSP = () =>
+  flatten(`
+  ${baseCSP()}
+  frame-ancestors 'none';
+`)
+
+// We rewrite Mintlify docs to polar.sh/docs, so we need a specific CSP for them
+// Ref: https://www.mintlify.com/docs/guides/csp-configuration#content-security-policy-csp-configuration
+export const docsCSP = () =>
+  flatten(`
+  default-src 'self';
+  script-src 'self' 'unsafe-inline' 'unsafe-eval' cdn.jsdelivr.net www.googletagmanager.com cdn.segment.com plausible.io
+  us.posthog.com tag.clearbitscripts.com cdn.heapanalytics.com chat.cdn-plain.com chat-assets.frontapp.com
+  browser.sentry-cdn.com js.sentry-cdn.com;
+  style-src 'self' 'unsafe-inline' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com;
+  font-src 'self' d4tuoctqmanu0.cloudfront.net fonts.googleapis.com;
+  img-src 'self' data: blob: d3gk2c5xim1je2.cloudfront.net mintcdn.com *.mintcdn.com cdn.jsdelivr.net mintlify.s3.us-west-1.amazonaws.com;
+  connect-src 'self' *.mintlify.dev *.mintlify.com d1ctpt7j8wusba.cloudfront.net mintcdn.com *.mintcdn.com
+  api.mintlifytrieve.com www.googletagmanager.com cdn.segment.com plausible.io us.posthog.com browser.sentry-cdn.com;
+  frame-src 'self' *.mintlify.dev https://polar-public-assets.s3.us-east-2.amazonaws.com;
+`)

--- a/clients/apps/web/src/csp.mjs
+++ b/clients/apps/web/src/csp.mjs
@@ -55,3 +55,10 @@ export const docsCSP = () =>
   api.mintlifytrieve.com www.googletagmanager.com cdn.segment.com plausible.io us.posthog.com browser.sentry-cdn.com;
   frame-src 'self' *.mintlify.dev https://polar-public-assets.s3.us-east-2.amazonaws.com;
 `)
+
+export const checkoutCSP = (frameAncestors) =>
+  flatten(`
+  ${baseCSP()}
+  form-action 'self' ${process.env.NEXT_PUBLIC_API_URL} polar:;
+  frame-ancestors ${frameAncestors};
+`)

--- a/clients/apps/web/src/csp.mjs
+++ b/clients/apps/web/src/csp.mjs
@@ -1,4 +1,5 @@
-/* global process */
+import process from 'node:process'
+
 export const ENVIRONMENT =
   process.env.VERCEL_ENV || process.env.NEXT_PUBLIC_VERCEL_ENV || 'development'
 

--- a/clients/apps/web/src/proxy.test.ts
+++ b/clients/apps/web/src/proxy.test.ts
@@ -476,14 +476,46 @@ describe('checkout frame ancestors', () => {
     )
   })
 
-  it('asks nothing on a top-level navigation', async () => {
+  it('admits the hosts the organization listed', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        frame_ancestors: ['https://example.com', 'https://*.shop.example.com'],
+      }),
+    })
+
+    const response = await proxy(
+      framedRequest('https://polar.sh/checkout/polar_c_123'),
+    )
+
+    const policy = response.headers.get('Content-Security-Policy')
+    expect(policy).toContain(
+      'frame-ancestors https://example.com https://*.shop.example.com;',
+    )
+    expect(policy).toContain("script-src 'self'")
+    expect(response.headers.get('X-Frame-Options')).toBeNull()
+  })
+
+  it('asks nothing on a top-level navigation, and refuses framing', async () => {
     const request = new NextRequest('https://polar.sh/checkout/polar_c_123', {
       headers: { 'Sec-Fetch-Dest': 'document' },
     })
 
-    await proxy(request)
+    const response = await proxy(request)
 
     expect(mockFetch).not.toHaveBeenCalled()
+    expect(response.headers.get('Content-Security-Policy')).toContain(
+      "frame-ancestors 'none';",
+    )
+    expect(response.headers.get('X-Frame-Options')).toBe('DENY')
+  })
+
+  it('leaves other pages to the static policy', async () => {
+    const response = await proxy(
+      framedRequest('https://polar.sh/embed/payment-method'),
+    )
+
+    expect(response.headers.get('Content-Security-Policy')).toBeNull()
   })
 
   it('asks when the browser sends no fetch destination', async () => {
@@ -498,7 +530,7 @@ describe('checkout frame ancestors', () => {
     expect(mockFetch).not.toHaveBeenCalled()
   })
 
-  it('swallows a failed call', async () => {
+  it('refuses framing when the call fails', async () => {
     mockFetch.mockRejectedValue(new Error('unreachable'))
 
     const response = await proxy(
@@ -506,5 +538,8 @@ describe('checkout frame ancestors', () => {
     )
 
     expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Security-Policy')).toContain(
+      "frame-ancestors 'none';",
+    )
   })
 })

--- a/clients/apps/web/src/proxy.test.ts
+++ b/clients/apps/web/src/proxy.test.ts
@@ -516,6 +516,19 @@ describe('checkout frame ancestors', () => {
     expect(response.headers.get('Content-Security-Policy')).toBeNull()
   })
 
+  it.each(['iframe', 'frame', 'object', 'embed'])(
+    'asks for every destination that can hold a document: %s',
+    async (destination) => {
+      await proxy(
+        new NextRequest('https://polar.sh/checkout/polar_c_123', {
+          headers: { 'Sec-Fetch-Dest': destination },
+        }),
+      )
+
+      expect(mockFetch).toHaveBeenCalledOnce()
+    },
+  )
+
   it('asks when the browser sends no fetch destination', async () => {
     await proxy(new NextRequest('https://polar.sh/checkout/polar_c_123'))
 

--- a/clients/apps/web/src/proxy.test.ts
+++ b/clients/apps/web/src/proxy.test.ts
@@ -493,7 +493,6 @@ describe('checkout frame ancestors', () => {
       'frame-ancestors https://example.com https://*.shop.example.com;',
     )
     expect(policy).toContain("script-src 'self'")
-    expect(response.headers.get('X-Frame-Options')).toBeNull()
   })
 
   it('asks nothing on a top-level navigation, and refuses framing', async () => {
@@ -507,7 +506,6 @@ describe('checkout frame ancestors', () => {
     expect(response.headers.get('Content-Security-Policy')).toContain(
       "frame-ancestors 'none';",
     )
-    expect(response.headers.get('X-Frame-Options')).toBe('DENY')
   })
 
   it('leaves other pages to the static policy', async () => {

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -8,6 +8,7 @@ import {
   DISTINCT_ID_COOKIE,
   DISTINCT_ID_HEADER,
 } from './experiments/constants'
+import { checkoutCSP } from './csp.mjs'
 import { getServerURL } from './utils/api'
 import { createServerSideAPI } from './utils/client'
 import { CONFIG } from './utils/config'
@@ -95,7 +96,8 @@ const requiresAuthentication = (request: NextRequest): boolean => {
 }
 
 const CHECKOUT_CLIENT_SECRET = /^\/checkout\/([^/]+)/
-const NO_FRAME_ANCESTORS = ["'none'"]
+const NONE = "'none'"
+const NO_FRAME_ANCESTORS = [NONE]
 
 const isFramed = (request: NextRequest): boolean => {
   const destination = request.headers.get('Sec-Fetch-Dest')
@@ -328,16 +330,25 @@ export async function proxy(request: NextRequest) {
     )
   }
 
-  const checkout = request.nextUrl.pathname.match(CHECKOUT_CLIENT_SECRET)
-  if (checkout && isFramed(request)) {
-    await getFrameAncestors(request, checkout[1])
-  }
-
   const response = NextResponse.next({
     request: {
       headers: requestHeaders,
     },
   })
+
+  const checkout = request.nextUrl.pathname.match(CHECKOUT_CLIENT_SECRET)
+  if (checkout) {
+    const frameAncestors = isFramed(request)
+      ? await getFrameAncestors(request, checkout[1])
+      : NO_FRAME_ANCESTORS
+    response.headers.set(
+      'Content-Security-Policy',
+      checkoutCSP(frameAncestors.join(' ')),
+    )
+    if (frameAncestors.length === 1 && frameAncestors[0] === NONE) {
+      response.headers.set('X-Frame-Options', 'DENY')
+    }
+  }
 
   if (isNewDistinctId) {
     response.cookies.set(DISTINCT_ID_COOKIE, distinctId, {

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -96,8 +96,7 @@ const requiresAuthentication = (request: NextRequest): boolean => {
 }
 
 const CHECKOUT_CLIENT_SECRET = /^\/checkout\/([^/]+)/
-const NONE = "'none'"
-const NO_FRAME_ANCESTORS = [NONE]
+const NO_FRAME_ANCESTORS = ["'none'"]
 
 const isFramed = (request: NextRequest): boolean => {
   const destination = request.headers.get('Sec-Fetch-Dest')
@@ -345,9 +344,6 @@ export async function proxy(request: NextRequest) {
       'Content-Security-Policy',
       checkoutCSP(frameAncestors.join(' ')),
     )
-    if (frameAncestors.length === 1 && frameAncestors[0] === NONE) {
-      response.headers.set('X-Frame-Options', 'DENY')
-    }
   }
 
   if (isNewDistinctId) {

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -98,11 +98,11 @@ const requiresAuthentication = (request: NextRequest): boolean => {
 const CHECKOUT_CLIENT_SECRET = /^\/checkout\/([^/]+)/
 const NO_FRAME_ANCESTORS = ["'none'"]
 
+const FRAMING_DESTINATIONS = ['iframe', 'frame', 'object', 'embed']
+
 const isFramed = (request: NextRequest): boolean => {
   const destination = request.headers.get('Sec-Fetch-Dest')
-  return (
-    destination === null || destination === 'iframe' || destination === 'frame'
-  )
+  return destination === null || FRAMING_DESTINATIONS.includes(destination)
 }
 
 const getFrameAncestors = async (

--- a/docs/features/checkout/embed.mdx
+++ b/docs/features/checkout/embed.mdx
@@ -88,7 +88,7 @@ For this to work, make sure to set the [`embed_origin`](/api-reference/checkouts
 
 ## Embed Hosts
 
-List the hosts allowed to embed your checkout under **Settings → Preferences → Embedding**. An embedded checkout only opens on a host you've listed.
+List the hosts allowed to embed your checkout under **Settings → Preferences → Embedding**. An embedded checkout only opens on a host you've listed, and the browser refuses to frame it anywhere else.
 
 After a payment, the checkout sends your page a message carrying a session token for your customer. The allowlist is how we know that page is yours.
 


### PR DESCRIPTION
## Summary

Actual enforcement of for [ENG-12](https://linear.app/polarsh/issue/ENG-12/enforce-embed-hosts-through-frame-ancestors-csp). 

~To be merged later when we checked the logs for breaking framed page.~

Behind a feature flag, safe to merge now https://github.com/polarsource/polar/pull/14349

 
## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

