### PR TITLE
subscriptions: accept ISO 8601 durations for `current_billing_period_end`

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -36734,13 +36734,13 @@ export interface components {
     SubscriptionUpdateBillingPeriod: {
       /**
        * Current Billing Period End
-       * Format: date-time
        * @description Set a new date for the end of the current billing period. The subscription will renew on this date. The new date can be earlier or later than the current period end, as long as it's in the future.
+       *
+       *     Alternatively, you can pass an ISO 8601 duration, like `P1M` or `P14D`, to extend the current billing period by that duration. Months and years are calendar-aware: `P1M` moves the renewal to the same day of the next month.
        *
        *     If the subscription is set to cancel at the end of the period, it'll end on this new date instead.
        *
        *     It is not possible to update the current billing period on a subscription that's already revoked or not active.
-       * @example 2026-01-01T00:00:00.000000Z
        */
       current_billing_period_end: string
     }

--- a/docs/features/subscriptions/manage.mdx
+++ b/docs/features/subscriptions/manage.mdx
@@ -99,6 +99,16 @@ curl --request PATCH \
   --data '{ "current_billing_period_end": "2026-07-15T00:00:00Z" }'
 ```
 
+Instead of a date, you can pass an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) to extend the current period by that much, without computing the new date yourself. Months and years are calendar-aware: `P1M` on a period ending January 31st moves the renewal to February 28th.
+
+```bash cURL
+curl --request PATCH \
+  --url https://api.polar.sh/v1/subscriptions/{subscription_id} \
+  --header 'Authorization: Bearer <TOKEN>' \
+  --header 'Content-Type: application/json' \
+  --data '{ "current_billing_period_end": "P1M" }'
+```
+
 ## Pause and resume
 
 Pausing stops billing without ending the subscription. Use it for seasonal plans or account "freezes", where a customer steps away for a while and comes back to the same subscription and payment method.

--- a/server/polar/kit/schemas.py
+++ b/server/polar/kit/schemas.py
@@ -1,9 +1,11 @@
 import dataclasses
+import re
 from collections.abc import Collection, Mapping, Sequence
 from datetime import datetime
 from typing import Annotated, Any, Literal, cast, get_args, overload
 
 from annotated_types import Ge, Le
+from dateutil.relativedelta import relativedelta
 from pydantic import (
     UUID4,
     AfterValidator,
@@ -13,6 +15,7 @@ from pydantic import (
     Field,
     GetCoreSchemaHandler,
     GetJsonSchemaHandler,
+    GetPydanticSchema,
     HttpUrl,
     PlainSerializer,
     UrlConstraints,
@@ -170,6 +173,84 @@ class MergeJSONSchema:
 
     def __hash__(self) -> int:
         return hash(type(self.mode))
+
+
+_ISO8601_DURATION_JSON_SCHEMA_PATTERN = (
+    r"^P(?:\d+Y)?(?:\d+M)?(?:\d+W)?(?:\d+D)?(?:T(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$"
+)
+_ISO8601_DURATION_PATTERN = re.compile(
+    r"^P(?!$)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?"
+    r"(?:T(?!$)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$"
+)
+
+
+def parse_iso8601_duration(value: str) -> relativedelta:
+    """
+    Parse an ISO 8601 duration, e.g. `P1M`, into a calendar-aware `relativedelta`.
+
+    Unlike a `timedelta`, it keeps months and years as such: adding `P1M` to a date
+    lands on the same day of the next month, matching how billing periods are computed.
+    """
+    match = _ISO8601_DURATION_PATTERN.match(value)
+    if match is None:
+        raise ValueError(
+            "Input should be a valid ISO 8601 duration, like `P1M` or `P14D`"
+        )
+
+    years, months, weeks, days, hours, minutes, seconds = (
+        int(group) if group else 0 for group in match.groups()
+    )
+    duration = relativedelta(
+        years=years,
+        months=months,
+        weeks=weeks,
+        days=days,
+        hours=hours,
+        minutes=minutes,
+        seconds=seconds,
+    )
+
+    if not duration:
+        raise ValueError("Input should be a duration greater than zero")
+
+    return duration
+
+
+def format_iso8601_duration(duration: relativedelta) -> str:
+    date_designators = (
+        (duration.years, "Y"),
+        (duration.months, "M"),
+        (duration.days, "D"),
+    )
+    time_designators = (
+        (duration.hours, "H"),
+        (duration.minutes, "M"),
+        (duration.seconds, "S"),
+    )
+    date_part = "".join(
+        f"{value}{designator}" for value, designator in date_designators if value
+    )
+    time_part = "".join(
+        f"{value}{designator}" for value, designator in time_designators if value
+    )
+    return f"P{date_part}" + (f"T{time_part}" if time_part else "")
+
+
+ISO8601Duration = Annotated[
+    relativedelta,
+    GetPydanticSchema(
+        lambda source_type, handler: core_schema.no_info_after_validator_function(
+            parse_iso8601_duration, core_schema.str_schema()
+        )
+    ),
+    PlainSerializer(format_iso8601_duration, return_type=str),
+    MergeJSONSchema(
+        {
+            "pattern": _ISO8601_DURATION_JSON_SCHEMA_PATTERN,
+            "examples": ["P1M", "P14D"],
+        }
+    ),
+]
 
 
 @dataclasses.dataclass(slots=True)

--- a/server/polar/kit/schemas.py
+++ b/server/polar/kit/schemas.py
@@ -175,13 +175,22 @@ class MergeJSONSchema:
         return hash(type(self.mode))
 
 
-_ISO8601_DURATION_JSON_SCHEMA_PATTERN = (
-    r"^P(?:\d+Y)?(?:\d+M)?(?:\d+W)?(?:\d+D)?(?:T(?:\d+H)?(?:\d+M)?(?:\d+S)?)?$"
+# Each branch starts with the highest designator it carries, so that at least one
+# component is required: `P`, `PT` and `P1MT` are not durations.
+_ISO8601_DURATION_DATE = (
+    r"\d+Y(?:\d+M)?(?:\d+W)?(?:\d+D)?|\d+M(?:\d+W)?(?:\d+D)?|\d+W(?:\d+D)?|\d+D"
 )
-_ISO8601_DURATION_PATTERN = re.compile(
-    r"^P(?!$)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?"
-    r"(?:T(?!$)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$"
+_ISO8601_DURATION_TIME = r"\d+H(?:\d+M)?(?:\d+S)?|\d+M(?:\d+S)?|\d+S"
+# Published in the OpenAPI schema, so it must stay the single source of truth for
+# what the parser below accepts.
+ISO8601_DURATION_PATTERN = (
+    rf"^P(?:(?:{_ISO8601_DURATION_DATE})(?:T(?:{_ISO8601_DURATION_TIME}))?"
+    rf"|T(?:{_ISO8601_DURATION_TIME}))$"
 )
+_ISO8601_DURATION_RE = re.compile(ISO8601_DURATION_PATTERN)
+_ISO8601_DURATION_COMPONENT_RE = re.compile(r"(\d+)([A-Z])")
+_ISO8601_DURATION_DATE_UNITS = {"Y": "years", "M": "months", "W": "weeks", "D": "days"}
+_ISO8601_DURATION_TIME_UNITS = {"H": "hours", "M": "minutes", "S": "seconds"}
 
 
 def parse_iso8601_duration(value: str) -> relativedelta:
@@ -191,24 +200,20 @@ def parse_iso8601_duration(value: str) -> relativedelta:
     Unlike a `timedelta`, it keeps months and years as such: adding `P1M` to a date
     lands on the same day of the next month, matching how billing periods are computed.
     """
-    match = _ISO8601_DURATION_PATTERN.match(value)
-    if match is None:
+    if _ISO8601_DURATION_RE.fullmatch(value) is None:
         raise ValueError(
             "Input should be a valid ISO 8601 duration, like `P1M` or `P14D`"
         )
 
-    years, months, weeks, days, hours, minutes, seconds = (
-        int(group) if group else 0 for group in match.groups()
-    )
-    duration = relativedelta(
-        years=years,
-        months=months,
-        weeks=weeks,
-        days=days,
-        hours=hours,
-        minutes=minutes,
-        seconds=seconds,
-    )
+    date_part, _, time_part = value.partition("T")
+    components = {
+        _ISO8601_DURATION_DATE_UNITS[designator]: int(amount)
+        for amount, designator in _ISO8601_DURATION_COMPONENT_RE.findall(date_part)
+    } | {
+        _ISO8601_DURATION_TIME_UNITS[designator]: int(amount)
+        for amount, designator in _ISO8601_DURATION_COMPONENT_RE.findall(time_part)
+    }
+    duration = relativedelta(**components)
 
     if not duration:
         raise ValueError("Input should be a duration greater than zero")
@@ -244,12 +249,7 @@ ISO8601Duration = Annotated[
         )
     ),
     PlainSerializer(format_iso8601_duration, return_type=str),
-    MergeJSONSchema(
-        {
-            "pattern": _ISO8601_DURATION_JSON_SCHEMA_PATTERN,
-            "examples": ["P1M", "P14D"],
-        }
-    ),
+    MergeJSONSchema({"pattern": ISO8601_DURATION_PATTERN, "examples": ["P1M", "P14D"]}),
 ]
 
 

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -25,6 +25,7 @@ from polar.kit.schemas import (
     PRODUCT_ID_EXAMPLE,
     IDSchema,
     Int32,
+    ISO8601Duration,
     MergeJSONSchema,
     Schema,
     SetSchemaReference,
@@ -401,10 +402,12 @@ class SubscriptionUpdateUnits(Schema):
 class SubscriptionUpdateBillingPeriod(Schema):
     model_config = ConfigDict(extra="forbid")
 
-    current_billing_period_end: FutureDatetime = Field(
+    current_billing_period_end: FutureDatetime | ISO8601Duration = Field(
         description=inspect.cleandoc(
             """
             Set a new date for the end of the current billing period. The subscription will renew on this date. The new date can be earlier or later than the current period end, as long as it's in the future.
+
+            Alternatively, you can pass an ISO 8601 duration, like `P1M` or `P14D`, to extend the current billing period by that duration. Months and years are calendar-aware: `P1M` moves the renewal to the same day of the next month.
 
             If the subscription is set to cancel at the end of the period, it'll end on this new date instead.
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -65,6 +65,7 @@ from polar.invoice.generator import format_date
 from polar.kit.db.postgres import AsyncReadSession, AsyncSession
 from polar.kit.metadata import MetadataQuery, apply_metadata_clause
 from polar.kit.pagination import PaginationParams
+from polar.kit.schemas import format_iso8601_duration
 from polar.kit.sorting import Sorting
 from polar.kit.utils import utc_now
 from polar.kit.visibility import Visibility
@@ -2561,7 +2562,20 @@ class SubscriptionService:
 
         # A duration extends the current period, so it's relative to its end
         if isinstance(new_period_end, relativedelta):
-            new_period_end = old_period_end + new_period_end
+            duration = format_iso8601_duration(new_period_end)
+            try:
+                new_period_end = old_period_end + new_period_end
+            except (OverflowError, ValueError) as e:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "value_error",
+                            "loc": ("body", "current_billing_period_end"),
+                            "msg": "The resulting billing period end is out of range.",
+                            "input": duration,
+                        }
+                    ]
+                ) from e
             if new_period_end <= utc_now():
                 raise PolarRequestValidationError(
                     [
@@ -2569,7 +2583,7 @@ class SubscriptionService:
                             "type": "value_error",
                             "loc": ("body", "current_billing_period_end"),
                             "msg": "The resulting billing period end must be in the future.",
-                            "input": new_period_end,
+                            "input": duration,
                         }
                     ]
                 )

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, Self, Unpack, cast, overload
 from urllib.parse import urlencode
 
 import structlog
+from dateutil.relativedelta import relativedelta
 from sqlalchemy import select
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
@@ -2548,7 +2549,7 @@ class SubscriptionService:
         ctx: SubscriptionUpdateContext,
         subscription: Subscription,
         *,
-        new_period_end: datetime,
+        new_period_end: datetime | relativedelta,
     ) -> Subscription:
         if subscription.revoked:
             raise AlreadyCanceledSubscription(subscription)
@@ -2557,6 +2558,21 @@ class SubscriptionService:
             raise InactiveSubscription(subscription)
 
         old_period_end = subscription.current_period_end
+
+        # A duration extends the current period, so it's relative to its end
+        if isinstance(new_period_end, relativedelta):
+            new_period_end = old_period_end + new_period_end
+            if new_period_end <= utc_now():
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "value_error",
+                            "loc": ("body", "current_billing_period_end"),
+                            "msg": "The resulting billing period end must be in the future.",
+                            "input": new_period_end,
+                        }
+                    ]
+                )
 
         subscription.current_period_end = new_period_end
         subscription.anchor_day = new_period_end.day

--- a/server/tests/kit/test_schemas.py
+++ b/server/tests/kit/test_schemas.py
@@ -132,7 +132,9 @@ def test_parse_iso8601_duration(value: str, expected: relativedelta) -> None:
     assert parse_iso8601_duration(format_iso8601_duration(duration)) == expected
 
 
-@pytest.mark.parametrize("value", ["", "P", "PT", "1 month", "-P1M", "p1m", "P0D"])
+@pytest.mark.parametrize(
+    "value", ["", "P", "PT", "P1MT", "P1D1Y", "1 month", "-P1M", "p1m", "P0D"]
+)
 def test_parse_iso8601_duration_invalid(value: str) -> None:
     with pytest.raises(ValueError, match="Input should be"):
         parse_iso8601_duration(value)

--- a/server/tests/kit/test_schemas.py
+++ b/server/tests/kit/test_schemas.py
@@ -2,10 +2,16 @@ from datetime import datetime
 from typing import Any
 
 import pytest
+from dateutil.relativedelta import relativedelta
 from pydantic import Field, ValidationError
 from pydantic.json_schema import JsonSchemaMode
 
-from polar.kit.schemas import Schema, TimestampedSchema
+from polar.kit.schemas import (
+    Schema,
+    TimestampedSchema,
+    format_iso8601_duration,
+    parse_iso8601_duration,
+)
 
 
 class StringSchema(Schema):
@@ -107,3 +113,26 @@ def test_rejects_nul_character_in_circular_collection() -> None:
 
     with pytest.raises(ValidationError, match="This value contains invalid characters"):
         AnySchema(value=circular_dict)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("P1M", relativedelta(months=1)),
+        ("P14D", relativedelta(days=14)),
+        ("P1W", relativedelta(weeks=1)),
+        ("P1Y2M10D", relativedelta(years=1, months=2, days=10)),
+        ("PT12H", relativedelta(hours=12)),
+    ],
+)
+def test_parse_iso8601_duration(value: str, expected: relativedelta) -> None:
+    duration = parse_iso8601_duration(value)
+
+    assert duration == expected
+    assert parse_iso8601_duration(format_iso8601_duration(duration)) == expected
+
+
+@pytest.mark.parametrize("value", ["", "P", "PT", "1 month", "-P1M", "p1m", "P0D"])
+def test_parse_iso8601_duration_invalid(value: str) -> None:
+    with pytest.raises(ValueError, match="Input should be"):
+        parse_iso8601_duration(value)

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -1559,6 +1559,55 @@ class TestSubscriptionUpdateBillingPeriod:
         assert response.status_code == 403
         assert response.json()["error"] == "InactiveSubscription"
 
+    @pytest.mark.auth
+    async def test_iso8601_duration(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            started_at=datetime(2023, 1, 1, tzinfo=UTC),
+            current_period_end=datetime(2030, 1, 31, tzinfo=UTC),
+        )
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"current_billing_period_end": "P1M"},
+        )
+
+        assert response.status_code == 200
+        updated_subscription = response.json()
+        assert datetime.fromisoformat(
+            updated_subscription["current_period_end"]
+        ) == datetime(2030, 2, 28, tzinfo=UTC)
+
+    @pytest.mark.auth
+    async def test_invalid_iso8601_duration(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"current_billing_period_end": "1 month"},
+        )
+
+        assert response.status_code == 422
+
 
 EXPORT_DEFAULT_HEADER = (
     "Email,Started At,Product,Amount,Currency,Status,Billing Interval"

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -1608,6 +1608,26 @@ class TestSubscriptionUpdateBillingPeriod:
 
         assert response.status_code == 422
 
+    @pytest.mark.auth
+    async def test_out_of_range_iso8601_duration(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"current_billing_period_end": "P10000Y"},
+        )
+
+        assert response.status_code == 422
+
 
 EXPORT_DEFAULT_HEADER = (
     "Email,Started At,Product,Amount,Currency,Status,Billing Interval"

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -9,6 +9,7 @@ import freezegun
 import pytest
 import pytest_asyncio
 import stripe as stripe_lib
+from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 from pytest_mock import MockerFixture
 from sqlalchemy.util.typing import TypeAlias
@@ -9725,6 +9726,61 @@ class TestUpdateBillingPeriod:
         assert event.user_metadata["billing_period_end"] == new_period_end.isoformat()
         assert event.customer_id == customer.id
         assert event.organization_id == customer.organization_id
+
+    async def test_duration_extends_current_period_end(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            current_period_end=datetime(2030, 1, 31, tzinfo=UTC),
+        )
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = (
+                await subscription_service.update_currrent_billing_period_end(
+                    session,
+                    ctx,
+                    subscription,
+                    new_period_end=relativedelta(months=1),
+                )
+            )
+
+        assert updated_subscription.current_period_end == datetime(
+            2030, 2, 28, tzinfo=UTC
+        )
+
+    async def test_duration_resulting_in_past_period_end_raises(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            current_period_end=utc_now() - timedelta(days=10),
+        )
+
+        with pytest.raises(PolarRequestValidationError):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_currrent_billing_period_end(
+                    session,
+                    ctx,
+                    subscription,
+                    new_period_end=relativedelta(days=1),
+                )
 
     async def test_cancel_at_period_end_moves_ends_at(
         self,


### PR DESCRIPTION
Had a back and forth with a merchant about this.

Rescheduling a renewal required computing the new date client-side, which makes you deal with calendars and subscription anchor days. It was also error-prone in the off-chance that the subscription state drifts from the local state and we don't have a way to ensure that (e.g. a `ETag` + `If-Match` combination to ensure Polar state matches what you based the `PATCH` on)

You can now pass a duration, e.g. `P1M`, to extend the current billing period by that much, relative to the current period end. Durations are parsed into a `relativedelta` rather than a `timedelta`, so months and years stay calendar-aware: `P1M` moves the renewal to the same day of the next month instead of adding 30 days.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

