### PR TITLE
feat(backoffice): Activate action for created organizations

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -2519,6 +2519,123 @@ async def under_review_dialog(
 
 
 @router.api_route(
+    "/{organization_id}/activate-dialog",
+    name="organizations:activate_dialog",
+    methods=["GET", "POST"],
+    response_model=None,
+)
+async def activate_dialog(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> HXRedirectResponse | None:
+    """Activate a CREATED organization, showing onboarding readiness first."""
+    repository = OrganizationRepository(session)
+
+    organization = await repository.get_by_id(organization_id, include_blocked=True)
+    if not organization:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    readiness = await organization_service.get_activation_readiness(
+        session, organization
+    )
+    error_message: str | None = None
+
+    if request.method == "POST":
+        try:
+            await organization_service.backoffice_activate(session, organization)
+        except OrganizationError as e:
+            error_message = e.message
+        else:
+            await add_toast(
+                request,
+                "Organization activated.",
+                "success",
+            )
+            return HXRedirectResponse(
+                request,
+                str(
+                    request.url_for(
+                        "organizations:detail", organization_id=organization_id
+                    )
+                ),
+                303,
+            )
+
+    can_activate = organization.status == OrganizationStatus.CREATED
+
+    with modal("Activate Organization", open=True):
+        with tag.div(classes="flex flex-col gap-4"):
+            if error_message:
+                with tag.div(classes="alert alert-error"):
+                    text(error_message)
+
+            if readiness.is_ready:
+                with tag.div(
+                    classes="bg-success/10 border border-success/20 p-4 rounded-lg"
+                ):
+                    with tag.p(classes="font-semibold mb-1"):
+                        text("Ready to activate")
+                    with tag.p(classes="text-sm"):
+                        text(
+                            "All onboarding and review gates have passed. "
+                            "Activating will set status to Active and enable "
+                            "the default Active capabilities."
+                        )
+            else:
+                with tag.div(
+                    classes="bg-warning/10 border border-warning/20 p-4 rounded-lg"
+                ):
+                    with tag.p(classes="font-semibold mb-1"):
+                        text("Not fully ready to activate")
+                    with tag.p(classes="text-sm"):
+                        text(
+                            "Some gates have not passed. You can still activate "
+                            "from Created — capabilities will follow Active "
+                            "defaults. Review the missing items below."
+                        )
+
+            with tag.ul(classes="space-y-2"):
+                for requirement in readiness.requirements:
+                    with tag.li(classes="flex items-start gap-2 text-sm"):
+                        if requirement.ready:
+                            with tag.span(classes="text-success font-semibold"):
+                                text("✓")
+                            with tag.span():
+                                text(requirement.label)
+                        else:
+                            with tag.span(classes="text-error font-semibold"):
+                                text("✗")
+                            with tag.div():
+                                with tag.p(classes="font-medium"):
+                                    text(requirement.label)
+                                if requirement.missing:
+                                    with tag.p(classes="text-base-content/70"):
+                                        text(requirement.missing)
+
+            with tag.div(classes="modal-action pt-6 border-t border-base-200"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                if can_activate:
+                    with tag.form(
+                        hx_post=str(
+                            request.url_for(
+                                "organizations:activate_dialog",
+                                organization_id=organization_id,
+                            )
+                        ),
+                    ):
+                        with button(
+                            variant="success" if readiness.is_ready else "warning",
+                            type="submit",
+                        ):
+                            text("Activate")
+
+    return None
+
+
+@router.api_route(
     "/{organization_id}/snooze-dialog",
     name="organizations:snooze_dialog",
     methods=["GET", "POST"],

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -75,6 +75,8 @@ from polar.organization.schemas import OrganizationFeatureSettings
 from polar.organization.service import (
     SNOOZE_MAX_DAYS,
     SNOOZE_MIN_DAYS,
+    ActivationGate,
+    BackofficeActivationResult,
     OrganizationError,
 )
 from polar.organization.service import organization as organization_service
@@ -2537,20 +2539,22 @@ async def activate_dialog(
     if not organization:
         raise HTTPException(status_code=404, detail="Organization not found")
 
+    detail_url = str(
+        request.url_for("organizations:detail", organization_id=organization_id)
+    )
     readiness = await organization_service.get_activation_readiness(
         session, organization
     )
     error_message: str | None = None
-    can_submit_review = organization.status == OrganizationStatus.CREATED and (
+    is_created = organization.status == OrganizationStatus.CREATED
+    can_submit_review = is_created and (
         organization.details_submitted_at is None or not readiness.review_exists
     )
-    can_activate = (
-        organization.status == OrganizationStatus.CREATED and readiness.is_ready
-    )
+    can_activate = is_created and readiness.is_ready
 
     if request.method == "POST":
         try:
-            outcome = await organization_service.backoffice_submit_and_maybe_activate(
+            result = await organization_service.backoffice_submit_and_maybe_activate(
                 session, organization
             )
         except OrganizationError as e:
@@ -2558,32 +2562,27 @@ async def activate_dialog(
         except PolarRequestValidationError as e:
             error_message = "; ".join(error["msg"] for error in e.errors())
         else:
-            if outcome.activated:
-                await add_toast(request, "Organization activated.", "success")
-            elif outcome.submitted_for_review:
-                await add_toast(
-                    request,
-                    "Submitted for review. The organization will activate "
-                    "automatically if the review passes and onboarding is complete.",
-                    "success",
-                )
-            else:
-                missing = ", ".join(item.label.lower() for item in readiness.missing)
-                await add_toast(
-                    request,
-                    "Could not activate yet. Still missing: "
-                    f"{missing or 'review or onboarding'}.",
-                    "warning",
-                )
-            return HXRedirectResponse(
-                request,
-                str(
-                    request.url_for(
-                        "organizations:detail", organization_id=organization_id
+            match result:
+                case BackofficeActivationResult.activated:
+                    await add_toast(request, "Organization activated.", "success")
+                case BackofficeActivationResult.submitted_for_review:
+                    await add_toast(
+                        request,
+                        "Submitted for review. The organization will activate "
+                        "automatically if the review passes and onboarding is "
+                        "complete.",
+                        "success",
                     )
-                ),
-                303,
-            )
+                case BackofficeActivationResult.still_incomplete:
+                    missing = ", ".join(
+                        item.label.lower() for item in readiness.missing
+                    )
+                    await add_toast(
+                        request,
+                        f"Could not activate yet. Still missing: {missing}.",
+                        "warning",
+                    )
+            return HXRedirectResponse(request, detail_url, 303)
 
         readiness = await organization_service.get_activation_readiness(
             session, organization
@@ -2595,63 +2594,51 @@ async def activate_dialog(
                 with tag.div(classes="alert alert-error"):
                     text(error_message)
 
-            if readiness.is_ready:
-                with tag.div(
-                    classes="bg-success/10 border border-success/20 p-4 rounded-lg"
-                ):
-                    with tag.p(classes="font-semibold mb-1"):
-                        text("Ready to activate")
-                    with tag.p(classes="text-sm"):
-                        text(
-                            "All onboarding and review gates have passed. "
-                            "Activate uses the same path as automatic activation."
-                        )
-            else:
-                with tag.div(
-                    classes="bg-warning/10 border border-warning/20 p-4 rounded-lg"
-                ):
-                    with tag.p(classes="font-semibold mb-1"):
-                        text("Not fully ready to activate")
-                    with tag.p(classes="text-sm"):
-                        text(
-                            "Complete the missing steps below. Submitting for "
-                            "review queues the review agent; the organization "
-                            "activates automatically if the review passes and "
-                            "payout and identity checks are ready."
-                        )
+            with tag.div(
+                classes="bg-success/10 border border-success/20 p-4 rounded-lg"
+                if readiness.is_ready
+                else "bg-warning/10 border border-warning/20 p-4 rounded-lg"
+            ):
+                with tag.p(classes="font-semibold mb-1"):
+                    text(
+                        "Ready to activate"
+                        if readiness.is_ready
+                        else "Not fully ready to activate"
+                    )
+                with tag.p(classes="text-sm"):
+                    text(
+                        "All onboarding and review gates have passed. Activate "
+                        "uses the same path as automatic activation."
+                        if readiness.is_ready
+                        else "Complete the missing steps below. Submitting for "
+                        "review queues the review agent; the organization "
+                        "activates automatically if the review passes and "
+                        "payout and identity checks are ready."
+                    )
 
             with tag.ul(classes="space-y-2"):
                 for requirement in readiness.requirements:
                     with tag.li(classes="flex items-start gap-2 text-sm"):
-                        if requirement.ready:
-                            with tag.span(classes="text-success font-semibold"):
-                                text("✓")
-                            with tag.span():
+                        icon_color = (
+                            "text-success" if requirement.ready else "text-error"
+                        )
+                        with tag.span(classes=f"{icon_color} font-semibold"):
+                            text("✓" if requirement.ready else "✗")
+                        with tag.div():
+                            with tag.p(classes="font-medium"):
                                 text(requirement.label)
-                        else:
-                            with tag.span(classes="text-error font-semibold"):
-                                text("✗")
-                            with tag.div():
-                                with tag.p(classes="font-medium"):
-                                    text(requirement.label)
-                                if requirement.missing:
-                                    with tag.p(classes="text-base-content/70"):
-                                        text(requirement.missing)
-                                if requirement is readiness.payout_account_ready:
-                                    account_url = (
-                                        str(
-                                            request.url_for(
-                                                "organizations:detail",
-                                                organization_id=organization_id,
-                                            )
-                                        )
-                                        + "?section=account"
-                                    )
-                                    with tag.a(
-                                        href=account_url,
-                                        classes="link link-primary text-sm",
-                                    ):
-                                        text("Go to account")
+                            if requirement.missing:
+                                with tag.p(classes="text-base-content/70"):
+                                    text(requirement.missing)
+                            if (
+                                not requirement.ready
+                                and requirement.gate is ActivationGate.payout_account
+                            ):
+                                with tag.a(
+                                    href=f"{detail_url}?section=account",
+                                    classes="link link-primary text-sm",
+                                ):
+                                    text("Go to account")
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
                 with tag.form(method="dialog"):

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -2547,9 +2547,7 @@ async def activate_dialog(
     )
     error_message: str | None = None
     is_created = organization.status == OrganizationStatus.CREATED
-    can_submit_review = is_created and (
-        organization.details_submitted_at is None or not readiness.review_exists
-    )
+    can_submit_review = is_created and organization.details_submitted_at is None
     can_activate = is_created and readiness.is_ready
 
     if request.method == "POST":

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -2533,7 +2533,7 @@ async def activate_dialog(
     session: AsyncSession = Depends(get_db_session),
 ) -> HXRedirectResponse | None:
     """Submit a CREATED org for review and/or run maybe_activate."""
-    repository = OrganizationRepository(session)
+    repository = OrganizationRepository.from_session(session)
 
     organization = await repository.get_by_id(organization_id, include_blocked=True)
     if not organization:

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -2637,6 +2637,21 @@ async def activate_dialog(
                                 if requirement.missing:
                                     with tag.p(classes="text-base-content/70"):
                                         text(requirement.missing)
+                                if requirement is readiness.payout_account_ready:
+                                    account_url = (
+                                        str(
+                                            request.url_for(
+                                                "organizations:detail",
+                                                organization_id=organization_id,
+                                            )
+                                        )
+                                        + "?section=account"
+                                    )
+                                    with tag.a(
+                                        href=account_url,
+                                        classes="link link-primary text-sm",
+                                    ):
+                                        text("Go to account")
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
                 with tag.form(method="dialog"):

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -31,6 +31,7 @@ from polar.account_credit.service import account_credit_service
 from polar.backoffice.routing import BackofficeRouter
 from polar.config import settings
 from polar.enums import PayoutAccountType
+from polar.exceptions import PolarRequestValidationError
 from polar.file.repository import FileRepository
 from polar.file.sorting import FileSortProperty
 from polar.integrations.plain.service import (
@@ -2529,7 +2530,7 @@ async def activate_dialog(
     organization_id: UUID4,
     session: AsyncSession = Depends(get_db_session),
 ) -> HXRedirectResponse | None:
-    """Activate a CREATED organization, showing onboarding readiness first."""
+    """Submit a CREATED org for review and/or run maybe_activate."""
     repository = OrganizationRepository(session)
 
     organization = await repository.get_by_id(organization_id, include_blocked=True)
@@ -2540,18 +2541,40 @@ async def activate_dialog(
         session, organization
     )
     error_message: str | None = None
+    can_submit_review = organization.status == OrganizationStatus.CREATED and (
+        organization.details_submitted_at is None or not readiness.review_exists
+    )
+    can_activate = (
+        organization.status == OrganizationStatus.CREATED and readiness.is_ready
+    )
 
     if request.method == "POST":
         try:
-            await organization_service.backoffice_activate(session, organization)
+            outcome = await organization_service.backoffice_submit_and_maybe_activate(
+                session, organization
+            )
         except OrganizationError as e:
             error_message = e.message
+        except PolarRequestValidationError as e:
+            error_message = "; ".join(error["msg"] for error in e.errors())
         else:
-            await add_toast(
-                request,
-                "Organization activated.",
-                "success",
-            )
+            if outcome.activated:
+                await add_toast(request, "Organization activated.", "success")
+            elif outcome.submitted_for_review:
+                await add_toast(
+                    request,
+                    "Submitted for review. The organization will activate "
+                    "automatically if the review passes and onboarding is complete.",
+                    "success",
+                )
+            else:
+                missing = ", ".join(item.label.lower() for item in readiness.missing)
+                await add_toast(
+                    request,
+                    "Could not activate yet. Still missing: "
+                    f"{missing or 'review or onboarding'}.",
+                    "warning",
+                )
             return HXRedirectResponse(
                 request,
                 str(
@@ -2562,7 +2585,9 @@ async def activate_dialog(
                 303,
             )
 
-    can_activate = organization.status == OrganizationStatus.CREATED
+        readiness = await organization_service.get_activation_readiness(
+            session, organization
+        )
 
     with modal("Activate Organization", open=True):
         with tag.div(classes="flex flex-col gap-4"):
@@ -2579,8 +2604,7 @@ async def activate_dialog(
                     with tag.p(classes="text-sm"):
                         text(
                             "All onboarding and review gates have passed. "
-                            "Activating will set status to Active and enable "
-                            "the default Active capabilities."
+                            "Activate uses the same path as automatic activation."
                         )
             else:
                 with tag.div(
@@ -2590,9 +2614,10 @@ async def activate_dialog(
                         text("Not fully ready to activate")
                     with tag.p(classes="text-sm"):
                         text(
-                            "Some gates have not passed. You can still activate "
-                            "from Created — capabilities will follow Active "
-                            "defaults. Review the missing items below."
+                            "Complete the missing steps below. Submitting for "
+                            "review queues the review agent; the organization "
+                            "activates automatically if the review passes and "
+                            "payout and identity checks are ready."
                         )
 
             with tag.ul(classes="space-y-2"):
@@ -2617,7 +2642,7 @@ async def activate_dialog(
                 with tag.form(method="dialog"):
                     with button(ghost=True):
                         text("Cancel")
-                if can_activate:
+                if can_activate or can_submit_review:
                     with tag.form(
                         hx_post=str(
                             request.url_for(
@@ -2627,10 +2652,10 @@ async def activate_dialog(
                         ),
                     ):
                         with button(
-                            variant="success" if readiness.is_ready else "warning",
+                            variant="success" if can_activate else "warning",
                             type="submit",
                         ):
-                            text("Activate")
+                            text("Activate" if can_activate else "Submit for review")
 
     return None
 

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -746,6 +746,21 @@ class OrganizationDetailView:
                                 outline=True,
                                 hx_get=str(
                                     request.url_for(
+                                        "organizations:activate_dialog",
+                                        organization_id=self.org.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Activate")
+
+                        with tag.div(classes="w-full"):
+                            with button(
+                                variant="secondary",
+                                size="sm",
+                                outline=True,
+                                hx_get=str(
+                                    request.url_for(
                                         "organizations:deny_dialog",
                                         organization_id=self.org.id,
                                     )

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -214,7 +214,7 @@ def _payout_account_missing(payout_account: PayoutAccount | None) -> str | None:
 def _owner_identity_missing(owner_user: User | None) -> str | None:
     if owner_user is None:
         return "Organization has no owner"
-    if owner_user.identity_verification_status != IdentityVerificationStatus.verified:
+    if not owner_user.identity_verified:
         return (
             "Owner identity is "
             f"{owner_user.identity_verification_status.get_display_name()}"
@@ -1309,7 +1309,7 @@ class OrganizationService:
         return confirmed
 
     async def get_activation_readiness(
-        self, session: AsyncSession, organization: Organization
+        self, session: AsyncReadSession, organization: Organization
     ) -> ActivationReadiness:
         """Checklist of gates that must pass for CREATED → ACTIVE.
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -262,6 +262,7 @@ class ActivationReadiness:
     payout_account_ready: ActivationRequirement
     owner_identity_verified: ActivationRequirement
     review_approved: ActivationRequirement
+    review_exists: bool
 
     @property
     def requirements(self) -> tuple[ActivationRequirement, ...]:
@@ -289,6 +290,12 @@ class ActivationReadiness:
         return [
             requirement for requirement in self.requirements if not requirement.ready
         ]
+
+
+@dataclass(frozen=True)
+class BackofficeActivationOutcome:
+    submitted_for_review: bool
+    activated: bool
 
 
 class CannotChangeOwnerError(OrganizationError):
@@ -1353,6 +1360,7 @@ class OrganizationService:
             payout_account_ready=payout_account_ready,
             owner_identity_verified=owner_identity_verified,
             review_approved=review_requirement,
+            review_exists=review is not None,
         )
 
     async def _is_activation_ready(
@@ -1416,17 +1424,16 @@ class OrganizationService:
         )
         return True
 
-    async def backoffice_activate(
+    async def backoffice_submit_and_maybe_activate(
         self,
         session: AsyncSession,
         organization: Organization,
-    ) -> Organization:
-        """Admin override: CREATED → ACTIVE, syncing ACTIVE capabilities.
+    ) -> BackofficeActivationOutcome:
+        """Complete review submission from backoffice, then try `maybe_activate`.
 
-        Bypasses the review-approval gate that `maybe_activate` requires so
-        that backoffice can activate orgs that never submitted for review
-        (e.g. manual payout accounts). Onboarding gaps are surfaced in the
-        dialog; this method still performs the transition.
+        Does not force ``CREATED → ACTIVE``. If onboarding or review is still
+        incomplete after submission, the org stays ``CREATED`` until a later
+        `maybe_activate` (review agent, payout account, identity webhook).
         """
         if organization.status != OrganizationStatus.CREATED:
             raise OrganizationError(
@@ -1435,19 +1442,37 @@ class OrganizationService:
                 409,
             )
 
-        organization.set_status(OrganizationStatus.ACTIVE)
-        if organization.initially_reviewed_at is None:
-            organization.initially_reviewed_at = datetime.now(UTC)
-        _append_internal_note(
-            organization, "Organization activated from created via backoffice."
-        )
-        session.add(organization)
+        submitted_for_review = False
+        review_repository = OrganizationReviewRepository.from_session(session)
+        review = await review_repository.get_by_organization(organization.id)
+
+        if organization.details_submitted_at is None:
+            await self.submit_for_review(session, organization)
+            submitted_for_review = True
+            _append_internal_note(organization, "Submitted for review via backoffice.")
+        elif review is None:
+            enqueue_job(
+                "organization_review.run_agent",
+                organization_id=organization.id,
+                context=ReviewContext.SUBMISSION,
+            )
+            submitted_for_review = True
+            _append_internal_note(
+                organization, "Queued organization review via backoffice."
+            )
+
+        activated = await self.maybe_activate(session, organization)
         log.info(
-            "organization.backoffice_activate.activated",
+            "organization.backoffice_submit_and_maybe_activate",
             organization_id=str(organization.id),
             slug=organization.slug,
+            submitted_for_review=submitted_for_review,
+            activated=activated,
         )
-        return organization
+        return BackofficeActivationOutcome(
+            submitted_for_review=submitted_for_review,
+            activated=activated,
+        )
 
     async def _reactivate_organization(
         self,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1,6 +1,7 @@
 import asyncio
 import uuid
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, assert_never, cast
 from urllib.parse import urlparse
@@ -246,6 +247,48 @@ class OrganizationDeletionCheckResult(BaseModel):
 
 
 class OrganizationError(PolarError): ...
+
+
+@dataclass(frozen=True)
+class ActivationRequirement:
+    label: str
+    ready: bool
+    missing: str | None = None
+
+
+@dataclass(frozen=True)
+class ActivationReadiness:
+    details_submitted: ActivationRequirement
+    payout_account_ready: ActivationRequirement
+    owner_identity_verified: ActivationRequirement
+    review_approved: ActivationRequirement
+
+    @property
+    def requirements(self) -> tuple[ActivationRequirement, ...]:
+        return (
+            self.details_submitted,
+            self.payout_account_ready,
+            self.owner_identity_verified,
+            self.review_approved,
+        )
+
+    @property
+    def onboarding_ready(self) -> bool:
+        return (
+            self.details_submitted.ready
+            and self.payout_account_ready.ready
+            and self.owner_identity_verified.ready
+        )
+
+    @property
+    def is_ready(self) -> bool:
+        return self.onboarding_ready and self.review_approved.ready
+
+    @property
+    def missing(self) -> list[ActivationRequirement]:
+        return [
+            requirement for requirement in self.requirements if not requirement.ready
+        ]
 
 
 class CannotChangeOwnerError(OrganizationError):
@@ -1225,6 +1268,93 @@ class OrganizationService:
 
         return confirmed
 
+    async def get_activation_readiness(
+        self, session: AsyncSession, organization: Organization
+    ) -> ActivationReadiness:
+        """Checklist of gates that must pass for CREATED → ACTIVE.
+
+        Used by automated activation (`maybe_activate`) and the backoffice
+        Activate dialog. Review approval is listed separately from onboarding
+        (details, payout account, owner identity).
+        """
+        details_ready = bool(organization.details_submitted_at and organization.details)
+        details_submitted = ActivationRequirement(
+            label="Organization details submitted",
+            ready=details_ready,
+            missing=(
+                None
+                if details_ready
+                else "Organization details have not been submitted"
+            ),
+        )
+
+        payout_account: PayoutAccount | None = None
+        if organization.payout_account_id is not None:
+            payout_account_repository = PayoutAccountRepository.from_session(session)
+            payout_account = await payout_account_repository.get_by_id(
+                organization.payout_account_id,
+            )
+        payout_ready = payout_account is not None and payout_account.is_payout_ready
+        if payout_account is None:
+            payout_missing = "No payout account is connected"
+        elif not payout_account.is_payout_ready:
+            payout_missing = (
+                f"Payout account is not ready ({payout_account.status.value})"
+            )
+        else:
+            payout_missing = None
+        payout_account_ready = ActivationRequirement(
+            label="Payout account ready",
+            ready=payout_ready,
+            missing=payout_missing,
+        )
+
+        organization_repository = OrganizationRepository.from_session(session)
+        owner_user = await organization_repository.get_owner_user(organization)
+        owner_verified = (
+            owner_user is not None
+            and owner_user.identity_verification_status
+            == IdentityVerificationStatus.verified
+        )
+        if owner_user is None:
+            identity_missing = "Organization has no owner"
+        elif not owner_verified:
+            identity_missing = (
+                "Owner identity is "
+                f"{owner_user.identity_verification_status.get_display_name()}"
+            )
+        else:
+            identity_missing = None
+        owner_identity_verified = ActivationRequirement(
+            label="Owner identity verified",
+            ready=owner_verified,
+            missing=identity_missing,
+        )
+
+        review_repository = OrganizationReviewRepository.from_session(session)
+        review = await review_repository.get_by_organization(organization.id)
+        review_approved = review is not None and review.is_approved
+        if review is None:
+            review_missing = "No organization review has been submitted"
+        elif not review.is_approved:
+            review_missing = f"Review verdict is {review.verdict.value}"
+            if review.appeal_decision is not None:
+                review_missing += f" (appeal {review.appeal_decision.value})"
+        else:
+            review_missing = None
+        review_requirement = ActivationRequirement(
+            label="Review approved",
+            ready=review_approved,
+            missing=review_missing,
+        )
+
+        return ActivationReadiness(
+            details_submitted=details_submitted,
+            payout_account_ready=payout_account_ready,
+            owner_identity_verified=owner_identity_verified,
+            review_approved=review_requirement,
+        )
+
     async def _is_activation_ready(
         self, session: AsyncSession, organization: Organization
     ) -> bool:
@@ -1234,26 +1364,8 @@ class OrganizationService:
         backoffice approval path can decide whether a reactivation should go
         straight to ACTIVE or revert to CREATED to finish onboarding.
         """
-        if not organization.details_submitted_at or not organization.details:
-            return False
-
-        if organization.payout_account_id is None:
-            return False
-
-        payout_account_repository = PayoutAccountRepository.from_session(session)
-        payout_account = await payout_account_repository.get_by_id(
-            organization.payout_account_id,
-        )
-        if payout_account is None or not payout_account.is_payout_ready:
-            return False
-
-        organization_repository = OrganizationRepository.from_session(session)
-        owner_user = await organization_repository.get_owner_user(organization)
-        return not (
-            owner_user is None
-            or owner_user.identity_verification_status
-            != IdentityVerificationStatus.verified
-        )
+        readiness = await self.get_activation_readiness(session, organization)
+        return readiness.onboarding_ready
 
     async def maybe_activate(
         self, session: AsyncSession, organization: Organization
@@ -1303,6 +1415,39 @@ class OrganizationService:
             slug=organization.slug,
         )
         return True
+
+    async def backoffice_activate(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> Organization:
+        """Admin override: CREATED → ACTIVE, syncing ACTIVE capabilities.
+
+        Bypasses the review-approval gate that `maybe_activate` requires so
+        that backoffice can activate orgs that never submitted for review
+        (e.g. manual payout accounts). Onboarding gaps are surfaced in the
+        dialog; this method still performs the transition.
+        """
+        if organization.status != OrganizationStatus.CREATED:
+            raise OrganizationError(
+                f"Cannot activate organization {organization.id}: requires "
+                f"CREATED status, got {organization.status.get_display_name()}.",
+                409,
+            )
+
+        organization.set_status(OrganizationStatus.ACTIVE)
+        if organization.initially_reviewed_at is None:
+            organization.initially_reviewed_at = datetime.now(UTC)
+        _append_internal_note(
+            organization, "Organization activated from created via backoffice."
+        )
+        session.add(organization)
+        log.info(
+            "organization.backoffice_activate.activated",
+            organization_id=str(organization.id),
+            slug=organization.slug,
+        )
+        return organization
 
     async def _reactivate_organization(
         self,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -3,6 +3,7 @@ import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from enum import StrEnum
 from typing import Any, assert_never, cast
 from urllib.parse import urlparse
 from uuid import UUID
@@ -202,6 +203,36 @@ def _append_internal_note(
         organization.internal_notes = note
 
 
+def _payout_account_missing(payout_account: PayoutAccount | None) -> str | None:
+    if payout_account is None:
+        return "No payout account is connected"
+    if not payout_account.is_payout_ready:
+        return f"Payout account is not ready ({payout_account.status.value})"
+    return None
+
+
+def _owner_identity_missing(owner_user: User | None) -> str | None:
+    if owner_user is None:
+        return "Organization has no owner"
+    if owner_user.identity_verification_status != IdentityVerificationStatus.verified:
+        return (
+            "Owner identity is "
+            f"{owner_user.identity_verification_status.get_display_name()}"
+        )
+    return None
+
+
+def _review_missing(review: OrganizationReview | None) -> str | None:
+    if review is None:
+        return "No organization review has been submitted"
+    if review.is_approved:
+        return None
+    missing = f"Review verdict is {review.verdict.value}"
+    if review.appeal_decision is not None:
+        missing += f" (appeal {review.appeal_decision.value})"
+    return missing
+
+
 def _merge_customer_portal_settings(
     stored: OrganizationCustomerPortalSettings,
     update: OrganizationCustomerPortalSettings,
@@ -249,41 +280,43 @@ class OrganizationDeletionCheckResult(BaseModel):
 class OrganizationError(PolarError): ...
 
 
+class ActivationGate(StrEnum):
+    details = "Organization details submitted"
+    payout_account = "Payout account ready"
+    owner_identity = "Owner identity verified"
+    review = "Review approved"
+
+
 @dataclass(frozen=True)
 class ActivationRequirement:
-    label: str
-    ready: bool
+    gate: ActivationGate
     missing: str | None = None
+
+    @property
+    def label(self) -> str:
+        return self.gate.value
+
+    @property
+    def ready(self) -> bool:
+        return self.missing is None
 
 
 @dataclass(frozen=True)
 class ActivationReadiness:
-    details_submitted: ActivationRequirement
-    payout_account_ready: ActivationRequirement
-    owner_identity_verified: ActivationRequirement
-    review_approved: ActivationRequirement
+    requirements: tuple[ActivationRequirement, ...]
     review_exists: bool
 
     @property
-    def requirements(self) -> tuple[ActivationRequirement, ...]:
-        return (
-            self.details_submitted,
-            self.payout_account_ready,
-            self.owner_identity_verified,
-            self.review_approved,
-        )
-
-    @property
     def onboarding_ready(self) -> bool:
-        return (
-            self.details_submitted.ready
-            and self.payout_account_ready.ready
-            and self.owner_identity_verified.ready
+        return all(
+            requirement.ready
+            for requirement in self.requirements
+            if requirement.gate is not ActivationGate.review
         )
 
     @property
     def is_ready(self) -> bool:
-        return self.onboarding_ready and self.review_approved.ready
+        return all(requirement.ready for requirement in self.requirements)
 
     @property
     def missing(self) -> list[ActivationRequirement]:
@@ -292,10 +325,10 @@ class ActivationReadiness:
         ]
 
 
-@dataclass(frozen=True)
-class BackofficeActivationOutcome:
-    submitted_for_review: bool
-    activated: bool
+class BackofficeActivationResult(StrEnum):
+    activated = "activated"
+    submitted_for_review = "submitted_for_review"
+    still_incomplete = "still_incomplete"
 
 
 class CannotChangeOwnerError(OrganizationError):
@@ -1284,108 +1317,47 @@ class OrganizationService:
         Activate dialog. Review approval is listed separately from onboarding
         (details, payout account, owner identity).
         """
-        details_ready = bool(organization.details_submitted_at and organization.details)
-        details_submitted = ActivationRequirement(
-            label="Organization details submitted",
-            ready=details_ready,
-            missing=(
-                None
-                if details_ready
-                else "Organization details have not been submitted"
-            ),
-        )
-
         payout_account: PayoutAccount | None = None
         if organization.payout_account_id is not None:
             payout_account_repository = PayoutAccountRepository.from_session(session)
             payout_account = await payout_account_repository.get_by_id(
                 organization.payout_account_id,
             )
-        payout_ready = payout_account is not None and payout_account.is_payout_ready
-        if payout_account is None:
-            payout_missing = "No payout account is connected"
-        elif not payout_account.is_payout_ready:
-            payout_missing = (
-                f"Payout account is not ready ({payout_account.status.value})"
-            )
-        else:
-            payout_missing = None
-        payout_account_ready = ActivationRequirement(
-            label="Payout account ready",
-            ready=payout_ready,
-            missing=payout_missing,
-        )
 
         organization_repository = OrganizationRepository.from_session(session)
         owner_user = await organization_repository.get_owner_user(organization)
-        owner_verified = (
-            owner_user is not None
-            and owner_user.identity_verification_status
-            == IdentityVerificationStatus.verified
-        )
-        if owner_user is None:
-            identity_missing = "Organization has no owner"
-        elif not owner_verified:
-            identity_missing = (
-                "Owner identity is "
-                f"{owner_user.identity_verification_status.get_display_name()}"
-            )
-        else:
-            identity_missing = None
-        owner_identity_verified = ActivationRequirement(
-            label="Owner identity verified",
-            ready=owner_verified,
-            missing=identity_missing,
-        )
 
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)
-        review_approved = review is not None and review.is_approved
-        if review is None:
-            review_missing = "No organization review has been submitted"
-        elif not review.is_approved:
-            review_missing = f"Review verdict is {review.verdict.value}"
-            if review.appeal_decision is not None:
-                review_missing += f" (appeal {review.appeal_decision.value})"
-        else:
-            review_missing = None
-        review_requirement = ActivationRequirement(
-            label="Review approved",
-            ready=review_approved,
-            missing=review_missing,
-        )
 
         return ActivationReadiness(
-            details_submitted=details_submitted,
-            payout_account_ready=payout_account_ready,
-            owner_identity_verified=owner_identity_verified,
-            review_approved=review_requirement,
+            requirements=(
+                ActivationRequirement(
+                    ActivationGate.details,
+                    None
+                    if organization.details_submitted_at and organization.details
+                    else "Organization details have not been submitted",
+                ),
+                ActivationRequirement(
+                    ActivationGate.payout_account,
+                    _payout_account_missing(payout_account),
+                ),
+                ActivationRequirement(
+                    ActivationGate.owner_identity, _owner_identity_missing(owner_user)
+                ),
+                ActivationRequirement(ActivationGate.review, _review_missing(review)),
+            ),
             review_exists=review is not None,
         )
-
-    async def _is_activation_ready(
-        self, session: AsyncSession, organization: Organization
-    ) -> bool:
-        """Whether onboarding gates (details, payout account, KYC) are met.
-
-        Mirrors the non-review gates checked by `maybe_activate` so the
-        backoffice approval path can decide whether a reactivation should go
-        straight to ACTIVE or revert to CREATED to finish onboarding.
-        """
-        readiness = await self.get_activation_readiness(session, organization)
-        return readiness.onboarding_ready
 
     async def maybe_activate(
         self, session: AsyncSession, organization: Organization
     ) -> bool:
         """Transition CREATED → ACTIVE when every onboarding gate passes.
 
-        Gates:
-          1. Status is CREATED.
-          2. Review is approved: verdict PASS, or verdict FAIL with an
-             APPROVED appeal.
-          3. Details submitted, payout account ready, owner identity
-             verified (see `_is_activation_ready`).
+        Gates: status is CREATED and every `get_activation_readiness`
+        requirement passes (details submitted, payout account ready, owner
+        identity verified, review approved).
 
         Idempotent — safe to call from automated triggers (AI review, Stripe
         ``account.updated``, identity verification). Returns True iff the org
@@ -1399,12 +1371,8 @@ class OrganizationService:
         if organization.status != OrganizationStatus.CREATED:
             return False
 
-        review_repository = OrganizationReviewRepository.from_session(session)
-        review = await review_repository.get_by_organization(organization.id)
-        if review is None or not review.is_approved:
-            return False
-
-        if not await self._is_activation_ready(session, organization):
+        readiness = await self.get_activation_readiness(session, organization)
+        if not readiness.is_ready:
             return False
 
         organization.set_status(OrganizationStatus.ACTIVE)
@@ -1428,7 +1396,7 @@ class OrganizationService:
         self,
         session: AsyncSession,
         organization: Organization,
-    ) -> BackofficeActivationOutcome:
+    ) -> BackofficeActivationResult:
         """Complete review submission from backoffice, then try `maybe_activate`.
 
         Does not force ``CREATED → ACTIVE``. If onboarding or review is still
@@ -1442,37 +1410,37 @@ class OrganizationService:
                 409,
             )
 
-        submitted_for_review = False
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)
+        needs_submission = organization.details_submitted_at is None
+        submitted_for_review = needs_submission or review is None
 
-        if organization.details_submitted_at is None:
+        if needs_submission:
+            # Sets `details_submitted_at` and queues the review agent itself.
             await self.submit_for_review(session, organization)
-            submitted_for_review = True
-            _append_internal_note(organization, "Submitted for review via backoffice.")
         elif review is None:
             enqueue_job(
                 "organization_review.run_agent",
                 organization_id=organization.id,
                 context=ReviewContext.SUBMISSION,
             )
-            submitted_for_review = True
-            _append_internal_note(
-                organization, "Queued organization review via backoffice."
-            )
+        if submitted_for_review:
+            _append_internal_note(organization, "Submitted for review via backoffice.")
 
-        activated = await self.maybe_activate(session, organization)
+        if await self.maybe_activate(session, organization):
+            result = BackofficeActivationResult.activated
+        elif submitted_for_review:
+            result = BackofficeActivationResult.submitted_for_review
+        else:
+            result = BackofficeActivationResult.still_incomplete
+
         log.info(
             "organization.backoffice_submit_and_maybe_activate",
             organization_id=str(organization.id),
             slug=organization.slug,
-            submitted_for_review=submitted_for_review,
-            activated=activated,
+            result=result.value,
         )
-        return BackofficeActivationOutcome(
-            submitted_for_review=submitted_for_review,
-            activated=activated,
-        )
+        return result
 
     async def _reactivate_organization(
         self,
@@ -1492,7 +1460,8 @@ class OrganizationService:
         if next_review_threshold is None:
             next_review_threshold = FIRST_REVIEW_THRESHOLD_CENTS
 
-        is_ready = await self._is_activation_ready(session, organization)
+        readiness = await self.get_activation_readiness(session, organization)
+        is_ready = readiness.onboarding_ready
         target_status = (
             OrganizationStatus.ACTIVE if is_ready else OrganizationStatus.CREATED
         )

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -304,7 +304,6 @@ class ActivationRequirement:
 @dataclass(frozen=True)
 class ActivationReadiness:
     requirements: tuple[ActivationRequirement, ...]
-    review_exists: bool
 
     @property
     def onboarding_ready(self) -> bool:
@@ -1347,7 +1346,6 @@ class OrganizationService:
                 ),
                 ActivationRequirement(ActivationGate.review, _review_missing(review)),
             ),
-            review_exists=review is not None,
         )
 
     async def maybe_activate(
@@ -1410,37 +1408,15 @@ class OrganizationService:
                 409,
             )
 
-        review_repository = OrganizationReviewRepository.from_session(session)
-        review = await review_repository.get_by_organization(organization.id)
-        needs_submission = organization.details_submitted_at is None
-        submitted_for_review = needs_submission or review is None
-
-        if needs_submission:
-            # Sets `details_submitted_at` and queues the review agent itself.
-            await self.submit_for_review(session, organization)
-        elif review is None:
-            enqueue_job(
-                "organization_review.run_agent",
-                organization_id=organization.id,
-                context=ReviewContext.SUBMISSION,
-            )
+        submitted_for_review = organization.details_submitted_at is None
         if submitted_for_review:
-            _append_internal_note(organization, "Submitted for review via backoffice.")
+            await self.submit_for_review(session, organization)
 
         if await self.maybe_activate(session, organization):
-            result = BackofficeActivationResult.activated
-        elif submitted_for_review:
-            result = BackofficeActivationResult.submitted_for_review
-        else:
-            result = BackofficeActivationResult.still_incomplete
-
-        log.info(
-            "organization.backoffice_submit_and_maybe_activate",
-            organization_id=str(organization.id),
-            slug=organization.slug,
-            result=result.value,
-        )
-        return result
+            return BackofficeActivationResult.activated
+        if submitted_for_review:
+            return BackofficeActivationResult.submitted_for_review
+        return BackofficeActivationResult.still_incomplete
 
     async def _reactivate_organization(
         self,

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -618,9 +618,7 @@ class TestActivateDialog:
         assert "No organization review has been submitted" in response.text
         assert "Submit for review" in response.text
         assert "Go to account" in response.text
-        assert (
-            f'/organizations/{organization.id}?section=account"' in response.text
-        )
+        assert f'/organizations/{organization.id}?section=account"' in response.text
 
     async def test_get_shows_ready_when_gates_pass(
         self,

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -578,6 +578,38 @@ class TestOverviewLazyCards:
         assert "<html" not in response.text
 
 
+@pytest_asyncio.fixture
+async def activation_ready_organization(
+    save_fixture: SaveFixture, organization: Organization, user: User
+) -> Organization:
+    organization.status = OrganizationStatus.CREATED
+    organization.details = {"about": "A merchant"}
+    organization.details_submitted_at = datetime.now(UTC)
+    await save_fixture(organization)
+
+    user.identity_verification_status = IdentityVerificationStatus.verified
+    await save_fixture(user)
+    await save_fixture(
+        UserOrganization(
+            user_id=user.id,
+            organization_id=organization.id,
+            role=OrganizationRole.owner,
+        )
+    )
+    await create_payout_account(save_fixture, organization, user)
+    await save_fixture(
+        OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.PASS,
+            risk_score=10.0,
+            violated_sections=[],
+            reason="Clean",
+            model_used="test",
+        )
+    )
+    return organization
+
+
 @pytest.mark.asyncio
 class TestActivateDialog:
     async def test_created_org_detail_shows_activate_button(
@@ -623,39 +655,10 @@ class TestActivateDialog:
     async def test_get_shows_ready_when_gates_pass(
         self,
         backoffice_client: httpx.AsyncClient,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        organization: Organization,
-        user: User,
+        activation_ready_organization: Organization,
     ) -> None:
-        organization.status = OrganizationStatus.CREATED
-        organization.details = {"about": "A merchant"}
-        organization.details_submitted_at = datetime.now(UTC)
-        await save_fixture(organization)
-
-        user.identity_verification_status = IdentityVerificationStatus.verified
-        await save_fixture(user)
-        await save_fixture(
-            UserOrganization(
-                user_id=user.id,
-                organization_id=organization.id,
-                role=OrganizationRole.owner,
-            )
-        )
-        await create_payout_account(save_fixture, organization, user)
-        await save_fixture(
-            OrganizationReview(
-                organization_id=organization.id,
-                verdict=OrganizationReview.Verdict.PASS,
-                risk_score=10.0,
-                violated_sections=[],
-                reason="Clean",
-                model_used="test",
-            )
-        )
-
         response = await backoffice_client.get(
-            f"/organizations/{organization.id}/activate-dialog"
+            f"/organizations/{activation_ready_organization.id}/activate-dialog"
         )
 
         assert response.status_code == 200
@@ -709,51 +712,22 @@ class TestActivateDialog:
         )
 
         assert response.status_code == 200
-        assert organization.status == OrganizationStatus.CREATED
         await session.refresh(organization)
         assert organization.status == OrganizationStatus.CREATED
 
     async def test_post_activates_when_ready(
         self,
         backoffice_client: httpx.AsyncClient,
-        save_fixture: SaveFixture,
         session: AsyncSession,
-        organization: Organization,
-        user: User,
+        activation_ready_organization: Organization,
     ) -> None:
-        organization.status = OrganizationStatus.CREATED
-        organization.details = {"about": "A merchant"}
-        organization.details_submitted_at = datetime.now(UTC)
-        await save_fixture(organization)
-
-        user.identity_verification_status = IdentityVerificationStatus.verified
-        await save_fixture(user)
-        await save_fixture(
-            UserOrganization(
-                user_id=user.id,
-                organization_id=organization.id,
-                role=OrganizationRole.owner,
-            )
-        )
-        await create_payout_account(save_fixture, organization, user)
-        await save_fixture(
-            OrganizationReview(
-                organization_id=organization.id,
-                verdict=OrganizationReview.Verdict.PASS,
-                risk_score=10.0,
-                violated_sections=[],
-                reason="Clean",
-                model_used="test",
-            )
-        )
-
         response = await backoffice_client.post(
-            f"/organizations/{organization.id}/activate-dialog"
+            f"/organizations/{activation_ready_organization.id}/activate-dialog"
         )
 
         assert response.status_code == 303
-        await session.refresh(organization)
-        assert organization.status == OrganizationStatus.ACTIVE
+        await session.refresh(activation_ready_organization)
+        assert activation_ready_organization.status == OrganizationStatus.ACTIVE
 
     async def test_post_rejects_non_created(
         self,

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -9,18 +9,15 @@ from pytest_mock import MockerFixture
 from polar.backoffice import app as backoffice_app
 from polar.backoffice.dependencies import get_admin
 from polar.backoffice.organizations_v2.endpoints import _stripe_reject_reason_for_aup
-from polar.models import PayoutAccount, UserOrganization
+from polar.models import PayoutAccount
 from polar.models.organization import Organization, OrganizationStatus
-from polar.models.organization_review import OrganizationReview
 from polar.models.organization_risk_signal import OrganizationRiskSignal
-from polar.models.user import IdentityVerificationStatus, User
-from polar.models.user_organization import OrganizationRole
+from polar.models.user import User
 from polar.models.user_session import UserSession
 from polar.organization_review.repository import OrganizationReviewRepository
 from polar.organization_review.schemas import AUPSection
 from polar.postgres import AsyncSession, get_db_session
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_payout_account
 
 
 @pytest_asyncio.fixture
@@ -576,167 +573,3 @@ class TestOverviewLazyCards:
         assert "Checkout Links" in response.text
         assert "Payout Account" in response.text
         assert "<html" not in response.text
-
-
-@pytest_asyncio.fixture
-async def activation_ready_organization(
-    save_fixture: SaveFixture, organization: Organization, user: User
-) -> Organization:
-    organization.status = OrganizationStatus.CREATED
-    organization.details = {"about": "A merchant"}
-    organization.details_submitted_at = datetime.now(UTC)
-    await save_fixture(organization)
-
-    user.identity_verification_status = IdentityVerificationStatus.verified
-    await save_fixture(user)
-    await save_fixture(
-        UserOrganization(
-            user=user,
-            organization=organization,
-            role=OrganizationRole.owner,
-        )
-    )
-    await create_payout_account(save_fixture, organization, user)
-    await save_fixture(
-        OrganizationReview(
-            organization=organization,
-            verdict=OrganizationReview.Verdict.PASS,
-            risk_score=10.0,
-            violated_sections=[],
-            reason="Clean",
-            model_used="test",
-        )
-    )
-    return organization
-
-
-@pytest.mark.asyncio
-class TestActivateDialog:
-    async def test_created_org_detail_shows_activate_button(
-        self,
-        backoffice_client: httpx.AsyncClient,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        organization.status = OrganizationStatus.CREATED
-        session.add(organization)
-        await session.flush()
-
-        response = await backoffice_client.get(f"/organizations/{organization.id}")
-
-        assert response.status_code == 200
-        assert "Activate" in response.text
-        assert f"/organizations/{organization.id}/activate-dialog" in response.text
-
-    async def test_get_shows_missing_requirements(
-        self,
-        backoffice_client: httpx.AsyncClient,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        organization.status = OrganizationStatus.CREATED
-        session.add(organization)
-        await session.flush()
-
-        response = await backoffice_client.get(
-            f"/organizations/{organization.id}/activate-dialog"
-        )
-
-        assert response.status_code == 200
-        assert "Activate Organization" in response.text
-        assert "Not fully ready to activate" in response.text
-        assert "Organization details have not been submitted" in response.text
-        assert "No payout account is connected" in response.text
-        assert "No organization review has been submitted" in response.text
-        assert "Submit for review" in response.text
-        assert "Go to account" in response.text
-        assert f'/organizations/{organization.id}?section=account"' in response.text
-
-    async def test_get_shows_ready_when_gates_pass(
-        self,
-        backoffice_client: httpx.AsyncClient,
-        activation_ready_organization: Organization,
-    ) -> None:
-        response = await backoffice_client.get(
-            f"/organizations/{activation_ready_organization.id}/activate-dialog"
-        )
-
-        assert response.status_code == 200
-        assert "Ready to activate" in response.text
-        assert "Not fully ready to activate" not in response.text
-
-    async def test_post_submits_valid_details_without_forcing_active(
-        self,
-        mocker: MockerFixture,
-        backoffice_client: httpx.AsyncClient,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        mocker.patch("polar.organization.service.enqueue_job")
-        organization.status = OrganizationStatus.CREATED
-        organization.website = "https://example.com"
-        organization.email = "support@example.com"
-        organization.details = {
-            "product_description": "Subscription SaaS for software teams and agencies.",
-            "selling_categories": ["Software / SaaS"],
-            "pricing_models": ["Subscription"],
-            "switching": False,
-        }
-        organization.details_submitted_at = None
-        session.add(organization)
-        await session.flush()
-
-        response = await backoffice_client.post(
-            f"/organizations/{organization.id}/activate-dialog"
-        )
-
-        assert response.status_code == 303
-        await session.refresh(organization)
-        assert organization.status == OrganizationStatus.CREATED
-        assert organization.details_submitted_at is not None
-
-    async def test_post_rejects_incomplete_details(
-        self,
-        backoffice_client: httpx.AsyncClient,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        organization.status = OrganizationStatus.CREATED
-        organization.details = {}
-        organization.details_submitted_at = None
-        session.add(organization)
-        await session.flush()
-
-        response = await backoffice_client.post(
-            f"/organizations/{organization.id}/activate-dialog"
-        )
-
-        assert response.status_code == 200
-        await session.refresh(organization)
-        assert organization.status == OrganizationStatus.CREATED
-
-    async def test_post_activates_when_ready(
-        self,
-        backoffice_client: httpx.AsyncClient,
-        session: AsyncSession,
-        activation_ready_organization: Organization,
-    ) -> None:
-        response = await backoffice_client.post(
-            f"/organizations/{activation_ready_organization.id}/activate-dialog"
-        )
-
-        assert response.status_code == 303
-        await session.refresh(activation_ready_organization)
-        assert activation_ready_organization.status == OrganizationStatus.ACTIVE
-
-    async def test_post_rejects_non_created(
-        self,
-        backoffice_client: httpx.AsyncClient,
-        organization: Organization,
-    ) -> None:
-        response = await backoffice_client.post(
-            f"/organizations/{organization.id}/activate-dialog"
-        )
-
-        assert response.status_code == 200
-        assert "requires CREATED status" in response.text

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -591,15 +591,15 @@ async def activation_ready_organization(
     await save_fixture(user)
     await save_fixture(
         UserOrganization(
-            user_id=user.id,
-            organization_id=organization.id,
+            user=user,
+            organization=organization,
             role=OrganizationRole.owner,
         )
     )
     await create_payout_account(save_fixture, organization, user)
     await save_fixture(
         OrganizationReview(
-            organization_id=organization.id,
+            organization=organization,
             verdict=OrganizationReview.Verdict.PASS,
             risk_score=10.0,
             violated_sections=[],

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -9,15 +9,18 @@ from pytest_mock import MockerFixture
 from polar.backoffice import app as backoffice_app
 from polar.backoffice.dependencies import get_admin
 from polar.backoffice.organizations_v2.endpoints import _stripe_reject_reason_for_aup
-from polar.models import PayoutAccount
+from polar.models import PayoutAccount, UserOrganization
 from polar.models.organization import Organization, OrganizationStatus
+from polar.models.organization_review import OrganizationReview
 from polar.models.organization_risk_signal import OrganizationRiskSignal
-from polar.models.user import User
+from polar.models.user import IdentityVerificationStatus, User
+from polar.models.user_organization import OrganizationRole
 from polar.models.user_session import UserSession
 from polar.organization_review.repository import OrganizationReviewRepository
 from polar.organization_review.schemas import AUPSection
 from polar.postgres import AsyncSession, get_db_session
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_payout_account
 
 
 @pytest_asyncio.fixture
@@ -573,3 +576,115 @@ class TestOverviewLazyCards:
         assert "Checkout Links" in response.text
         assert "Payout Account" in response.text
         assert "<html" not in response.text
+
+
+@pytest.mark.asyncio
+class TestActivateDialog:
+    async def test_created_org_detail_shows_activate_button(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        session.add(organization)
+        await session.flush()
+
+        response = await backoffice_client.get(f"/organizations/{organization.id}")
+
+        assert response.status_code == 200
+        assert "Activate" in response.text
+        assert f"/organizations/{organization.id}/activate-dialog" in response.text
+    async def test_get_shows_missing_requirements(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        session.add(organization)
+        await session.flush()
+
+        response = await backoffice_client.get(
+            f"/organizations/{organization.id}/activate-dialog"
+        )
+
+        assert response.status_code == 200
+        assert "Activate Organization" in response.text
+        assert "Not fully ready to activate" in response.text
+        assert "Organization details have not been submitted" in response.text
+        assert "No payout account is connected" in response.text
+        assert "No organization review has been submitted" in response.text
+        assert "Activate" in response.text
+
+    async def test_get_shows_ready_when_gates_pass(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        organization.details = {"about": "A merchant"}
+        organization.details_submitted_at = datetime.now(UTC)
+        await save_fixture(organization)
+
+        user.identity_verification_status = IdentityVerificationStatus.verified
+        await save_fixture(user)
+        await save_fixture(
+            UserOrganization(
+                user_id=user.id,
+                organization_id=organization.id,
+                role=OrganizationRole.owner,
+            )
+        )
+        await create_payout_account(save_fixture, organization, user)
+        await save_fixture(
+            OrganizationReview(
+                organization_id=organization.id,
+                verdict=OrganizationReview.Verdict.PASS,
+                risk_score=10.0,
+                violated_sections=[],
+                reason="Clean",
+                model_used="test",
+            )
+        )
+
+        response = await backoffice_client.get(
+            f"/organizations/{organization.id}/activate-dialog"
+        )
+
+        assert response.status_code == 200
+        assert "Ready to activate" in response.text
+        assert "Not fully ready to activate" not in response.text
+
+    async def test_post_activates_created_organization(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        session.add(organization)
+        await session.flush()
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/activate-dialog"
+        )
+
+        assert response.status_code == 303
+        await session.refresh(organization)
+        assert organization.status == OrganizationStatus.ACTIVE
+
+    async def test_post_rejects_non_created(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        organization: Organization,
+    ) -> None:
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/activate-dialog"
+        )
+
+        assert response.status_code == 200
+        assert "requires CREATED status" in response.text

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -595,6 +595,7 @@ class TestActivateDialog:
         assert response.status_code == 200
         assert "Activate" in response.text
         assert f"/organizations/{organization.id}/activate-dialog" in response.text
+
     async def test_get_shows_missing_requirements(
         self,
         backoffice_client: httpx.AsyncClient,
@@ -615,7 +616,7 @@ class TestActivateDialog:
         assert "Organization details have not been submitted" in response.text
         assert "No payout account is connected" in response.text
         assert "No organization review has been submitted" in response.text
-        assert "Activate" in response.text
+        assert "Submit for review" in response.text
 
     async def test_get_shows_ready_when_gates_pass(
         self,
@@ -659,15 +660,90 @@ class TestActivateDialog:
         assert "Ready to activate" in response.text
         assert "Not fully ready to activate" not in response.text
 
-    async def test_post_activates_created_organization(
+    async def test_post_submits_valid_details_without_forcing_active(
+        self,
+        mocker: MockerFixture,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        mocker.patch("polar.organization.service.enqueue_job")
+        organization.status = OrganizationStatus.CREATED
+        organization.website = "https://example.com"
+        organization.email = "support@example.com"
+        organization.details = {
+            "product_description": "Subscription SaaS for software teams and agencies.",
+            "selling_categories": ["Software / SaaS"],
+            "pricing_models": ["Subscription"],
+            "switching": False,
+        }
+        organization.details_submitted_at = None
+        session.add(organization)
+        await session.flush()
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/activate-dialog"
+        )
+
+        assert response.status_code == 303
+        await session.refresh(organization)
+        assert organization.status == OrganizationStatus.CREATED
+        assert organization.details_submitted_at is not None
+
+    async def test_post_rejects_incomplete_details(
         self,
         backoffice_client: httpx.AsyncClient,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
         organization.status = OrganizationStatus.CREATED
+        organization.details = {}
+        organization.details_submitted_at = None
         session.add(organization)
         await session.flush()
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/activate-dialog"
+        )
+
+        assert response.status_code == 200
+        assert organization.status == OrganizationStatus.CREATED
+        await session.refresh(organization)
+        assert organization.status == OrganizationStatus.CREATED
+
+    async def test_post_activates_when_ready(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        organization.details = {"about": "A merchant"}
+        organization.details_submitted_at = datetime.now(UTC)
+        await save_fixture(organization)
+
+        user.identity_verification_status = IdentityVerificationStatus.verified
+        await save_fixture(user)
+        await save_fixture(
+            UserOrganization(
+                user_id=user.id,
+                organization_id=organization.id,
+                role=OrganizationRole.owner,
+            )
+        )
+        await create_payout_account(save_fixture, organization, user)
+        await save_fixture(
+            OrganizationReview(
+                organization_id=organization.id,
+                verdict=OrganizationReview.Verdict.PASS,
+                risk_score=10.0,
+                violated_sections=[],
+                reason="Clean",
+                model_used="test",
+            )
+        )
 
         response = await backoffice_client.post(
             f"/organizations/{organization.id}/activate-dialog"

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -617,6 +617,10 @@ class TestActivateDialog:
         assert "No payout account is connected" in response.text
         assert "No organization review has been submitted" in response.text
         assert "Submit for review" in response.text
+        assert "Go to account" in response.text
+        assert (
+            f'/organizations/{organization.id}?section=account"' in response.text
+        )
 
     async def test_get_shows_ready_when_gates_pass(
         self,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1655,6 +1655,130 @@ class TestMaybeActivate:
 
 
 @pytest.mark.asyncio
+class TestGetActivationReadiness:
+    async def test_reports_missing_gates(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        organization.details = {}
+        organization.details_submitted_at = None
+
+        readiness = await organization_service.get_activation_readiness(
+            session, organization
+        )
+
+        assert readiness.is_ready is False
+        assert readiness.onboarding_ready is False
+        missing_labels = {item.label for item in readiness.missing}
+        assert missing_labels == {
+            "Organization details submitted",
+            "Payout account ready",
+            "Owner identity verified",
+            "Review approved",
+        }
+
+    async def test_ready_when_onboarding_and_review_pass(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        await _setup_passing_org(save_fixture, organization, user)
+        organization.status = OrganizationStatus.CREATED
+        organization.details_submitted_at = datetime.now(UTC)
+        await save_fixture(organization)
+
+        session.add(
+            OrganizationReview(
+                organization_id=organization.id,
+                verdict=OrganizationReview.Verdict.PASS,
+                risk_score=10.0,
+                violated_sections=[],
+                reason="Clean",
+                model_used="test",
+            )
+        )
+        await session.flush()
+
+        readiness = await organization_service.get_activation_readiness(
+            session, organization
+        )
+
+        assert readiness.is_ready is True
+        assert readiness.missing == []
+
+    async def test_onboarding_ready_without_review(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        await _setup_passing_org(save_fixture, organization, user)
+        organization.status = OrganizationStatus.CREATED
+        organization.details_submitted_at = datetime.now(UTC)
+        await save_fixture(organization)
+
+        readiness = await organization_service.get_activation_readiness(
+            session, organization
+        )
+
+        assert readiness.onboarding_ready is True
+        assert readiness.is_ready is False
+        assert readiness.review_approved.missing == (
+            "No organization review has been submitted"
+        )
+
+
+@pytest.mark.asyncio
+class TestBackofficeActivate:
+    async def test_activates_created_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        organization.capabilities = {**STATUS_CAPABILITIES[OrganizationStatus.CREATED]}
+        await save_fixture(organization)
+
+        result = await organization_service.backoffice_activate(session, organization)
+
+        assert result.status == OrganizationStatus.ACTIVE
+        assert result.capabilities == STATUS_CAPABILITIES[OrganizationStatus.ACTIVE]
+        assert result.initially_reviewed_at is not None
+        assert result.internal_notes is not None
+        assert "activated from created via backoffice" in result.internal_notes
+
+    async def test_rejects_non_created(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+
+        with pytest.raises(OrganizationError, match="CREATED"):
+            await organization_service.backoffice_activate(session, organization)
+
+    async def test_activates_even_when_gates_are_missing(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        organization.details = {}
+        organization.details_submitted_at = None
+        organization.payout_account_id = None
+
+        result = await organization_service.backoffice_activate(session, organization)
+
+        assert result.status == OrganizationStatus.ACTIVE
+
+
+@pytest.mark.asyncio
 class TestBackofficeApprove:
     async def test_rejects_non_denied_or_blocked(
         self,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1734,25 +1734,7 @@ class TestGetActivationReadiness:
 
 
 @pytest.mark.asyncio
-class TestBackofficeActivate:
-    async def test_activates_created_organization(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        organization.status = OrganizationStatus.CREATED
-        organization.capabilities = {**STATUS_CAPABILITIES[OrganizationStatus.CREATED]}
-        await save_fixture(organization)
-
-        result = await organization_service.backoffice_activate(session, organization)
-
-        assert result.status == OrganizationStatus.ACTIVE
-        assert result.capabilities == STATUS_CAPABILITIES[OrganizationStatus.ACTIVE]
-        assert result.initially_reviewed_at is not None
-        assert result.internal_notes is not None
-        assert "activated from created via backoffice" in result.internal_notes
-
+class TestBackofficeSubmitAndMaybeActivate:
     async def test_rejects_non_created(
         self,
         session: AsyncSession,
@@ -1761,9 +1743,11 @@ class TestBackofficeActivate:
         organization.status = OrganizationStatus.REVIEW
 
         with pytest.raises(OrganizationError, match="CREATED"):
-            await organization_service.backoffice_activate(session, organization)
+            await organization_service.backoffice_submit_and_maybe_activate(
+                session, organization
+            )
 
-    async def test_activates_even_when_gates_are_missing(
+    async def test_rejects_incomplete_details(
         self,
         session: AsyncSession,
         organization: Organization,
@@ -1771,11 +1755,78 @@ class TestBackofficeActivate:
         organization.status = OrganizationStatus.CREATED
         organization.details = {}
         organization.details_submitted_at = None
+
+        with pytest.raises(PolarRequestValidationError):
+            await organization_service.backoffice_submit_and_maybe_activate(
+                session, organization
+            )
+
+        assert organization.status == OrganizationStatus.CREATED
+
+    async def test_submits_for_review_without_forcing_active(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        mocker.patch("polar.organization.service.enqueue_job")
+        organization.status = OrganizationStatus.CREATED
+        organization.website = "https://example.com"
+        organization.email = "support@example.com"
+        organization.details = {
+            "product_description": "Subscription SaaS for software teams and agencies.",
+            "selling_categories": ["Software / SaaS"],
+            "pricing_models": ["Subscription"],
+            "switching": False,
+        }
+        organization.details_submitted_at = None
         organization.payout_account_id = None
 
-        result = await organization_service.backoffice_activate(session, organization)
+        outcome = await organization_service.backoffice_submit_and_maybe_activate(
+            session, organization
+        )
 
-        assert result.status == OrganizationStatus.ACTIVE
+        assert outcome.submitted_for_review is True
+        assert outcome.activated is False
+        assert organization.status == OrganizationStatus.CREATED
+        assert organization.details_submitted_at is not None
+        assert organization.internal_notes is not None
+        assert "Submitted for review via backoffice" in organization.internal_notes
+
+    async def test_activates_when_all_gates_pass(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        await _setup_passing_org(save_fixture, organization, user)
+        organization.status = OrganizationStatus.CREATED
+        organization.details_submitted_at = datetime.now(UTC)
+        organization.capabilities = {**STATUS_CAPABILITIES[OrganizationStatus.CREATED]}
+        await save_fixture(organization)
+        session.add(
+            OrganizationReview(
+                organization_id=organization.id,
+                verdict=OrganizationReview.Verdict.PASS,
+                risk_score=10.0,
+                violated_sections=[],
+                reason="Clean",
+                model_used="test",
+            )
+        )
+        await session.flush()
+
+        outcome = await organization_service.backoffice_submit_and_maybe_activate(
+            session, organization
+        )
+
+        assert outcome.submitted_for_review is False
+        assert outcome.activated is True
+        assert organization.status == OrganizationStatus.ACTIVE
+        assert (
+            organization.capabilities == STATUS_CAPABILITIES[OrganizationStatus.ACTIVE]
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1774,8 +1774,6 @@ class TestBackofficeSubmitAndMaybeActivate:
         assert result == BackofficeActivationResult.submitted_for_review
         assert organization.status == OrganizationStatus.CREATED
         assert organization.details_submitted_at is not None
-        assert organization.internal_notes is not None
-        assert "Submitted for review via backoffice" in organization.internal_notes
 
     async def test_activates_when_all_gates_pass(
         self,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1697,7 +1697,7 @@ class TestGetActivationReadiness:
         if reviewed:
             session.add(
                 OrganizationReview(
-                    organization_id=organization.id,
+                    organization=organization,
                     verdict=OrganizationReview.Verdict.PASS,
                     risk_score=10.0,
                     violated_sections=[],
@@ -1791,7 +1791,7 @@ class TestBackofficeSubmitAndMaybeActivate:
         await save_fixture(organization)
         session.add(
             OrganizationReview(
-                organization_id=organization.id,
+                organization=organization,
                 verdict=OrganizationReview.Verdict.PASS,
                 risk_score=10.0,
                 violated_sections=[],

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -68,6 +68,7 @@ from polar.organization.schemas import (
     OrganizationUpdate,
 )
 from polar.organization.service import (
+    BackofficeActivationResult,
     CannotCreateOrganizationError,
     OrganizationError,
 )
@@ -1679,57 +1680,41 @@ class TestGetActivationReadiness:
             "Review approved",
         }
 
-    async def test_ready_when_onboarding_and_review_pass(
+    @pytest.mark.parametrize("reviewed", [True, False])
+    async def test_review_is_last_gate_after_onboarding(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
         user: User,
+        reviewed: bool,
     ) -> None:
         await _setup_passing_org(save_fixture, organization, user)
         organization.status = OrganizationStatus.CREATED
         organization.details_submitted_at = datetime.now(UTC)
         await save_fixture(organization)
 
-        session.add(
-            OrganizationReview(
-                organization_id=organization.id,
-                verdict=OrganizationReview.Verdict.PASS,
-                risk_score=10.0,
-                violated_sections=[],
-                reason="Clean",
-                model_used="test",
+        if reviewed:
+            session.add(
+                OrganizationReview(
+                    organization_id=organization.id,
+                    verdict=OrganizationReview.Verdict.PASS,
+                    risk_score=10.0,
+                    violated_sections=[],
+                    reason="Clean",
+                    model_used="test",
+                )
             )
-        )
-        await session.flush()
-
-        readiness = await organization_service.get_activation_readiness(
-            session, organization
-        )
-
-        assert readiness.is_ready is True
-        assert readiness.missing == []
-
-    async def test_onboarding_ready_without_review(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        organization: Organization,
-        user: User,
-    ) -> None:
-        await _setup_passing_org(save_fixture, organization, user)
-        organization.status = OrganizationStatus.CREATED
-        organization.details_submitted_at = datetime.now(UTC)
-        await save_fixture(organization)
+            await session.flush()
 
         readiness = await organization_service.get_activation_readiness(
             session, organization
         )
 
         assert readiness.onboarding_ready is True
-        assert readiness.is_ready is False
-        assert readiness.review_approved.missing == (
-            "No organization review has been submitted"
+        assert readiness.is_ready is reviewed
+        assert [item.missing for item in readiness.missing] == (
+            [] if reviewed else ["No organization review has been submitted"]
         )
 
 
@@ -1782,12 +1767,11 @@ class TestBackofficeSubmitAndMaybeActivate:
         organization.details_submitted_at = None
         organization.payout_account_id = None
 
-        outcome = await organization_service.backoffice_submit_and_maybe_activate(
+        result = await organization_service.backoffice_submit_and_maybe_activate(
             session, organization
         )
 
-        assert outcome.submitted_for_review is True
-        assert outcome.activated is False
+        assert result == BackofficeActivationResult.submitted_for_review
         assert organization.status == OrganizationStatus.CREATED
         assert organization.details_submitted_at is not None
         assert organization.internal_notes is not None
@@ -1817,12 +1801,11 @@ class TestBackofficeSubmitAndMaybeActivate:
         )
         await session.flush()
 
-        outcome = await organization_service.backoffice_submit_and_maybe_activate(
+        result = await organization_service.backoffice_submit_and_maybe_activate(
             session, organization
         )
 
-        assert outcome.submitted_for_review is False
-        assert outcome.activated is True
+        assert result == BackofficeActivationResult.activated
         assert organization.status == OrganizationStatus.ACTIVE
         assert (
             organization.capabilities == STATUS_CAPABILITIES[OrganizationStatus.ACTIVE]


### PR DESCRIPTION
## Summary

Add a new `Activate` button on the backoffice for `created` orgs. This don't bypass the activation logic, it displays a confirmation dialog with the missing pieces and if eveyrhitng is completed it allows to activate or submit for review.


## Why
Manual payout orgs are left on created because they never submitted for review as merchants needs to click the button. Now we display that button on the backoffice.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`ruff check`, `ruff format`, `mypy` on the changed modules)
- [x] No unrelated changes or drive-by fixes are included

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://polar-sh.slack.com/archives/C0942KS0BD2/p1788936597029019?thread_ts=1788936597.029019&cid=C0942KS0BD2)

<div><a href="https://cursor.com/agents/bc-fb721a97-df4d-5986-9945-28b2e8ff980d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb721a97-df4d-5986-9945-28b2e8ff980d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

