### PR TITLE
server/payout: mark paid transactions with a single UPDATE query

### DIFF
--- a/server/polar/transaction/repository.py
+++ b/server/polar/transaction/repository.py
@@ -21,12 +21,15 @@ class TransactionRepository(
 ):
     model = Transaction
 
-    async def get_all_unpaid_by_account(self, account: UUID) -> Sequence[Transaction]:
+    async def set_unpaid_transactions_payout(
+        self, account: UUID, payout_transaction_id: UUID
+    ) -> None:
         statement = (
-            self.get_base_statement()
-            .join(Account, Account.id == Transaction.account_id)
+            update(Transaction)
             .where(
+                ~Transaction.is_deleted,
                 Transaction.account_id == account,
+                Account.id == Transaction.account_id,
                 Transaction.payout_transaction_id.is_(None),
                 or_(
                     # Balance transactions that are either :
@@ -46,13 +49,9 @@ class TransactionRepository(
                     Transaction.type == TransactionType.payout_reversal,
                 ),
             )
-            .options(
-                selectinload(Transaction.balance_reversal_transaction),
-                selectinload(Transaction.balance_reversal_transactions),
-                selectinload(Transaction.payment_transaction),
-            )
+            .values(payout_transaction_id=payout_transaction_id)
         )
-        return await self.get_all(statement)
+        await self.session.execute(statement)
 
     async def get_all_paid_transactions_by_payout(
         self, payout_transaction_id: UUID

--- a/server/polar/transaction/service/payout.py
+++ b/server/polar/transaction/service/payout.py
@@ -42,18 +42,10 @@ class PayoutTransactionService(BaseTransactionService):
             payout=payout,
         )
 
-        transaction_repository = TransactionRepository.from_session(session)
-        unpaid_balance_transactions = (
-            await transaction_repository.get_all_unpaid_by_account(account.id)
-        )
-
         if payout.processor == PayoutAccountType.stripe:
             transaction.processor = Processor.stripe
         elif payout.processor == PayoutAccountType.manual:
             transaction.processor = Processor.manual
-
-        for balance_transaction in unpaid_balance_transactions:
-            transaction.paid_transactions.append(balance_transaction)
 
         for outgoing, incoming in fees_balances:
             transaction.incurred_transactions.append(outgoing)
@@ -61,7 +53,14 @@ class PayoutTransactionService(BaseTransactionService):
             transaction.incurred_transactions.append(incoming)
 
         repository = PayoutTransactionRepository.from_session(session)
-        return await repository.create(transaction, flush=True)
+        transaction = await repository.create(transaction, flush=True)
+
+        transaction_repository = TransactionRepository.from_session(session)
+        await transaction_repository.set_unpaid_transactions_payout(
+            account.id, transaction.id
+        )
+
+        return transaction
 
     async def reverse(
         self,

--- a/server/tests/transaction/service/test_payout.py
+++ b/server/tests/transaction/service/test_payout.py
@@ -15,6 +15,7 @@ from polar.models import (
 )
 from polar.models.transaction import Processor, TransactionType
 from polar.postgres import AsyncSession
+from polar.transaction.repository import TransactionRepository
 from polar.transaction.service.payout import (
     payout_transaction as payout_transaction_service,
 )
@@ -136,10 +137,16 @@ class TestCreate:
         assert transaction.account_amount < 0
         assert transaction.transfer_id is None
 
-        assert len(transaction.paid_transactions) == 3 + len(
+        transaction_repository = TransactionRepository.from_session(session)
+        paid_transactions = (
+            await transaction_repository.get_all_paid_transactions_by_payout(
+                transaction.id
+            )
+        )
+        assert len(paid_transactions) == 3 + len(
             transaction.account_incurred_transactions
         )
-        paid_transaction_ids = {t.id for t in transaction.paid_transactions}
+        paid_transaction_ids = {t.id for t in paid_transactions}
         assert balance_transaction_1.id in paid_transaction_ids
         assert balance_transaction_2.id in paid_transaction_ids
         assert payout_reversal_transaction.id in paid_transaction_ids


### PR DESCRIPTION

The previous approach relied on fetching all matching transactions from database and marking them individually, which was failing for very large payouts.

Moving to a single UPDATE query should be more efficient.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

