### PR TITLE
feat: make migrated payment method assignment deterministic

### DIFF
--- a/server/polar/backoffice/merchant_migrations/endpoints.py
+++ b/server/polar/backoffice/merchant_migrations/endpoints.py
@@ -7,12 +7,15 @@ from uuid import UUID
 
 from fastapi import Depends, HTTPException, Query, Request
 from pydantic import UUID4, ValidationError
+from starlette.datastructures import UploadFile
 from tagflow import tag, text
 
 from polar.backoffice.routing import BackofficeRouter
 from polar.config import settings
 from polar.kit.pagination import PaginationParamsQuery
+from polar.merchant_migration.cards import PaymentMethodMappingCSVError
 from polar.merchant_migration.pan_transfer import (
+    STEP_STRIPE_COPY,
     PanStepOwner,
     PanStepStatus,
     PanTransferStep,
@@ -69,6 +72,7 @@ router = BackofficeRouter()
 # A failed record needs reading, not scrolling: past this many, one page of
 # examples already tells us what broke.
 FAILED_RECORDS_LIMIT = 50
+PAYMENT_METHOD_MAPPING_MAX_BYTES = 20 * 1024 * 1024
 
 
 class View(StrEnum):
@@ -455,22 +459,43 @@ async def complete_step(
 ) -> HXRedirectResponse | None:
     migration = await _get_migration(session, id, for_update=request.method == "POST")
     step = _get_step(migration, key)
+    current = current_pan_step(migration)
     inputs = step_inputs(migration, key)
+    mapping_error: str | None = None
 
     if request.method == "POST":
         form_data = await request.form()
-        await merchant_migration_service.complete_pan_step_as_ops(
-            session,
-            migration,
-            key,
-            inputs={name: str(form_data.get(name, "")) for name, _ in inputs},
-        )
-        await add_toast(
-            request,
-            f"Completed “{PAN_STEP_LABELS.get(key, key)}”",
-            variant="success",
-        )
-        return _detail_redirect(request, id)
+        try:
+            if key == STEP_STRIPE_COPY and current is not None and current.key == key:
+                mapping_file = form_data.get("payment_method_mapping")
+                if not isinstance(mapping_file, UploadFile):
+                    raise PaymentMethodMappingCSVError(
+                        "Upload Stripe's payment method mapping CSV."
+                    )
+                contents = await mapping_file.read(PAYMENT_METHOD_MAPPING_MAX_BYTES + 1)
+                if len(contents) > PAYMENT_METHOD_MAPPING_MAX_BYTES:
+                    raise PaymentMethodMappingCSVError(
+                        "The payment method mapping CSV is larger than 20 MB."
+                    )
+                async with session.begin_nested():
+                    await merchant_migration_service.import_payment_method_mappings(
+                        session, migration, contents
+                    )
+            await merchant_migration_service.complete_pan_step_as_ops(
+                session,
+                migration,
+                key,
+                inputs={name: str(form_data.get(name, "")) for name, _ in inputs},
+            )
+        except PaymentMethodMappingCSVError as e:
+            mapping_error = str(e)
+        else:
+            await add_toast(
+                request,
+                f"Completed “{PAN_STEP_LABELS.get(key, key)}”",
+                variant="success",
+            )
+            return _detail_redirect(request, id)
 
     label = PAN_STEP_LABELS.get(key, key)
     with modal(f"Complete: {label}", open=True):
@@ -482,6 +507,7 @@ async def complete_step(
             ),
             hx_target="#modal",
             classes="flex flex-col gap-4",
+            enctype="multipart/form-data",
         ):
             with tag.p(classes="text-sm"):
                 text(
@@ -507,6 +533,30 @@ async def complete_step(
                         value=step.inputs.get(name, ""),
                     ):
                         pass
+            if key == STEP_STRIPE_COPY:
+                if mapping_error is not None:
+                    with alert("error", soft=True):
+                        text(mapping_error)
+                with tag.fieldset(classes="fieldset"):
+                    with tag.label(
+                        classes="label", **{"for": "payment_method_mapping"}
+                    ):
+                        text("Stripe payment method mapping")
+                    with tag.input(
+                        id="payment_method_mapping",
+                        name="payment_method_mapping",
+                        type="file",
+                        accept=".csv,text/csv",
+                        classes="file-input w-full",
+                        required=True,
+                    ):
+                        pass
+                    with tag.p(classes="text-xs text-base-content/60"):
+                        text(
+                            "Upload the CSV from Stripe Documents with "
+                            "customer_id_old, source_id_old, customer_id_new, and "
+                            "source_id_new columns."
+                        )
             with tag.div(classes="modal-action"):
                 with tag.form(method="dialog"):
                     with button(ghost=True):

--- a/server/polar/backoffice/merchant_migrations/endpoints.py
+++ b/server/polar/backoffice/merchant_migrations/endpoints.py
@@ -72,7 +72,7 @@ router = BackofficeRouter()
 # A failed record needs reading, not scrolling: past this many, one page of
 # examples already tells us what broke.
 FAILED_RECORDS_LIMIT = 50
-PAYMENT_METHOD_MAPPING_MAX_BYTES = 20 * 1024 * 1024
+PAYMENT_METHOD_MAPPING_MAX_BYTES = settings.API_MAX_REQUEST_BODY_SIZE
 
 
 class View(StrEnum):
@@ -475,7 +475,8 @@ async def complete_step(
                 contents = await mapping_file.read(PAYMENT_METHOD_MAPPING_MAX_BYTES + 1)
                 if len(contents) > PAYMENT_METHOD_MAPPING_MAX_BYTES:
                     raise PaymentMethodMappingCSVError(
-                        "The payment method mapping CSV is larger than 20 MB."
+                        "The payment method mapping CSV is larger than "
+                        f"{PAYMENT_METHOD_MAPPING_MAX_BYTES // (1024 * 1024)} MB."
                     )
                 async with session.begin_nested():
                     await merchant_migration_service.import_payment_method_mappings(

--- a/server/polar/backoffice/merchant_migrations/endpoints.py
+++ b/server/polar/backoffice/merchant_migrations/endpoints.py
@@ -461,7 +461,7 @@ async def complete_step(
     step = _get_step(migration, key)
     current = current_pan_step(migration)
     inputs = step_inputs(migration, key)
-    mapping_error: str | None = None
+    mapping_errors: list[str] = []
 
     if request.method == "POST":
         form_data = await request.form()
@@ -478,18 +478,21 @@ async def complete_step(
                         "The payment method mapping CSV is larger than 20 MB."
                     )
                 async with session.begin_nested():
-                    await merchant_migration_service.import_payment_method_mappings(
-                        session, migration, contents
+                    mapping_errors = (
+                        await merchant_migration_service.import_payment_method_mappings(
+                            session, migration, contents
+                        )
                     )
-            await merchant_migration_service.complete_pan_step_as_ops(
-                session,
-                migration,
-                key,
-                inputs={name: str(form_data.get(name, "")) for name, _ in inputs},
-            )
+            if not mapping_errors:
+                await merchant_migration_service.complete_pan_step_as_ops(
+                    session,
+                    migration,
+                    key,
+                    inputs={name: str(form_data.get(name, "")) for name, _ in inputs},
+                )
         except PaymentMethodMappingCSVError as e:
-            mapping_error = str(e)
-        else:
+            mapping_errors = [str(e)]
+        if not mapping_errors:
             await add_toast(
                 request,
                 f"Completed “{PAN_STEP_LABELS.get(key, key)}”",
@@ -534,9 +537,12 @@ async def complete_step(
                     ):
                         pass
             if key == STEP_STRIPE_COPY:
-                if mapping_error is not None:
+                if mapping_errors:
                     with alert("error", soft=True):
-                        text(mapping_error)
+                        with tag.ul(classes="list-disc pl-4"):
+                            for error in mapping_errors:
+                                with tag.li():
+                                    text(error)
                 with tag.fieldset(classes="fieldset"):
                     with tag.label(
                         classes="label", **{"for": "payment_method_mapping"}

--- a/server/polar/backoffice/merchant_migrations/endpoints.py
+++ b/server/polar/backoffice/merchant_migrations/endpoints.py
@@ -461,7 +461,7 @@ async def complete_step(
     step = _get_step(migration, key)
     current = current_pan_step(migration)
     inputs = step_inputs(migration, key)
-    mapping_errors: list[str] = []
+    mapping_errors: Sequence[str] = []
 
     if request.method == "POST":
         form_data = await request.form()

--- a/server/polar/backoffice/merchant_migrations/endpoints.py
+++ b/server/polar/backoffice/merchant_migrations/endpoints.py
@@ -478,21 +478,18 @@ async def complete_step(
                         "The payment method mapping CSV is larger than 20 MB."
                     )
                 async with session.begin_nested():
-                    mapping_errors = (
-                        await merchant_migration_service.import_payment_method_mappings(
-                            session, migration, contents
-                        )
+                    await merchant_migration_service.import_payment_method_mappings(
+                        session, migration, contents
                     )
-            if not mapping_errors:
-                await merchant_migration_service.complete_pan_step_as_ops(
-                    session,
-                    migration,
-                    key,
-                    inputs={name: str(form_data.get(name, "")) for name, _ in inputs},
-                )
+            await merchant_migration_service.complete_pan_step_as_ops(
+                session,
+                migration,
+                key,
+                inputs={name: str(form_data.get(name, "")) for name, _ in inputs},
+            )
         except PaymentMethodMappingCSVError as e:
             mapping_errors = [str(e)]
-        if not mapping_errors:
+        else:
             await add_toast(
                 request,
                 f"Completed “{PAN_STEP_LABELS.get(key, key)}”",

--- a/server/polar/merchant_migration/cards.py
+++ b/server/polar/merchant_migration/cards.py
@@ -51,9 +51,8 @@ class PaymentMethodMappingCSVError(MerchantMigrationError):
 
 @dataclass(frozen=True)
 class PaymentMethodMapping:
-    source_customer_id: str
+    customer_id: str
     source_payment_method_id: str
-    destination_customer_id: str
     destination_payment_method_id: str
 
 
@@ -75,8 +74,6 @@ def parse_payment_method_mapping_csv(contents: bytes) -> list[PaymentMethodMappi
 
     by_source: dict[str, PaymentMethodMapping] = {}
     by_destination: dict[str, PaymentMethodMapping] = {}
-    customer_destinations: dict[str, str] = {}
-    destination_sources: dict[str, str] = {}
     for line_number, row in enumerate(reader, start=2):
         if None in row:
             raise PaymentMethodMappingCSVError(
@@ -90,10 +87,13 @@ def parse_payment_method_mapping_csv(contents: bytes) -> list[PaymentMethodMappi
             raise PaymentMethodMappingCSVError(
                 f"Line {line_number} has an empty mapping value."
             )
+        if values["customer_id_old"] != values["customer_id_new"]:
+            raise PaymentMethodMappingCSVError(
+                f"Line {line_number} changes the Stripe customer ID."
+            )
         mapping = PaymentMethodMapping(
-            source_customer_id=values["customer_id_old"],
+            customer_id=values["customer_id_old"],
             source_payment_method_id=values["source_id_old"],
-            destination_customer_id=values["customer_id_new"],
             destination_payment_method_id=values["source_id_new"],
         )
         existing = by_source.get(mapping.source_payment_method_id)
@@ -108,32 +108,8 @@ def parse_payment_method_mapping_csv(contents: bytes) -> list[PaymentMethodMappi
                 f"Destination payment method {mapping.destination_payment_method_id} "
                 "is mapped more than once."
             )
-        customer_destination = customer_destinations.get(mapping.source_customer_id)
-        if (
-            customer_destination is not None
-            and customer_destination != mapping.destination_customer_id
-        ):
-            raise PaymentMethodMappingCSVError(
-                f"Source customer {mapping.source_customer_id} has conflicting "
-                "destination customers."
-            )
         by_source[mapping.source_payment_method_id] = mapping
         by_destination[mapping.destination_payment_method_id] = mapping
-        customer_destinations[mapping.source_customer_id] = (
-            mapping.destination_customer_id
-        )
-        destination_source = destination_sources.get(mapping.destination_customer_id)
-        if (
-            destination_source is not None
-            and destination_source != mapping.source_customer_id
-        ):
-            raise PaymentMethodMappingCSVError(
-                f"Destination customer {mapping.destination_customer_id} is mapped "
-                "from more than one source customer."
-            )
-        destination_sources[mapping.destination_customer_id] = (
-            mapping.source_customer_id
-        )
 
     if not by_source:
         raise PaymentMethodMappingCSVError("The mapping CSV has no data rows.")
@@ -196,11 +172,11 @@ async def link_mapped_payment_method(
     stripe_customer = stripe_payment_method.customer
     if (
         stripe_customer is None
-        or get_expandable_id(stripe_customer) != mapping.destination_customer_id
+        or get_expandable_id(stripe_customer) != mapping.customer_id
     ):
         raise PaymentMethodMappingCSVError(
             f"Copied payment method {mapping.destination_payment_method_id} does not "
-            "belong to the destination customer in Stripe's mapping."
+            "belong to the customer in Stripe's mapping."
         )
     return await payment_method_service.upsert_from_stripe(
         session, customer, stripe_payment_method, flush=True

--- a/server/polar/merchant_migration/cards.py
+++ b/server/polar/merchant_migration/cards.py
@@ -111,8 +111,6 @@ def parse_payment_method_mapping_csv(contents: bytes) -> list[PaymentMethodMappi
         by_source[mapping.source_payment_method_id] = mapping
         by_destination[mapping.destination_payment_method_id] = mapping
 
-    if not by_source:
-        raise PaymentMethodMappingCSVError("The mapping CSV has no data rows.")
     return list(by_source.values())
 
 

--- a/server/polar/merchant_migration/cards.py
+++ b/server/polar/merchant_migration/cards.py
@@ -4,13 +4,17 @@ A copy lands them under the source's `cus_…` id but with fresh `pm_…` ids, s
 they stay invisible to Polar until stored as payment methods of our own.
 """
 
+import csv
+import io
 from collections.abc import Sequence
+from dataclasses import dataclass
 from uuid import UUID
 
 import stripe as stripe_lib
 
 from polar.customer.repository import CustomerRepository
 from polar.integrations.stripe.service import stripe as stripe_service
+from polar.integrations.stripe.utils import get_expandable_id
 from polar.models import Customer, PaymentMethod
 from polar.payment_method.service import payment_method as payment_method_service
 from polar.postgres import AsyncSession
@@ -19,6 +23,12 @@ from .canonical import CanonicalPaymentMethod
 from .errors import MerchantMigrationError
 
 CARD_TYPE = "card"
+PAYMENT_METHOD_MAPPING_HEADERS = (
+    "customer_id_old",
+    "source_id_old",
+    "customer_id_new",
+    "source_id_new",
+)
 
 
 class AmbiguousCopiedCard(MerchantMigrationError):
@@ -34,6 +44,102 @@ class AmbiguousCopiedCard(MerchantMigrationError):
         )
 
 
+class PaymentMethodMappingCSVError(MerchantMigrationError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, 400)
+
+
+@dataclass(frozen=True)
+class PaymentMethodMapping:
+    source_customer_id: str
+    source_payment_method_id: str
+    destination_customer_id: str
+    destination_payment_method_id: str
+
+
+def parse_payment_method_mapping_csv(contents: bytes) -> list[PaymentMethodMapping]:
+    try:
+        decoded = contents.decode("utf-8-sig")
+    except UnicodeDecodeError as e:
+        raise PaymentMethodMappingCSVError(
+            "The mapping must be a UTF-8 CSV file."
+        ) from e
+
+    reader = csv.DictReader(io.StringIO(decoded))
+    if tuple(reader.fieldnames or ()) != PAYMENT_METHOD_MAPPING_HEADERS:
+        raise PaymentMethodMappingCSVError(
+            "The CSV headers must be: "
+            + ", ".join(PAYMENT_METHOD_MAPPING_HEADERS)
+            + "."
+        )
+
+    by_source: dict[str, PaymentMethodMapping] = {}
+    by_destination: dict[str, PaymentMethodMapping] = {}
+    customer_destinations: dict[str, str] = {}
+    destination_sources: dict[str, str] = {}
+    for line_number, row in enumerate(reader, start=2):
+        if None in row:
+            raise PaymentMethodMappingCSVError(
+                f"Line {line_number} has more than four values."
+            )
+        values = {
+            header: (row.get(header) or "").strip()
+            for header in PAYMENT_METHOD_MAPPING_HEADERS
+        }
+        if not all(values.values()):
+            raise PaymentMethodMappingCSVError(
+                f"Line {line_number} has an empty mapping value."
+            )
+        mapping = PaymentMethodMapping(
+            source_customer_id=values["customer_id_old"],
+            source_payment_method_id=values["source_id_old"],
+            destination_customer_id=values["customer_id_new"],
+            destination_payment_method_id=values["source_id_new"],
+        )
+        existing = by_source.get(mapping.source_payment_method_id)
+        if existing is not None and existing != mapping:
+            raise PaymentMethodMappingCSVError(
+                f"Source payment method {mapping.source_payment_method_id} has "
+                "conflicting mappings."
+            )
+        destination_existing = by_destination.get(mapping.destination_payment_method_id)
+        if destination_existing is not None and destination_existing != mapping:
+            raise PaymentMethodMappingCSVError(
+                f"Destination payment method {mapping.destination_payment_method_id} "
+                "is mapped more than once."
+            )
+        customer_destination = customer_destinations.get(mapping.source_customer_id)
+        if (
+            customer_destination is not None
+            and customer_destination != mapping.destination_customer_id
+        ):
+            raise PaymentMethodMappingCSVError(
+                f"Source customer {mapping.source_customer_id} has conflicting "
+                "destination customers."
+            )
+        by_source[mapping.source_payment_method_id] = mapping
+        by_destination[mapping.destination_payment_method_id] = mapping
+        customer_destinations[mapping.source_customer_id] = (
+            mapping.destination_customer_id
+        )
+        destination_source = destination_sources.get(mapping.destination_customer_id)
+        if (
+            destination_source is not None
+            and destination_source != mapping.source_customer_id
+        ):
+            raise PaymentMethodMappingCSVError(
+                f"Destination customer {mapping.destination_customer_id} is mapped "
+                "from more than one source customer."
+            )
+        destination_sources[mapping.destination_customer_id] = (
+            mapping.source_customer_id
+        )
+
+    if not by_source:
+        raise PaymentMethodMappingCSVError("The mapping CSV has no data rows.")
+    return list(by_source.values())
+
+
 async def link_payment_method(
     session: AsyncSession,
     customer: Customer,
@@ -47,7 +153,6 @@ async def link_payment_method(
     """
     if customer.stripe_customer_id is None:
         return None
-
     try:
         stripe_payment_methods = [
             stripe_payment_method
@@ -75,6 +180,31 @@ async def link_payment_method(
             customer, update_dict={"default_payment_method_id": preferred.id}
         )
     return preferred
+
+
+async def link_mapped_payment_method(
+    session: AsyncSession,
+    customer: Customer,
+    mapping: PaymentMethodMapping,
+) -> PaymentMethod | None:
+    try:
+        stripe_payment_method = await stripe_service.get_payment_method(
+            mapping.destination_payment_method_id
+        )
+    except stripe_lib.InvalidRequestError:
+        return None
+    stripe_customer = stripe_payment_method.customer
+    if (
+        stripe_customer is None
+        or get_expandable_id(stripe_customer) != mapping.destination_customer_id
+    ):
+        raise PaymentMethodMappingCSVError(
+            f"Copied payment method {mapping.destination_payment_method_id} does not "
+            "belong to the destination customer in Stripe's mapping."
+        )
+    return await payment_method_service.upsert_from_stripe(
+        session, customer, stripe_payment_method, flush=True
+    )
 
 
 def _preferred(

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -13,6 +13,7 @@ import structlog
 from sqlalchemy.orm import joinedload, noload, selectinload
 
 from polar.customer.repository import CustomerRepository
+from polar.enums import PaymentProcessor
 from polar.kit.utils import utc_now
 from polar.logging import Logger
 from polar.models import (
@@ -28,11 +29,13 @@ from polar.models.merchant_migration_record import (
     MerchantMigrationRecordStatus,
 )
 from polar.models.subscription import SubscriptionStatus
+from polar.payment_method.repository import PaymentMethodRepository
 from polar.postgres import AsyncSession
 from polar.product.repository import ProductRepository
 from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.service import subscription as subscription_service
 
+from . import pan_transfer
 from .adapters import SourceAdapter
 from .canonical import (
     CanonicalProduct,
@@ -158,10 +161,11 @@ class SubscriptionCutover:
         except AmbiguousCopiedCard as e:
             # Recorded rather than raised: one customer must not stop the run.
             log.warning(
-                "merchant_migration.cutover.ambiguous_card",
+                "merchant_migration.cutover.card_resolution_error",
                 migration_id=self.migration.id,
                 record_id=record.id,
-                customer_id=e.customer_id,
+                subscription_id=record.target_id,
+                error=str(e),
             )
             return _fail(str(e))
         except stripe_lib.StripeError as e:
@@ -214,8 +218,8 @@ class SubscriptionCutover:
 
         # Behind the gate above because resolving writes: it upserts the copied
         # methods and may set the customer's default.
-        payment_method = await link_payment_method(
-            self.session, customer, source_method=source.payment_method
+        payment_method = await self._resolve_payment_method(
+            record, customer, source, subscription
         )
         if already_stopped:
             # An unproven card beats no biller at all: a failed first renewal
@@ -329,9 +333,7 @@ class SubscriptionCutover:
         ):
             return _skip(_CUSTOMER_ALREADY_SUBSCRIBED.message)
 
-        payment_method = await link_payment_method(
-            self.session, customer, source_method=source.payment_method
-        )
+        payment_method = await self._resolve_payment_method(record, customer, source)
         if already_stopped:
             if payment_method is None or payment_method.type != "card":
                 log.error(
@@ -484,6 +486,39 @@ class SubscriptionCutover:
             f"It renews on the source at {renewal.isoformat()}, too soon to hand "
             "over without risking a double charge. Retry once that renewal has "
             "gone through."
+        )
+
+    async def _resolve_payment_method(
+        self,
+        record: MerchantMigrationRecord,
+        customer: Customer,
+        source: CanonicalSubscription,
+        subscription: Subscription | None = None,
+    ) -> PaymentMethod | None:
+        repository = PaymentMethodRepository.from_session(self.session)
+        if subscription is not None and subscription.payment_method_id is not None:
+            payment_method = await repository.get_by_id(subscription.payment_method_id)
+            if payment_method is not None:
+                return payment_method
+        if pan_transfer.stripe_mapping_applied(
+            self.migration.pan_transfer_method, self.migration.pan_transfer_steps
+        ):
+            try:
+                staged = deserialize(record.type, record.canonical)
+            except KeyError, TypeError, ValueError:
+                return None
+            if (
+                not isinstance(staged, CanonicalSubscription)
+                or staged.payment_method is None
+            ):
+                return None
+            return await repository.get_by_customer_and_processor_id(
+                customer.id,
+                PaymentProcessor.stripe,
+                staged.payment_method.source_id,
+            )
+        return await link_payment_method(
+            self.session, customer, source_method=source.payment_method
         )
 
     def _card_note(self, payment_method: PaymentMethod) -> str | None:

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -508,15 +508,21 @@ class SubscriptionCutover:
             except KeyError, TypeError, ValueError:
                 return None
             if (
-                not isinstance(staged, CanonicalSubscription)
-                or staged.payment_method is None
+                isinstance(staged, CanonicalSubscription)
+                and staged.payment_method is not None
             ):
-                return None
-            return await repository.get_by_customer_and_processor_id(
-                customer.id,
-                PaymentProcessor.stripe,
-                staged.payment_method.source_id,
-            )
+                payment_method = await repository.get_by_customer_and_processor_id(
+                    customer.id,
+                    PaymentProcessor.stripe,
+                    staged.payment_method.source_id,
+                )
+                if payment_method is not None:
+                    return payment_method
+            if customer.default_payment_method_id is not None:
+                return await repository.get_by_id_and_customer(
+                    customer.default_payment_method_id, customer.id
+                )
+            return None
         return await link_payment_method(
             self.session, customer, source_method=source.payment_method
         )

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -286,10 +286,10 @@ class SubscriptionCutover:
             return _skip(_NOT_IMPORTED)
 
         customer_record = await self.record_repository.get_imported_customer_dependency(
-            self.migration.id, staged.customer_source_id
+            self.migration.organization_id, staged.customer_source_id
         )
         product_record = await self.record_repository.get_imported_product_dependency(
-            self.migration.id, staged.price_source_id
+            self.migration.organization_id, staged.price_source_id
         )
         if (
             customer_record is None

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -218,9 +218,7 @@ class SubscriptionCutover:
 
         # Behind the gate above because resolving writes: it upserts the copied
         # methods and may set the customer's default.
-        payment_method = await self._resolve_payment_method(
-            record, customer, source, subscription
-        )
+        payment_method = await self._resolve_payment_method(record, customer, source)
         if already_stopped:
             # An unproven card beats no biller at all: a failed first renewal
             # goes to dunning, which is recoverable.
@@ -493,13 +491,8 @@ class SubscriptionCutover:
         record: MerchantMigrationRecord,
         customer: Customer,
         source: CanonicalSubscription,
-        subscription: Subscription | None = None,
     ) -> PaymentMethod | None:
         repository = PaymentMethodRepository.from_session(self.session)
-        if subscription is not None and subscription.payment_method_id is not None:
-            payment_method = await repository.get_by_id(subscription.payment_method_id)
-            if payment_method is not None:
-                return payment_method
         if pan_transfer.stripe_mapping_applied(
             self.migration.pan_transfer_method, self.migration.pan_transfer_steps
         ):

--- a/server/polar/merchant_migration/pan_transfer.py
+++ b/server/polar/merchant_migration/pan_transfer.py
@@ -95,12 +95,22 @@ _ACTOR_OWNERS: dict[PanStepActor, frozenset[PanStepOwner]] = {
 
 _ACTIONABLE = (PanStepStatus.pending, PanStepStatus.in_progress)
 
+STEP_STRIPE_COPY = "stripe_copy"
 STEP_VERIFY_CARDS = "verify_cards"
 STEP_RESOLVE_UNCOVERED = "resolve_uncovered"
 STEP_CUTOVER = "cutover"
 STEP_MOVE_SUBSCRIPTIONS = "move_subscriptions"
 STRIPE_MIGRATION_REQUEST_ID_INPUT = "stripe_migration_request_id"
 STRIPE_MIGRATION_REQUEST_ID_PATTERN = re.compile(r"^migreq_[A-Za-z0-9_]+$")
+
+
+def stripe_mapping_applied(
+    method: PanTransferMethod | None, steps: Sequence["PanTransferStep"]
+) -> bool:
+    return method == PanTransferMethod.pan_copy and any(
+        step.key == STEP_STRIPE_COPY and step.status == PanStepStatus.completed
+        for step in steps
+    )
 
 
 class PanTransferError(MerchantMigrationError): ...

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -508,9 +508,12 @@ class MerchantMigrationRecordRepository(
         ]
         if exact:
             payment_method_filters.append(
-                PaymentMethod.processor_id
-                == MerchantMigrationRecord.canonical["payment_method"].op("->>")(
-                    "source_id"
+                or_(
+                    PaymentMethod.processor_id
+                    == MerchantMigrationRecord.canonical["payment_method"].op("->>")(
+                        "source_id"
+                    ),
+                    PaymentMethod.id == Customer.default_payment_method_id,
                 )
             )
         statement = (

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -306,10 +306,10 @@ class MerchantMigrationRecordRepository(
         return await self.get_all(statement)
 
     async def get_imported_customer_dependency(
-        self, migration_id: UUID, customer_source_id: str
+        self, organization_id: UUID, customer_source_id: str
     ) -> MerchantMigrationRecord | None:
         statement = self.get_base_statement().where(
-            MerchantMigrationRecord.merchant_migration_id == migration_id,
+            MerchantMigrationRecord.organization_id == organization_id,
             MerchantMigrationRecord.type == MerchantMigrationRecordType.customer,
             MerchantMigrationRecord.status == MerchantMigrationRecordStatus.imported,
             MerchantMigrationRecord.target_id.is_not(None),
@@ -318,10 +318,10 @@ class MerchantMigrationRecordRepository(
         return await self.get_one_or_none(statement)
 
     async def get_imported_product_dependency(
-        self, migration_id: UUID, price_source_id: str
+        self, organization_id: UUID, price_source_id: str
     ) -> MerchantMigrationRecord | None:
         statement = self.get_base_statement().where(
-            MerchantMigrationRecord.merchant_migration_id == migration_id,
+            MerchantMigrationRecord.organization_id == organization_id,
             MerchantMigrationRecord.type == MerchantMigrationRecordType.product,
             MerchantMigrationRecord.status == MerchantMigrationRecordStatus.imported,
             MerchantMigrationRecord.target_id.is_not(None),

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -401,6 +401,24 @@ class MerchantMigrationRecordRepository(
         )
         return await self.get_all(statement)
 
+    async def stream_imported_subscriptions(
+        self, migration_id: UUID
+    ) -> AsyncGenerator[MerchantMigrationRecord]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                MerchantMigrationRecord.merchant_migration_id == migration_id,
+                MerchantMigrationRecord.type
+                == MerchantMigrationRecordType.subscription,
+            )
+            .order_by(
+                MerchantMigrationRecord.created_at,
+                MerchantMigrationRecord.id,
+            )
+        )
+        async for record in self.stream(statement):
+            yield record
+
     def _selection_filter(
         self, selection: MerchantMigrationOperationSelection | None
     ) -> list[ColumnElement[bool]]:
@@ -478,9 +496,23 @@ class MerchantMigrationRecordRepository(
         result = await self.session.execute(statement)
         return {status: count for status, count in result.all()}
 
-    async def payment_method_coverage(self, migration_id: UUID) -> set[UUID]:
+    async def payment_method_coverage(
+        self, migration_id: UUID, *, exact: bool = False
+    ) -> set[UUID]:
         """Switchable subscription record ids whose Polar customer has a card."""
         CustomerRecord = aliased(MerchantMigrationRecord)
+        payment_method_filters = [
+            PaymentMethod.customer_id == Customer.id,
+            PaymentMethod.deleted_at.is_(None),
+            PaymentMethod.type == "card",
+        ]
+        if exact:
+            payment_method_filters.append(
+                PaymentMethod.processor_id
+                == MerchantMigrationRecord.canonical["payment_method"].op("->>")(
+                    "source_id"
+                )
+            )
         statement = (
             self._switchable_subscriptions_statement(migration_id)
             .join(
@@ -507,11 +539,7 @@ class MerchantMigrationRecordRepository(
             )
             .join(
                 PaymentMethod,
-                and_(
-                    PaymentMethod.customer_id == Customer.id,
-                    PaymentMethod.deleted_at.is_(None),
-                    PaymentMethod.type == "card",
-                ),
+                and_(*payment_method_filters),
             )
             .with_only_columns(MerchantMigrationRecord.id)
             .order_by(None)

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -39,7 +39,6 @@ from polar.models.merchant_migration_record import (
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
 from polar.product.repository import ProductRepository
-from polar.subscription.repository import SubscriptionRepository
 from polar.worker import enqueue_job
 
 from . import pan_transfer
@@ -701,7 +700,7 @@ class MerchantMigrationService:
         payment_methods, errors = await self._link_mapped_payment_methods(
             session, migration, mappings
         )
-        await self._assign_mapped_payment_methods(
+        await self._rewrite_staged_payment_methods(
             session, migration.id, payment_methods
         )
         return errors
@@ -762,44 +761,28 @@ class MerchantMigrationService:
             ] = payment_method
         return payment_methods, errors
 
-    async def _assign_mapped_payment_methods(
+    async def _rewrite_staged_payment_methods(
         self,
         session: AsyncSession,
         migration_id: UUID,
         payment_methods: MappedPaymentMethods,
     ) -> None:
         record_repository = MerchantMigrationRecordRepository.from_session(session)
-        subscription_repository = SubscriptionRepository.from_session(session)
         async for record in record_repository.stream_imported_subscriptions(
             migration_id
         ):
             staged = _staged_subscription(record)
-            if staged is None:
+            if staged is None or staged.payment_method is None:
                 continue
-            source_method = staged.payment_method
-            payment_method = None
-            if source_method is not None:
-                payment_method = payment_methods.get(
-                    (staged.customer_source_id, source_method.source_id)
-                )
-                if payment_method is not None:
-                    source_method.source_id = payment_method.processor_id
-                    await record_repository.update(
-                        record, update_dict={"canonical": serialize(staged)}
-                    )
-            if record.target_id is not None:
-                subscription = await subscription_repository.get_by_id(record.target_id)
-                if subscription is not None:
-                    await subscription_repository.update(
-                        subscription,
-                        update_dict={
-                            "payment_method_id": (
-                                payment_method.id
-                                if payment_method is not None
-                                else None
-                            )
-                        },
-                    )
+            payment_method = payment_methods.get(
+                (staged.customer_source_id, staged.payment_method.source_id)
+            )
+            if payment_method is None:
+                continue
+            staged.payment_method.source_id = payment_method.processor_id
+            await record_repository.update(
+                record, update_dict={"canonical": serialize(staged)}
+            )
 
     async def run_card_verification(
         self, session: AsyncSession, migration_id: UUID, *, offset: int = 0

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -762,17 +762,14 @@ class MerchantMigrationService:
             payment_method = (
                 payment_methods[record_mapping.source_payment_method_id]
                 if record_mapping is not None
-                and staged is not None
                 and staged.customer_source_id == record_mapping.source_customer_id
                 else None
             )
-            if payment_method is None or staged.payment_method is None:
-                staged.payment_method = None
-            else:
+            if payment_method is not None and staged.payment_method is not None:
                 staged.payment_method.source_id = payment_method.processor_id
-            await record_repository.update(
-                record, update_dict={"canonical": serialize(staged)}
-            )
+                await record_repository.update(
+                    record, update_dict={"canonical": serialize(staged)}
+                )
             if record.target_id is not None:
                 subscription = await subscription_repository.get_by_id(record.target_id)
                 if subscription is not None:

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -693,7 +693,7 @@ class MerchantMigrationService:
         session: AsyncSession,
         migration: MerchantMigration,
         contents: bytes,
-    ) -> list[str]:
+    ) -> Sequence[str]:
         mappings = parse_payment_method_mapping_csv(contents)
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         customer_repository = CustomerRepository.from_session(session)

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -54,6 +54,7 @@ from .canonical import (
 )
 from .cards import (
     AmbiguousCopiedCard,
+    PaymentMethodMapping,
     PaymentMethodMappingCSVError,
     link_mapped_payment_method,
     link_payment_method,
@@ -118,6 +119,8 @@ SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT = {
     "table": "merchant_migrations",
     "column": "source_credentials",
 }
+type MappedPaymentMethods = dict[tuple[str, str], PaymentMethod]
+type PaymentMethodMappingErrors = list[str]
 
 _STEP_TASKS = {
     STEP_VERIFY_CARDS: "merchant_migration.verify_cards",
@@ -695,10 +698,24 @@ class MerchantMigrationService:
         contents: bytes,
     ) -> Sequence[str]:
         mappings = parse_payment_method_mapping_csv(contents)
+        payment_methods, errors = await self._link_mapped_payment_methods(
+            session, migration, mappings
+        )
+        await self._assign_mapped_payment_methods(
+            session, migration.id, payment_methods
+        )
+        return errors
+
+    async def _link_mapped_payment_methods(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        mappings: Sequence[PaymentMethodMapping],
+    ) -> tuple[MappedPaymentMethods, PaymentMethodMappingErrors]:
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         customer_repository = CustomerRepository.from_session(session)
         customers: dict[str, Customer] = {}
-        errors: list[str] = []
+        errors: PaymentMethodMappingErrors = []
         for mapping in mappings:
             customer_record = await record_repository.get_imported_customer_dependency(
                 migration.id, mapping.source_customer_id
@@ -720,7 +737,7 @@ class MerchantMigrationService:
                 continue
             customers[mapping.source_customer_id] = customer
 
-        payment_methods: dict[str, PaymentMethod] = {}
+        payment_methods: MappedPaymentMethods = {}
         for mapping in mappings:
             customer = customers.get(mapping.source_customer_id)
             if customer is None:
@@ -740,35 +757,36 @@ class MerchantMigrationService:
                     f"Copied payment method {mapping.destination_payment_method_id} "
                     "does not exist on Polar's Stripe account."
                 )
-            payment_methods[mapping.source_payment_method_id] = payment_method
+            payment_methods[
+                mapping.source_customer_id, mapping.source_payment_method_id
+            ] = payment_method
+        return payment_methods, errors
 
-        mappings_by_source = {
-            mapping.source_payment_method_id: mapping for mapping in mappings
-        }
+    async def _assign_mapped_payment_methods(
+        self,
+        session: AsyncSession,
+        migration_id: UUID,
+        payment_methods: MappedPaymentMethods,
+    ) -> None:
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
         subscription_repository = SubscriptionRepository.from_session(session)
         async for record in record_repository.stream_imported_subscriptions(
-            migration.id
+            migration_id
         ):
             staged = _staged_subscription(record)
             if staged is None:
                 continue
             source_method = staged.payment_method
-            record_mapping = (
-                mappings_by_source.get(source_method.source_id)
-                if source_method is not None
-                else None
-            )
-            payment_method = (
-                payment_methods.get(record_mapping.source_payment_method_id)
-                if record_mapping is not None
-                and staged.customer_source_id == record_mapping.source_customer_id
-                else None
-            )
-            if payment_method is not None and staged.payment_method is not None:
-                staged.payment_method.source_id = payment_method.processor_id
-                await record_repository.update(
-                    record, update_dict={"canonical": serialize(staged)}
+            payment_method = None
+            if source_method is not None:
+                payment_method = payment_methods.get(
+                    (staged.customer_source_id, source_method.source_id)
                 )
+                if payment_method is not None:
+                    source_method.source_id = payment_method.processor_id
+                    await record_repository.update(
+                        record, update_dict={"canonical": serialize(staged)}
+                    )
             if record.target_id is not None:
                 subscription = await subscription_repository.get_by_id(record.target_id)
                 if subscription is not None:
@@ -782,7 +800,6 @@ class MerchantMigrationService:
                             )
                         },
                     )
-        return errors
 
     async def run_card_verification(
         self, session: AsyncSession, migration_id: UUID, *, offset: int = 0

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -39,6 +39,7 @@ from polar.models.merchant_migration_record import (
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
 from polar.product.repository import ProductRepository
+from polar.subscription.repository import SubscriptionRepository
 from polar.worker import enqueue_job
 
 from . import pan_transfer
@@ -49,8 +50,15 @@ from .canonical import (
     CanonicalRecord,
     CanonicalSubscription,
     deserialize,
+    serialize,
 )
-from .cards import AmbiguousCopiedCard, link_payment_method
+from .cards import (
+    AmbiguousCopiedCard,
+    PaymentMethodMappingCSVError,
+    link_mapped_payment_method,
+    link_payment_method,
+    parse_payment_method_mapping_csv,
+)
 from .cutover import SubscriptionCutover
 from .errors import MerchantMigrationError
 from .importer import CatalogImporter
@@ -680,6 +688,105 @@ class MerchantMigrationService:
         await repository.update(migration, update_dict={"pan_transfer_steps": steps})
         return self._checklist(migration, steps)
 
+    async def import_payment_method_mappings(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        contents: bytes,
+    ) -> None:
+        mappings = parse_payment_method_mapping_csv(contents)
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        customer_repository = CustomerRepository.from_session(session)
+        customers: dict[str, Customer] = {}
+        for mapping in mappings:
+            customer_record = await record_repository.get_imported_customer_dependency(
+                migration.id, mapping.source_customer_id
+            )
+            if customer_record is None or customer_record.target_id is None:
+                raise PaymentMethodMappingCSVError(
+                    f"Source customer {mapping.source_customer_id} was not imported "
+                    "by this migration."
+                )
+            customer = await customer_repository.get_by_id(customer_record.target_id)
+            if customer is None:
+                raise PaymentMethodMappingCSVError(
+                    f"Imported customer {mapping.source_customer_id} no longer exists."
+                )
+            if customer.stripe_customer_id not in (
+                None,
+                mapping.source_customer_id,
+                mapping.destination_customer_id,
+            ):
+                raise PaymentMethodMappingCSVError(
+                    f"Imported customer {mapping.source_customer_id} is linked to a "
+                    "different Stripe customer."
+                )
+            customers[mapping.source_customer_id] = customer
+
+        payment_methods: dict[str, PaymentMethod] = {}
+        for mapping in mappings:
+            customer = customers[mapping.source_customer_id]
+            if customer.stripe_customer_id != mapping.destination_customer_id:
+                await customer_repository.update(
+                    customer,
+                    update_dict={"stripe_customer_id": mapping.destination_customer_id},
+                )
+            payment_method = await link_mapped_payment_method(
+                session,
+                customer,
+                mapping,
+            )
+            if payment_method is None:
+                raise PaymentMethodMappingCSVError(
+                    f"Copied payment method {mapping.destination_payment_method_id} "
+                    "does not exist on Polar's Stripe account."
+                )
+            payment_methods[mapping.source_payment_method_id] = payment_method
+
+        mappings_by_source = {
+            mapping.source_payment_method_id: mapping for mapping in mappings
+        }
+        subscription_repository = SubscriptionRepository.from_session(session)
+        async for record in record_repository.stream_imported_subscriptions(
+            migration.id
+        ):
+            staged = _staged_subscription(record)
+            if staged is None:
+                continue
+            source_method = staged.payment_method
+            record_mapping = (
+                mappings_by_source.get(source_method.source_id)
+                if source_method is not None
+                else None
+            )
+            payment_method = (
+                payment_methods[record_mapping.source_payment_method_id]
+                if record_mapping is not None
+                and staged is not None
+                and staged.customer_source_id == record_mapping.source_customer_id
+                else None
+            )
+            if payment_method is None or staged.payment_method is None:
+                staged.payment_method = None
+            else:
+                staged.payment_method.source_id = payment_method.processor_id
+            await record_repository.update(
+                record, update_dict={"canonical": serialize(staged)}
+            )
+            if record.target_id is not None:
+                subscription = await subscription_repository.get_by_id(record.target_id)
+                if subscription is not None:
+                    await subscription_repository.update(
+                        subscription,
+                        update_dict={
+                            "payment_method_id": (
+                                payment_method.id
+                                if payment_method is not None
+                                else None
+                            )
+                        },
+                    )
+
     async def run_card_verification(
         self, session: AsyncSession, migration_id: UUID, *, offset: int = 0
     ) -> None:
@@ -689,6 +796,12 @@ class MerchantMigrationService:
             log.warning(
                 "merchant_migration.missing", merchant_migration_id=migration_id
             )
+            return
+        if pan_transfer.stripe_mapping_applied(
+            migration.pan_transfer_method, migration.pan_transfer_steps
+        ):
+            await repository.refresh_for_update(migration)
+            await self._complete_step(session, migration, STEP_VERIFY_CARDS)
             return
 
         record_repository = MerchantMigrationRecordRepository.from_session(session)
@@ -743,10 +856,11 @@ class MerchantMigrationService:
                 )
             except AmbiguousCopiedCard as e:
                 log.error(
-                    "merchant_migration.verify_cards.ambiguous_card",
+                    "merchant_migration.verify_cards.card_resolution_error",
                     merchant_migration_id=record.merchant_migration_id,
                     record_id=record.id,
-                    customer_id=e.customer_id,
+                    customer_id=customer.id,
+                    error=str(e),
                 )
                 resolved[key] = None
         return resolved[key]
@@ -1213,7 +1327,12 @@ class MerchantMigrationService:
         if not any(item.entity == PrecheckEntity.subscriptions for item in items):
             return
         record_repository = MerchantMigrationRecordRepository.from_session(session)
-        covered = await record_repository.payment_method_coverage(migration.id)
+        covered = await record_repository.payment_method_coverage(
+            migration.id,
+            exact=pan_transfer.stripe_mapping_applied(
+                migration.pan_transfer_method, migration.pan_transfer_steps
+            ),
+        )
         for item in items:
             if item.entity != PrecheckEntity.subscriptions or item.record_id is None:
                 continue

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -693,39 +693,38 @@ class MerchantMigrationService:
         session: AsyncSession,
         migration: MerchantMigration,
         contents: bytes,
-    ) -> None:
+    ) -> list[str]:
         mappings = parse_payment_method_mapping_csv(contents)
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         customer_repository = CustomerRepository.from_session(session)
         customers: dict[str, Customer] = {}
+        errors: list[str] = []
         for mapping in mappings:
             customer_record = await record_repository.get_imported_customer_dependency(
                 migration.id, mapping.source_customer_id
             )
             if customer_record is None or customer_record.target_id is None:
-                raise PaymentMethodMappingCSVError(
-                    f"Source customer {mapping.source_customer_id} was not imported "
-                    "by this migration."
-                )
+                continue
             customer = await customer_repository.get_by_id(customer_record.target_id)
             if customer is None:
-                raise PaymentMethodMappingCSVError(
-                    f"Imported customer {mapping.source_customer_id} no longer exists."
-                )
+                continue
             if customer.stripe_customer_id not in (
                 None,
                 mapping.source_customer_id,
                 mapping.destination_customer_id,
             ):
-                raise PaymentMethodMappingCSVError(
+                errors.append(
                     f"Imported customer {mapping.source_customer_id} is linked to a "
                     "different Stripe customer."
                 )
+                continue
             customers[mapping.source_customer_id] = customer
 
         payment_methods: dict[str, PaymentMethod] = {}
         for mapping in mappings:
-            customer = customers[mapping.source_customer_id]
+            customer = customers.get(mapping.source_customer_id)
+            if customer is None:
+                continue
             if customer.stripe_customer_id != mapping.destination_customer_id:
                 await customer_repository.update(
                     customer,
@@ -760,7 +759,7 @@ class MerchantMigrationService:
                 else None
             )
             payment_method = (
-                payment_methods[record_mapping.source_payment_method_id]
+                payment_methods.get(record_mapping.source_payment_method_id)
                 if record_mapping is not None
                 and staged.customer_source_id == record_mapping.source_customer_id
                 else None
@@ -783,6 +782,7 @@ class MerchantMigrationService:
                             )
                         },
                     )
+        return errors
 
     async def run_card_verification(
         self, session: AsyncSession, migration_id: UUID, *, offset: int = 0

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -714,7 +714,7 @@ class MerchantMigrationService:
         payment_methods: MappedPaymentMethods = {}
         for mapping in mappings:
             customer_record = await record_repository.get_imported_customer_dependency(
-                migration.id, mapping.customer_id
+                migration.organization_id, mapping.customer_id
             )
             if customer_record is None or customer_record.target_id is None:
                 continue
@@ -787,7 +787,7 @@ class MerchantMigrationService:
             if staged is None:
                 continue
             customer_record = await record_repository.get_imported_customer_dependency(
-                migration.id, staged.customer_source_id
+                migration.organization_id, staged.customer_source_id
             )
             if customer_record is None or customer_record.target_id is None:
                 continue

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -119,7 +119,6 @@ SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT = {
     "column": "source_credentials",
 }
 type MappedPaymentMethods = dict[tuple[str, str], PaymentMethod]
-type PaymentMethodMappingErrors = list[str]
 
 _STEP_TASKS = {
     STEP_VERIFY_CARDS: "merchant_migration.verify_cards",
@@ -695,57 +694,33 @@ class MerchantMigrationService:
         session: AsyncSession,
         migration: MerchantMigration,
         contents: bytes,
-    ) -> Sequence[str]:
+    ) -> None:
         mappings = parse_payment_method_mapping_csv(contents)
-        payment_methods, errors = await self._link_mapped_payment_methods(
+        payment_methods = await self._link_mapped_payment_methods(
             session, migration, mappings
         )
         await self._rewrite_staged_payment_methods(
             session, migration.id, payment_methods
         )
-        return errors
 
     async def _link_mapped_payment_methods(
         self,
         session: AsyncSession,
         migration: MerchantMigration,
         mappings: Sequence[PaymentMethodMapping],
-    ) -> tuple[MappedPaymentMethods, PaymentMethodMappingErrors]:
+    ) -> MappedPaymentMethods:
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         customer_repository = CustomerRepository.from_session(session)
-        customers: dict[str, Customer] = {}
-        errors: PaymentMethodMappingErrors = []
+        payment_methods: MappedPaymentMethods = {}
         for mapping in mappings:
             customer_record = await record_repository.get_imported_customer_dependency(
-                migration.id, mapping.source_customer_id
+                migration.id, mapping.customer_id
             )
             if customer_record is None or customer_record.target_id is None:
                 continue
             customer = await customer_repository.get_by_id(customer_record.target_id)
             if customer is None:
                 continue
-            if customer.stripe_customer_id not in (
-                None,
-                mapping.source_customer_id,
-                mapping.destination_customer_id,
-            ):
-                errors.append(
-                    f"Imported customer {mapping.source_customer_id} is linked to a "
-                    "different Stripe customer."
-                )
-                continue
-            customers[mapping.source_customer_id] = customer
-
-        payment_methods: MappedPaymentMethods = {}
-        for mapping in mappings:
-            customer = customers.get(mapping.source_customer_id)
-            if customer is None:
-                continue
-            if customer.stripe_customer_id != mapping.destination_customer_id:
-                await customer_repository.update(
-                    customer,
-                    update_dict={"stripe_customer_id": mapping.destination_customer_id},
-                )
             payment_method = await link_mapped_payment_method(
                 session,
                 customer,
@@ -756,10 +731,10 @@ class MerchantMigrationService:
                     f"Copied payment method {mapping.destination_payment_method_id} "
                     "does not exist on Polar's Stripe account."
                 )
-            payment_methods[
-                mapping.source_customer_id, mapping.source_payment_method_id
-            ] = payment_method
-        return payment_methods, errors
+            payment_methods[mapping.customer_id, mapping.source_payment_method_id] = (
+                payment_method
+            )
+        return payment_methods
 
     async def _rewrite_staged_payment_methods(
         self,

--- a/server/tests/backoffice/merchant_migrations/test_endpoints.py
+++ b/server/tests/backoffice/merchant_migrations/test_endpoints.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 import httpx
 import pytest
 import pytest_asyncio
-from pytest_mock import MockerFixture
 
 from polar.backoffice import app as backoffice_app
 from polar.backoffice.dependencies import get_admin
@@ -13,14 +12,11 @@ from polar.merchant_migration import pan_transfer
 from polar.merchant_migration.canonical import (
     CanonicalCollectionMethod,
     CanonicalCustomer,
-    CanonicalPaymentMethod,
-    CanonicalPaymentMethodType,
     CanonicalPrice,
     CanonicalPricingScheme,
     CanonicalProduct,
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
-    serialize,
 )
 from polar.merchant_migration.pan_transfer import (
     PanStepActor,
@@ -30,25 +26,15 @@ from polar.merchant_migration.pan_transfer import (
     PanTransferStep,
 )
 from polar.merchant_migration.repository import MerchantMigrationRecordRepository
-from polar.models import (
-    MerchantMigration,
-    MerchantMigrationRecord,
-    Organization,
-    User,
-)
+from polar.models import MerchantMigration, Organization, User
 from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
-from polar.models.merchant_migration_record import (
-    MerchantMigrationRecordStatus,
-    MerchantMigrationRecordType,
-)
+from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
 from polar.models.user_session import UserSession
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_customer
-from tests.fixtures.stripe import build_stripe_payment_method
 from tests.merchant_migration._helpers import pan_step_required_inputs
 
 
@@ -468,116 +454,6 @@ class TestCompleteStep:
             step for step in migration.pan_transfer_steps if step.key == "start_copy"
         )
         assert step.inputs == {"stripe_migration_request_id": "migreq_123"}
-
-    async def test_stripe_copy_requires_the_mapping_csv(
-        self,
-        backoffice_client: httpx.AsyncClient,
-        save_fixture: SaveFixture,
-        organization: Organization,
-    ) -> None:
-        migration = await _create_migration(
-            save_fixture,
-            organization,
-            step=MerchantMigrationStep.copy_cards,
-            steps=_advance_to("stripe_copy"),
-        )
-
-        response = await backoffice_client.get(
-            f"/merchant-migrations/{migration.id}/steps/stripe_copy/complete"
-        )
-
-        assert response.status_code == 200
-        assert 'name="payment_method_mapping"' in response.text
-        assert "customer_id_old" in response.text
-
-    async def test_uploads_mapping_before_completing_stripe_copy(
-        self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        backoffice_client: httpx.AsyncClient,
-        save_fixture: SaveFixture,
-        organization: Organization,
-    ) -> None:
-        migration = await _create_migration(
-            save_fixture,
-            organization,
-            step=MerchantMigrationStep.copy_cards,
-            steps=_advance_to("stripe_copy"),
-        )
-        customer = await create_customer(
-            save_fixture,
-            organization=organization,
-            email="mapped@example.com",
-            stripe_customer_id="cus_old",
-        )
-        await save_fixture(
-            MerchantMigrationRecord(
-                merchant_migration=migration,
-                organization=organization,
-                type=MerchantMigrationRecordType.customer,
-                status=MerchantMigrationRecordStatus.imported,
-                source_id="cus_old",
-                target_id=customer.id,
-                canonical=serialize(
-                    CanonicalCustomer(
-                        source_id="cus_old",
-                        email="mapped@example.com",
-                        name=None,
-                        country=None,
-                    )
-                ),
-            )
-        )
-        record = MerchantMigrationRecord(
-            merchant_migration=migration,
-            organization=organization,
-            type=MerchantMigrationRecordType.subscription,
-            status=MerchantMigrationRecordStatus.pending,
-            source_id="sub_1",
-            canonical=serialize(
-                CanonicalSubscription(
-                    source_id="sub_1",
-                    customer_source_id="cus_old",
-                    price_source_id="price_1",
-                    status=CanonicalSubscriptionStatus.active,
-                    collection_method=CanonicalCollectionMethod.charge_automatically,
-                    current_period_start=None,
-                    current_period_end=None,
-                    trialing=False,
-                    paused_collection=False,
-                    line_item_count=1,
-                    quantity=1,
-                    payment_method=CanonicalPaymentMethod(
-                        source_id="pm_old",
-                        type=CanonicalPaymentMethodType.card,
-                    ),
-                )
-            ),
-        )
-        await save_fixture(record)
-        stripe_payment_method = build_stripe_payment_method(customer="cus_new")
-        stripe_payment_method.id = "pm_new"
-        mocker.patch(
-            "polar.merchant_migration.cards.stripe_service.get_payment_method",
-            new=mocker.AsyncMock(return_value=stripe_payment_method),
-        )
-        contents = (
-            b"customer_id_old,source_id_old,customer_id_new,source_id_new\n"
-            b"cus_old,pm_old,cus_new,pm_new\n"
-        )
-
-        response = await backoffice_client.post(
-            f"/merchant-migrations/{migration.id}/steps/stripe_copy/complete",
-            files={"payment_method_mapping": ("mapping.csv", contents, "text/csv")},
-            headers={"HX-Request": "true"},
-        )
-
-        assert response.status_code == 200
-        assert "merchant-migrations" in response.headers["HX-Redirect"]
-        await _reload(session, migration)
-        current = pan_transfer.current(migration.pan_transfer_steps)
-        assert current is not None
-        assert current.key == "verify_cards"
 
     async def test_warns_when_completing_on_the_merchants_behalf(
         self,

--- a/server/tests/backoffice/merchant_migrations/test_endpoints.py
+++ b/server/tests/backoffice/merchant_migrations/test_endpoints.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import httpx
 import pytest
 import pytest_asyncio
+from pytest_mock import MockerFixture
 
 from polar.backoffice import app as backoffice_app
 from polar.backoffice.dependencies import get_admin
@@ -12,11 +13,14 @@ from polar.merchant_migration import pan_transfer
 from polar.merchant_migration.canonical import (
     CanonicalCollectionMethod,
     CanonicalCustomer,
+    CanonicalPaymentMethod,
+    CanonicalPaymentMethodType,
     CanonicalPrice,
     CanonicalPricingScheme,
     CanonicalProduct,
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
+    serialize,
 )
 from polar.merchant_migration.pan_transfer import (
     PanStepActor,
@@ -26,15 +30,25 @@ from polar.merchant_migration.pan_transfer import (
     PanTransferStep,
 )
 from polar.merchant_migration.repository import MerchantMigrationRecordRepository
-from polar.models import MerchantMigration, Organization, User
+from polar.models import (
+    MerchantMigration,
+    MerchantMigrationRecord,
+    Organization,
+    User,
+)
 from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
-from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
+)
 from polar.models.user_session import UserSession
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_customer
+from tests.fixtures.stripe import build_stripe_payment_method
 from tests.merchant_migration._helpers import pan_step_required_inputs
 
 
@@ -454,6 +468,116 @@ class TestCompleteStep:
             step for step in migration.pan_transfer_steps if step.key == "start_copy"
         )
         assert step.inputs == {"stripe_migration_request_id": "migreq_123"}
+
+    async def test_stripe_copy_requires_the_mapping_csv(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        migration = await _create_migration(
+            save_fixture,
+            organization,
+            step=MerchantMigrationStep.copy_cards,
+            steps=_advance_to("stripe_copy"),
+        )
+
+        response = await backoffice_client.get(
+            f"/merchant-migrations/{migration.id}/steps/stripe_copy/complete"
+        )
+
+        assert response.status_code == 200
+        assert 'name="payment_method_mapping"' in response.text
+        assert "customer_id_old" in response.text
+
+    async def test_uploads_mapping_before_completing_stripe_copy(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        migration = await _create_migration(
+            save_fixture,
+            organization,
+            step=MerchantMigrationStep.copy_cards,
+            steps=_advance_to("stripe_copy"),
+        )
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="mapped@example.com",
+            stripe_customer_id="cus_old",
+        )
+        await save_fixture(
+            MerchantMigrationRecord(
+                merchant_migration=migration,
+                organization=organization,
+                type=MerchantMigrationRecordType.customer,
+                status=MerchantMigrationRecordStatus.imported,
+                source_id="cus_old",
+                target_id=customer.id,
+                canonical=serialize(
+                    CanonicalCustomer(
+                        source_id="cus_old",
+                        email="mapped@example.com",
+                        name=None,
+                        country=None,
+                    )
+                ),
+            )
+        )
+        record = MerchantMigrationRecord(
+            merchant_migration=migration,
+            organization=organization,
+            type=MerchantMigrationRecordType.subscription,
+            status=MerchantMigrationRecordStatus.pending,
+            source_id="sub_1",
+            canonical=serialize(
+                CanonicalSubscription(
+                    source_id="sub_1",
+                    customer_source_id="cus_old",
+                    price_source_id="price_1",
+                    status=CanonicalSubscriptionStatus.active,
+                    collection_method=CanonicalCollectionMethod.charge_automatically,
+                    current_period_start=None,
+                    current_period_end=None,
+                    trialing=False,
+                    paused_collection=False,
+                    line_item_count=1,
+                    quantity=1,
+                    payment_method=CanonicalPaymentMethod(
+                        source_id="pm_old",
+                        type=CanonicalPaymentMethodType.card,
+                    ),
+                )
+            ),
+        )
+        await save_fixture(record)
+        stripe_payment_method = build_stripe_payment_method(customer="cus_new")
+        stripe_payment_method.id = "pm_new"
+        mocker.patch(
+            "polar.merchant_migration.cards.stripe_service.get_payment_method",
+            new=mocker.AsyncMock(return_value=stripe_payment_method),
+        )
+        contents = (
+            b"customer_id_old,source_id_old,customer_id_new,source_id_new\n"
+            b"cus_old,pm_old,cus_new,pm_new\n"
+        )
+
+        response = await backoffice_client.post(
+            f"/merchant-migrations/{migration.id}/steps/stripe_copy/complete",
+            files={"payment_method_mapping": ("mapping.csv", contents, "text/csv")},
+            headers={"HX-Request": "true"},
+        )
+
+        assert response.status_code == 200
+        assert "merchant-migrations" in response.headers["HX-Redirect"]
+        await _reload(session, migration)
+        current = pan_transfer.current(migration.pan_transfer_steps)
+        assert current is not None
+        assert current.key == "verify_cards"
 
     async def test_warns_when_completing_on_the_merchants_behalf(
         self,

--- a/server/tests/merchant_migration/test_cards.py
+++ b/server/tests/merchant_migration/test_cards.py
@@ -12,7 +12,14 @@ from polar.merchant_migration.canonical import (
     CanonicalPaymentMethod,
     CanonicalPaymentMethodType,
 )
-from polar.merchant_migration.cards import AmbiguousCopiedCard, link_payment_method
+from polar.merchant_migration.cards import (
+    AmbiguousCopiedCard,
+    PaymentMethodMapping,
+    PaymentMethodMappingCSVError,
+    link_mapped_payment_method,
+    link_payment_method,
+    parse_payment_method_mapping_csv,
+)
 from polar.models import Customer, Organization, PaymentMethod
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
@@ -32,6 +39,51 @@ def _stripe_payment_method(
 
 def _card(last4: str) -> dict[str, Any]:
     return {"last4": last4, "brand": "visa", "exp_month": 4, "exp_year": 2030}
+
+
+MAPPING_CSV_HEADER = b"customer_id_old,source_id_old,customer_id_new,source_id_new\n"
+
+
+class TestParsePaymentMethodMappingCSV:
+    def test_valid(self) -> None:
+        mappings = parse_payment_method_mapping_csv(
+            MAPPING_CSV_HEADER + b"cus_old,pm_old,cus_new,pm_new\n"
+        )
+
+        assert mappings == [
+            PaymentMethodMapping(
+                source_customer_id="cus_old",
+                source_payment_method_id="pm_old",
+                destination_customer_id="cus_new",
+                destination_payment_method_id="pm_new",
+            )
+        ]
+
+    def test_rejects_incorrect_headers(self) -> None:
+        with pytest.raises(PaymentMethodMappingCSVError):
+            parse_payment_method_mapping_csv(b"source_id_old,source_id_new\npm_1,pm_2")
+
+    def test_rejects_extra_values(self) -> None:
+        with pytest.raises(PaymentMethodMappingCSVError):
+            parse_payment_method_mapping_csv(
+                MAPPING_CSV_HEADER + b"cus_old,pm_old,cus_new,pm_new,unexpected\n"
+            )
+
+    def test_rejects_conflicting_source_mapping(self) -> None:
+        with pytest.raises(PaymentMethodMappingCSVError):
+            parse_payment_method_mapping_csv(
+                MAPPING_CSV_HEADER
+                + b"cus_old,pm_old,cus_new,pm_new\n"
+                + b"cus_old,pm_old,cus_new,pm_different\n"
+            )
+
+    def test_rejects_shared_destination_customer(self) -> None:
+        with pytest.raises(PaymentMethodMappingCSVError):
+            parse_payment_method_mapping_csv(
+                MAPPING_CSV_HEADER
+                + b"cus_old_1,pm_old_1,cus_new,pm_new_1\n"
+                + b"cus_old_2,pm_old_2,cus_new,pm_new_2\n"
+            )
 
 
 def _listing(
@@ -126,6 +178,62 @@ class TestLinkPaymentMethod:
         assert payment_method is not None
         assert payment_method.processor_id == "pm_copied"
         assert imported_customer.default_payment_method_id == payment_method.id
+
+    async def test_uses_the_exact_mapped_payment_method(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        mapped = _stripe_payment_method("pm_mapped", details=_card("1111"))
+        mocker.patch(
+            "polar.merchant_migration.cards.stripe_service.get_payment_method",
+            new=mocker.AsyncMock(return_value=mapped),
+        )
+        list_payment_methods = mocker.patch(
+            "polar.merchant_migration.cards.stripe_service.list_payment_methods"
+        )
+
+        payment_method = await link_mapped_payment_method(
+            session,
+            imported_customer,
+            PaymentMethodMapping(
+                source_customer_id="cus_source",
+                source_payment_method_id="pm_source",
+                destination_customer_id="cus_1",
+                destination_payment_method_id="pm_mapped",
+            ),
+        )
+
+        assert payment_method is not None
+        assert payment_method.processor_id == "pm_mapped"
+        assert imported_customer.default_payment_method_id is None
+        list_payment_methods.assert_not_called()
+
+    async def test_rejects_a_mapped_method_owned_by_another_customer(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        mapped = _stripe_payment_method("pm_mapped", details=_card("1111"))
+        mapped.customer = "cus_other"
+        mocker.patch(
+            "polar.merchant_migration.cards.stripe_service.get_payment_method",
+            new=mocker.AsyncMock(return_value=mapped),
+        )
+
+        with pytest.raises(PaymentMethodMappingCSVError):
+            await link_mapped_payment_method(
+                session,
+                imported_customer,
+                PaymentMethodMapping(
+                    source_customer_id="cus_source",
+                    source_payment_method_id="pm_source",
+                    destination_customer_id="cus_1",
+                    destination_payment_method_id="pm_mapped",
+                ),
+            )
 
     async def test_prefers_a_card_over_a_bank_account(
         self,

--- a/server/tests/merchant_migration/test_cards.py
+++ b/server/tests/merchant_migration/test_cards.py
@@ -58,6 +58,9 @@ class TestParsePaymentMethodMappingCSV:
             )
         ]
 
+    def test_accepts_header_only(self) -> None:
+        assert parse_payment_method_mapping_csv(MAPPING_CSV_HEADER) == []
+
     def test_rejects_incorrect_headers(self) -> None:
         with pytest.raises(PaymentMethodMappingCSVError):
             parse_payment_method_mapping_csv(b"source_id_old,source_id_new\npm_1,pm_2")

--- a/server/tests/merchant_migration/test_cards.py
+++ b/server/tests/merchant_migration/test_cards.py
@@ -47,14 +47,13 @@ MAPPING_CSV_HEADER = b"customer_id_old,source_id_old,customer_id_new,source_id_n
 class TestParsePaymentMethodMappingCSV:
     def test_valid(self) -> None:
         mappings = parse_payment_method_mapping_csv(
-            MAPPING_CSV_HEADER + b"cus_old,pm_old,cus_new,pm_new\n"
+            MAPPING_CSV_HEADER + b"cus_1,pm_old,cus_1,pm_new\n"
         )
 
         assert mappings == [
             PaymentMethodMapping(
-                source_customer_id="cus_old",
+                customer_id="cus_1",
                 source_payment_method_id="pm_old",
-                destination_customer_id="cus_new",
                 destination_payment_method_id="pm_new",
             )
         ]
@@ -66,23 +65,21 @@ class TestParsePaymentMethodMappingCSV:
     def test_rejects_extra_values(self) -> None:
         with pytest.raises(PaymentMethodMappingCSVError):
             parse_payment_method_mapping_csv(
-                MAPPING_CSV_HEADER + b"cus_old,pm_old,cus_new,pm_new,unexpected\n"
+                MAPPING_CSV_HEADER + b"cus_1,pm_old,cus_1,pm_new,unexpected\n"
             )
 
     def test_rejects_conflicting_source_mapping(self) -> None:
         with pytest.raises(PaymentMethodMappingCSVError):
             parse_payment_method_mapping_csv(
                 MAPPING_CSV_HEADER
-                + b"cus_old,pm_old,cus_new,pm_new\n"
-                + b"cus_old,pm_old,cus_new,pm_different\n"
+                + b"cus_1,pm_old,cus_1,pm_new\n"
+                + b"cus_1,pm_old,cus_1,pm_different\n"
             )
 
-    def test_rejects_shared_destination_customer(self) -> None:
+    def test_rejects_changed_customer_id(self) -> None:
         with pytest.raises(PaymentMethodMappingCSVError):
             parse_payment_method_mapping_csv(
-                MAPPING_CSV_HEADER
-                + b"cus_old_1,pm_old_1,cus_new,pm_new_1\n"
-                + b"cus_old_2,pm_old_2,cus_new,pm_new_2\n"
+                MAPPING_CSV_HEADER + b"cus_old,pm_old,cus_new,pm_new\n"
             )
 
 
@@ -198,9 +195,8 @@ class TestLinkPaymentMethod:
             session,
             imported_customer,
             PaymentMethodMapping(
-                source_customer_id="cus_source",
+                customer_id="cus_1",
                 source_payment_method_id="pm_source",
-                destination_customer_id="cus_1",
                 destination_payment_method_id="pm_mapped",
             ),
         )
@@ -228,9 +224,8 @@ class TestLinkPaymentMethod:
                 session,
                 imported_customer,
                 PaymentMethodMapping(
-                    source_customer_id="cus_source",
+                    customer_id="cus_1",
                     source_payment_method_id="pm_source",
-                    destination_customer_id="cus_1",
                     destination_payment_method_id="pm_mapped",
                 ),
             )

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -44,6 +44,7 @@ from polar.subscription.repository import SubscriptionRepository
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_customer,
+    create_payment_method,
     create_subscription,
 )
 from tests.fixtures.stripe import build_stripe_payment_method
@@ -51,6 +52,7 @@ from tests.merchant_migration._helpers import (
     build_connected_migration,
     canonical_subscription,
     copied_cards,
+    pan_steps_until,
     stage_subscription_record,
 )
 
@@ -324,6 +326,72 @@ class TestRun:
         assert outcome.status == MerchantMigrationCutoverStatus.moved
         subscription = await _created(session, pending_record)
         assert subscription.payment_method_id is not None
+
+    async def test_does_not_guess_when_a_mapping_was_uploaded(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        cutover: RunCutover,
+        pending_record: MerchantMigrationRecord,
+    ) -> None:
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, "verify_cards"
+        )
+        await save_fixture(migration)
+        copied_cards(mocker, build_stripe_payment_method(customer="cus_1"))
+        adapter = _source()
+
+        outcome = await cutover(adapter)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        _assert_left_alone(adapter, pending_record)
+
+    async def test_uses_the_exact_mapped_method_already_in_polar(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        cutover: RunCutover,
+        imported_customer: Customer,
+        pending_record: MerchantMigrationRecord,
+    ) -> None:
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, "verify_cards"
+        )
+        payment_method = await create_payment_method(
+            save_fixture, imported_customer, processor_id="pm_destination"
+        )
+        staged = deserialize(pending_record.type, pending_record.canonical)
+        assert isinstance(staged, CanonicalSubscription)
+        staged.payment_method = CanonicalPaymentMethod(
+            source_id=payment_method.processor_id,
+            type=CanonicalPaymentMethodType.card,
+        )
+        pending_record.canonical = serialize(staged)
+        await save_fixture(pending_record)
+        await save_fixture(migration)
+        get_payment_method = mocker.patch(
+            "polar.merchant_migration.cards.stripe_service.get_payment_method",
+            new=mocker.AsyncMock(
+                side_effect=stripe_lib.InvalidRequestError("unavailable", "id")
+            ),
+        )
+
+        outcome = await cutover(
+            _source(
+                payment_method=CanonicalPaymentMethod(
+                    source_id="pm_source",
+                    type=CanonicalPaymentMethodType.card,
+                )
+            )
+        )
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        subscription = await _created(session, pending_record)
+        assert subscription.payment_method_id == payment_method.id
+        get_payment_method.assert_not_awaited()
 
     async def test_keeps_a_running_trial_running(
         self,

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -347,6 +347,29 @@ class TestRun:
         assert outcome.status == MerchantMigrationCutoverStatus.skipped
         _assert_left_alone(adapter, pending_record)
 
+    async def test_uses_customer_default_for_an_uncovered_subscription(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        cutover: RunCutover,
+        imported_customer: Customer,
+        pending_record: MerchantMigrationRecord,
+    ) -> None:
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, "verify_cards"
+        )
+        payment_method = await create_payment_method(save_fixture, imported_customer)
+        imported_customer.default_payment_method_id = payment_method.id
+        await save_fixture(imported_customer)
+        await save_fixture(migration)
+
+        outcome = await cutover(_source())
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        subscription = await _created(session, pending_record)
+        assert subscription.payment_method_id == payment_method.id
+
     async def test_uses_the_exact_mapped_method_already_in_polar(
         self,
         mocker: MockerFixture,

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -13,6 +13,7 @@ from polar.auth.models import AuthSubject
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
 from polar.customer.service import customer as customer_service
+from polar.enums import PaymentProcessor
 from polar.kit import encryption
 from polar.kit.encryption import LocalKeyProvider
 from polar.kit.pagination import PaginationParams
@@ -29,9 +30,13 @@ from polar.merchant_migration.canonical import (
     CanonicalRecord,
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
+    deserialize,
     serialize,
 )
-from polar.merchant_migration.cards import AmbiguousCopiedCard
+from polar.merchant_migration.cards import (
+    AmbiguousCopiedCard,
+    PaymentMethodMappingCSVError,
+)
 from polar.merchant_migration.cutover import CutoverOutcome, SubscriptionCutover
 from polar.merchant_migration.pan_transfer import (
     STEP_CUTOVER,
@@ -92,6 +97,7 @@ from polar.models.merchant_migration_record import (
 from polar.models.organization import STATUS_CAPABILITIES, OrganizationStatus
 from polar.models.product_price import ProductPriceFixed
 from polar.models.subscription import SubscriptionStatus
+from polar.payment_method.repository import PaymentMethodRepository
 from polar.postgres import AsyncSession
 from polar.product.service import product as product_service
 from polar.subscription.repository import SubscriptionRepository
@@ -1707,7 +1713,10 @@ async def _imported_subscription(
 ) -> MerchantMigrationRecord:
     """A pending subscription whose customer and product are already in Polar."""
     customer = await create_customer(
-        save_fixture, organization=organization, email=email
+        save_fixture,
+        organization=organization,
+        email=email,
+        stripe_customer_id=f"cus_{source_id}",
     )
     await save_fixture(
         MerchantMigrationRecord(
@@ -1769,6 +1778,107 @@ async def _imported_subscription(
 
 
 @pytest.mark.asyncio
+class TestImportPaymentMethodMappings:
+    async def test_imports_and_assigns_the_exact_payment_method(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        mapped = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_1",
+            email="mapped@example.com",
+            payment_method=CanonicalPaymentMethod(
+                source_id="pm_old",
+                type=CanonicalPaymentMethodType.card,
+            ),
+        )
+        uncovered = await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_uncovered",
+            email="uncovered@example.com",
+            payment_method=CanonicalPaymentMethod(
+                source_id="pm_uncovered",
+                type=CanonicalPaymentMethodType.card,
+            ),
+        )
+        uncovered_subscription = deserialize(uncovered.type, uncovered.canonical)
+        assert isinstance(uncovered_subscription, CanonicalSubscription)
+        uncovered_subscription.customer_source_id = "cus_sub_1"
+        uncovered.canonical = serialize(uncovered_subscription)
+        await save_fixture(uncovered)
+        stripe_payment_method = build_stripe_payment_method(customer="cus_new")
+        stripe_payment_method.id = "pm_new"
+        mocker.patch(
+            "polar.merchant_migration.cards.stripe_service.get_payment_method",
+            new=mocker.AsyncMock(return_value=stripe_payment_method),
+        )
+
+        await service.import_payment_method_mappings(
+            session,
+            migration,
+            (
+                b"customer_id_old,source_id_old,customer_id_new,source_id_new\n"
+                b"cus_sub_1,pm_old,cus_new,pm_new\n"
+            ),
+        )
+
+        customer_record = await MerchantMigrationRecordRepository.from_session(
+            session
+        ).get_imported_customer_dependency(migration.id, "cus_sub_1")
+        assert customer_record is not None
+        assert customer_record.target_id is not None
+        customer = await session.get(Customer, customer_record.target_id)
+        assert customer is not None
+        assert customer.stripe_customer_id == "cus_new"
+        payment_method = await PaymentMethodRepository.from_session(
+            session
+        ).get_by_customer_and_processor_id(
+            customer.id, PaymentProcessor.stripe, "pm_new"
+        )
+        assert payment_method is not None
+        mapped_subscription = deserialize(mapped.type, mapped.canonical)
+        assert isinstance(mapped_subscription, CanonicalSubscription)
+        assert mapped_subscription.payment_method is not None
+        assert mapped_subscription.payment_method.source_id == "pm_new"
+        uncovered_subscription = deserialize(uncovered.type, uncovered.canonical)
+        assert isinstance(uncovered_subscription, CanonicalSubscription)
+        assert uncovered_subscription.payment_method is None
+        coverage = await MerchantMigrationRecordRepository.from_session(
+            session
+        ).payment_method_coverage(migration.id, exact=True)
+        assert coverage == {mapped.id}
+
+    async def test_rejects_a_mapping_for_another_migration(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+
+        with pytest.raises(PaymentMethodMappingCSVError):
+            await service.import_payment_method_mappings(
+                session,
+                migration,
+                (
+                    b"customer_id_old,source_id_old,customer_id_new,source_id_new\n"
+                    b"cus_unknown,pm_old,cus_new,pm_new\n"
+                ),
+            )
+
+
+@pytest.mark.asyncio
 class TestRunCardVerification:
     @pytest.mark.auth
     async def test_links_card_to_pending_subscription_customer(
@@ -1793,6 +1903,7 @@ class TestRunCardVerification:
         migration.pan_transfer_steps = pan_steps_until(
             migration.pan_transfer_method, STEP_VERIFY_CARDS
         )
+        migration.source_platform = MerchantMigrationSourcePlatform.lemon_squeezy
         await save_fixture(migration)
         customer = await CustomerRepository.from_session(
             session
@@ -1827,6 +1938,7 @@ class TestRunCardVerification:
         migration.pan_transfer_steps = pan_steps_until(
             migration.pan_transfer_method, STEP_VERIFY_CARDS
         )
+        migration.source_platform = MerchantMigrationSourcePlatform.lemon_squeezy
         await save_fixture(migration)
         await _imported_subscription(
             save_fixture,
@@ -1880,6 +1992,7 @@ class TestRunCardVerification:
         migration.pan_transfer_steps = pan_steps_until(
             migration.pan_transfer_method, STEP_VERIFY_CARDS
         )
+        migration.source_platform = MerchantMigrationSourcePlatform.lemon_squeezy
         await save_fixture(migration)
         await _imported_subscription(
             save_fixture,
@@ -1948,6 +2061,7 @@ class TestRunCardVerification:
         migration.pan_transfer_steps = pan_steps_until(
             migration.pan_transfer_method, STEP_VERIFY_CARDS
         )
+        migration.source_platform = MerchantMigrationSourcePlatform.lemon_squeezy
         await save_fixture(migration)
         charged = CanonicalPaymentMethod(
             source_id="pm_source",
@@ -1997,6 +2111,7 @@ class TestRunCardVerification:
         migration.pan_transfer_steps = pan_steps_until(
             migration.pan_transfer_method, STEP_VERIFY_CARDS
         )
+        migration.source_platform = MerchantMigrationSourcePlatform.lemon_squeezy
         await save_fixture(migration)
         await _imported_subscription(
             save_fixture,
@@ -2057,6 +2172,7 @@ class TestRunCardVerification:
         migration.pan_transfer_steps = pan_steps_until(
             migration.pan_transfer_method, STEP_VERIFY_CARDS
         )
+        migration.source_platform = MerchantMigrationSourcePlatform.lemon_squeezy
         await save_fixture(migration)
         first = await _imported_subscription(
             save_fixture,

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1816,27 +1816,30 @@ class TestImportPaymentMethodMappings:
         uncovered_subscription.customer_source_id = "cus_sub_1"
         uncovered.canonical = serialize(uncovered_subscription)
         await save_fixture(uncovered)
-        await _imported_subscription(
+        conflict_customer = await create_customer(
             save_fixture,
-            migration,
-            organization,
-            product,
-            source_id="sub_conflict",
+            organization=organization,
             email="conflict@example.com",
-            payment_method=CanonicalPaymentMethod(
-                source_id="pm_conflict",
-                type=CanonicalPaymentMethodType.card,
-            ),
+            stripe_customer_id="cus_different",
         )
-        conflict_record = await MerchantMigrationRecordRepository.from_session(
-            session
-        ).get_imported_customer_dependency(migration.id, "cus_sub_conflict")
-        assert conflict_record is not None
-        assert conflict_record.target_id is not None
-        conflict_customer = await session.get(Customer, conflict_record.target_id)
-        assert conflict_customer is not None
-        conflict_customer.stripe_customer_id = "cus_different"
-        await session.flush()
+        await save_fixture(
+            MerchantMigrationRecord(
+                merchant_migration=migration,
+                organization=organization,
+                type=MerchantMigrationRecordType.customer,
+                status=MerchantMigrationRecordStatus.imported,
+                source_id="cus_sub_conflict",
+                target_id=conflict_customer.id,
+                canonical=serialize(
+                    CanonicalCustomer(
+                        source_id="cus_sub_conflict",
+                        email="conflict@example.com",
+                        name=None,
+                        country=None,
+                    )
+                ),
+            )
+        )
         stripe_payment_method = build_stripe_payment_method(customer="cus_new")
         stripe_payment_method.id = "pm_new"
         mocker.patch(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -104,6 +104,7 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_customer,
     create_payment_method,
+    create_subscription,
 )
 from tests.fixtures.stripe import build_stripe_payment_method
 from tests.merchant_migration._helpers import (
@@ -1799,6 +1800,21 @@ class TestImportPaymentMethodMappings:
                 type=CanonicalPaymentMethodType.card,
             ),
         )
+        mapped_customer_record = await MerchantMigrationRecordRepository.from_session(
+            session
+        ).get_imported_customer_dependency(migration.id, "cus_sub_1")
+        assert mapped_customer_record is not None
+        assert mapped_customer_record.target_id is not None
+        mapped_customer = await session.get(Customer, mapped_customer_record.target_id)
+        assert mapped_customer is not None
+        mapped_target = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=mapped_customer,
+            status=SubscriptionStatus.paused,
+        )
+        mapped.target_id = mapped_target.id
+        await session.flush()
         uncovered = await _imported_subscription(
             save_fixture,
             migration,
@@ -1878,6 +1894,7 @@ class TestImportPaymentMethodMappings:
         assert isinstance(mapped_subscription, CanonicalSubscription)
         assert mapped_subscription.payment_method is not None
         assert mapped_subscription.payment_method.source_id == "pm_new"
+        assert mapped_target.payment_method_id == payment_method.id
         uncovered_subscription = deserialize(uncovered.type, uncovered.canonical)
         assert isinstance(uncovered_subscription, CanonicalSubscription)
         assert uncovered_subscription.payment_method is not None

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -35,7 +35,6 @@ from polar.merchant_migration.canonical import (
 )
 from polar.merchant_migration.cards import (
     AmbiguousCopiedCard,
-    PaymentMethodMappingCSVError,
 )
 from polar.merchant_migration.cutover import CutoverOutcome, SubscriptionCutover
 from polar.merchant_migration.pan_transfer import (
@@ -1817,6 +1816,29 @@ class TestImportPaymentMethodMappings:
         uncovered_subscription.customer_source_id = "cus_sub_1"
         uncovered.canonical = serialize(uncovered_subscription)
         await save_fixture(uncovered)
+        await _imported_subscription(
+            save_fixture,
+            migration,
+            organization,
+            product,
+            source_id="sub_conflict",
+            email="conflict@example.com",
+            payment_method=CanonicalPaymentMethod(
+                source_id="pm_conflict",
+                type=CanonicalPaymentMethodType.card,
+            ),
+        )
+        conflict_record = (
+            await MerchantMigrationRecordRepository.from_session(
+                session
+            ).get_imported_customer_dependency(migration.id, "cus_sub_conflict")
+        )
+        assert conflict_record is not None
+        assert conflict_record.target_id is not None
+        conflict_customer = await session.get(Customer, conflict_record.target_id)
+        assert conflict_customer is not None
+        conflict_customer.stripe_customer_id = "cus_different"
+        await session.flush()
         stripe_payment_method = build_stripe_payment_method(customer="cus_new")
         stripe_payment_method.id = "pm_new"
         mocker.patch(
@@ -1824,15 +1846,20 @@ class TestImportPaymentMethodMappings:
             new=mocker.AsyncMock(return_value=stripe_payment_method),
         )
 
-        await service.import_payment_method_mappings(
+        errors = await service.import_payment_method_mappings(
             session,
             migration,
             (
                 b"customer_id_old,source_id_old,customer_id_new,source_id_new\n"
                 b"cus_sub_1,pm_old,cus_new,pm_new\n"
+                b"cus_sub_conflict,pm_conflict,cus_new_conflict,pm_new_conflict\n"
             ),
         )
 
+        assert errors == [
+            "Imported customer cus_sub_conflict is linked to a different Stripe "
+            "customer."
+        ]
         customer_record = await MerchantMigrationRecordRepository.from_session(
             session
         ).get_imported_customer_dependency(migration.id, "cus_sub_1")
@@ -1866,7 +1893,7 @@ class TestImportPaymentMethodMappings:
         ).payment_method_coverage(migration.id, exact=True)
         assert coverage == {mapped.id, uncovered.id}
 
-    async def test_rejects_a_mapping_for_another_migration(
+    async def test_skips_a_mapping_for_another_migration(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -1874,15 +1901,16 @@ class TestImportPaymentMethodMappings:
     ) -> None:
         migration = await build_connected_migration(save_fixture, organization)
 
-        with pytest.raises(PaymentMethodMappingCSVError):
-            await service.import_payment_method_mappings(
-                session,
-                migration,
-                (
-                    b"customer_id_old,source_id_old,customer_id_new,source_id_new\n"
-                    b"cus_unknown,pm_old,cus_new,pm_new\n"
-                ),
-            )
+        errors = await service.import_payment_method_mappings(
+            session,
+            migration,
+            (
+                b"customer_id_old,source_id_old,customer_id_new,source_id_new\n"
+                b"cus_unknown,pm_old,cus_new,pm_new\n"
+            ),
+        )
+
+        assert errors == []
 
 
 @pytest.mark.asyncio

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1828,11 +1828,9 @@ class TestImportPaymentMethodMappings:
                 type=CanonicalPaymentMethodType.card,
             ),
         )
-        conflict_record = (
-            await MerchantMigrationRecordRepository.from_session(
-                session
-            ).get_imported_customer_dependency(migration.id, "cus_sub_conflict")
-        )
+        conflict_record = await MerchantMigrationRecordRepository.from_session(
+            session
+        ).get_imported_customer_dependency(migration.id, "cus_sub_conflict")
         assert conflict_record is not None
         assert conflict_record.target_id is not None
         conflict_customer = await session.get(Customer, conflict_record.target_id)
@@ -1857,8 +1855,7 @@ class TestImportPaymentMethodMappings:
         )
 
         assert errors == [
-            "Imported customer cus_sub_conflict is linked to a different Stripe "
-            "customer."
+            "Imported customer cus_sub_conflict is linked to a different Stripe customer."
         ]
         customer_record = await MerchantMigrationRecordRepository.from_session(
             session

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -104,7 +104,6 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_customer,
     create_payment_method,
-    create_subscription,
 )
 from tests.fixtures.stripe import build_stripe_payment_method
 from tests.merchant_migration._helpers import (
@@ -1800,21 +1799,6 @@ class TestImportPaymentMethodMappings:
                 type=CanonicalPaymentMethodType.card,
             ),
         )
-        mapped_customer_record = await MerchantMigrationRecordRepository.from_session(
-            session
-        ).get_imported_customer_dependency(migration.id, "cus_sub_1")
-        assert mapped_customer_record is not None
-        assert mapped_customer_record.target_id is not None
-        mapped_customer = await session.get(Customer, mapped_customer_record.target_id)
-        assert mapped_customer is not None
-        mapped_target = await create_subscription(
-            save_fixture,
-            product=product,
-            customer=mapped_customer,
-            status=SubscriptionStatus.paused,
-        )
-        mapped.target_id = mapped_target.id
-        await session.flush()
         uncovered = await _imported_subscription(
             save_fixture,
             migration,
@@ -1894,7 +1878,6 @@ class TestImportPaymentMethodMappings:
         assert isinstance(mapped_subscription, CanonicalSubscription)
         assert mapped_subscription.payment_method is not None
         assert mapped_subscription.payment_method.source_id == "pm_new"
-        assert mapped_target.payment_method_id == payment_method.id
         uncovered_subscription = deserialize(uncovered.type, uncovered.canonical)
         assert isinstance(uncovered_subscription, CanonicalSubscription)
         assert uncovered_subscription.payment_method is not None

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1853,11 +1853,18 @@ class TestImportPaymentMethodMappings:
         assert mapped_subscription.payment_method.source_id == "pm_new"
         uncovered_subscription = deserialize(uncovered.type, uncovered.canonical)
         assert isinstance(uncovered_subscription, CanonicalSubscription)
-        assert uncovered_subscription.payment_method is None
+        assert uncovered_subscription.payment_method is not None
+        assert uncovered_subscription.payment_method.source_id == "pm_uncovered"
         coverage = await MerchantMigrationRecordRepository.from_session(
             session
         ).payment_method_coverage(migration.id, exact=True)
         assert coverage == {mapped.id}
+        customer.default_payment_method_id = payment_method.id
+        await session.flush()
+        coverage = await MerchantMigrationRecordRepository.from_session(
+            session
+        ).payment_method_coverage(migration.id, exact=True)
+        assert coverage == {mapped.id, uncovered.id}
 
     async def test_rejects_a_mapping_for_another_migration(
         self,

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1834,7 +1834,7 @@ class TestImportPaymentMethodMappings:
 
         customer_record = await MerchantMigrationRecordRepository.from_session(
             session
-        ).get_imported_customer_dependency(migration.id, "cus_sub_1")
+        ).get_imported_customer_dependency(migration.organization_id, "cus_sub_1")
         assert customer_record is not None
         assert customer_record.target_id is not None
         customer = await session.get(Customer, customer_record.target_id)

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1816,50 +1816,22 @@ class TestImportPaymentMethodMappings:
         uncovered_subscription.customer_source_id = "cus_sub_1"
         uncovered.canonical = serialize(uncovered_subscription)
         await save_fixture(uncovered)
-        conflict_customer = await create_customer(
-            save_fixture,
-            organization=organization,
-            email="conflict@example.com",
-            stripe_customer_id="cus_different",
-        )
-        await save_fixture(
-            MerchantMigrationRecord(
-                merchant_migration=migration,
-                organization=organization,
-                type=MerchantMigrationRecordType.customer,
-                status=MerchantMigrationRecordStatus.imported,
-                source_id="cus_sub_conflict",
-                target_id=conflict_customer.id,
-                canonical=serialize(
-                    CanonicalCustomer(
-                        source_id="cus_sub_conflict",
-                        email="conflict@example.com",
-                        name=None,
-                        country=None,
-                    )
-                ),
-            )
-        )
-        stripe_payment_method = build_stripe_payment_method(customer="cus_new")
+        stripe_payment_method = build_stripe_payment_method(customer="cus_sub_1")
         stripe_payment_method.id = "pm_new"
         mocker.patch(
             "polar.merchant_migration.cards.stripe_service.get_payment_method",
             new=mocker.AsyncMock(return_value=stripe_payment_method),
         )
 
-        errors = await service.import_payment_method_mappings(
+        await service.import_payment_method_mappings(
             session,
             migration,
             (
                 b"customer_id_old,source_id_old,customer_id_new,source_id_new\n"
-                b"cus_sub_1,pm_old,cus_new,pm_new\n"
-                b"cus_sub_conflict,pm_conflict,cus_new_conflict,pm_new_conflict\n"
+                b"cus_sub_1,pm_old,cus_sub_1,pm_new\n"
             ),
         )
 
-        assert errors == [
-            "Imported customer cus_sub_conflict is linked to a different Stripe customer."
-        ]
         customer_record = await MerchantMigrationRecordRepository.from_session(
             session
         ).get_imported_customer_dependency(migration.id, "cus_sub_1")
@@ -1867,7 +1839,7 @@ class TestImportPaymentMethodMappings:
         assert customer_record.target_id is not None
         customer = await session.get(Customer, customer_record.target_id)
         assert customer is not None
-        assert customer.stripe_customer_id == "cus_new"
+        assert customer.stripe_customer_id == "cus_sub_1"
         payment_method = await PaymentMethodRepository.from_session(
             session
         ).get_by_customer_and_processor_id(
@@ -1901,16 +1873,14 @@ class TestImportPaymentMethodMappings:
     ) -> None:
         migration = await build_connected_migration(save_fixture, organization)
 
-        errors = await service.import_payment_method_mappings(
+        await service.import_payment_method_mappings(
             session,
             migration,
             (
                 b"customer_id_old,source_id_old,customer_id_new,source_id_new\n"
-                b"cus_unknown,pm_old,cus_new,pm_new\n"
+                b"cus_unknown,pm_old,cus_unknown,pm_new\n"
             ),
         )
-
-        assert errors == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Seems that Stripe now exposes a CSV mapping the original payment method id to the new payment method on our end. Then, we can map the payment methods deterministically. 


PLR-101

## What

1. Added feature to upload csv in the backoffice doing basic validations.
2. Resolve the mapped method if for subscription at creation time, or we fallback to the customer default.
3. We skip rows for customers not in the migration. Merchant can trigger a copy of their full table.

## Checklist

- [x] This PR addresses a single concern
- [x] New functionality is covered by tests
- [x] Linting and type checking pass
- [x] No unrelated changes are included
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0db2caf9-0977-4c3e-b155-fcae95ce1ac4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0db2caf9-0977-4c3e-b155-fcae95ce1ac4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

