### PR TITLE
server/observability: add invariant to detect unhandled external events

### DIFF
--- a/server/polar/external_event/repository.py
+++ b/server/polar/external_event/repository.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import delete
+from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from polar.kit.repository import (
@@ -84,6 +84,22 @@ class ExternalEventRepository(
             ExternalEvent.handled_at.is_not(None), ExternalEvent.created_at < before
         )
         await self.session.execute(statement)
+
+    async def get_unhandled_ids(
+        self, older_than: datetime, *, limit: int
+    ) -> tuple[list[UUID], int]:
+        statement = (
+            select(ExternalEvent.id, func.count().over())
+            .where(
+                ExternalEvent.handled_at.is_(None),
+                ExternalEvent.created_at < older_than,
+            )
+            .order_by(ExternalEvent.created_at.asc(), ExternalEvent.id.asc())
+            .limit(limit)
+        )
+        result = await self.session.execute(statement)
+        rows = result.fetchall()
+        return [row[0] for row in rows], rows[0][1] if rows else 0
 
     def get_sorting_clause(self, property: ExternalEventSortProperty) -> SortingClause:
         match property:

--- a/server/polar/observability/invariants/rules/__init__.py
+++ b/server/polar/observability/invariants/rules/__init__.py
@@ -1,4 +1,5 @@
 from .base import Invariant, InvariantError
+from .external_events_unhandled import ExternalEventsUnhandledInvariant
 from .no_recent_orders import NoRecentOrdersInvariant
 from .no_recent_subscriptions import NoRecentSubscriptionsInvariant
 from .payout_transactions_amount_invariant import PayoutTransactionsAmountInvariant
@@ -10,6 +11,7 @@ from .subscriptions_future_period_start import SubscriptionsFuturePeriodStartInv
 from .subscriptions_locked_invariant import SubscriptionsLockedInvariant
 
 INVARIANTS: set[type[Invariant]] = {
+    ExternalEventsUnhandledInvariant,
     NoRecentOrdersInvariant,
     NoRecentSubscriptionsInvariant,
     PayoutTransactionsAmountInvariant,

--- a/server/polar/observability/invariants/rules/external_events_unhandled.py
+++ b/server/polar/observability/invariants/rules/external_events_unhandled.py
@@ -1,0 +1,35 @@
+import uuid
+from datetime import timedelta
+
+from polar.external_event.repository import ExternalEventRepository
+from polar.kit.utils import utc_now
+
+from .base import Invariant, InvariantError
+
+
+class ExternalEventsUnhandledInvariantError(InvariantError):
+    def __init__(self, count: int, external_events: list[uuid.UUID]) -> None:
+        super().__init__(
+            ExternalEventsUnhandledInvariant,
+            f"Found {count} external events unhandled for more than 5 minutes after creation.",
+            {
+                "count": count,
+                "external_events": {
+                    "ids": external_events,
+                    "has_more": count > len(external_events),
+                },
+            },
+        )
+
+
+class ExternalEventsUnhandledInvariant(Invariant):
+    LEEWAY = timedelta(minutes=5)
+    LIMIT = 10
+
+    async def check(self) -> None:
+        repository = ExternalEventRepository.from_session(self.session)
+        external_events, count = await repository.get_unhandled_ids(
+            utc_now() - self.LEEWAY, limit=self.LIMIT
+        )
+        if count > 0:
+            raise ExternalEventsUnhandledInvariantError(count, external_events)

--- a/server/tests/observability/invariants/rules/test_external_events_unhandled.py
+++ b/server/tests/observability/invariants/rules/test_external_events_unhandled.py
@@ -1,0 +1,74 @@
+from datetime import timedelta
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.kit.utils import utc_now
+from polar.models import ExternalEvent
+from polar.models.external_event import ExternalEventSource
+from polar.observability.invariants.rules.external_events_unhandled import (
+    ExternalEventsUnhandledInvariant,
+    ExternalEventsUnhandledInvariantError,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+@pytest.mark.asyncio
+class TestCheck:
+    @pytest.mark.parametrize("count", [0, 1, 15])
+    async def test_unhandled_events(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        count: int,
+    ) -> None:
+        now = utc_now()
+        mocker.patch(
+            "polar.observability.invariants.rules.external_events_unhandled.utc_now",
+            return_value=now,
+        )
+        for index, (age, handled_at) in enumerate(
+            [
+                (timedelta(minutes=10), now),
+                (timedelta(minutes=5), None),
+                (timedelta(minutes=1), None),
+            ]
+        ):
+            await save_fixture(
+                ExternalEvent(
+                    source=ExternalEventSource.stripe,
+                    task_name="task_name",
+                    external_id=f"ignored_{index}",
+                    data={},
+                    created_at=now - age,
+                    handled_at=handled_at,
+                )
+            )
+
+        events = []
+        for index in range(count):
+            event = ExternalEvent(
+                source=list(ExternalEventSource)[index % len(ExternalEventSource)],
+                task_name="task_name",
+                external_id=f"unhandled_{index}",
+                data={},
+                created_at=now - timedelta(minutes=6 + index),
+            )
+            await save_fixture(event)
+            events.append(event)
+
+        invariant = ExternalEventsUnhandledInvariant(session)
+        if count == 0:
+            await invariant.check()
+        else:
+            with pytest.raises(ExternalEventsUnhandledInvariantError) as exc_info:
+                await invariant.check()
+            assert exc_info.value.context == {
+                "count": count,
+                "external_events": {
+                    "ids": [event.id for event in reversed(events)][:10],
+                    "has_more": count > 10,
+                },
+            }


### PR DESCRIPTION

External Events (mostly Stripe) should be handled quickly after their creation. If not, it's a smell that something is wrong:

- Inconsistent app state
- Unexpected event
- Down or lagging worker

This invariant will help us detect these issues early.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

