### PR TITLE
db: add period timestamps to order items

### DIFF
--- a/server/migrations/versions/2026-09-08-0943_add_order_item_period_timestamps.py
+++ b/server/migrations/versions/2026-09-08-0943_add_order_item_period_timestamps.py
@@ -1,0 +1,36 @@
+"""Add order item period timestamps
+
+Revision ID: 80df375e5679
+Revises: fec1e6242c3f
+Create Date: 2026-09-08 09:43:45.550891
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "80df375e5679"
+down_revision = "fec1e6242c3f"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.add_column(
+        "order_items",
+        sa.Column("start_timestamp", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "order_items",
+        sa.Column("end_timestamp", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.drop_column("order_items", "end_timestamp")
+    op.drop_column("order_items", "start_timestamp")

--- a/server/polar/models/order_item.py
+++ b/server/polar/models/order_item.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Self
 from uuid import UUID
 
 from babel.dates import format_date
-from sqlalchemy import BigInteger, Boolean, ForeignKey, String, Uuid
+from sqlalchemy import TIMESTAMP, BigInteger, Boolean, ForeignKey, String, Uuid
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
@@ -30,6 +30,12 @@ class OrderItem(RecordModel):
     net_amount: Mapped[int] = mapped_column("net_amount_v2", BigInteger, nullable=False)
     tax_amount: Mapped[int] = mapped_column("tax_amount_v2", BigInteger, nullable=False)
     proration: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    start_timestamp: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
+    end_timestamp: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True
+    )
     order_id: Mapped[UUID] = mapped_column(
         Uuid, ForeignKey("orders.id", ondelete="cascade"), index=True
     )


### PR DESCRIPTION
Add start and end timestamp columns to OrderItem, in preparation of the follow up PR that'll add the logic to track items covered time period on Orders

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

