### PR TITLE
fix(payout): block cancellation after an active or successful attempt

### DIFF
--- a/server/polar/backoffice/payouts/endpoints.py
+++ b/server/polar/backoffice/payouts/endpoints.py
@@ -401,7 +401,7 @@ async def get(
                                 hx_target="#modal",
                             ):
                                 text("Retry Payout")
-                        if payout.status.is_cancelable():
+                        if payout.is_cancelable:
                             with tag.button(
                                 classes="btn btn-error",
                                 hx_get=str(

--- a/server/polar/models/payout.py
+++ b/server/polar/models/payout.py
@@ -118,6 +118,12 @@ class Payout(RecordModel):
     """Payout attempts associated with this payout."""
 
     @property
+    def is_cancelable(self) -> bool:
+        return self.status.is_cancelable() and all(
+            attempt.status == PayoutAttemptStatus.failed for attempt in self.attempts
+        )
+
+    @property
     def transaction(self) -> "Transaction":
         return next(
             transaction

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -252,9 +252,10 @@ class PayoutNotCancelable(PayoutError):
     def __init__(self, payout: Payout) -> None:
         self.payout = payout
         message = (
-            f"Payout {payout.id} cannot be canceled because of its current status."
+            f"Payout {payout.id} cannot be canceled because of its current status "
+            "or a pending, in-transit, or successful attempt."
         )
-        super().__init__(message)
+        super().__init__(message, 409)
 
 
 class NoSyncableAttempt(PayoutError):
@@ -782,7 +783,7 @@ class PayoutService:
         # backoffice cancel racing cancel_pending_payouts) so they can't each
         # write a reversal and double-credit the merchant.
         await session.refresh(payout, attribute_names=["status"], with_for_update=True)
-        if not payout.status.is_cancelable():
+        if not payout.is_cancelable:
             raise PayoutNotCancelable(payout)
 
         payout_transaction = payout.transaction

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -1048,6 +1048,46 @@ class TestTransferStripe:
 
 @pytest.mark.asyncio
 class TestCancel:
+    @pytest.mark.parametrize(
+        "attempt_status",
+        [
+            PayoutAttemptStatus.pending,
+            PayoutAttemptStatus.in_transit,
+            PayoutAttemptStatus.succeeded,
+        ],
+    )
+    async def test_non_failed_attempt_blocks_cancellation(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        stripe_service_mock: MagicMock,
+        payout_transaction_service_mock: MagicMock,
+        attempt_status: PayoutAttemptStatus,
+    ) -> None:
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            attempts=[attempt_status, PayoutAttemptStatus.failed],
+        )
+        payout.status = PayoutStatus.pending
+        await save_fixture(payout)
+
+        with pytest.raises(PayoutNotCancelable) as exc:
+            await payout_service.cancel(session, payout)
+
+        assert exc.value.status_code == 409
+        assert payout.status == PayoutStatus.pending
+        assert not payout.is_cancelable
+        payout_transaction_service_mock.reverse.assert_not_called()
+        stripe_service_mock.reverse_transfer.assert_not_called()
+
     async def test_not_cancelable(
         self,
         save_fixture: SaveFixture,
@@ -1069,6 +1109,7 @@ class TestCancel:
         with pytest.raises(PayoutNotCancelable):
             await payout_service.cancel(session, payout)
 
+    @pytest.mark.parametrize("attempts", [[], [PayoutAttemptStatus.failed]])
     async def test_valid(
         self,
         save_fixture: SaveFixture,
@@ -1077,6 +1118,7 @@ class TestCancel:
         user: User,
         stripe_service_mock: MagicMock,
         payout_transaction_service_mock: MagicMock,
+        attempts: list[PayoutAttemptStatus],
     ) -> None:
         account = await create_account(save_fixture, user)
         payout_account = await create_payout_account(
@@ -1087,7 +1129,7 @@ class TestCancel:
             account=account,
             payout_account=payout_account,
             status=PayoutStatus.pending,
-            attempts=[],
+            attempts=attempts,
         )
         payout_transaction = Transaction(
             type=TransactionType.payout,


### PR DESCRIPTION
## Summary

Block payout cancellation when any attempt is pending, in transit, or successful: the money can no longer be retrieved safely.

## What

Use the same eligibility check in the cancellation service and the backoffice Cancel Payout action. Payouts with no attempts or only failed attempts remain cancelable, subject to the existing payout status check.

## Why

A payout can still have a cancelable status while an attempt is pending. Checking payout status alone could allow the merchant balance to be credited after the money has already been sent.

## How

Refresh attempts after acquiring the existing payout lock, then reject cancellation before any reversal. Return a 409 conflict for non-cancelable payouts.

Validation: 66 payout service and ledger tests pass, including regression cases for pending, in-transit, and successful attempts followed by a failed attempt. Ruff, formatting, and mypy pass for all four changed files. No migrations or manual deployment steps are required.

## Checklist

- [x] This PR addresses a single concern
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass for the changed files
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

