### PR TITLE
db: drop the seat-based pricing key from organization feature settings

### DIFF
--- a/server/migrations/versions/2026-09-09-0957_drop_seat_based_pricing_feature_flag.py
+++ b/server/migrations/versions/2026-09-09-0957_drop_seat_based_pricing_feature_flag.py
@@ -1,0 +1,42 @@
+"""drop seat based pricing feature flag
+
+Revision ID: f9cabfdff143
+Revises: 226afe0d783a
+Create Date: 2026-09-09 09:57:55.6N
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "f9cabfdff143"
+down_revision = "226afe0d783a"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '30s'")
+    op.execute(
+        """
+        UPDATE organizations
+        SET feature_settings = feature_settings - 'seat_based_pricing_enabled'
+        WHERE feature_settings ? 'seat_based_pricing_enabled'
+        """
+    )
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '30s'")
+    op.execute(
+        """
+        UPDATE organizations
+        SET feature_settings =
+            feature_settings || '{"seat_based_pricing_enabled": true}'::jsonb
+        WHERE NOT feature_settings ? 'seat_based_pricing_enabled'
+        """
+    )


### PR DESCRIPTION
## Summary

Cleanup script ran on sandbox and prod ✔️ 

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

