### PR TITLE
Allow OAT creation for OAuth sessions

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5890,10 +5890,15 @@ export interface paths {
     /**
      * List
      * @description List organization access tokens.
+     *
+     *     **Scopes**: `organization_access_tokens:read` `organization_access_tokens:write`
      */
     get: operations['organization_access_tokens:list']
     put?: never
-    /** Create */
+    /**
+     * Create
+     * @description **Scopes**: `organization_access_tokens:write`
+     */
     post: operations['organization_access_tokens:create']
     delete?: never
     options?: never
@@ -5911,11 +5916,17 @@ export interface paths {
     get?: never
     put?: never
     post?: never
-    /** Delete */
+    /**
+     * Delete
+     * @description **Scopes**: `organization_access_tokens:write`
+     */
     delete: operations['organization_access_tokens:delete']
     options?: never
     head?: never
-    /** Update */
+    /**
+     * Update
+     * @description **Scopes**: `organization_access_tokens:write`
+     */
     patch: operations['organization_access_tokens:update']
     trace?: never
   }

--- a/server/polar/organization_access_token/auth.py
+++ b/server/polar/organization_access_token/auth.py
@@ -1,12 +1,37 @@
+from collections.abc import Awaitable, Callable
 from typing import Annotated
 
 from fastapi import Depends
 
-from polar.auth.models import AuthSubject, User
+from polar.auth.dependencies import Authenticator
+from polar.auth.models import AuthSubject, User, is_web_session
 from polar.auth.scope import Scope
-from polar.authz.dependencies import WebUserAuthorizer, WebUserAuthorizerFresh
+from polar.authz.dependencies import ensure_session_fresh
+from polar.exceptions import NotPermitted
+from polar.models import OAuth2Token
 
-_OrganizationAccessTokensRead = WebUserAuthorizer(
+
+def OrganizationAccessTokenAuthorizer(
+    required_scopes: set[Scope], *, fresh: bool = False
+) -> Callable[..., Awaitable[AuthSubject[User]]]:
+    authenticator = Authenticator(
+        allowed_subjects={User}, required_scopes=required_scopes
+    )
+
+    async def dependency(
+        auth_subject: Annotated[AuthSubject[User], Depends(authenticator)],
+    ) -> AuthSubject[User]:
+        if is_web_session(auth_subject):
+            if fresh:
+                ensure_session_fresh(auth_subject)
+        elif not isinstance(auth_subject.session, OAuth2Token):
+            raise NotPermitted()
+        return auth_subject
+
+    return dependency
+
+
+_OrganizationAccessTokensRead = OrganizationAccessTokenAuthorizer(
     required_scopes={
         Scope.organization_access_tokens_read,
         Scope.organization_access_tokens_write,
@@ -16,7 +41,7 @@ OrganizationAccessTokensRead = Annotated[
     AuthSubject[User], Depends(_OrganizationAccessTokensRead)
 ]
 
-_OrganizationAccessTokensWrite = WebUserAuthorizer(
+_OrganizationAccessTokensWrite = OrganizationAccessTokenAuthorizer(
     required_scopes={
         Scope.organization_access_tokens_write,
     }
@@ -25,10 +50,11 @@ OrganizationAccessTokensWrite = Annotated[
     AuthSubject[User], Depends(_OrganizationAccessTokensWrite)
 ]
 
-_OrganizationAccessTokensWriteFresh = WebUserAuthorizerFresh(
+_OrganizationAccessTokensWriteFresh = OrganizationAccessTokenAuthorizer(
     required_scopes={
         Scope.organization_access_tokens_write,
-    }
+    },
+    fresh=True,
 )
 OrganizationAccessTokensWriteFresh = Annotated[
     AuthSubject[User], Depends(_OrganizationAccessTokensWriteFresh)

--- a/server/tests/organization_access_token/test_endpoints.py
+++ b/server/tests/organization_access_token/test_endpoints.py
@@ -8,9 +8,104 @@ from polar.auth.scope import Scope
 from polar.config import settings
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
-from polar.models import Organization, OrganizationAccessToken, User, UserOrganization
+from polar.models import (
+    OAuth2Client,
+    OAuth2Token,
+    Organization,
+    OrganizationAccessToken,
+    User,
+    UserOrganization,
+)
 from tests.fixtures.auth import AuthSubjectFixture, make_session_stale
 from tests.fixtures.database import SaveFixture
+
+
+@pytest.mark.asyncio
+class TestOAuthAuthentication:
+    @pytest.fixture(autouse=True)
+    def oauth_session(self, auth_subject: AuthSubject[User]) -> None:
+        auth_subject.session = OAuth2Token(client=OAuth2Client())
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(
+            scopes={Scope.organization_access_tokens_write, Scope.metrics_read}
+        )
+    )
+    async def test_token_lifecycle(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/organization-access-tokens/",
+            json={
+                "organization_id": str(organization.id),
+                "comment": "OAuth token",
+                "scopes": ["metrics:read"],
+            },
+        )
+        assert response.status_code == 201
+        token_id = response.json()["organization_access_token"]["id"]
+
+        response = await client.get("/v1/organization-access-tokens/")
+        assert response.status_code == 200
+        assert [item["id"] for item in response.json()["items"]] == [token_id]
+
+        response = await client.patch(
+            f"/v1/organization-access-tokens/{token_id}",
+            json={"comment": "updated"},
+        )
+        assert response.status_code == 200
+        assert response.json()["comment"] == "updated"
+
+        response = await client.delete(f"/v1/organization-access-tokens/{token_id}")
+        assert response.status_code == 204
+        response = await client.get("/v1/organization-access-tokens/")
+        assert response.status_code == 200
+        assert response.json()["items"] == []
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(scopes={Scope.organization_access_tokens_read})
+    )
+    async def test_read_only(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get("/v1/organization-access-tokens/")
+        assert response.status_code == 200
+
+        response = await client.post(
+            "/v1/organization-access-tokens/",
+            json={
+                "organization_id": str(organization.id),
+                "comment": "forbidden",
+                "scopes": ["metrics:read"],
+            },
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(scopes={Scope.organization_access_tokens_write})
+    )
+    async def test_cannot_escalate_scopes(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/organization-access-tokens/",
+            json={
+                "organization_id": str(organization.id),
+                "comment": "forbidden",
+                "scopes": ["orders:write"],
+            },
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["loc"] == ["body", "scopes"]
 
 
 async def _build_oat(


### PR DESCRIPTION
We rolled back OAT creation for sessions authenticated by an OAT, rightfully so. When rolling that back, we limited these endpoints to only web sessions.

To allow the CLI to create OAT, so that agents can implement Polar directly, this PR opens up these endpoints to OAuth sessions too. One of the reasons OAT-creating-OAT wasn't good was the risk of scope escalation, but with OAuth, this doesn't apply, I made sure to test for that.

We will not open this up further to API key sessions, and we also won't add expose these endpoints to the MCP as tools, as that would by definition leak the created tokens.

About `OrganizationAccessTokenAuthorizer`, I'm not fond of the naming but it does clearly state what it does, and I'm having trouble coming up with a better name.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

