### PR TITLE
15x increase of load performance on /organizations

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -53,23 +53,22 @@ class OrganizationListView:
     async def get_status_counts(
         self, deleted: DeletedFilter = "exclude"
     ) -> dict[OrganizationStatus, int]:
-        """Get count of organizations by status for tab badges."""
+        """Get count of organizations by status for tab badges.
+
+        ``count()`` rather than ``count(id)`` so Postgres can answer from the
+        partial status index instead of scanning the organizations table.
+        """
         stmt = select(
             Organization.status,
-            func.count(Organization.id).label("count"),
+            func.count().label("count"),
         ).group_by(Organization.status)
         stmt = apply_deleted_filter(stmt, deleted)
         result = await self.session.execute(stmt)
         return {row.status: row.count for row in result}  # type: ignore[misc]
 
     async def get_distinct_countries(self) -> list[str]:
-        """Get list of distinct countries from organizations with payout accounts."""
-        stmt = (
-            select(PayoutAccount.country)
-            .join(Organization, Organization.payout_account_id == PayoutAccount.id)
-            .distinct()
-            .order_by(PayoutAccount.country)
-        )
+        """Get list of distinct countries across payout accounts."""
+        stmt = select(PayoutAccount.country).distinct().order_by(PayoutAccount.country)
         result = await self.session.execute(stmt)
         return [row[0] for row in result.all()]
 

--- a/server/polar/backoffice/support_cases/queries.py
+++ b/server/polar/backoffice/support_cases/queries.py
@@ -1,8 +1,9 @@
 """Shared query for backoffice support-case lists.
 
 Both the dedicated Cases list and an organization's Support Cases tab read the
-same polymorphic ``SupportCase`` set. The organization is resolved per type:
-appeals link through their review, disputes through their dispute → order.
+same polymorphic ``SupportCase`` set. Every case carries its organization id
+directly, so no query needs to reach through the appeal's review or the
+dispute's order to find the owning org.
 """
 
 from collections.abc import Sequence
@@ -12,12 +13,10 @@ from uuid import UUID
 
 from sqlalchemy import Select, and_, func, or_, select
 
-from polar.models import Dispute, Order, Organization, User
+from polar.models import Dispute, Organization, User
 from polar.models.dispute import DisputeStatus
-from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import (
     DisputeSupportCase,
-    ReviewAppealSupportCase,
     SupportCase,
     SupportCaseMessage,
     SupportCaseMessageType,
@@ -114,23 +113,14 @@ def cases_statement(
             Dispute.evidence_due_by.label("evidence_due_by"),
             Dispute.past_due.label("evidence_past_due"),
         )
-        .outerjoin(
-            OrganizationReview,
-            ReviewAppealSupportCase.organization_review_id == OrganizationReview.id,
-        )
+        .join(Organization, Organization.id == SupportCase.organization_id)
         .outerjoin(Dispute, DisputeSupportCase.dispute_id == Dispute.id)
-        .outerjoin(Order, Dispute.order_id == Order.id)
-        .join(
-            Organization,
-            Organization.id
-            == func.coalesce(OrganizationReview.organization_id, Order.organization_id),
-        )
         .outerjoin(User, SupportCase.assigned_user_id == User.id)
         .where(SupportCase.deleted_at.is_(None))
     )
 
     if organization_id is not None:
-        statement = statement.where(Organization.id == organization_id)
+        statement = statement.where(SupportCase.organization_id == organization_id)
     if status == "open":
         statement = statement.where(is_open)
     elif status == "closed":
@@ -170,18 +160,8 @@ def open_case_organization_ids(
     type. With ``awaiting_reply``, only those whose open case is waiting on a
     platform reply. ``organization_ids`` narrows the scan to a known page.
     """
-    organization_id = func.coalesce(
-        OrganizationReview.organization_id, Order.organization_id
-    )
     statement = (
-        select(organization_id)
-        .select_from(SupportCase)
-        .outerjoin(
-            OrganizationReview,
-            ReviewAppealSupportCase.organization_review_id == OrganizationReview.id,
-        )
-        .outerjoin(Dispute, DisputeSupportCase.dispute_id == Dispute.id)
-        .outerjoin(Order, Dispute.order_id == Order.id)
+        select(SupportCase.organization_id)
         .where(
             SupportCase.deleted_at.is_(None),
             SupportCaseMessageRepository.is_open_expression(),
@@ -193,7 +173,7 @@ def open_case_organization_ids(
             SupportCaseMessageRepository.awaiting_platform_expression()
         )
     if organization_ids is not None:
-        statement = statement.where(organization_id.in_(organization_ids))
+        statement = statement.where(SupportCase.organization_id.in_(organization_ids))
     return statement
 
 


### PR DESCRIPTION
## Summary

The `/organizations` route in Backoffice can be _extremely_ slow with a cold cache, sometimes taking up to almost 30 seconds:

<img width="652" height="341" alt="Monosnap Live · polar:polar · Pydantic Logfire 2026-09-07 19-49-26" src="https://github.com/user-attachments/assets/a5223c23-6906-4a24-a417-7b81155d3e4e" />

Looking at the trace:

<img width="635" height="435" alt="Screenshot 2026-09-07 at 19 42 29" src="https://github.com/user-attachments/assets/3f17b2bf-4741-4897-a537-3ab68cc2da09" />


we can see that three queries account for most of the slowness:

* Status tab counts (~10 seconds)
* Open case badges (~2 seconds)
* Country dropdown (~2 seconds)

This is fixed by using `count()` so the tab counts are used from the existing index, reading countries from `payout_accounts` directly and getting a support case org from its own `organization_id` column instead of a bunch of joins.


## Expected results

I've ran some benchmarks locally, with a seeded DB before/after this change and here's what we can expect once the PR lands:

| Query | Before | After |
|---|---|---|
| Status tab counts | ~20 s | ~10 ms |
| Open-case badges | ~4 s | ~20 ms |
| Country dropdown | ~3.4 s | ~5 ms |
| **Total** | **29.4 s** | **~2 s** |

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

