### PR TITLE
server/integrations/resend: handle invalid email errors

### DIFF
--- a/server/polar/integrations/resend/client.py
+++ b/server/polar/integrations/resend/client.py
@@ -4,6 +4,23 @@ from urllib.parse import quote
 import httpx
 
 from polar.config import settings
+from polar.exceptions import PolarError
+
+
+class ResendClientError(PolarError):
+    pass
+
+
+class ContactDoesNotExist(ResendClientError):
+    def __init__(self, identifier: str) -> None:
+        self.identifier = identifier
+        super().__init__(f"Contact does not exist: {identifier}")
+
+
+class InvalidIdentifier(ResendClientError):
+    def __init__(self, identifier: str) -> None:
+        self.identifier = identifier
+        super().__init__(f"Invalid identifier: {identifier}")
 
 
 class ResendClient:
@@ -13,10 +30,14 @@ class ResendClient:
             headers={"Authorization": f"Bearer {settings.RESEND_API_KEY}"},
         )
 
-    async def get_contact(self, id_or_email: str) -> dict[str, Any] | None:
-        response = await self.client.get(f"/contacts/{quote(id_or_email, safe='')}")
+    async def get_contact(self, identifier: str) -> dict[str, Any]:
+        response = await self.client.get(f"/contacts/{quote(identifier, safe='')}")
+
         if response.status_code == 404:
-            return None
+            raise ContactDoesNotExist(identifier)
+        elif response.status_code == 422:
+            raise InvalidIdentifier(identifier)
+
         response.raise_for_status()
         return response.json()
 

--- a/server/polar/integrations/resend/service.py
+++ b/server/polar/integrations/resend/service.py
@@ -1,3 +1,4 @@
+import typing
 from uuid import UUID
 
 from polar.config import settings
@@ -7,7 +8,7 @@ from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
 from polar.worker import enqueue_job
 
-from .client import client
+from .client import ContactDoesNotExist, InvalidIdentifier, client
 
 
 class ResendServiceError(PolarError): ...
@@ -48,37 +49,49 @@ class ResendService:
         if user.is_deleted:
             contact_ids: set[str] = set()
             for identifier in (user.resend_id, previous_email or user.email):
-                if identifier is not None:
+                if identifier is None:
+                    continue
+                try:
                     contact = await client.get_contact(identifier)
-                    if contact is not None:
-                        contact_ids.add(contact["id"])
+                except ContactDoesNotExist, InvalidIdentifier:
+                    continue
+                contact_ids.add(contact["id"])
             for contact_id in contact_ids:
                 await client.delete_contact(contact_id)
             return await repository.update(user, update_dict={"resend_id": None})
 
-        contact_identifier = previous_email or user.resend_id or user.email
-        contact = await client.get_contact(contact_identifier)
-        previous_contact = contact
-        if contact is None or contact["email"].lower() != user.email.lower():
-            if contact_identifier.lower() != user.email.lower():
-                contact = await client.get_contact(user.email)
-            if contact is None:
-                contact = await client.create_contact(
-                    user.email,
-                    unsubscribed=bool(
-                        previous_contact and previous_contact["unsubscribed"]
-                    ),
-                )
+        previous_contact: dict[str, typing.Any] | None = None
+        previous_identifier = previous_email or user.resend_id
+        if previous_identifier is not None:
+            try:
+                previous_contact = await client.get_contact(previous_identifier)
+            except ContactDoesNotExist, InvalidIdentifier:
+                pass
 
         if (
             previous_contact is not None
-            and previous_contact.get("unsubscribed")
-            and contact.get("unsubscribed") is False
+            and previous_contact["email"].lower() == user.email.lower()
         ):
-            await client.update_contact(contact["id"], unsubscribed=True)
+            contact = previous_contact
+        else:
+            unsubscribed = (
+                previous_contact["unsubscribed"] if previous_contact else False
+            )
+            try:
+                contact = await client.get_contact(user.email)
+            except ContactDoesNotExist:
+                contact = await client.create_contact(
+                    user.email, unsubscribed=unsubscribed
+                )
+            except InvalidIdentifier:
+                return user
+            else:
+                if unsubscribed != contact["unsubscribed"]:
+                    await client.update_contact(
+                        contact["id"], unsubscribed=unsubscribed
+                    )
 
         await client.add_contact_to_segment(contact["id"], segment_id)
-        # Resend contact emails are immutable; replace the contact on email changes.
         if previous_contact is not None and previous_contact["id"] != contact["id"]:
             await client.delete_contact(previous_contact["id"])
         return await repository.update(user, update_dict={"resend_id": contact["id"]})

--- a/server/tests/integrations/resend/test_service.py
+++ b/server/tests/integrations/resend/test_service.py
@@ -1,6 +1,7 @@
 import json
 from uuid import uuid4
 
+import httpx
 import pytest
 import respx
 from pytest_mock import MockerFixture
@@ -38,7 +39,7 @@ class TestSyncUser:
         existing: bool,
     ) -> None:
         mocker.patch.object(settings, "RESEND_ACTIVE_USERS_SEGMENT_ID", "active-users")
-        contact = {"id": "contact-id", "email": user.email, "unsubscribed": True}
+        contact = {"id": "contact-id", "email": user.email, "unsubscribed": False}
         lookup = respx_mock.get(path=f"/contacts/{user.email}").respond(
             200 if existing else 404, json=contact if existing else None
         )
@@ -60,6 +61,31 @@ class TestSyncUser:
                 "email": user.email,
                 "unsubscribed": False,
             }
+
+    @pytest.mark.parametrize("email", ["user@example.com", "USER@example.com"])
+    async def test_reuses_linked_contact(
+        self,
+        session: AsyncSession,
+        user: User,
+        mocker: MockerFixture,
+        respx_mock: respx.MockRouter,
+        email: str,
+    ) -> None:
+        mocker.patch.object(settings, "RESEND_ACTIVE_USERS_SEGMENT_ID", "active-users")
+        user.email = "user@example.com"
+        user.resend_id = "contact-id"
+        respx_mock.get(path="/contacts/contact-id").respond(
+            200, json={"id": "contact-id", "email": email, "unsubscribed": True}
+        )
+        segment = respx_mock.post(
+            path="/contacts/contact-id/segments/active-users"
+        ).respond(200)
+
+        user = await resend_service.sync_user(session, user.id)
+
+        assert user.resend_id == "contact-id"
+        assert segment.called
+        assert len(respx_mock.calls) == 2
 
     @pytest.mark.parametrize("linked", [False, True])
     async def test_email_change(
@@ -95,6 +121,41 @@ class TestSyncUser:
             "unsubscribed": True,
         }
         assert delete.called
+
+    @pytest.mark.parametrize("failure_stage", ["create", "segment"])
+    async def test_email_change_preserves_old_contact_on_failure(
+        self,
+        session: AsyncSession,
+        user: User,
+        mocker: MockerFixture,
+        respx_mock: respx.MockRouter,
+        failure_stage: str,
+    ) -> None:
+        mocker.patch.object(settings, "RESEND_ACTIVE_USERS_SEGMENT_ID", "active-users")
+        delete = mocker.patch("polar.integrations.resend.service.client.delete_contact")
+        previous_email = user.email
+        user.email = "new@example.com"
+        user.resend_id = "old-contact"
+        respx_mock.get(path=f"/contacts/{previous_email}").respond(
+            200,
+            json={"id": "old-contact", "email": previous_email, "unsubscribed": True},
+        )
+        respx_mock.get(path="/contacts/new@example.com").respond(404)
+        respx_mock.post(path="/contacts").respond(
+            500 if failure_stage == "create" else 200, json={"id": "new-contact"}
+        )
+        if failure_stage == "segment":
+            respx_mock.post(path="/contacts/new-contact/segments/active-users").respond(
+                500
+            )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await resend_service.sync_user(
+                session, user.id, previous_email=previous_email
+            )
+
+        delete.assert_not_awaited()
+        assert user.resend_id == "old-contact"
 
     @pytest.mark.parametrize("linked", [False, True])
     async def test_deleted_user(


### PR DESCRIPTION

Resend is a bit more strict than us about email addresses. We now handle this more gracefully.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

