### PR TITLE
Lazy load org status counts in Backoffice

### DIFF
--- a/server/polar/backoffice/components/_tab_nav.py
+++ b/server/polar/backoffice/components/_tab_nav.py
@@ -17,6 +17,7 @@ class Tab:
     badge_variant: str | None = None
     # A small status dot (e.g. "needs attention"). Takes precedence over count.
     dot: bool = False
+    loading: bool = False
     # Extra classes on the tab element, e.g. "ml-auto" to push it to the right.
     extra_classes: str = ""
 
@@ -31,6 +32,10 @@ def _render_tab_indicator(tab: Tab) -> None:
     elif tab.count is not None:
         with tag.span(classes=f"badge badge-{variant} ml-2"):
             text(str(tab.count))
+    elif tab.loading:
+        with tag.span(classes=f"badge badge-{variant} ml-2", role="status"):
+            with tag.span(classes="loading loading-spinner loading-xs"):
+                pass
 
 
 @contextlib.contextmanager

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -494,6 +494,22 @@ async def _build_review_signals(
     return signals
 
 
+_STATUS_FILTERS: dict[str, OrganizationStatus] = {
+    "active": OrganizationStatus.ACTIVE,
+    "denied": OrganizationStatus.DENIED,
+    "created": OrganizationStatus.CREATED,
+    "offboarding": OrganizationStatus.OFFBOARDING,
+    "offboarded": OrganizationStatus.OFFBOARDED,
+    "review": OrganizationStatus.REVIEW,
+    "snoozed": OrganizationStatus.SNOOZED,
+    "blocked": OrganizationStatus.BLOCKED,
+}
+
+
+def _parse_status_filter(status: str | None) -> OrganizationStatus | None:
+    return _STATUS_FILTERS.get(status) if status else None
+
+
 def _apply_sql_sort(stmt: Select[Any], sort: str, direction: str) -> Select[Any]:
     is_desc = direction == "desc"
     if sort == "name":
@@ -580,24 +596,7 @@ async def list_organizations(
     # When searching, include deleted so matches surface.
     deleted_filter: DeletedFilter = deleted or ("include" if q else "exclude")
 
-    # Parse status filter
-    status_filter: OrganizationStatus | None = None
-    if status == "active":
-        status_filter = OrganizationStatus.ACTIVE
-    elif status == "denied":
-        status_filter = OrganizationStatus.DENIED
-    elif status == "created":
-        status_filter = OrganizationStatus.CREATED
-    elif status == "offboarding":
-        status_filter = OrganizationStatus.OFFBOARDING
-    elif status == "offboarded":
-        status_filter = OrganizationStatus.OFFBOARDED
-    elif status == "review":
-        status_filter = OrganizationStatus.REVIEW
-    elif status == "snoozed":
-        status_filter = OrganizationStatus.SNOOZED
-    elif status == "blocked":
-        status_filter = OrganizationStatus.BLOCKED
+    status_filter = _parse_status_filter(status)
 
     # "Open cases" is a separate dimension (not an org status).
     selected_open_cases = status == "open_cases"
@@ -773,7 +772,6 @@ async def list_organizations(
         ):
             pass
     else:
-        status_counts = await list_view.get_status_counts(deleted_filter)
         countries = await list_view.get_distinct_countries()
         open_cases_count = (
             await session.scalar(
@@ -792,7 +790,7 @@ async def list_organizations(
                 request,
                 organizations,
                 status_filter,
-                status_counts,
+                None,
                 page,
                 has_more,
                 sort,
@@ -810,8 +808,38 @@ async def list_organizations(
                 awaiting_reply_org_ids=awaiting_reply_org_ids,
                 selected_open_cases=selected_open_cases,
                 open_cases_count=open_cases_count,
+                lazy_counts_url=str(
+                    request.url_for("organizations:status_counts").include_query_params(
+                        **{k: v for k, v in request.query_params.items() if v}
+                    )
+                ),
             ):
                 pass
+
+
+@router.get("/status-counts", name="organizations:status_counts")
+async def status_counts(
+    request: Request,
+    session: AsyncSession = Depends(get_db_session),
+    status: str | None = Query(None),
+    q: str | None = Query(None),
+    deleted: DeletedFilter | None = Query(None),
+) -> None:
+    list_view = OrganizationListView(session)
+    deleted_filter: DeletedFilter = deleted or ("include" if q else "exclude")
+    open_cases_count = (
+        await session.scalar(
+            select(func.count()).select_from(open_case_organization_ids().subquery())
+        )
+        or 0
+    )
+    list_view.render_status_tabs(
+        request,
+        _parse_status_filter(status),
+        await list_view.get_status_counts(deleted_filter),
+        status == "open_cases",
+        open_cases_count,
+    )
 
 
 @router.get("/{organization_id}", name="organizations:detail")

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -336,13 +336,131 @@ class OrganizationListView:
 
         yield
 
+    def render_status_tabs(
+        self,
+        request: Request,
+        status_filter: OrganizationStatus | None,
+        status_counts: dict[OrganizationStatus, int] | None,
+        selected_open_cases: bool,
+        open_cases_count: int,
+        lazy_counts_url: str | None = None,
+    ) -> None:
+        def count_of(status: OrganizationStatus) -> int | None:
+            if status_counts is None:
+                return None
+            return status_counts.get(status, 0)
+
+        tabs = [
+            Tab(
+                label="All",
+                url=str(request.url_for("organizations:list")),
+                active=status_filter is None and not selected_open_cases,
+                # Mirror the default list, which hides denied/blocked/offboarded
+                # orgs (they have their own tabs) — otherwise the count overstates
+                # the rows.
+                count=(
+                    sum(
+                        count
+                        for status, count in status_counts.items()
+                        if status
+                        not in (
+                            OrganizationStatus.DENIED,
+                            OrganizationStatus.BLOCKED,
+                            OrganizationStatus.OFFBOARDED,
+                        )
+                    )
+                    if status_counts is not None
+                    else None
+                ),
+                loading=status_counts is None,
+            ),
+            Tab(
+                label="Active",
+                url=str(request.url_for("organizations:list")) + "?status=active",
+                active=status_filter == OrganizationStatus.ACTIVE,
+                count=count_of(OrganizationStatus.ACTIVE),
+                loading=status_counts is None,
+                badge_variant="success",
+            ),
+            Tab(
+                label="Review",
+                url=str(request.url_for("organizations:list")) + "?status=review",
+                active=status_filter == OrganizationStatus.REVIEW,
+                count=count_of(OrganizationStatus.REVIEW),
+                loading=status_counts is None,
+                badge_variant="warning",
+            ),
+            Tab(
+                label="Snoozed",
+                url=str(request.url_for("organizations:list")) + "?status=snoozed",
+                active=status_filter == OrganizationStatus.SNOOZED,
+                count=count_of(OrganizationStatus.SNOOZED),
+                loading=status_counts is None,
+                badge_variant="warning",
+            ),
+            Tab(
+                label="Offboarding",
+                url=str(request.url_for("organizations:list")) + "?status=offboarding",
+                active=status_filter == OrganizationStatus.OFFBOARDING,
+                count=count_of(OrganizationStatus.OFFBOARDING),
+                loading=status_counts is None,
+                badge_variant="warning",
+            ),
+            Tab(
+                label="Offboarded",
+                url=str(request.url_for("organizations:list")) + "?status=offboarded",
+                active=status_filter == OrganizationStatus.OFFBOARDED,
+                count=count_of(OrganizationStatus.OFFBOARDED),
+                loading=status_counts is None,
+                badge_variant="error",
+            ),
+            Tab(
+                label="Denied",
+                url=str(request.url_for("organizations:list")) + "?status=denied",
+                active=status_filter == OrganizationStatus.DENIED,
+                count=count_of(OrganizationStatus.DENIED),
+                loading=status_counts is None,
+                badge_variant="error",
+            ),
+            Tab(
+                label="Blocked",
+                url=str(request.url_for("organizations:list")) + "?status=blocked",
+                active=status_filter == OrganizationStatus.BLOCKED,
+                count=count_of(OrganizationStatus.BLOCKED),
+                loading=status_counts is None,
+                badge_variant="error",
+            ),
+            # Pushed to the right — a separate dimension from the status tabs.
+            Tab(
+                label="Open cases",
+                url=str(request.url_for("organizations:list")) + "?status=open_cases",
+                active=selected_open_cases,
+                count=open_cases_count,
+                badge_variant="warning",
+                extra_classes="ml-auto",
+            ),
+        ]
+
+        if status_counts is None:
+            with tab_nav(
+                tabs,
+                hx_get=lazy_counts_url,
+                hx_trigger="load",
+                hx_target="this",
+                hx_swap="outerHTML",
+            ):
+                pass
+        else:
+            with tab_nav(tabs):
+                pass
+
     @contextlib.contextmanager
     def render(
         self,
         request: Request,
         organizations: list[Organization],
         status_filter: OrganizationStatus | None,
-        status_counts: dict[OrganizationStatus, int],
+        status_counts: dict[OrganizationStatus, int] | None,
         page: int,
         has_more: bool,
         current_sort: str = "priority",
@@ -360,96 +478,22 @@ class OrganizationListView:
         awaiting_reply_org_ids: set[uuid.UUID] | None = None,
         selected_open_cases: bool = False,
         open_cases_count: int = 0,
+        lazy_counts_url: str | None = None,
     ) -> Generator[None]:
         """Render the complete list view."""
 
-        # Page header
         with tag.div(classes="flex items-center justify-between mb-8"):
             with tag.h1(classes="text-3xl font-bold"):
                 text("Organizations")
 
-        # Status tabs
-        tabs = [
-            Tab(
-                label="All",
-                url=str(request.url_for("organizations:list")),
-                active=status_filter is None and not selected_open_cases,
-                # Mirror the default list, which hides denied/blocked/offboarded
-                # orgs (they have their own tabs) — otherwise the count overstates
-                # the rows.
-                count=sum(
-                    count
-                    for status, count in status_counts.items()
-                    if status
-                    not in (
-                        OrganizationStatus.DENIED,
-                        OrganizationStatus.BLOCKED,
-                        OrganizationStatus.OFFBOARDED,
-                    )
-                ),
-            ),
-            Tab(
-                label="Active",
-                url=str(request.url_for("organizations:list")) + "?status=active",
-                active=status_filter == OrganizationStatus.ACTIVE,
-                count=status_counts.get(OrganizationStatus.ACTIVE, 0),
-                badge_variant="success",
-            ),
-            Tab(
-                label="Review",
-                url=str(request.url_for("organizations:list")) + "?status=review",
-                active=status_filter == OrganizationStatus.REVIEW,
-                count=status_counts.get(OrganizationStatus.REVIEW, 0),
-                badge_variant="warning",
-            ),
-            Tab(
-                label="Snoozed",
-                url=str(request.url_for("organizations:list")) + "?status=snoozed",
-                active=status_filter == OrganizationStatus.SNOOZED,
-                count=status_counts.get(OrganizationStatus.SNOOZED, 0),
-                badge_variant="warning",
-            ),
-            Tab(
-                label="Offboarding",
-                url=str(request.url_for("organizations:list")) + "?status=offboarding",
-                active=status_filter == OrganizationStatus.OFFBOARDING,
-                count=status_counts.get(OrganizationStatus.OFFBOARDING, 0),
-                badge_variant="warning",
-            ),
-            Tab(
-                label="Offboarded",
-                url=str(request.url_for("organizations:list")) + "?status=offboarded",
-                active=status_filter == OrganizationStatus.OFFBOARDED,
-                count=status_counts.get(OrganizationStatus.OFFBOARDED, 0),
-                badge_variant="error",
-            ),
-            Tab(
-                label="Denied",
-                url=str(request.url_for("organizations:list")) + "?status=denied",
-                active=status_filter == OrganizationStatus.DENIED,
-                count=status_counts.get(OrganizationStatus.DENIED, 0),
-                badge_variant="error",
-            ),
-            Tab(
-                label="Blocked",
-                url=str(request.url_for("organizations:list")) + "?status=blocked",
-                active=status_filter == OrganizationStatus.BLOCKED,
-                count=status_counts.get(OrganizationStatus.BLOCKED, 0),
-                badge_variant="error",
-            ),
-            # Pushed to the right — a separate dimension from the status tabs.
-            Tab(
-                label="Open cases",
-                url=str(request.url_for("organizations:list")) + "?status=open_cases",
-                active=selected_open_cases,
-                count=open_cases_count,
-                badge_variant="warning",
-                extra_classes="ml-auto",
-            ),
-        ]
-
-        with tab_nav(tabs):
-            pass
+        self.render_status_tabs(
+            request,
+            status_filter,
+            status_counts,
+            selected_open_cases,
+            open_cases_count,
+            lazy_counts_url=lazy_counts_url,
+        )
 
         # Search and filters section
         with tag.div(classes="my-6"):


### PR DESCRIPTION
## Summary

So viewing or searching our `/organizations` route in Backoffice can be _really_ slow, up to 54s:

<img width="1712" height="1010" alt="Screenshot 2026-09-08 at 12 57 01" src="https://github.com/user-attachments/assets/cbb2507f-5a9a-48df-aa4b-d5bf02d60472" />


Where the main culprit is these badges:

<img width="1166" height="124" alt="Screenshot 2026-09-08 at 12 57 50" src="https://github.com/user-attachments/assets/5f94d2ba-a5ec-4202-8cd8-c59a453cdb3a" />

<img width="1544" height="846" alt="Screenshot 2026-09-08 at 12 49 24" src="https://github.com/user-attachments/assets/93a62d8a-3db3-4f82-81cc-b6b9f003b535" />



As a bandaid, this PR will lazily load these badges, which should render `/organizations` near instantly, but with a loading state for the badges:

<img width="1372" height="778" alt="Screenshot 2026-09-08 at 12 53 20" src="https://github.com/user-attachments/assets/7fdbf380-7a1f-4082-992b-433901a793ad" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

