### PR TITLE
sdk/typescript: prevent version overload on versioned client

### DIFF
--- a/sdk/generator/typescript/template/src/version/client.ts
+++ b/sdk/generator/typescript/template/src/version/client.ts
@@ -14,7 +14,6 @@ const SERVERS: Record<Environment, string> = {
 
 export interface PolarOptions
   extends Omit<ClientOptions, "baseUrl" | "version"> {
-  version?: string;
   environment?: Environment;
   baseUrl?: string;
 }
@@ -27,7 +26,7 @@ export function createPolarCore(options: PolarOptions) {
       options.environment ?? "production",
       options.baseUrl,
     ),
-    version: options.version ?? "{{ api.version }}",
+    version: "{{ api.version }}",
   });
 }
 

--- a/sdk/typescript/src/2026-04/client.ts
+++ b/sdk/typescript/src/2026-04/client.ts
@@ -34,7 +34,6 @@ const SERVERS: Record<Environment, string> = {
 };
 
 export interface PolarOptions extends Omit<ClientOptions, "baseUrl" | "version"> {
-  version?: string;
   environment?: Environment;
   baseUrl?: string;
 }
@@ -43,7 +42,7 @@ export function createPolarCore(options: PolarOptions) {
   return new ClientBase({
     ...options,
     baseUrl: resolveBaseUrl(SERVERS, options.environment ?? "production", options.baseUrl),
-    version: options.version ?? "2026-04",
+    version: "2026-04",
   });
 }
 

--- a/sdk/typescript/src/2026-10/client.ts
+++ b/sdk/typescript/src/2026-10/client.ts
@@ -34,7 +34,6 @@ const SERVERS: Record<Environment, string> = {
 };
 
 export interface PolarOptions extends Omit<ClientOptions, "baseUrl" | "version"> {
-  version?: string;
   environment?: Environment;
   baseUrl?: string;
 }
@@ -43,7 +42,7 @@ export function createPolarCore(options: PolarOptions) {
   return new ClientBase({
     ...options,
     baseUrl: resolveBaseUrl(SERVERS, options.environment ?? "production", options.baseUrl),
-    version: options.version ?? "2026-10",
+    version: "2026-10",
   });
 }
 


### PR DESCRIPTION

The generated version client in the TypeScript SDK was allowing the `version` property to be overloaded. This is a semantical error and contrary to the spirit of those versioned clients: sending a request with a specific version contract may not work if used with a different version. We also see the intent was already there in the code, with the `Omit<ClientOptions, "baseUrl" | "version">` that was already there.

This PR removes the possibility to overload the version, and hardcode the version on the versioned client. It aligns with how the Python versioned clients are working.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

