### PR TITLE
Keep pending subscription updates aligned with the billing period end

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -2243,24 +2243,25 @@ class SubscriptionService:
             product_repository = ProductRepository.from_session(session)
             new_product = await product_repository.get_by_id(pending_update.product_id)
 
+        recurring_interval = subscription.recurring_interval
+        recurring_interval_count = subscription.recurring_interval_count
+        if new_product is not None and is_recurring_product(new_product):
+            recurring_interval = new_product.recurring_interval
+            recurring_interval_count = new_product.recurring_interval_count
+
+        # Same condition as `cycle`, which leaves the period dates entirely to an
+        # update that resets the cycle: such an update has to carry the whole new
+        # period, so recompute it from the new period end.
         if (
-            new_product is not None
-            and is_recurring_product(new_product)
-            and (
-                new_product.recurring_interval != subscription.recurring_interval
-                or new_product.recurring_interval_count
-                != subscription.recurring_interval_count
-            )
+            pending_update.proration_behavior == SubscriptionProrationBehavior.reset
+            or recurring_interval != subscription.recurring_interval
+            or recurring_interval_count != subscription.recurring_interval_count
         ):
-            # The update opens a brand new cycle when it applies: move it along
-            # with the period end.
             pending_update.new_cycle_start = new_period_end
-            pending_update.new_cycle_end = (
-                new_product.recurring_interval.get_next_period(
-                    new_period_end,
-                    new_period_end.day,
-                    new_product.recurring_interval_count,
-                )
+            pending_update.new_cycle_end = recurring_interval.get_next_period(
+                new_period_end,
+                new_period_end.day,
+                recurring_interval_count,
             )
         else:
             # The update keeps the subscription's own cycle: stop pinning it, so

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -2218,6 +2218,61 @@ class SubscriptionService:
             )
             return subscription
 
+    async def _realign_pending_update_cycle(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+    ) -> None:
+        """Re-anchor a pending update on the subscription's current period.
+
+        A pending update is scheduled for the period end that was current when
+        it was created, and snapshots that cycle in `applies_at` and the
+        `new_cycle_*` fields. Once the period end moves, those snapshots are
+        stale and `apply_update` would rewind the subscription to the old cycle
+        the next time it cycles.
+        """
+        pending_update = subscription.pending_update
+        if pending_update is None:
+            return
+
+        new_period_end = subscription.current_period_end
+        pending_update.applies_at = new_period_end
+
+        new_product: Product | None = None
+        if pending_update.product_id is not None:
+            product_repository = ProductRepository.from_session(session)
+            new_product = await product_repository.get_by_id(pending_update.product_id)
+
+        if (
+            new_product is not None
+            and is_recurring_product(new_product)
+            and (
+                new_product.recurring_interval != subscription.recurring_interval
+                or new_product.recurring_interval_count
+                != subscription.recurring_interval_count
+            )
+        ):
+            # The update opens a brand new cycle when it applies: move it along
+            # with the period end.
+            pending_update.new_cycle_start = new_period_end
+            pending_update.new_cycle_end = (
+                new_product.recurring_interval.get_next_period(
+                    new_period_end,
+                    new_period_end.day,
+                    new_product.recurring_interval_count,
+                )
+            )
+        else:
+            # The update keeps the subscription's own cycle: stop pinning it, so
+            # `cycle` derives the next period from the new period end.
+            pending_update.new_cycle_start = None
+            pending_update.new_cycle_end = None
+
+        subscription_update_repository = SubscriptionUpdateRepository.from_session(
+            session
+        )
+        await subscription_update_repository.update(pending_update)
+
     async def update_trial(
         self,
         session: AsyncSession,
@@ -2271,15 +2326,7 @@ class SubscriptionService:
                 subscription.trial_start = utc_now()
                 subscription.trial_end = subscription.current_period_end = trial_end
 
-        # Keep any pending update's cycle end in sync with the new period end,
-        # otherwise apply_update() will clobber current_period_end back to the
-        # stale value when cycle() next runs.
-        if subscription.pending_update is not None:
-            subscription_update_repository = SubscriptionUpdateRepository.from_session(
-                session
-            )
-            subscription.pending_update.new_cycle_end = subscription.current_period_end
-            await subscription_update_repository.update(subscription.pending_update)
+        await self._realign_pending_update_cycle(session, subscription)
 
         repository = SubscriptionRepository.from_session(session)
         subscription = await repository.update(subscription)
@@ -2563,6 +2610,8 @@ class SubscriptionService:
 
         if subscription.cancel_at_period_end:
             subscription.ends_at = new_period_end
+
+        await self._realign_pending_update_cycle(session, subscription)
 
         await event_service.create_event(
             session,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -9903,6 +9903,63 @@ class TestUpdateBillingPeriod:
         assert updated_subscription.current_period_start == new_period_end
         assert updated_subscription.current_period_end == expected_new_cycle_end
 
+    async def test_pending_reset_update_follows_new_period_end(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        product_second: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+        )
+        old_period_end = subscription.current_period_end
+
+        with freeze_time(old_period_end):
+            subscription_update, _ = generate_subscription_update(
+                subscription,
+                SubscriptionProrationBehavior.reset,
+                product=product_second,
+            )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        await save_fixture(subscription)
+
+        assert not subscription_update.is_interval_changed()
+
+        new_period_end = old_period_end + timedelta(days=7)
+        expected_new_cycle_end = SubscriptionRecurringInterval.month.get_next_period(
+            new_period_end, new_period_end.day
+        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_currrent_billing_period_end(
+                session,
+                ctx,
+                subscription,
+                new_period_end=new_period_end,
+            )
+
+        assert subscription_update.new_cycle_start == new_period_end
+        assert subscription_update.new_cycle_end == expected_new_cycle_end
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
+
+        # A reset update carries the whole period: `cycle` doesn't advance the
+        # dates itself, so the update must open a fresh period at the new end.
+        assert updated_subscription.current_period_start == new_period_end
+        assert updated_subscription.current_period_end == expected_new_cycle_end
+
 
 @pytest.mark.asyncio
 class TestCancelCustomer:

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -9786,6 +9786,123 @@ class TestUpdateBillingPeriod:
                     new_period_end=new_period_end,
                 )
 
+    async def test_pending_update_follows_new_period_end(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        product_second: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+        )
+        old_period_end = subscription.current_period_end
+
+        subscription_update, _ = generate_subscription_update(
+            subscription,
+            SubscriptionProrationBehavior.next_period,
+            product=product_second,
+        )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        await save_fixture(subscription)
+
+        assert subscription_update.applies_at == old_period_end
+        assert subscription_update.new_cycle_end == old_period_end
+
+        new_period_end = old_period_end + timedelta(days=7)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_currrent_billing_period_end(
+                session,
+                ctx,
+                subscription,
+                new_period_end=new_period_end,
+            )
+
+        assert subscription_update.applies_at == new_period_end
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
+
+        assert updated_subscription.product == product_second
+        assert updated_subscription.current_period_start == new_period_end
+        assert (
+            updated_subscription.current_period_end
+            == SubscriptionRecurringInterval.month.get_next_period(
+                new_period_end, new_period_end.day
+            )
+        )
+
+    async def test_pending_interval_change_follows_new_period_end(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        yearly_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.year,
+        )
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+        )
+        old_period_end = subscription.current_period_end
+
+        subscription_update, _ = generate_subscription_update(
+            subscription,
+            SubscriptionProrationBehavior.next_period,
+            product=yearly_product,
+        )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        await save_fixture(subscription)
+
+        assert subscription_update.new_cycle_start == old_period_end
+
+        new_period_end = old_period_end + timedelta(days=7)
+        expected_new_cycle_end = SubscriptionRecurringInterval.year.get_next_period(
+            new_period_end, new_period_end.day
+        )
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_currrent_billing_period_end(
+                session,
+                ctx,
+                subscription,
+                new_period_end=new_period_end,
+            )
+
+        assert subscription_update.new_cycle_start == new_period_end
+        assert subscription_update.new_cycle_end == expected_new_cycle_end
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
+
+        assert updated_subscription.product == yearly_product
+        assert updated_subscription.current_period_start == new_period_end
+        assert updated_subscription.current_period_end == expected_new_cycle_end
+
 
 @pytest.mark.asyncio
 class TestCancelCustomer:


### PR DESCRIPTION
We calculate `applies_at` and `new_cycle_start|end` on a pending update, but we still allow updating `current_billing_period_end` on subscriptions with a pending update, which makes them go out of sync.

We already handled this on trial extensions, this PR attempts to marry the two.