### PR TITLE
orders: expose line item period timestamps

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -26976,6 +26976,16 @@ export interface components {
        * @description Associated price ID, if any.
        */
       product_price_id: string | null
+      /**
+       * Start Timestamp
+       * @description Start of the period covered by this line item, if any.
+       */
+      start_timestamp: string | null
+      /**
+       * End Timestamp
+       * @description End of the period covered by this line item, if any.
+       */
+      end_timestamp: string | null
     }
     /** OrderNotDraft */
     OrderNotDraft: {

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -1646,6 +1646,16 @@ export interface components {
        * @description Associated price ID, if any.
        */
       product_price_id: string | null
+      /**
+       * Start Timestamp
+       * @description Start of the period covered by this line item, if any.
+       */
+      start_timestamp: string | null
+      /**
+       * End Timestamp
+       * @description End of the period covered by this line item, if any.
+       */
+      end_timestamp: string | null
     }
     /**
      * OrderStatus

--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -35,6 +35,8 @@ log = structlog.get_logger(__name__)
 @dataclasses.dataclass
 class StaticLineItem:
     price: StaticPrice
+    start_timestamp: datetime
+    end_timestamp: datetime
     amount: int
     currency: str
     label: str
@@ -91,6 +93,8 @@ class BillingEntryService:
                 net_amount=line_item.amount,
                 tax_amount=0,
                 proration=line_item.proration,
+                start_timestamp=line_item.start_timestamp,
+                end_timestamp=line_item.end_timestamp,
                 product_price=line_item.price,
             )
             item_entries_map[order_item] = selector
@@ -363,6 +367,8 @@ class BillingEntryService:
 
         return StaticLineItem(
             price=price,
+            start_timestamp=entry.start_timestamp,
+            end_timestamp=entry.end_timestamp,
             amount=amount,
             currency=entry.currency,
             label=label,

--- a/server/polar/models/order_item.py
+++ b/server/polar/models/order_item.py
@@ -122,7 +122,15 @@ class OrderItem(RecordModel):
         formatted_start = format_date(start.date(), locale="en_US")
         formatted_end = format_date(end.date(), locale="en_US")
         label = f"Trial period for {product.name} ({formatted_start} - {formatted_end})"
-        return cls(label=label, amount=0, tax_amount=0, net_amount=0, proration=False)
+        return cls(
+            label=label,
+            amount=0,
+            tax_amount=0,
+            net_amount=0,
+            proration=False,
+            start_timestamp=start,
+            end_timestamp=end,
+        )
 
     @classmethod
     def from_wallet(cls, wallet: "Wallet", amount: int) -> Self:

--- a/server/polar/order/schemas.py
+++ b/server/polar/order/schemas.py
@@ -248,6 +248,12 @@ class OrderItemSchema(IDSchema, TimestampedSchema):
         description="Whether this charge is due to a proration.", examples=[False]
     )
     product_price_id: UUID4 | None = Field(description="Associated price ID, if any.")
+    start_timestamp: datetime | None = Field(
+        description="Start of the period covered by this line item, if any."
+    )
+    end_timestamp: datetime | None = Field(
+        description="End of the period covered by this line item, if any."
+    )
 
 
 class Order(CustomFieldDataOutputMixin, MetadataOutputMixin, OrderBase):

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -864,6 +864,10 @@ class OrderService:
                     units=checkout.units,
                 )
             )
+            if subscription is not None:
+                for item in items:
+                    item.start_timestamp = subscription.current_period_start
+                    item.end_timestamp = subscription.current_period_end
 
         discount_amount = checkout.discount_amount
 

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -441,6 +441,8 @@ class TestCreateOrderItemsFromPending:
             order_item = order_items[0]
             assert meter.name in order_item.label
             assert order_item.amount == 50_00
+            assert order_item.start_timestamp == entries[1].start_timestamp
+            assert order_item.end_timestamp == entries[2].end_timestamp
 
             order = await create_order(
                 save_fixture,
@@ -840,6 +842,8 @@ class TestCreateOrderItemsFromPending:
             order_item = order_items[0]
             assert order_item.amount == 50_00
             assert order_item.proration is True
+            assert order_item.start_timestamp == entry.start_timestamp
+            assert order_item.end_timestamp == entry.end_timestamp
 
             # Seat-change prorations charge a delta, not the full seat amount.
             # The label shows the seat transition (old → new), read from the
@@ -1036,6 +1040,11 @@ class TestCreateOrderItemsFromPending:
             ),
         ]
 
+        entries[1].start_timestamp -= timedelta(days=2)
+        entries[2].start_timestamp -= timedelta(days=1)
+        await save_fixture(entries[1])
+        await save_fixture(entries[2])
+
         async with billing_entry_service.create_order_items_from_pending(
             session, subscription
         ) as order_items:
@@ -1044,10 +1053,14 @@ class TestCreateOrderItemsFromPending:
             order_item_1 = order_items[0]
             assert product.name in order_item_1.label
             assert order_item_1.proration is False
+            assert order_item_1.start_timestamp == entries[1].start_timestamp
+            assert order_item_1.end_timestamp == entries[1].end_timestamp
 
             order_item_2 = order_items[1]
             assert product.name in order_item_2.label
             assert order_item_2.proration is True
+            assert order_item_2.start_timestamp == entries[2].start_timestamp
+            assert order_item_2.end_timestamp == entries[2].end_timestamp
 
             # Fixed-only product: no seats qualifier should appear.
             assert "seat" not in order_item_1.label

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -968,6 +968,8 @@ class TestCreateFromCheckoutSubscription:
         assert order.customer == checkout.customer
         assert order.product == product
         assert len(order.items) == len(product.prices)
+        assert order.items[0].start_timestamp == subscription.current_period_start
+        assert order.items[0].end_timestamp == subscription.current_period_end
 
     async def test_metered(
         self,
@@ -2859,6 +2861,8 @@ class TestCreateTrialOrder:
         assert order.product == product
         assert order.subscription == subscription
         assert len(order.items) == 1
+        assert order.items[0].start_timestamp == subscription.trial_start
+        assert order.items[0].end_timestamp == subscription.trial_end
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Track for each OrderItem the time period it covers. It'll help users of the API to track on a given invoice which period is paid for.

Stacked on #14244.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

