### PR TITLE
feat(auth): run Turnstile in invisible mode

### DIFF
--- a/clients/apps/web/src/components/Auth/EmailOTPForm.test.tsx
+++ b/clients/apps/web/src/components/Auth/EmailOTPForm.test.tsx
@@ -106,6 +106,7 @@ describe('EmailOTPForm', () => {
     expect(turnstile.render).toHaveBeenCalledTimes(1)
     expect(turnstile.render.mock.calls[0]?.[1]).toMatchObject({
       action: 'turnstile-spin-v2',
+      appearance: 'interaction-only',
       sitekey: '0x4AAAAAAD7cBrbpX3kX8K9g',
     })
 

--- a/clients/apps/web/src/components/Auth/EmailOTPForm.tsx
+++ b/clients/apps/web/src/components/Auth/EmailOTPForm.tsx
@@ -42,6 +42,7 @@ const EmailOTPForm = ({
   const {
     containerRef: turnstileContainerRef,
     render: renderTurnstile,
+    execute: executeTurnstile,
     getToken: getTurnstileToken,
     reset: resetTurnstile,
   } = useTurnstile(TURNSTILE_ACTION)
@@ -112,7 +113,7 @@ const EmailOTPForm = ({
       />
       <Form {...form}>
         <form
-          className="flex w-full flex-col gap-2"
+          className="flex w-full flex-col"
           onSubmit={handleSubmit(onSubmit)}
         >
           <FormField
@@ -120,7 +121,7 @@ const EmailOTPForm = ({
             name="email"
             render={({ field }) => {
               return (
-                <FormItem>
+                <FormItem className="mb-2">
                   <FormControl>
                     <Input
                       type="email"
@@ -129,6 +130,7 @@ const EmailOTPForm = ({
                       autoComplete="off"
                       data-1p-ignore
                       {...field}
+                      onFocus={executeTurnstile}
                     />
                   </FormControl>
                   <FormMessage />
@@ -136,6 +138,8 @@ const EmailOTPForm = ({
               )
             }}
           />
+          <div ref={turnstileContainerRef} />
+
           <Button
             type="submit"
             variant="secondary"
@@ -145,7 +149,6 @@ const EmailOTPForm = ({
           >
             {signup ? 'Sign up with email' : 'Sign in with email'}
           </Button>
-          <div ref={turnstileContainerRef} />
         </form>
       </Form>
     </>

--- a/clients/apps/web/src/components/Auth/EmailOTPForm.tsx
+++ b/clients/apps/web/src/components/Auth/EmailOTPForm.tsx
@@ -112,7 +112,7 @@ const EmailOTPForm = ({
       />
       <Form {...form}>
         <form
-          className="flex w-full flex-col"
+          className="flex w-full flex-col gap-2"
           onSubmit={handleSubmit(onSubmit)}
         >
           <FormField
@@ -121,33 +121,30 @@ const EmailOTPForm = ({
             render={({ field }) => {
               return (
                 <FormItem>
-                  <FormControl className="w-full">
-                    <div className="flex w-full flex-col gap-2">
-                      <Input
-                        type="email"
-                        required
-                        placeholder="Email"
-                        autoComplete="off"
-                        data-1p-ignore
-                        {...field}
-                      />
-                      <Button
-                        type="submit"
-                        variant="secondary"
-                        fullWidth
-                        loading={loading}
-                        disabled={loading}
-                      >
-                        {signup ? 'Sign up with email' : 'Sign in with email'}
-                      </Button>
-                    </div>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      required
+                      placeholder="Email"
+                      autoComplete="off"
+                      data-1p-ignore
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )
             }}
           />
-          {/* Stays out of the field stack so the hidden widget adds no gap. */}
+          <Button
+            type="submit"
+            variant="secondary"
+            fullWidth
+            loading={loading}
+            disabled={loading}
+          >
+            {signup ? 'Sign up with email' : 'Sign in with email'}
+          </Button>
           <div ref={turnstileContainerRef} />
         </form>
       </Form>

--- a/clients/apps/web/src/components/Auth/EmailOTPForm.tsx
+++ b/clients/apps/web/src/components/Auth/EmailOTPForm.tsx
@@ -2,9 +2,9 @@
 
 import { useAuthSessionStart, useEmailOTPRequest } from '@/hooks'
 import { usePostHog, type EventName } from '@/hooks/posthog'
+import { TURNSTILE_SCRIPT_URL, useTurnstile } from '@/hooks/useTurnstile'
 import { setValidationErrors } from '@/utils/api/errors'
 import { isValidationError, schemas } from '@polar-sh/client'
-import { CONFIG } from '@/utils/config'
 import { Button } from '@polar-sh/orbit'
 import { Input } from '@polar-sh/orbit'
 import {
@@ -16,7 +16,7 @@ import {
 } from '@polar-sh/ui/components/ui/form'
 import { useRouter } from 'next/navigation'
 import Script from 'next/script'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
 interface EmailOTPFormProps {
@@ -25,31 +25,6 @@ interface EmailOTPFormProps {
   signup?: boolean
 }
 
-interface TurnstileWindow extends Window {
-  turnstile?: {
-    remove: (widgetId: string) => void
-    render: (
-      container: HTMLElement,
-      options: {
-        sitekey: string
-        action: string
-        size?: 'normal' | 'flexible' | 'compact'
-      },
-    ) => string
-    reset: (widgetId: string) => void
-  }
-}
-
-// Cloudflare's test sitekey renders a visible, always-passing widget whose
-// dummy token verifies against the paired test secret (server .env.template),
-// so local login works without the production secret or a real challenge.
-// The env override serves deployments on domains outside the production
-// sitekey's allowlist (e.g. *.vercel.app), paired with a matching secret.
-const TURNSTILE_SITE_KEY =
-  process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ||
-  (CONFIG.ENVIRONMENT === 'development'
-    ? '1x00000000000000000000AA'
-    : '0x4AAAAAAD7cBrbpX3kX8K9g')
 const TURNSTILE_ACTION = 'turnstile-spin-v2'
 
 const EmailOTPForm = ({
@@ -64,58 +39,28 @@ const EmailOTPForm = ({
   })
   const { control, handleSubmit, setError } = form
   const [loading, setLoading] = useState(false)
-  const turnstileContainerRef = useRef<HTMLDivElement>(null)
-  const turnstileWidgetIdRef = useRef<string | null>(null)
+  const {
+    containerRef: turnstileContainerRef,
+    render: renderTurnstile,
+    getToken: getTurnstileToken,
+    reset: resetTurnstile,
+  } = useTurnstile(TURNSTILE_ACTION)
   const authSessionStart = useAuthSessionStart()
   const emailOTPRequest = useEmailOTPRequest()
   const posthog = usePostHog()
   const router = useRouter()
 
-  const renderTurnstile = useCallback(() => {
-    const turnstile = (window as TurnstileWindow).turnstile
-    const container = turnstileContainerRef.current
-    if (!turnstile || !container || turnstileWidgetIdRef.current) {
-      return
-    }
-
-    turnstileWidgetIdRef.current = turnstile.render(container, {
-      sitekey: TURNSTILE_SITE_KEY,
-      action: TURNSTILE_ACTION,
-      size: 'flexible',
-    })
-  }, [])
-
-  useEffect(() => {
-    renderTurnstile()
-
-    return () => {
-      const turnstile = (window as TurnstileWindow).turnstile
-      const widgetId = turnstileWidgetIdRef.current
-      if (turnstile && widgetId) {
-        turnstile.remove(widgetId)
-      }
-      turnstileWidgetIdRef.current = null
-    }
-  }, [renderTurnstile])
-
-  const onSubmit: SubmitHandler<{ email: string }> = async (
-    { email },
-    event,
-  ) => {
-    const formElement = event?.target
-    const turnstileToken =
-      formElement instanceof HTMLFormElement
-        ? new FormData(formElement).get('cf-turnstile-response')
-        : null
-    if (typeof turnstileToken !== 'string' || !turnstileToken) {
-      setError('email', {
-        message: 'Please complete the verification challenge.',
-      })
-      return
-    }
-
+  const onSubmit: SubmitHandler<{ email: string }> = async ({ email }) => {
     setLoading(true)
     try {
+      const turnstileToken = await getTurnstileToken()
+      if (!turnstileToken) {
+        setError('email', {
+          message: 'Verification failed. Please try again.',
+        })
+        return
+      }
+
       let eventName: EventName = 'global:user:login:submit'
       if (signup) {
         eventName = 'global:user:signup:submit'
@@ -152,11 +97,7 @@ const EmailOTPForm = ({
         message: 'An unexpected error occurred. Please try again.',
       })
     } finally {
-      const turnstileWindow = window as TurnstileWindow
-      const widgetId = turnstileWidgetIdRef.current
-      if (widgetId) {
-        turnstileWindow.turnstile?.reset(widgetId)
-      }
+      resetTurnstile()
       setLoading(false)
     }
   }
@@ -164,7 +105,7 @@ const EmailOTPForm = ({
   return (
     <>
       <Script
-        src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+        src={TURNSTILE_SCRIPT_URL}
         strategy="afterInteractive"
         onLoad={renderTurnstile}
         onReady={renderTurnstile}
@@ -190,13 +131,6 @@ const EmailOTPForm = ({
                         data-1p-ignore
                         {...field}
                       />
-                      <div
-                        ref={turnstileContainerRef}
-                        className="cf-turnstile"
-                        data-sitekey={TURNSTILE_SITE_KEY}
-                        data-action={TURNSTILE_ACTION}
-                        data-size="flexible"
-                      />
                       <Button
                         type="submit"
                         variant="secondary"
@@ -213,6 +147,8 @@ const EmailOTPForm = ({
               )
             }}
           />
+          {/* Stays out of the field stack so the hidden widget adds no gap. */}
+          <div ref={turnstileContainerRef} />
         </form>
       </Form>
     </>

--- a/clients/apps/web/src/hooks/useTurnstile.ts
+++ b/clients/apps/web/src/hooks/useTurnstile.ts
@@ -7,6 +7,7 @@ interface TurnstileRenderOptions {
   sitekey: string
   action: string
   appearance?: 'always' | 'execute' | 'interaction-only'
+  execution?: 'render' | 'execute'
   size?: 'normal' | 'flexible' | 'compact'
   callback?: (token: string) => void
   'error-callback'?: () => void
@@ -17,6 +18,7 @@ interface TurnstileWindow extends Window {
   turnstile?: {
     remove: (widgetId: string) => void
     render: (container: HTMLElement, options: TurnstileRenderOptions) => string
+    execute: (widgetId: string) => void
     reset: (widgetId: string) => void
   }
 }
@@ -42,6 +44,7 @@ const TOKEN_TIMEOUT_MS = 15000
 export const useTurnstile = (action: string) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const widgetIdRef = useRef<string | null>(null)
+  const executedRef = useRef(false)
   const tokenRef = useRef<string | null>(null)
   const waitersRef = useRef<((token: string | null) => void)[]>([])
 
@@ -65,6 +68,9 @@ export const useTurnstile = (action: string) => {
       sitekey: TURNSTILE_SITE_KEY,
       action,
       appearance: 'interaction-only',
+      // Hold the challenge until execute() is called (on first email focus)
+      // rather than running it eagerly at render.
+      execution: 'execute',
       size: 'flexible',
       callback: settleToken,
       'error-callback': () => settleToken(null),
@@ -86,10 +92,23 @@ export const useTurnstile = (action: string) => {
         turnstile.remove(widgetId)
       }
       widgetIdRef.current = null
+      executedRef.current = false
       tokenRef.current = null
       waitersRef.current = []
     }
   }, [render])
+
+  // Kick off the deferred challenge. Safe to call repeatedly — it runs the
+  // challenge only once per widget lifecycle.
+  const execute = useCallback(() => {
+    const turnstile = (window as TurnstileWindow).turnstile
+    const widgetId = widgetIdRef.current
+    if (!turnstile || !widgetId || executedRef.current) {
+      return
+    }
+    executedRef.current = true
+    turnstile.execute(widgetId)
+  }, [])
 
   const getToken = useCallback(
     () =>
@@ -99,23 +118,28 @@ export const useTurnstile = (action: string) => {
           return
         }
 
+        // Fallback: a submit without a prior focus (e.g. autofill) still needs
+        // the challenge started, or getToken would wait out the timeout.
+        execute()
+
         const timeoutId = setTimeout(() => resolve(null), TOKEN_TIMEOUT_MS)
         waitersRef.current.push((token) => {
           clearTimeout(timeoutId)
           resolve(token)
         })
       }),
-    [],
+    [execute],
   )
 
   const reset = useCallback(() => {
     const turnstile = (window as TurnstileWindow).turnstile
     const widgetId = widgetIdRef.current
     tokenRef.current = null
+    executedRef.current = false
     if (turnstile && widgetId) {
       turnstile.reset(widgetId)
     }
   }, [])
 
-  return { containerRef, render, getToken, reset }
+  return { containerRef, render, execute, getToken, reset }
 }

--- a/clients/apps/web/src/hooks/useTurnstile.ts
+++ b/clients/apps/web/src/hooks/useTurnstile.ts
@@ -1,0 +1,121 @@
+'use client'
+
+import { CONFIG } from '@/utils/config'
+import { useCallback, useEffect, useRef } from 'react'
+
+interface TurnstileRenderOptions {
+  sitekey: string
+  action: string
+  appearance?: 'always' | 'execute' | 'interaction-only'
+  size?: 'normal' | 'flexible' | 'compact'
+  callback?: (token: string) => void
+  'error-callback'?: () => void
+  'expired-callback'?: () => void
+}
+
+interface TurnstileWindow extends Window {
+  turnstile?: {
+    remove: (widgetId: string) => void
+    render: (container: HTMLElement, options: TurnstileRenderOptions) => string
+    reset: (widgetId: string) => void
+  }
+}
+
+export const TURNSTILE_SCRIPT_URL =
+  'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+
+// Cloudflare's invisible test sitekey always passes without showing a widget,
+// and its dummy token verifies against the paired test secret (server
+// .env.template), so local login works without the production secret.
+// The env override serves deployments on domains outside the production
+// sitekey's allowlist (e.g. *.vercel.app), paired with a matching secret.
+const TURNSTILE_SITE_KEY =
+  process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ||
+  (CONFIG.ENVIRONMENT === 'development'
+    ? '1x00000000000000000000BB'
+    : '0x4AAAAAAD7cBrbpX3kX8K9g')
+
+// The challenge runs in the background, so a submit may land before a token
+// exists. Give up rather than leaving the form spinning forever.
+const TOKEN_TIMEOUT_MS = 15000
+
+export const useTurnstile = (action: string) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const widgetIdRef = useRef<string | null>(null)
+  const tokenRef = useRef<string | null>(null)
+  const waitersRef = useRef<((token: string | null) => void)[]>([])
+
+  const settleToken = useCallback((token: string | null) => {
+    tokenRef.current = token
+    const waiters = waitersRef.current
+    waitersRef.current = []
+    for (const waiter of waiters) {
+      waiter(token)
+    }
+  }, [])
+
+  const render = useCallback(() => {
+    const turnstile = (window as TurnstileWindow).turnstile
+    const container = containerRef.current
+    if (!turnstile || !container || widgetIdRef.current) {
+      return
+    }
+
+    widgetIdRef.current = turnstile.render(container, {
+      sitekey: TURNSTILE_SITE_KEY,
+      action,
+      appearance: 'interaction-only',
+      size: 'flexible',
+      callback: settleToken,
+      'error-callback': () => settleToken(null),
+      // Turnstile refreshes expired tokens on its own, so only drop the stale
+      // one and let the next callback settle any pending submit.
+      'expired-callback': () => {
+        tokenRef.current = null
+      },
+    })
+  }, [action, settleToken])
+
+  useEffect(() => {
+    render()
+
+    return () => {
+      const turnstile = (window as TurnstileWindow).turnstile
+      const widgetId = widgetIdRef.current
+      if (turnstile && widgetId) {
+        turnstile.remove(widgetId)
+      }
+      widgetIdRef.current = null
+      tokenRef.current = null
+      waitersRef.current = []
+    }
+  }, [render])
+
+  const getToken = useCallback(
+    () =>
+      new Promise<string | null>((resolve) => {
+        if (tokenRef.current) {
+          resolve(tokenRef.current)
+          return
+        }
+
+        const timeoutId = setTimeout(() => resolve(null), TOKEN_TIMEOUT_MS)
+        waitersRef.current.push((token) => {
+          clearTimeout(timeoutId)
+          resolve(token)
+        })
+      }),
+    [],
+  )
+
+  const reset = useCallback(() => {
+    const turnstile = (window as TurnstileWindow).turnstile
+    const widgetId = widgetIdRef.current
+    tokenRef.current = null
+    if (turnstile && widgetId) {
+      turnstile.reset(widgetId)
+    }
+  }, [])
+
+  return { containerRef, render, getToken, reset }
+}


### PR DESCRIPTION
Render the widget with `appearance: 'interaction-only'` so it stays hidden and solves the challenge in the background, only surfacing when Cloudflare actually needs an interaction.

Because there is no widget to complete, the token now arrives asynchronously via the render callback instead of being read out of the form's hidden input on submit. Submitting waits for that token (with a timeout) rather than failing with a "complete the challenge" message the user has no way to act on.

Turnstile lifecycle moves into a `useTurnstile` hook, and local development switches to Cloudflare's invisible always-passes test sitekey.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

