### PR TITLE
fix(tax): validate NZ GST via stdnum.nz.ird

### DIFF
--- a/server/polar/tax/tax_id.py
+++ b/server/polar/tax/tax_id.py
@@ -12,6 +12,7 @@ import stdnum.exceptions
 import stdnum.il.idnr
 import stdnum.in_.gstin
 import stdnum.mk.edb
+import stdnum.nz.ird
 import stdnum.tr.vkn
 import stdnum.tw.ubn
 import stdnum.uy.rut
@@ -426,6 +427,17 @@ class MKVATValidator(ValidatorProtocol):
             raise InvalidTaxID(number, country) from e
 
 
+# NZ GST numbers are IRD numbers. stdnum registers the module under the "vat"
+# alias only, so the generic StdNumValidator lookup on ("nz", "gst") finds nothing.
+class NZGSTValidator(ValidatorProtocol):
+    def validate(self, number: str, country: str) -> str:
+        number = stdnum.nz.ird.compact(number)
+        try:
+            return stdnum.nz.ird.validate(number)
+        except stdnum.exceptions.ValidationError as e:
+            raise InvalidTaxID(number, country) from e
+
+
 class GEVATValidator(ValidatorProtocol):
     def validate(self, number: str, country: str) -> str:
         number = number.replace(" ", "").replace("-", "").replace(".", "").strip()
@@ -481,6 +493,8 @@ def _get_validator(tax_id_type: TaxIDFormat) -> ValidatorProtocol:
             return ILVATValidator()
         case TaxIDFormat.mk_vat:
             return MKVATValidator()
+        case TaxIDFormat.nz_gst:
+            return NZGSTValidator()
         case TaxIDFormat.tr_tin:
             return TRTINValidator()
         case TaxIDFormat.tw_vat:

--- a/server/tests/tax/test_tax_id.py
+++ b/server/tests/tax/test_tax_id.py
@@ -88,6 +88,10 @@ from polar.tax.tax_id import InvalidTaxID, TaxID, TaxIDFormat, validate_tax_id
         ("98765432", "HK", ("98765432", TaxIDFormat.hk_br)),
         ("1234567-8", "HK", ("12345678", TaxIDFormat.hk_br)),
         ("1234567(8)", "HK", ("12345678", TaxIDFormat.hk_br)),
+        # NZ GST: IRD number, 8 or 9 digits
+        ("49098576", "NZ", ("49098576", TaxIDFormat.nz_gst)),
+        ("49-098-576", "NZ", ("49098576", TaxIDFormat.nz_gst)),
+        ("136410132", "NZ", ("136410132", TaxIDFormat.nz_gst)),
     ],
 )
 def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> None:
@@ -126,6 +130,8 @@ def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> No
         ("1-1000-0001", "CR"),  # cédula física (individual), not accepted
         ("210303670014", "UY"),  # Wrong check digit
         ("1234567", "HK"),  # Too short (7 digits)
+        ("49098577", "NZ"),  # Wrong check digit
+        ("1234567", "NZ"),  # Too short (7 digits)
     ],
 )
 def test_validate_tax_id_invalid(number: str, country: str) -> None:


### PR DESCRIPTION
## Summary

**Related Issue**: #14263

Closes #14263

New Zealand tax IDs are always rejected, including valid IRD numbers. This adds a dedicated validator so `nz_gst` resolves to the right stdnum module.

## What

- Add `NZGSTValidator` in `server/polar/tax/tax_id.py`, wrapping `stdnum.nz.ird`.
- Dispatch `TaxIDFormat.nz_gst` to it in `_get_validator`.
- Add NZ cases to the existing valid/invalid parametrised tests.

## Why

`nz_gst` had no dedicated validator, so it fell through to `StdNumValidator`, which derives the stdnum module from the format name by splitting on the first underscore — `("nz", "gst")`:

```python
get_cc_module("nz", "gst")  # -> None
get_cc_module("nz", "vat")  # -> <module 'stdnum.nz.ird'>
```

stdnum registers New Zealand's IRD module under the `vat` alias only, so the `gst` lookup always returns `None` and `StdNumValidator.__init__` raises `UnsupportedTaxIDFormat`. `validate_tax_id` swallows that and continues to the next format, but `COUNTRY_TAX_ID_MAP["NZ"]` contains only `nz_gst`, so every NZ number falls through to `InvalidTaxID`.

Confirmed with stdnum's own known-valid test number:

```
before:  validate_tax_id("49098576", "NZ")  -> InvalidTaxID
after:   validate_tax_id("49098576", "NZ")  -> ("49098576", nz_gst)
```

This is the same shape of bug as #12628 (`cr_tin` resolving to a nonexistent `stdnum.cr.tin`).

## How

Rather than teaching `StdNumValidator` to map `gst` → `vat`, this adds a dedicated validator that imports `stdnum.nz.ird` directly — consistent with how every other special-cased format in the module is handled (`cr_tin`, `mk_vat`, `uy_ruc`, …), and it keeps the alias quirk from becoming a general indirection.

`stdnum.nz.ird` already compacts separators and accepts both 8- and 9-digit IRD numbers, so `49-098-576` normalises to `49098576`.

Note that Norway works today for the opposite reason: `no_vat` splits to `("no", "vat")`, and stdnum does register `stdnum.no.mva` under `vat`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

Verified locally: `tests/tax/test_tax_id.py` — 87 passed (5 new NZ cases); `uv run task lint` and `uv run task lint_types` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sN5JGvXiJVNkLvGQSMQiE

---
_Generated by [Claude Code](https://claude.ai/code/session_015sN5JGvXiJVNkLvGQSMQiE)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

