### PR TITLE
fix(clients): make select triggers tabbable in Safari

### DIFF
--- a/clients/packages/checkout/src/components/ui/Select.tsx
+++ b/clients/packages/checkout/src/components/ui/Select.tsx
@@ -66,6 +66,9 @@ const SelectTrigger = ({
       'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex cursor-pointer flex-row gap-x-2 rounded-xl border border-gray-200 bg-white px-3 shadow-xs transition-colors hover:border-gray-300 dark:text-white text-black',
       className,
     )}
+    // Safari only tabs to form controls with an explicit tabindex, so without
+    // this the trigger is skipped in the tab order (unlike a native <select>).
+    tabIndex={0}
     {...props}
   >
     {children}

--- a/clients/packages/orbit/src/components/ui/select.tsx
+++ b/clients/packages/orbit/src/components/ui/select.tsx
@@ -24,6 +24,9 @@ const SelectTrigger = ({
       'border-input bg-background ring-offset-background data-placeholder:text-muted-foreground focus:ring-ring flex h-10 w-full items-center justify-between rounded-md border px-3 py-2 md:text-sm focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className,
     )}
+    // Safari only tabs to form controls with an explicit tabindex, so without
+    // this the trigger is skipped in the tab order (unlike a native <select>).
+    tabIndex={0}
     {...props}
   >
     {children}


### PR DESCRIPTION
Safari only includes text fields, native `<select>` and elements with an explicit `tabindex` in the tab order. Radix renders the select trigger as a `<button>`, so it was skipped: on /onboarding/personal, tabbing out of "Last Name" jumped past the country and date-of-birth selects with no visible focus target.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

