### PR TITLE
server/checkout: handle race condition between sync failed payment and success payment

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -1336,6 +1336,7 @@ class CheckoutService:
                     else:
                         checkout.payment_processor_metadata = {
                             **checkout.payment_processor_metadata,
+                            "intent_id": intent.id,
                             "intent_client_secret": intent.client_secret,
                             "intent_status": intent.status,
                         }
@@ -1584,12 +1585,7 @@ class CheckoutService:
     async def handle_failure(
         self, session: AsyncSession, checkout: Checkout, payment: Payment | None = None
     ) -> Checkout:
-        # Checkout is in an unrecoverable status: do nothing
-        if checkout.status in {
-            CheckoutStatus.expired,
-            CheckoutStatus.succeeded,
-            CheckoutStatus.failed,
-        }:
+        if checkout.status != CheckoutStatus.confirmed:
             return checkout
 
         # Put back checkout in open state so the customer can try another payment method

--- a/server/polar/integrations/stripe/payment.py
+++ b/server/polar/integrations/stripe/payment.py
@@ -12,6 +12,7 @@ from polar.integrations.stripe.service import (
 from polar.integrations.stripe.service import (
     stripe as stripe_service,
 )
+from polar.integrations.stripe.utils import get_expandable_id
 from polar.logging import Logger
 from polar.models import (
     Checkout,
@@ -116,7 +117,7 @@ async def resolve_checkout(
 
     repository = CheckoutRepository.from_session(session)
     return await repository.get_by_id(
-        uuid.UUID(checkout_id), options=repository.get_eager_options()
+        uuid.UUID(checkout_id), options=repository.get_eager_options(), for_update=True
     )
 
 
@@ -282,17 +283,30 @@ async def handle_failure(
     trigger = _resolve_trigger(object)
 
     payment: Payment | None = None
+    intent_id: str | None = None
     if object.OBJECT_NAME == "charge":
         payment = await payment_service.upsert_from_stripe_charge(
             session, object, organization, checkout, wallet, order, trigger=trigger
+        )
+        intent_id = (
+            get_expandable_id(object.payment_intent) if object.payment_intent else None
         )
     elif object.OBJECT_NAME == "payment_intent":
         payment = await payment_service.upsert_from_stripe_payment_intent(
             session, object, organization, checkout, order, trigger=trigger
         )
+        intent_id = object.id
+    elif object.OBJECT_NAME == "setup_intent":
+        intent_id = object.id
 
     if checkout is not None:
-        await checkout_service.handle_failure(session, checkout, payment=payment)
+        current_intent_id = checkout.payment_processor_metadata.get("intent_id")
+        if (
+            current_intent_id is None
+            or intent_id is None
+            or current_intent_id == intent_id
+        ):
+            await checkout_service.handle_failure(session, checkout, payment=payment)
 
     if order is not None:
         # Failures from triggers that don't count toward the dunning ceiling

--- a/server/tests/checkout/test_endpoints.py
+++ b/server/tests/checkout/test_endpoints.py
@@ -959,7 +959,7 @@ class TestClientConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
         response = await client.post(
             f"{api_prefix}/client/{checkout_open.client_secret}/confirm",
@@ -998,7 +998,7 @@ class TestClientConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         response = await client.post(

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -4892,7 +4892,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -4930,7 +4930,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -5052,7 +5052,7 @@ class TestConfirm:
             id=existing.stripe_customer_id
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -5250,7 +5250,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
         checkout = await checkout_service.confirm(
             session,
@@ -5268,6 +5268,7 @@ class TestConfirm:
 
         assert checkout.status == CheckoutStatus.confirmed
         assert checkout.payment_processor_metadata == {
+            "intent_id": "STRIPE_INTENT_ID",
             "intent_client_secret": "CLIENT_SECRET",
             "intent_status": "succeeded",
             "customer_id": "STRIPE_CUSTOMER_ID",
@@ -5317,7 +5318,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_setup_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
         checkout = await checkout_service.confirm(
             session,
@@ -5335,6 +5336,7 @@ class TestConfirm:
 
         assert checkout.status == CheckoutStatus.confirmed
         assert checkout.payment_processor_metadata == {
+            "intent_id": "STRIPE_INTENT_ID",
             "intent_client_secret": "CLIENT_SECRET",
             "intent_status": "succeeded",
             "customer_id": "STRIPE_CUSTOMER_ID",
@@ -5509,7 +5511,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
         checkout = await checkout_service.confirm(
             session,
@@ -5529,6 +5531,7 @@ class TestConfirm:
 
         assert checkout.status == CheckoutStatus.confirmed
         assert checkout.payment_processor_metadata == {
+            "intent_id": "STRIPE_INTENT_ID",
             "intent_client_secret": "CLIENT_SECRET",
             "intent_status": "succeeded",
             "customer_id": "STRIPE_CUSTOMER_ID",
@@ -5613,7 +5616,7 @@ class TestConfirm:
         await save_fixture(checkout_one_time_fixed)
 
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -5655,7 +5658,7 @@ class TestConfirm:
         await save_fixture(checkout_one_time_fixed)
 
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -5700,7 +5703,7 @@ class TestConfirm:
         await save_fixture(checkout_one_time_fixed)
 
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -5753,7 +5756,7 @@ class TestConfirm:
         await save_fixture(checkout_one_time_fixed)
 
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -5791,7 +5794,7 @@ class TestConfirm:
         checkout_one_time_fixed.customer_metadata = {"key": "updated", "key2": "value2"}
 
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -5826,7 +5829,7 @@ class TestConfirm:
         await save_fixture(checkout_one_time_fixed)
 
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
         stripe_service_mock.create_customer.return_value = SimpleNamespace(
             id="STRIPE_CUSTOMER_ID"
@@ -5862,7 +5865,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -5916,6 +5919,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_setup_intent.return_value = SimpleNamespace(
+            id="STRIPE_INTENT_ID",
             client_secret="CLIENT_SECRET",
             status="succeeded",
             payment_method=payment_method,
@@ -5977,6 +5981,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_setup_intent.return_value = SimpleNamespace(
+            id="STRIPE_INTENT_ID",
             client_secret="CLIENT_SECRET",
             status="succeeded",
             payment_method=SimpleNamespace(
@@ -6051,10 +6056,10 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
         stripe_service_mock.create_setup_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         with pytest.raises(DiscountRedemptionLimitReached):
@@ -6129,10 +6134,10 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
         stripe_service_mock.create_setup_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         # `customer_name` is set, so the token is only fetched because the discount
@@ -6185,7 +6190,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_setup_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         seen_customer_states: list[bool] = []
@@ -6194,7 +6199,9 @@ class TestConfirm:
             assert checkout.customer is not None
             state = orm_inspect(checkout.customer)
             seen_customer_states.append(state.persistent)
-            return SimpleNamespace(client_secret="CLIENT_SECRET", status="succeeded")
+            return SimpleNamespace(
+                id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
+            )
 
         stripe_service_mock.create_payment_intent.side_effect = _capture_intent
 
@@ -6240,7 +6247,7 @@ class TestConfirm:
         )
 
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -6283,7 +6290,7 @@ class TestConfirm:
         )
 
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -6797,7 +6804,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -6843,7 +6850,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -6891,7 +6898,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -6938,7 +6945,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -6976,7 +6983,7 @@ class TestConfirm:
             id="STRIPE_CUSTOMER_ID"
         )
         stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
-            client_secret="CLIENT_SECRET", status="succeeded"
+            id="STRIPE_INTENT_ID", client_secret="CLIENT_SECRET", status="succeeded"
         )
 
         checkout = await checkout_service.confirm(
@@ -7355,6 +7362,7 @@ class TestHandleFailure:
     @pytest.mark.parametrize(
         "status",
         [
+            CheckoutStatus.open,
             CheckoutStatus.expired,
             CheckoutStatus.succeeded,
             CheckoutStatus.failed,
@@ -7387,30 +7395,41 @@ class TestHandleFailure:
 
     async def test_valid_with_redemption(
         self,
+        mocker: MockerFixture,
         save_fixture: SaveFixture,
         session: AsyncSession,
         checkout_confirmed_one_time: Checkout,
         discount_fixed_once: Discount,
     ) -> None:
+        metadata = {
+            "intent_id": "pi_current",
+            "intent_client_secret": "pi_current_secret_test",
+            "intent_status": "requires_action",
+        }
+        checkout_confirmed_one_time.payment_processor_metadata = metadata
+        await save_fixture(checkout_confirmed_one_time)
         discount_redemption = DiscountRedemption(
             discount=discount_fixed_once,
             checkout=checkout_confirmed_one_time,
         )
         await save_fixture(discount_redemption)
+        remove_redemption = mocker.spy(discount_service, "remove_checkout_redemption")
 
         checkout = await checkout_service.handle_failure(
             session, checkout_confirmed_one_time
         )
 
-        assert checkout.status == CheckoutStatus.open
-
         discount_redemption_repository = DiscountRedemptionRepository.from_session(
             session
         )
+        assert checkout.status == CheckoutStatus.open
+        assert checkout.payment_processor_metadata == {"intent_id": "pi_current"}
         assert (
             await discount_redemption_repository.get_by_id(discount_redemption.id)
             is None
         )
+        await checkout_service.handle_failure(session, checkout)
+        remove_redemption.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/server/tests/e2e/purchase/one_time/test_payment_failure.py
+++ b/server/tests/e2e/purchase/one_time/test_payment_failure.py
@@ -5,20 +5,128 @@ When a charge fails, no order should be created and the checkout
 should return to open status so the customer can retry.
 """
 
+from uuid import UUID
+
 import pytest
+import stripe as stripe_lib
 from httpx import AsyncClient
 
+from polar.checkout.repository import CheckoutRepository
+from polar.discount.repository import DiscountRedemptionRepository
+from polar.enums import PaymentProcessor
 from polar.kit.db.postgres import AsyncSession
 from polar.models import Organization, Product
+from polar.models.checkout import CheckoutStatus
+from polar.models.discount import DiscountDuration, DiscountType
+from polar.models.payment import PaymentStatus
+from polar.payment.repository import PaymentRepository
 from tests.e2e.conftest import E2E_AUTH
 from tests.e2e.infra import DrainFn, StripeSimulator
 from tests.e2e.infra.stripe_simulator import simulate_webhook
 from tests.e2e.purchase.conftest import BILLING_ADDRESS, BUYER_EMAIL, BUYER_NAME
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_discount
 from tests.fixtures.stripe import build_stripe_charge
 
 
 @pytest.mark.asyncio
 class TestPaymentFailure:
+    @E2E_AUTH
+    async def test_stale_failure_does_not_block_fulfillment(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        stripe_sim: StripeSimulator,
+        drain: DrainFn,
+        organization: Organization,
+        one_time_product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.percentage,
+            basis_points=2000,
+            duration=DiscountDuration.once,
+            organization=organization,
+            products=[one_time_product],
+        )
+        response = await client.post(
+            "/v1/checkouts/",
+            json={
+                "products": [str(one_time_product.id)],
+                "discount_id": str(discount.id),
+            },
+        )
+        assert response.status_code == 201, response.text
+        checkout_id = response.json()["id"]
+        client_secret = response.json()["client_secret"]
+        await drain()
+
+        stripe_sim.expect_payment(amount=2000)
+        failed_charge = stripe_sim.build_charge(
+            organization_id=organization.id, checkout_id=checkout_id
+        )
+        failed_charge.id = "ch_stale"
+        failed_charge.status = "failed"
+        stripe_sim.mock.create_payment_intent.side_effect = stripe_lib.CardError(
+            "Incorrect CVC", param="cvc", code="incorrect_cvc"
+        )
+        confirm_payload = {
+            "confirmation_token_id": "tok_test_confirm",
+            "customer_email": BUYER_EMAIL,
+            "customer_billing_address": BILLING_ADDRESS,
+        }
+        response = await client.post(
+            f"/v1/checkouts/client/{client_secret}/confirm", json=confirm_payload
+        )
+        assert response.status_code == 400, response.text
+
+        stripe_sim.mock.create_payment_intent.side_effect = None
+        stripe_sim.payment_intent_id = "pi_new"
+        stripe_sim.expect_payment(amount=2000)
+        response = await client.post(
+            f"/v1/checkouts/client/{client_secret}/confirm", json=confirm_payload
+        )
+        assert response.status_code == 200, response.text
+        await drain()
+
+        repository = CheckoutRepository.from_session(session)
+        checkout = await repository.get_by_id(UUID(checkout_id))
+        assert checkout is not None
+        metadata = checkout.payment_processor_metadata.copy()
+        assert metadata["intent_id"] == "pi_new"
+        redemption_repository = DiscountRedemptionRepository.from_session(session)
+        redemption = await redemption_repository.get_one(
+            redemption_repository.get_base_statement().where(
+                redemption_repository.model.checkout_id == checkout.id
+            )
+        )
+
+        await simulate_webhook(session, "charge.failed", failed_charge)
+        await drain()
+        checkout = await repository.get_by_id(UUID(checkout_id))
+        assert checkout is not None
+        assert checkout.status == CheckoutStatus.confirmed
+        assert checkout.payment_processor_metadata == metadata
+        assert await redemption_repository.get_by_id(redemption.id) is not None
+        payment = await PaymentRepository.from_session(session).get_by_processor_id(
+            PaymentProcessor.stripe, failed_charge.id
+        )
+        assert payment is not None
+        assert payment.status == PaymentStatus.failed
+
+        await stripe_sim.send_charge_webhook(
+            session, organization_id=organization.id, checkout_id=checkout_id
+        )
+        await drain()
+        response = await client.get(f"/v1/checkouts/{checkout_id}")
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "succeeded"
+        response = await client.get("/v1/orders/")
+        assert response.status_code == 200, response.text
+        assert response.json()["pagination"]["total_count"] == 1
+        assert response.json()["items"][0]["status"] == "paid"
+
     @E2E_AUTH
     async def test_no_order_created_on_failed_charge(
         self,

--- a/server/tests/integrations/stripe/test_payment.py
+++ b/server/tests/integrations/stripe/test_payment.py
@@ -1,29 +1,47 @@
+import asyncio
 from datetime import timedelta
 
 import pytest
+import stripe as stripe_lib
 from freezegun import freeze_time
+from sqlalchemy import delete
 
+from polar.checkout.repository import CheckoutRepository
 from polar.enums import PaymentProcessor
 from polar.integrations.stripe.payment import (
     _resolve_trigger,
     handle_failure,
 )
-from polar.kit.db.postgres import AsyncSession
+from polar.kit.db.postgres import (
+    AsyncSession,
+    create_async_engine,
+    create_async_sessionmaker,
+)
 from polar.kit.utils import utc_now
 from polar.models import (
+    Account,
+    Checkout,
     Customer,
+    Organization,
     Product,
     Subscription,
+    User,
 )
+from polar.models.checkout import CheckoutStatus
 from polar.models.order import OrderStatus
 from polar.models.payment import PaymentTrigger
 from polar.models.subscription import SubscriptionStatus
 from polar.order.repository import OrderRepository
 from polar.payment.repository import PaymentRepository
 from polar.subscription.repository import SubscriptionRepository
-from tests.fixtures.database import SaveFixture
+from tests.fixtures.database import SaveFixture, get_database_url, save_fixture_factory
 from tests.fixtures.random_objects import (
+    create_account,
+    create_checkout,
     create_order,
+    create_organization,
+    create_product,
+    create_user,
 )
 from tests.fixtures.stripe import build_stripe_charge, build_stripe_payment_intent
 
@@ -33,6 +51,135 @@ class TestHandleFailure:
     """Integration tests for the failed payment. If it's an order, the subscription
     will be marked as past due, benefits will be revoked, and the order will have its next
     payment attempt scheduled."""
+
+    @pytest.mark.parametrize("current_intent_id", ["pi_failed", "pi_new"])
+    async def test_failure_waits_for_confirmation(
+        self, worker_id: str, current_intent_id: str
+    ) -> None:
+        engine = create_async_engine(
+            dsn=get_database_url(worker_id), pool_size=2, pool_recycle=3600
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+        async with sessionmaker() as setup:
+            save = save_fixture_factory(setup)
+            user = await create_user(save)
+            account = await create_account(save, user)
+            organization = await create_organization(save, account)
+            product = await create_product(
+                save, organization=organization, recurring_interval=None
+            )
+            checkout = await create_checkout(save, products=[product])
+            await setup.commit()
+
+        charge = build_stripe_charge(
+            status="failed",
+            payment_intent="pi_failed",
+            metadata={
+                "organization_id": str(organization.id),
+                "checkout_id": str(checkout.id),
+            },
+            billing_details={"email": "test@example.com"},
+            payment_method_details={"type": "card", "card": {"last4": "4242"}},
+        )
+        try:
+            async with sessionmaker() as confirmation, sessionmaker() as failure:
+                locked_checkout = await CheckoutRepository.from_session(
+                    confirmation
+                ).get_by_client_secret(checkout.client_secret, for_update=True)
+                assert locked_checkout is not None
+                locked_checkout.status = CheckoutStatus.confirmed
+                locked_checkout.payment_processor_metadata = {
+                    "intent_id": current_intent_id,
+                    "intent_status": "requires_action",
+                }
+                await confirmation.flush()
+
+                async with asyncio.TaskGroup() as tasks:
+                    failure_task = tasks.create_task(handle_failure(failure, charge))
+                    done, _ = await asyncio.wait({failure_task}, timeout=0.1)
+                    assert not done
+                    await confirmation.commit()
+
+                updated_checkout = await CheckoutRepository.from_session(
+                    failure
+                ).get_by_id(checkout.id)
+                assert updated_checkout is not None
+                assert updated_checkout.status == (
+                    CheckoutStatus.open
+                    if current_intent_id == "pi_failed"
+                    else CheckoutStatus.confirmed
+                )
+                assert (
+                    updated_checkout.payment_processor_metadata["intent_id"]
+                    == current_intent_id
+                )
+        finally:
+            async with sessionmaker() as cleanup:
+                await cleanup.execute(
+                    delete(Checkout).where(Checkout.id == checkout.id)
+                )
+                await cleanup.execute(delete(Product).where(Product.id == product.id))
+                await cleanup.execute(
+                    delete(Organization).where(Organization.id == organization.id)
+                )
+                await cleanup.execute(delete(Account).where(Account.id == account.id))
+                await cleanup.execute(delete(User).where(User.id == user.id))
+                await cleanup.commit()
+            await engine.dispose()
+
+    @pytest.mark.parametrize(
+        "current_intent_id", [None, "intent_current", "intent_stale"]
+    )
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            build_stripe_charge(
+                status="failed",
+                payment_intent="intent_current",
+                billing_details={"email": "test@example.com"},
+                payment_method_details={"type": "card", "card": {"last4": "4242"}},
+            ),
+            build_stripe_payment_intent(
+                id="intent_current",
+                last_payment_error={
+                    "message": "Authentication failed",
+                    "payment_method": {"type": "card", "card": {"last4": "4242"}},
+                },
+            ),
+            stripe_lib.SetupIntent.construct_from({"id": "intent_current"}, None),
+        ],
+        ids=["charge", "payment_intent", "setup_intent"],
+    )
+    async def test_checkout_failure_matches_current_intent(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        failure: stripe_lib.Charge | stripe_lib.PaymentIntent | stripe_lib.SetupIntent,
+        current_intent_id: str | None,
+    ) -> None:
+        metadata = {"intent_status": "requires_action"}
+        if current_intent_id is not None:
+            metadata["intent_id"] = current_intent_id
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            status=CheckoutStatus.confirmed,
+            payment_processor_metadata=metadata,
+        )
+        failure.metadata = {
+            "organization_id": str(product.organization_id),
+            "checkout_id": str(checkout.id),
+        }
+
+        await handle_failure(session, failure)
+
+        if current_intent_id == "intent_stale":
+            assert checkout.status == CheckoutStatus.confirmed
+            assert checkout.payment_processor_metadata == metadata
+        else:
+            assert checkout.status == CheckoutStatus.open
+            assert "intent_status" not in checkout.payment_processor_metadata
 
     @freeze_time("2024-01-01 12:00:00")
     async def test_full_dunning_flow_with_repositories(


### PR DESCRIPTION
When a payment is attempted, we immediately pass the checkout status to `confirmed`. Then, we wait for Stripe webhooks to either pass it to `succeeded` in case of successful payment, or put it back to `open` in case of failure, so the customer can try again.

However, some payment failures are immediate, like an incorrect CVC. In this case, the checkout stays `open`. But Stripe still sends the failure webhook. We've seen in the wild a case where the customer rapidly corrected their mistake, passing the checkout to `confirmed`. However, the failure webhook was processed shortly after, putting back the checkout to `open`, blocking the successful path.

This change makes sure to store the latest intent ID on the Checkout metadata, so we can check if the webhook we receive corresponds to the current attempt. If not, we can just record the failure but not touch the Checkout.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

