### PR TITLE
feat: show imported and pending migration subscriptions

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ImportedStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ImportedStep.tsx
@@ -61,7 +61,7 @@ export function ImportedStep({ migrationId }: { migrationId: string }) {
 
         {expanded && (
           <Box id={panelId} flexDirection="column">
-            <ReviewTable migrationId={migrationId} />
+            <ReviewTable migrationId={migrationId} defaultFilter="imported" />
           </Box>
         )}
       </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ImportedStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ImportedStep.tsx
@@ -4,7 +4,6 @@ import { Button, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { useId, useRef, useState } from 'react'
 import { ImportedHandoff } from './ImportedHandoff'
-import { importedTotal } from './review/importSummary'
 import { useRecordSummary } from './review/recordSummary'
 import { ReviewTable } from './review/ReviewTable'
 
@@ -73,8 +72,11 @@ function summary(outcome: ReturnType<typeof useRecordSummary>): string {
   if (outcome.isLoading || outcome.isError) {
     return ''
   }
-  const imported = `${importedTotal(outcome.imported)} imported`
-  return outcome.selectableTotal > 0
-    ? `${imported} · ${outcome.selectableTotal} not prepared`
-    : imported
+  const ready = outcome.counts.subscriptions.ready
+  const toPrepare = outcome.selectableTotal
+  const parts = [
+    ready > 0 ? `${ready} ready to switch` : null,
+    toPrepare > 0 ? `${toPrepare} to prepare` : null,
+  ].filter(Boolean)
+  return parts.join(' · ') || 'No subscriptions to prepare or switch'
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ImportedStep.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ImportedStep.tsx
@@ -61,7 +61,7 @@ export function ImportedStep({ migrationId }: { migrationId: string }) {
 
         {expanded && (
           <Box id={panelId} flexDirection="column">
-            <ReviewTable migrationId={migrationId} defaultFilter="imported" />
+            <ReviewTable migrationId={migrationId} />
           </Box>
         )}
       </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/CatalogEmptyPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/CatalogEmptyPanel.tsx
@@ -1,9 +1,6 @@
 import { Button, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import {
-  CATALOG_EMPTY_COPY,
-  ReviewCatalogEmptyKind,
-} from './reviewCatalog'
+import { CATALOG_EMPTY_COPY, ReviewCatalogEmptyKind } from './reviewCatalog'
 
 interface Props {
   kind: ReviewCatalogEmptyKind

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/CatalogEmptyPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/CatalogEmptyPanel.tsx
@@ -1,0 +1,54 @@
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import {
+  CATALOG_EMPTY_COPY,
+  ReviewCatalogEmptyKind,
+} from './reviewCatalog'
+
+interface Props {
+  kind: ReviewCatalogEmptyKind
+  onRerunPrecheck?: () => void
+  rerunning?: boolean
+}
+
+export function CatalogEmptyPanel({
+  kind,
+  onRerunPrecheck,
+  rerunning = false,
+}: Props) {
+  const { title, description } = CATALOG_EMPTY_COPY[kind]
+
+  return (
+    <Box
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+      borderRadius="l"
+      paddingVertical="3xl"
+      paddingHorizontal="xl"
+      flexDirection="column"
+      alignItems="center"
+      rowGap="l"
+      textAlign="center"
+    >
+      <Box flexDirection="column" rowGap="xs" alignItems="center">
+        <Text variant="heading-xs" as="h3">
+          {title}
+        </Text>
+        <Text variant="caption" color="muted">
+          {description}
+        </Text>
+      </Box>
+      {onRerunPrecheck && (
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={onRerunPrecheck}
+          disabled={rerunning}
+        >
+          {rerunning ? 'Refreshing…' : 'Refresh from Stripe'}
+        </Button>
+      )}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
@@ -1,6 +1,22 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { ReviewStatusTabs } from './ReviewStatusTabs'
+
+vi.mock('@polar-sh/orbit', () => ({
+  SegmentedControl: ({
+    options,
+    onChange,
+  }: {
+    options: { value: string; label: ReactNode }[]
+    onChange: (value: string) => void
+  }) =>
+    options.map((option) => (
+      <button key={option.value} onClick={() => onChange(option.value)}>
+        {option.label}
+      </button>
+    )),
+}))
 
 describe('ReviewStatusTabs', () => {
   it('shows imported and pending subscriptions as separate filters', () => {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ReviewStatusTabs } from './ReviewStatusTabs'
+
+describe('ReviewStatusTabs', () => {
+  it('shows imported and pending subscriptions as separate filters', () => {
+    const onChange = vi.fn()
+
+    render(
+      <ReviewStatusTabs
+        value="all"
+        counts={{
+          all: 58,
+          imported: 27,
+          pending: 31,
+          attention: 0,
+          skipped: 0,
+        }}
+        onChange={onChange}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'All rows 58' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Imported 27' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Pending 31' }))
+    expect(onChange).toHaveBeenCalledWith('pending')
+  })
+})

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
@@ -19,7 +19,7 @@ vi.mock('@polar-sh/orbit', () => ({
 }))
 
 describe('ReviewStatusTabs', () => {
-  it('shows imported and pending subscriptions as separate filters', () => {
+  it('separates subscriptions by migration stage', () => {
     const onChange = vi.fn()
 
     render(
@@ -27,8 +27,9 @@ describe('ReviewStatusTabs', () => {
         value="all"
         counts={{
           all: 58,
-          imported: 27,
-          pending: 31,
+          to_prepare: 20,
+          ready: 11,
+          switched: 27,
           attention: 0,
           skipped: 0,
         }}
@@ -37,8 +38,8 @@ describe('ReviewStatusTabs', () => {
     )
 
     expect(screen.getByRole('button', { name: 'All rows 58' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Imported 27' })).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Pending 31' }))
-    expect(onChange).toHaveBeenCalledWith('pending')
+    expect(screen.getByRole('button', { name: 'Switched 27' })).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Ready to switch 11' }))
+    expect(onChange).toHaveBeenCalledWith('ready')
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.test.tsx
@@ -28,8 +28,7 @@ describe('ReviewStatusTabs', () => {
         counts={{
           all: 58,
           to_prepare: 20,
-          ready: 11,
-          switched: 27,
+          ready: 38,
           attention: 0,
           skipped: 0,
         }}
@@ -38,8 +37,7 @@ describe('ReviewStatusTabs', () => {
     )
 
     expect(screen.getByRole('button', { name: 'All rows 58' })).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Switched 27' })).toBeTruthy()
-    fireEvent.click(screen.getByRole('button', { name: 'Ready to switch 11' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Ready to switch 38' }))
     expect(onChange).toHaveBeenCalledWith('ready')
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.tsx
@@ -1,6 +1,11 @@
 import { SegmentedControl } from '@polar-sh/orbit'
 
-export type ReviewFilter = 'attention' | 'skipped' | 'all'
+export type ReviewFilter =
+  | 'all'
+  | 'imported'
+  | 'pending'
+  | 'attention'
+  | 'skipped'
 
 export type ReviewFilterCounts = Record<ReviewFilter, number>
 
@@ -8,14 +13,18 @@ const numberFormat = new Intl.NumberFormat('en-US')
 
 const OPTIONS: { value: ReviewFilter; label: string }[] = [
   { value: 'all', label: 'All rows' },
+  { value: 'imported', label: 'Imported' },
+  { value: 'pending', label: 'Pending' },
   { value: 'attention', label: 'Needs attention' },
   { value: 'skipped', label: "Won't import" },
 ]
 
 export const EMPTY_MESSAGES: Record<ReviewFilter, string> = {
+  all: 'No subscriptions to show.',
+  imported: 'No subscriptions have been imported.',
+  pending: 'No subscriptions are pending.',
   attention: 'Nothing needs attention.',
   skipped: 'Nothing is staying on Stripe.',
-  all: 'No records to show.',
 }
 
 interface Props {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.tsx
@@ -2,8 +2,9 @@ import { SegmentedControl } from '@polar-sh/orbit'
 
 export type ReviewFilter =
   | 'all'
-  | 'imported'
-  | 'pending'
+  | 'to_prepare'
+  | 'ready'
+  | 'switched'
   | 'attention'
   | 'skipped'
 
@@ -13,16 +14,18 @@ const numberFormat = new Intl.NumberFormat('en-US')
 
 const OPTIONS: { value: ReviewFilter; label: string }[] = [
   { value: 'all', label: 'All rows' },
-  { value: 'imported', label: 'Imported' },
-  { value: 'pending', label: 'Pending' },
+  { value: 'to_prepare', label: 'To prepare' },
+  { value: 'ready', label: 'Ready to switch' },
+  { value: 'switched', label: 'Switched' },
   { value: 'attention', label: 'Needs attention' },
   { value: 'skipped', label: "Won't import" },
 ]
 
 export const EMPTY_MESSAGES: Record<ReviewFilter, string> = {
   all: 'No subscriptions to show.',
-  imported: 'No subscriptions have been imported.',
-  pending: 'No subscriptions are pending.',
+  to_prepare: 'No subscriptions need preparation.',
+  ready: 'No subscriptions are ready to switch.',
+  switched: 'No subscriptions have been switched.',
   attention: 'Nothing needs attention.',
   skipped: 'Nothing is staying on Stripe.',
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewStatusTabs.tsx
@@ -4,7 +4,6 @@ export type ReviewFilter =
   | 'all'
   | 'to_prepare'
   | 'ready'
-  | 'switched'
   | 'attention'
   | 'skipped'
 
@@ -16,7 +15,6 @@ const OPTIONS: { value: ReviewFilter; label: string }[] = [
   { value: 'all', label: 'All rows' },
   { value: 'to_prepare', label: 'To prepare' },
   { value: 'ready', label: 'Ready to switch' },
-  { value: 'switched', label: 'Switched' },
   { value: 'attention', label: 'Needs attention' },
   { value: 'skipped', label: "Won't import" },
 ]
@@ -25,7 +23,6 @@ export const EMPTY_MESSAGES: Record<ReviewFilter, string> = {
   all: 'No subscriptions to show.',
   to_prepare: 'No subscriptions need preparation.',
   ready: 'No subscriptions are ready to switch.',
-  switched: 'No subscriptions have been switched.',
   attention: 'Nothing needs attention.',
   skipped: 'Nothing is staying on Stripe.',
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -30,6 +30,8 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
     entity: 'subscriptions',
     page,
     limit: pageSize,
+    ...(filter === 'imported' ? { importStatus: 'imported' as const } : {}),
+    ...(filter === 'pending' ? { importStatus: 'pending' as const } : {}),
     ...(filter === 'attention' ? { reasonLevel: 'action_required' } : {}),
     ...(filter === 'skipped' ? { status: 'skipped' as const } : {}),
   })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -20,8 +20,14 @@ import {
 import { ReviewFilter } from './ReviewStatusTabs'
 import { ReviewTableView } from './ReviewTableView'
 
-export function ReviewTable({ migrationId }: { migrationId: string }) {
-  const [filter, setFilter] = useState<ReviewFilter>('all')
+export function ReviewTable({
+  migrationId,
+  defaultFilter = 'all',
+}: {
+  migrationId: string
+  defaultFilter?: ReviewFilter
+}) {
+  const [filter, setFilter] = useState<ReviewFilter>(defaultFilter)
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(20)
   const [selection, setSelection] = useState<SelectionState>(initialSelection)

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -30,6 +30,7 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
     entity: 'subscriptions',
     page,
     limit: pageSize,
+    excludeImportStatus: 'imported',
     ...(filter === 'to_prepare'
       ? {
           status: 'importable' as const,
@@ -44,7 +45,6 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
           dependenciesImported: true,
         }
       : {}),
-    ...(filter === 'switched' ? { importStatus: 'imported' as const } : {}),
     ...(filter === 'attention' ? { reasonLevel: 'action_required' } : {}),
     ...(filter === 'skipped' ? { status: 'skipped' as const } : {}),
   })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -20,14 +20,8 @@ import {
 import { ReviewFilter } from './ReviewStatusTabs'
 import { ReviewTableView } from './ReviewTableView'
 
-export function ReviewTable({
-  migrationId,
-  defaultFilter = 'all',
-}: {
-  migrationId: string
-  defaultFilter?: ReviewFilter
-}) {
-  const [filter, setFilter] = useState<ReviewFilter>(defaultFilter)
+export function ReviewTable({ migrationId }: { migrationId: string }) {
+  const [filter, setFilter] = useState<ReviewFilter>('all')
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(20)
   const [selection, setSelection] = useState<SelectionState>(initialSelection)
@@ -36,8 +30,21 @@ export function ReviewTable({
     entity: 'subscriptions',
     page,
     limit: pageSize,
-    ...(filter === 'imported' ? { importStatus: 'imported' as const } : {}),
-    ...(filter === 'pending' ? { importStatus: 'pending' as const } : {}),
+    ...(filter === 'to_prepare'
+      ? {
+          status: 'importable' as const,
+          importStatus: 'pending' as const,
+          dependenciesImported: false,
+        }
+      : {}),
+    ...(filter === 'ready'
+      ? {
+          status: 'importable' as const,
+          importStatus: 'pending' as const,
+          dependenciesImported: true,
+        }
+      : {}),
+    ...(filter === 'switched' ? { importStatus: 'imported' as const } : {}),
     ...(filter === 'attention' ? { reasonLevel: 'action_required' } : {}),
     ...(filter === 'skipped' ? { status: 'skipped' as const } : {}),
   })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -73,13 +73,14 @@ export function ReviewTableView({
   const selectableTotal = counts.subscriptions.selectable
 
   const importCount = selectedCount(selection, selectableTotal)
-  const importLabel = importing
-    ? 'Importing…'
+  const prepareLabel = importing
+    ? 'Preparing…'
     : importCount > 0
-      ? `Import ${numberFormat.format(importCount)} ${
+      ? `Prepare ${numberFormat.format(importCount)} ${
           importCount === 1 ? 'subscription' : 'subscriptions'
         }`
-      : 'Import subscriptions'
+      : 'Prepare subscriptions'
+  const canPrepare = filter === 'all' || filter === 'pending'
   const hasCatalog = rowTotal > 0
   const [openRow, setOpenRow] = useState<ReviewRow | null>(null)
 
@@ -169,7 +170,7 @@ export function ReviewTableView({
       {importError && (
         <Alert
           variant="danger"
-          title="We couldn't import the catalog"
+          title="We couldn't prepare these subscriptions"
           description={importError}
         />
       )}
@@ -206,18 +207,20 @@ export function ReviewTableView({
                 {rerunning ? 'Refreshing…' : 'Refresh from Stripe'}
               </Button>
             )}
-            <Button
-              size="sm"
-              onClick={onImport}
-              disabled={importing || importCount <= 0}
-            >
-              {importLabel}
-            </Button>
+            {canPrepare ? (
+              <Button
+                size="sm"
+                onClick={onImport}
+                disabled={importing || importCount <= 0}
+              >
+                {prepareLabel}
+              </Button>
+            ) : null}
           </Box>
         </Box>
 
         <Text variant="caption" color="muted">
-          Importing a subscription brings its customer and product to Polar.
+          Preparing a subscription brings its customer and product to Polar.
           Polar starts billing only when you switch.
         </Text>
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -186,9 +186,11 @@ export function ReviewTableView({
             <ReviewStatusTabs
               value={filter}
               counts={{
+                all: rowTotal,
+                imported: counts.subscriptions.imported,
+                pending: counts.subscriptions.pending,
                 attention: attentionCount,
                 skipped: skippedTotal,
-                all: rowTotal,
               }}
               onChange={onFilterChange}
             />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -68,7 +68,7 @@ export function ReviewTableView({
   blockers = [],
   attentionCount,
 }: Props) {
-  const rowTotal = counts.subscriptions.total
+  const rowTotal = counts.subscriptions.total - counts.subscriptions.imported
   const skippedTotal = counts.subscriptions.skipped
   const selectableTotal = counts.subscriptions.selectable
 
@@ -190,7 +190,6 @@ export function ReviewTableView({
                 all: rowTotal,
                 to_prepare: selectableTotal,
                 ready: counts.subscriptions.ready,
-                switched: counts.subscriptions.imported,
                 attention: attentionCount,
                 skipped: skippedTotal,
               }}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -5,6 +5,7 @@ import { Alert, Button, DataTable, InlineModal, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { OnChangeFn, PaginationState } from '@tanstack/react-table'
 import { useMemo, useState } from 'react'
+import { CatalogEmptyPanel } from './CatalogEmptyPanel'
 import { ReviewRecordModal } from './ReviewRecordModal'
 import {
   EMPTY_MESSAGES,
@@ -19,6 +20,10 @@ import {
   selectedCount,
   SelectionState,
 } from '../selection'
+import {
+  remainingSubscriptionCount,
+  reviewCatalogEmptyKind,
+} from './reviewCatalog'
 import { ReviewRow } from './reviewRows'
 
 const numberFormat = new Intl.NumberFormat('en-US')
@@ -68,10 +73,15 @@ export function ReviewTableView({
   blockers = [],
   attentionCount,
 }: Props) {
-  const rowTotal = counts.subscriptions.total - counts.subscriptions.imported
-  const skippedTotal = counts.subscriptions.skipped
+  const rowTotal = remainingSubscriptionCount(
+    counts.subscriptions.total,
+    counts.subscriptions.imported,
+  )
+  const catalogEmpty = reviewCatalogEmptyKind(
+    counts.subscriptions.total,
+    counts.subscriptions.imported,
+  )
   const selectableTotal = counts.subscriptions.selectable
-
   const importCount = selectedCount(selection, selectableTotal)
   const prepareLabel = importing
     ? 'Preparing…'
@@ -81,7 +91,6 @@ export function ReviewTableView({
         }`
       : 'Prepare subscriptions'
   const canPrepare = filter === 'all' || filter === 'to_prepare'
-  const hasCatalog = rowTotal > 0
   const [openRow, setOpenRow] = useState<ReviewRow | null>(null)
 
   const columns = useMemo(
@@ -126,42 +135,13 @@ export function ReviewTableView({
     )
   }
 
-  // Reaching this step means a scan already ran, so no subscription rows means
-  // Stripe had no subscriptions we can migrate.
-  if (!hasCatalog) {
+  if (catalogEmpty) {
     return (
-      <Box
-        borderWidth={1}
-        borderStyle="solid"
-        borderColor="border-primary"
-        borderRadius="l"
-        paddingVertical="3xl"
-        paddingHorizontal="xl"
-        flexDirection="column"
-        alignItems="center"
-        rowGap="l"
-        textAlign="center"
-      >
-        <Box flexDirection="column" rowGap="xs" alignItems="center">
-          <Text variant="heading-xs" as="h3">
-            Nothing to import
-          </Text>
-          <Text variant="caption" color="muted">
-            We found no subscriptions in Stripe that can move to Polar. If you
-            have added some since, scan again.
-          </Text>
-        </Box>
-        {onRerunPrecheck && (
-          <Button
-            size="sm"
-            variant="secondary"
-            onClick={onRerunPrecheck}
-            disabled={rerunning}
-          >
-            {rerunning ? 'Refreshing…' : 'Refresh from Stripe'}
-          </Button>
-        )}
-      </Box>
+      <CatalogEmptyPanel
+        kind={catalogEmpty}
+        onRerunPrecheck={onRerunPrecheck}
+        rerunning={rerunning}
+      />
     )
   }
 
@@ -191,7 +171,7 @@ export function ReviewTableView({
                 to_prepare: selectableTotal,
                 ready: counts.subscriptions.ready,
                 attention: attentionCount,
-                skipped: skippedTotal,
+                skipped: counts.subscriptions.skipped,
               }}
               onChange={onFilterChange}
             />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -80,7 +80,7 @@ export function ReviewTableView({
           importCount === 1 ? 'subscription' : 'subscriptions'
         }`
       : 'Prepare subscriptions'
-  const canPrepare = filter === 'all' || filter === 'pending'
+  const canPrepare = filter === 'all' || filter === 'to_prepare'
   const hasCatalog = rowTotal > 0
   const [openRow, setOpenRow] = useState<ReviewRow | null>(null)
 
@@ -188,8 +188,9 @@ export function ReviewTableView({
               value={filter}
               counts={{
                 all: rowTotal,
-                imported: counts.subscriptions.imported,
-                pending: counts.subscriptions.pending,
+                to_prepare: selectableTotal,
+                ready: counts.subscriptions.ready,
+                switched: counts.subscriptions.imported,
                 attention: attentionCount,
                 skipped: skippedTotal,
               }}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/recordSummary.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/recordSummary.ts
@@ -14,6 +14,8 @@ const empty = (entity: CountEntity): EntityCount => ({
   importable: 0,
   skipped: 0,
   imported: 0,
+  pending: 0,
+  action_required: 0,
   selectable: 0,
 })
 
@@ -37,7 +39,7 @@ export const useRecordSummary = (id: string) => {
         customers: counts.customers.imported,
       },
       selectableTotal: counts.subscriptions.selectable,
-      attentionCount: query.data?.action_required ?? 0,
+      attentionCount: counts.subscriptions.action_required,
     }
   }, [query.data])
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/recordSummary.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/recordSummary.ts
@@ -14,7 +14,7 @@ const empty = (entity: CountEntity): EntityCount => ({
   importable: 0,
   skipped: 0,
   imported: 0,
-  pending: 0,
+  ready: 0,
   action_required: 0,
   selectable: 0,
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewCatalog.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewCatalog.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import {
+  remainingSubscriptionCount,
+  reviewCatalogEmptyKind,
+} from './reviewCatalog'
+
+describe('remainingSubscriptionCount', () => {
+  it('excludes already switched subscriptions from the All tab', () => {
+    expect(remainingSubscriptionCount(58, 58)).toBe(0)
+    expect(remainingSubscriptionCount(58, 20)).toBe(38)
+  })
+})
+
+describe('reviewCatalogEmptyKind', () => {
+  it('treats a zero catalog as nothing in Stripe', () => {
+    expect(reviewCatalogEmptyKind(0, 0)).toBe('no_stripe_subscriptions')
+  })
+
+  it('does not claim Stripe is empty when every subscription is already switched', () => {
+    expect(reviewCatalogEmptyKind(58, 58)).toBe('all_switched')
+    expect(reviewCatalogEmptyKind(58, 58)).not.toBe('no_stripe_subscriptions')
+  })
+
+  it('shows the table when any subscription still needs work', () => {
+    expect(reviewCatalogEmptyKind(58, 20)).toBeNull()
+  })
+})

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewCatalog.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewCatalog.ts
@@ -1,6 +1,4 @@
-export type ReviewCatalogEmptyKind =
-  | 'no_stripe_subscriptions'
-  | 'all_switched'
+export type ReviewCatalogEmptyKind = 'no_stripe_subscriptions' | 'all_switched'
 
 export function remainingSubscriptionCount(
   total: number,

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewCatalog.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewCatalog.ts
@@ -1,0 +1,39 @@
+export type ReviewCatalogEmptyKind =
+  | 'no_stripe_subscriptions'
+  | 'all_switched'
+
+export function remainingSubscriptionCount(
+  total: number,
+  imported: number,
+): number {
+  return Math.max(total - imported, 0)
+}
+
+export function reviewCatalogEmptyKind(
+  total: number,
+  imported: number,
+): ReviewCatalogEmptyKind | null {
+  if (total <= 0) {
+    return 'no_stripe_subscriptions'
+  }
+  if (remainingSubscriptionCount(total, imported) <= 0) {
+    return 'all_switched'
+  }
+  return null
+}
+
+export const CATALOG_EMPTY_COPY: Record<
+  ReviewCatalogEmptyKind,
+  { title: string; description: string }
+> = {
+  all_switched: {
+    title: 'All subscriptions already switched',
+    description:
+      'Every Stripe subscription in this migration is already on Polar. Refresh if you have added more since.',
+  },
+  no_stripe_subscriptions: {
+    title: 'Nothing to import',
+    description:
+      'We found no subscriptions in Stripe that can move to Polar. If you have added some since, scan again.',
+  },
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewStatus.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewStatus.test.ts
@@ -22,21 +22,21 @@ function row(overrides: Partial<ReviewRow>): ReviewRow {
 }
 
 describe('reviewStatus', () => {
-  describe('imported', () => {
-    it('shows "Imported" (gray) when import_status is imported', () => {
+  describe('switched', () => {
+    it('shows "Switched" (gray) when import_status is imported', () => {
       expect(reviewStatus(row({ import_status: 'imported' }))).toEqual({
-        label: 'Imported',
+        label: 'Switched',
         color: 'gray',
       })
     })
 
     // `isImported` checks `import_status === 'imported'`, so a precheck-skipped
-    // row that somehow ended up imported should still surface as Imported — the
+    // row that somehow ended up imported should still surface as Switched — the
     // runtime outcome wins over the precheck prediction.
-    it('prefers "Imported" over a precheck-skipped status', () => {
+    it('prefers "Switched" over a precheck-skipped status', () => {
       expect(
         reviewStatus(row({ status: 'skipped', import_status: 'imported' })),
-      ).toEqual({ label: 'Imported', color: 'gray' })
+      ).toEqual({ label: 'Switched', color: 'gray' })
     })
   })
 
@@ -94,11 +94,11 @@ describe('reviewStatus', () => {
             reason_level: 'action_required',
           }),
         ),
-      ).toEqual({ label: 'Imported', color: 'gray' })
+      ).toEqual({ label: 'Switched', color: 'gray' })
     })
   })
 
-  describe('ready', () => {
+  describe('preparation', () => {
     it('shows "Ready to switch" when a pending subscription has imported dependencies', () => {
       expect(
         reviewStatus(
@@ -111,19 +111,19 @@ describe('reviewStatus', () => {
       ).toEqual({ label: 'Ready to switch' })
     })
 
-    it('shows "Ready" when importable and pending with no reason', () => {
+    it('shows "To prepare" when importable and pending with no reason', () => {
       expect(
         reviewStatus(row({ status: 'importable', import_status: 'pending' })),
-      ).toEqual({ label: 'Ready' })
+      ).toEqual({ label: 'To prepare' })
     })
 
-    it('shows "Ready" when import_status is null (price rows)', () => {
+    it('shows "To prepare" when import_status is null', () => {
       expect(
         reviewStatus(row({ status: 'importable', import_status: null })),
-      ).toEqual({ label: 'Ready' })
+      ).toEqual({ label: 'To prepare' })
     })
 
-    it('shows "Ready" for an info-level reason that does not need attention', () => {
+    it('shows "To prepare" for an info-level reason that does not need attention', () => {
       expect(
         reviewStatus(
           row({
@@ -132,7 +132,7 @@ describe('reviewStatus', () => {
             reason_level: 'info',
           }),
         ),
-      ).toEqual({ label: 'Ready' })
+      ).toEqual({ label: 'To prepare' })
     })
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewStatus.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/reviewStatus.ts
@@ -14,7 +14,7 @@ export interface ReviewStatus {
 // property of the Stripe record, so it lives in the row's detail modal.
 export function reviewStatus(row: ReviewRow): ReviewStatus {
   if (isImported(row)) {
-    return { label: 'Imported', color: 'gray' }
+    return { label: 'Switched', color: 'gray' }
   }
   if (row.import_status === 'failed') {
     return { label: 'Import failed', color: 'red' }
@@ -33,5 +33,5 @@ export function reviewStatus(row: ReviewRow): ReviewStatus {
   if (needsAttention(row)) {
     return { label: 'Needs info', color: 'yellow' }
   }
-  return { label: 'Ready' }
+  return { label: 'To prepare' }
 }

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -193,6 +193,7 @@ export const useMigrationRecords = (
     reasonLevel?: schemas['PrecheckReasonLevel']
     importStatus?: schemas['MerchantMigrationRecordStatus']
     cutoverStatus?: schemas['MerchantMigrationCutoverStatus']
+    dependenciesImported?: boolean
     page: number
     limit: number
   },
@@ -216,6 +217,9 @@ export const useMigrationRecords = (
                 : {}),
               ...(params.cutoverStatus
                 ? { cutover_status: params.cutoverStatus }
+                : {}),
+              ...(params.dependenciesImported !== undefined
+                ? { dependencies_imported: params.dependenciesImported }
                 : {}),
               page: params.page,
               limit: params.limit,

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -192,6 +192,7 @@ export const useMigrationRecords = (
     status?: schemas['PrecheckRecordStatus']
     reasonLevel?: schemas['PrecheckReasonLevel']
     importStatus?: schemas['MerchantMigrationRecordStatus']
+    excludeImportStatus?: schemas['MerchantMigrationRecordStatus']
     cutoverStatus?: schemas['MerchantMigrationCutoverStatus']
     dependenciesImported?: boolean
     page: number
@@ -214,6 +215,9 @@ export const useMigrationRecords = (
                 : {}),
               ...(params.importStatus
                 ? { import_status: params.importStatus }
+                : {}),
+              ...(params.excludeImportStatus
+                ? { exclude_import_status: params.excludeImportStatus }
                 : {}),
               ...(params.cutoverStatus
                 ? { cutover_status: params.cutoverStatus }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -25168,6 +25168,16 @@ export interface components {
        */
       imported: number
       /**
+       * Pending
+       * @description How many are waiting to be imported into Polar.
+       */
+      pending: number
+      /**
+       * Action Required
+       * @description How many require merchant action before they can be imported.
+       */
+      action_required: number
+      /**
        * Selectable
        * @description How many subscriptions an import would still prepare: importable by the pre-check, pending in the ledger, and not already backed by an imported customer and product. Zero for other entities.
        */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -56205,6 +56205,9 @@ export interface operations {
         import_status?:
           | components['schemas']['MerchantMigrationRecordStatus']
           | null
+        exclude_import_status?:
+          | components['schemas']['MerchantMigrationRecordStatus']
+          | null
         cutover_status?:
           | components['schemas']['MerchantMigrationCutoverStatus']
           | null

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -25168,13 +25168,13 @@ export interface components {
        */
       imported: number
       /**
-       * Pending
-       * @description How many are waiting to be imported into Polar.
+       * Ready
+       * @description How many subscriptions are prepared and ready to switch.
        */
-      pending: number
+      ready: number
       /**
        * Action Required
-       * @description How many require merchant action before they can be imported.
+       * @description How many require merchant action before they can be prepared.
        */
       action_required: number
       /**
@@ -56208,6 +56208,7 @@ export interface operations {
         cutover_status?:
           | components['schemas']['MerchantMigrationCutoverStatus']
           | null
+        dependencies_imported?: boolean | null
         /** @description Page number, defaults to 1. */
         page?: number
         /** @description Size of a page, defaults to 10. Maximum is 100. */

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -457,6 +457,9 @@ async def records(
     status: Annotated[PrecheckRecordStatus | None, Query()] = None,
     reason_level: Annotated[PrecheckReasonLevel | None, Query()] = None,
     import_status: Annotated[MerchantMigrationRecordStatus | None, Query()] = None,
+    exclude_import_status: Annotated[
+        MerchantMigrationRecordStatus | None, Query()
+    ] = None,
     cutover_status: Annotated[MerchantMigrationCutoverStatus | None, Query()] = None,
     dependencies_imported: Annotated[bool | None, Query()] = None,
     # The primary, like the summary above: it supplies the selection ceiling
@@ -472,6 +475,7 @@ async def records(
         status=status,
         reason_level=reason_level,
         import_status=import_status,
+        exclude_import_status=exclude_import_status,
         cutover_status=cutover_status,
         dependencies_imported=dependencies_imported,
         pagination=pagination,

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -458,6 +458,7 @@ async def records(
     reason_level: Annotated[PrecheckReasonLevel | None, Query()] = None,
     import_status: Annotated[MerchantMigrationRecordStatus | None, Query()] = None,
     cutover_status: Annotated[MerchantMigrationCutoverStatus | None, Query()] = None,
+    dependencies_imported: Annotated[bool | None, Query()] = None,
     # The primary, like the summary above: it supplies the selection ceiling
     # and these rows supply the checkboxes, so a split would let replica lag
     # show a tickable row the count doesn't include.
@@ -472,6 +473,7 @@ async def records(
         reason_level=reason_level,
         import_status=import_status,
         cutover_status=cutover_status,
+        dependencies_imported=dependencies_imported,
         pagination=pagination,
     )
     return ListResource.from_paginated_results(items, count, pagination)

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -209,6 +209,10 @@ class MerchantMigrationRecordSummaryEntity(PrecheckEntitySummary):
     """The pre-check's per-entity counts, plus where the ledger has got to."""
 
     imported: int = Field(description="How many are already in Polar.")
+    pending: int = Field(description="How many are waiting to be imported into Polar.")
+    action_required: int = Field(
+        description="How many require merchant action before they can be imported."
+    )
     selectable: int = Field(
         description="How many subscriptions an import would still prepare: "
         "importable by the pre-check, pending in the ledger, and not already backed "

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -209,9 +209,11 @@ class MerchantMigrationRecordSummaryEntity(PrecheckEntitySummary):
     """The pre-check's per-entity counts, plus where the ledger has got to."""
 
     imported: int = Field(description="How many are already in Polar.")
-    pending: int = Field(description="How many are waiting to be imported into Polar.")
+    ready: int = Field(
+        description="How many subscriptions are prepared and ready to switch."
+    )
     action_required: int = Field(
-        description="How many require merchant action before they can be imported."
+        description="How many require merchant action before they can be prepared."
     )
     selectable: int = Field(
         description="How many subscriptions an import would still prepare: "

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -273,7 +273,14 @@ def _summarize_entities(
 ) -> list[MerchantMigrationRecordSummaryEntity]:
     """Tally every entity in one pass over the classified rows."""
     tallies = {
-        entity: {"total": 0, "importable": 0, "imported": 0, "selectable": 0}
+        entity: {
+            "total": 0,
+            "importable": 0,
+            "imported": 0,
+            "pending": 0,
+            "action_required": 0,
+            "selectable": 0,
+        }
         for entity in entities
     }
     for item in items:
@@ -283,6 +290,10 @@ def _summarize_entities(
         tally["total"] += 1
         if item.import_status == MerchantMigrationRecordStatus.imported:
             tally["imported"] += 1
+        if item.import_status == MerchantMigrationRecordStatus.pending:
+            tally["pending"] += 1
+        if item.reason_level == PrecheckReasonLevel.action_required:
+            tally["action_required"] += 1
         if item.status != PrecheckRecordStatus.importable:
             continue
         tally["importable"] += 1
@@ -300,6 +311,8 @@ def _summarize_entities(
             importable=tally["importable"],
             skipped=tally["total"] - tally["importable"],
             imported=tally["imported"],
+            pending=tally["pending"],
+            action_required=tally["action_required"],
             selectable=tally["selectable"],
         )
         for entity, tally in tallies.items()

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -290,7 +290,10 @@ def _summarize_entities(
         tally["total"] += 1
         if item.import_status == MerchantMigrationRecordStatus.imported:
             tally["imported"] += 1
-        if item.reason_level == PrecheckReasonLevel.action_required:
+        if (
+            item.reason_level == PrecheckReasonLevel.action_required
+            and item.import_status != MerchantMigrationRecordStatus.imported
+        ):
             tally["action_required"] += 1
         if item.status != PrecheckRecordStatus.importable:
             continue
@@ -1143,6 +1146,7 @@ class MerchantMigrationService:
         status: PrecheckRecordStatus | None,
         reason_level: PrecheckReasonLevel | None = None,
         import_status: MerchantMigrationRecordStatus | None = None,
+        exclude_import_status: MerchantMigrationRecordStatus | None = None,
         cutover_status: MerchantMigrationCutoverStatus | None = None,
         dependencies_imported: bool | None = None,
         pagination: PaginationParams,
@@ -1151,13 +1155,11 @@ class MerchantMigrationService:
         memory. ``entity`` scopes to one type; ``None`` returns products, customers
         and subscriptions together. ``status`` filters to importable or skipped;
         ``reason_level`` filters to rows the merchant has to act on
-        (`action_required`) or only needs to know about (`info`);
-        ``import_status`` filters on the ledger outcome, which excludes price rows
-        since they have none; ``cutover_status`` narrows to what the switch did
-        with a subscription, which is how the merchant finds the ones it left on
-        the source; ``dependencies_imported`` separates subscriptions ready to
-        switch from those still needing preparation. Reads what ``run_precheck``
-        persisted."""
+        (`action_required`) or only needs to know about (`info`); the import status
+        filters include or exclude a ledger outcome; ``cutover_status`` narrows to
+        what the switch did with a subscription; ``dependencies_imported``
+        separates subscriptions ready to switch from those still needing
+        preparation. Reads what ``run_precheck`` persisted."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
         entities = [entity] if entity is not None else list(_ENTITY_RECORD_TYPE)
         items = await self._classify_staged(session, migration, entities)
@@ -1169,6 +1171,10 @@ class MerchantMigrationService:
             items = [item for item in items if item.reason_level == reason_level]
         if import_status is not None:
             items = [item for item in items if item.import_status == import_status]
+        if exclude_import_status is not None:
+            items = [
+                item for item in items if item.import_status != exclude_import_status
+            ]
         if cutover_status is not None:
             items = [item for item in items if item.cutover_status == cutover_status]
         if dependencies_imported is not None:

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -277,7 +277,7 @@ def _summarize_entities(
             "total": 0,
             "importable": 0,
             "imported": 0,
-            "pending": 0,
+            "ready": 0,
             "action_required": 0,
             "selectable": 0,
         }
@@ -290,13 +290,17 @@ def _summarize_entities(
         tally["total"] += 1
         if item.import_status == MerchantMigrationRecordStatus.imported:
             tally["imported"] += 1
-        if item.import_status == MerchantMigrationRecordStatus.pending:
-            tally["pending"] += 1
         if item.reason_level == PrecheckReasonLevel.action_required:
             tally["action_required"] += 1
         if item.status != PrecheckRecordStatus.importable:
             continue
         tally["importable"] += 1
+        if (
+            item.entity == PrecheckEntity.subscriptions
+            and item.import_status == MerchantMigrationRecordStatus.pending
+            and item.dependencies_imported
+        ):
+            tally["ready"] += 1
         if (
             item.entity == PrecheckEntity.subscriptions
             and item.import_status == MerchantMigrationRecordStatus.pending
@@ -311,7 +315,7 @@ def _summarize_entities(
             importable=tally["importable"],
             skipped=tally["total"] - tally["importable"],
             imported=tally["imported"],
-            pending=tally["pending"],
+            ready=tally["ready"],
             action_required=tally["action_required"],
             selectable=tally["selectable"],
         )
@@ -1140,6 +1144,7 @@ class MerchantMigrationService:
         reason_level: PrecheckReasonLevel | None = None,
         import_status: MerchantMigrationRecordStatus | None = None,
         cutover_status: MerchantMigrationCutoverStatus | None = None,
+        dependencies_imported: bool | None = None,
         pagination: PaginationParams,
     ) -> tuple[Sequence[MerchantMigrationRecordItem], int]:
         """Return staged records classified importable/skipped and paginated in
@@ -1150,7 +1155,9 @@ class MerchantMigrationService:
         ``import_status`` filters on the ledger outcome, which excludes price rows
         since they have none; ``cutover_status`` narrows to what the switch did
         with a subscription, which is how the merchant finds the ones it left on
-        the source. Reads what ``run_precheck`` persisted."""
+        the source; ``dependencies_imported`` separates subscriptions ready to
+        switch from those still needing preparation. Reads what ``run_precheck``
+        persisted."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
         entities = [entity] if entity is not None else list(_ENTITY_RECORD_TYPE)
         items = await self._classify_staged(session, migration, entities)
@@ -1164,6 +1171,12 @@ class MerchantMigrationService:
             items = [item for item in items if item.import_status == import_status]
         if cutover_status is not None:
             items = [item for item in items if item.cutover_status == cutover_status]
+        if dependencies_imported is not None:
+            items = [
+                item
+                for item in items
+                if item.dependencies_imported is dependencies_imported
+            ]
 
         start = (pagination.page - 1) * pagination.limit
         return items[start : start + pagination.limit], len(items)

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1519,11 +1519,14 @@ class TestSummarizeRecords:
         assert products.importable == 1
         assert products.skipped == 1
         assert products.imported == 1
+        assert products.pending == 1
+        assert products.action_required == 0
         assert products.selectable == 0
 
         customers = by_entity[PrecheckEntity.customers]
         assert customers.total == 1
         assert customers.imported == 1
+        assert customers.pending == 0
         assert customers.selectable == 0
 
         items, count = await service.list_records(
@@ -1536,6 +1539,7 @@ class TestSummarizeRecords:
             pagination=PaginationParams(page=1, limit=100),
         )
         assert summary.action_required == count
+        assert sum(entity.action_required for entity in summary.entities) == count
 
     @pytest.mark.auth
     async def test_summary_counts_what_is_still_selectable(
@@ -1556,8 +1560,11 @@ class TestSummarizeRecords:
         by_entity = {entry.entity: entry for entry in summary.entities}
         products = by_entity[PrecheckEntity.products]
         assert products.imported == 0
+        assert products.pending == 2
         assert products.selectable == 0
-        assert by_entity[PrecheckEntity.subscriptions].selectable == 1
+        subscriptions = by_entity[PrecheckEntity.subscriptions]
+        assert subscriptions.pending == 1
+        assert subscriptions.selectable == 1
 
 
 def _canonical_subscription(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -949,6 +949,19 @@ class TestImportCatalog:
         assert count == 1
         assert [item.source_id for item in items] == ["prod_1"]
 
+        items, count = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.products,
+            status=None,
+            exclude_import_status=MerchantMigrationRecordStatus.imported,
+            pagination=PaginationParams(page=1, limit=20),
+        )
+
+        assert count == 1
+        assert [item.source_id for item in items] == ["prod_2"]
+
     @pytest.mark.auth
     async def test_imports_subscription_dependencies_without_creating_subscription(
         self,

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1000,6 +1000,18 @@ class TestImportCatalog:
         )
         assert len(items) == 1
         assert items[0].dependencies_imported is True
+        ready_items, ready_count = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.subscriptions,
+            status=PrecheckRecordStatus.importable,
+            import_status=MerchantMigrationRecordStatus.pending,
+            dependencies_imported=True,
+            pagination=PaginationParams(page=1, limit=20),
+        )
+        assert ready_count == 1
+        assert ready_items[0].source_id == "sub_1"
         summary = await service.summarize_records(session, auth_subject, migration.id)
         subscriptions = next(
             entry
@@ -1007,6 +1019,7 @@ class TestImportCatalog:
             if entry.entity == PrecheckEntity.subscriptions
         )
         assert subscriptions.selectable == 0
+        assert subscriptions.ready == 1
 
     @pytest.mark.auth
     async def test_excluded_subscription_leaves_its_dependencies_pending(
@@ -1519,15 +1532,18 @@ class TestSummarizeRecords:
         assert products.importable == 1
         assert products.skipped == 1
         assert products.imported == 1
-        assert products.pending == 1
+        assert products.ready == 0
         assert products.action_required == 0
         assert products.selectable == 0
 
         customers = by_entity[PrecheckEntity.customers]
         assert customers.total == 1
         assert customers.imported == 1
-        assert customers.pending == 0
+        assert customers.ready == 0
         assert customers.selectable == 0
+
+        subscriptions = by_entity[PrecheckEntity.subscriptions]
+        assert subscriptions.ready == 1
 
         items, count = await service.list_records(
             session,
@@ -1560,10 +1576,10 @@ class TestSummarizeRecords:
         by_entity = {entry.entity: entry for entry in summary.entities}
         products = by_entity[PrecheckEntity.products]
         assert products.imported == 0
-        assert products.pending == 2
+        assert products.ready == 0
         assert products.selectable == 0
         subscriptions = by_entity[PrecheckEntity.subscriptions]
-        assert subscriptions.pending == 1
+        assert subscriptions.ready == 0
         assert subscriptions.selectable == 1
 
 


### PR DESCRIPTION
## Summary

Makes pending and ready to switch subscriptions visible in the migration records view. 

<img width="1973" height="1120" alt="image" src="https://github.com/user-attachments/assets/b82206f9-3dd5-44c6-b8f8-264eec3083b0" />


## What

- Renamed columns to: all, to prepare, ready to switch, needs attention and won't import
- Shows a Prepare subscriptions action button.

## Why

I need to see which subscriptions are ready to switch and which ones don't. 


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-604cd60d-152b-445c-bdef-0bc3400a5920?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-604cd60d-152b-445c-bdef-0bc3400a5920&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

