### PR TITLE
Allow changing current period end on a due-to-cancel subscription

### DIFF
--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionBillingPeriodForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionBillingPeriodForm.tsx
@@ -108,8 +108,9 @@ export const UpdateSubscriptionBillingPeriodForm = ({
                   <FormMessage />
                   {field.value && (
                     <FormDescription>
-                      The subscription will renew on the selected date and the
-                      customer will be charged for the next billing period.
+                      {subscription.cancel_at_period_end
+                        ? 'The subscription is set to cancel at the end of the period: it will end on the selected date instead.'
+                        : 'The subscription will renew on the selected date and the customer will be charged for the next billing period.'}
                     </FormDescription>
                   )}
                 </FormItem>

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -36749,7 +36749,9 @@ export interface components {
        * Format: date-time
        * @description Set a new date for the end of the current billing period. The subscription will renew on this date. The new date can be earlier or later than the current period end, as long as it's in the future.
        *
-       *     It is not possible to update the current billing period on a canceled subscription.
+       *     If the subscription is set to cancel at the end of the period, it'll end on this new date instead.
+       *
+       *     It is not possible to update the current billing period on a subscription that's already revoked or not active.
        * @example 2026-01-01T00:00:00.000000Z
        */
       current_billing_period_end: string

--- a/docs/features/subscriptions/manage.mdx
+++ b/docs/features/subscriptions/manage.mdx
@@ -87,7 +87,9 @@ curl --request PATCH \
 
 ## Reschedule the next renewal
 
-If you need to move a subscription's renewal date — for example, to align several subscriptions on the same day, or to extend the current period as a goodwill gesture — you can set a new `current_billing_period_end`. The new date has to be in the future, and this operation isn't available on canceled subscriptions.
+If you need to move a subscription's renewal date — for example, to align several subscriptions on the same day, or to extend the current period as a goodwill gesture — you can set a new `current_billing_period_end`. The new date has to be in the future, and this operation isn't available on revoked subscriptions.
+
+If the subscription is scheduled to cancel at period end, its `ends_at` moves with the new date: it ends then instead of on the original period end.
 
 ```bash cURL
 curl --request PATCH \

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -406,7 +406,9 @@ class SubscriptionUpdateBillingPeriod(Schema):
             """
             Set a new date for the end of the current billing period. The subscription will renew on this date. The new date can be earlier or later than the current period end, as long as it's in the future.
 
-            It is not possible to update the current billing period on a canceled subscription.
+            If the subscription is set to cancel at the end of the period, it'll end on this new date instead.
+
+            It is not possible to update the current billing period on a subscription that's already revoked or not active.
             """
         ),
     )

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -2556,15 +2556,14 @@ class SubscriptionService:
         if not subscription.active:
             raise InactiveSubscription(subscription)
 
-        if subscription.cancel_at_period_end:
-            raise AlreadyCanceledSubscription(subscription)
-
-        previous_status = subscription.status
-        previous_is_canceled = subscription.canceled
         old_period_end = subscription.current_period_end
 
         subscription.current_period_end = new_period_end
         subscription.anchor_day = new_period_end.day
+
+        # A cancellation scheduled at the period end moves with the period.
+        if subscription.cancel_at_period_end:
+            subscription.ends_at = new_period_end
 
         await event_service.create_event(
             session,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -2561,7 +2561,6 @@ class SubscriptionService:
         subscription.current_period_end = new_period_end
         subscription.anchor_day = new_period_end.day
 
-        # A cancellation scheduled at the period end moves with the period.
         if subscription.cancel_at_period_end:
             subscription.ends_at = new_period_end
 

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -1500,7 +1500,7 @@ class TestSubscriptionUpdateBillingPeriod:
         assert response.status_code == 403
 
     @pytest.mark.auth
-    async def test_cannot_extend_scheduled_cancellation(
+    async def test_extend_scheduled_cancellation(
         self,
         save_fixture: SaveFixture,
         client: AsyncClient,
@@ -1522,7 +1522,14 @@ class TestSubscriptionUpdateBillingPeriod:
             json={"current_billing_period_end": new_period_end.isoformat()},
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 200
+        updated_subscription = response.json()
+        assert (
+            datetime.fromisoformat(updated_subscription["current_period_end"])
+            == new_period_end
+        )
+        assert datetime.fromisoformat(updated_subscription["ends_at"]) == new_period_end
+        assert updated_subscription["cancel_at_period_end"] is True
 
     @pytest.mark.auth
     async def test_inactive_subscription_past_due(

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -9750,7 +9750,7 @@ class TestUpdateBillingPeriod:
         assert event.customer_id == customer.id
         assert event.organization_id == customer.organization_id
 
-    async def test_canceled_subscription_raises(
+    async def test_cancel_at_period_end_moves_ends_at(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -9761,6 +9761,40 @@ class TestUpdateBillingPeriod:
             save_fixture,
             product=product,
             customer=customer,
+        )
+
+        assert subscription.cancel_at_period_end is True
+        assert subscription.ends_at == subscription.current_period_end
+        new_period_end = subscription.current_period_end + timedelta(days=7)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = (
+                await subscription_service.update_currrent_billing_period_end(
+                    session,
+                    ctx,
+                    subscription,
+                    new_period_end=new_period_end,
+                )
+            )
+
+        assert updated_subscription.current_period_end == new_period_end
+        assert updated_subscription.ends_at == new_period_end
+        assert updated_subscription.cancel_at_period_end is True
+
+    async def test_revoked_subscription_raises(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_canceled_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            revoke=True,
         )
 
         new_period_end = utc_now() + timedelta(days=30)


### PR DESCRIPTION
If the subscription is set to cancel at period end, we can still allow updates to the current period's billing end. This has no customer impact, and there are cases where the merchant may want to grant some extra days at the end of the final period as a goodbye gesture, maybe.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

