### PR TITLE
fix(payout): one payout account per organization

### DIFF
--- a/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
@@ -45,7 +45,7 @@ export const PayoutAccountSection = ({
     initialOrg,
   )
   const returnPath = payoutOnboardingReturnPath(organization.slug)
-  const { payoutAccount, openManage, openPrimary, modals } =
+  const { payoutAccount, openCreate, openManage, modals } =
     usePayoutAccountSetup(organization, returnPath)
 
   const [resumeLoading, setResumeLoading] = useState(false)
@@ -155,7 +155,7 @@ export const PayoutAccountSection = ({
         title={presentation.title}
         description={presentation.description}
         action={
-          <Button onClick={openPrimary}>
+          <Button onClick={openCreate}>
             Connect payout account
             <ArrowRight className="ml-2 h-4 w-4" />
           </Button>

--- a/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
+++ b/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
@@ -34,7 +34,7 @@ export default function PayoutAccountStep({
   organization,
 }: PayoutAccountStepProps) {
   const returnPath = payoutOnboardingReturnPath(organization.slug)
-  const { payoutAccount, openPrimary, modals } = usePayoutAccountSetup(
+  const { payoutAccount, openCreate, modals } = usePayoutAccountSetup(
     organization,
     returnPath,
   )
@@ -43,7 +43,7 @@ export default function PayoutAccountStep({
 
   const handleStartAccountSetup = useCallback(async () => {
     if (!payoutAccount) {
-      openPrimary()
+      openCreate()
       return
     }
     const link = await unwrap(
@@ -60,7 +60,7 @@ export default function PayoutAccountStep({
       }),
     )
     window.location.href = link.url
-  }, [payoutAccount, organization.slug, openPrimary])
+  }, [payoutAccount, organization.slug, openCreate])
 
   const handleOpenStripeDashboard = useCallback(async () => {
     if (!payoutAccount) return

--- a/clients/apps/web/src/components/Payouts/AccountBalance.tsx
+++ b/clients/apps/web/src/components/Payouts/AccountBalance.tsx
@@ -31,7 +31,6 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
 
   const {
     payoutAccount,
-    hasReusableAccounts,
     openCreate,
     openManage,
     modals: payoutAccountModals,
@@ -119,7 +118,7 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
           <Text variant="heading-xxs" as="h2">
             Payout Account
           </Text>
-          {payoutAccount || hasReusableAccounts ? (
+          {payoutAccount ? (
             <Button
               className="self-start"
               variant="secondary"

--- a/clients/apps/web/src/components/Payouts/ManagePayoutAccountModal.tsx
+++ b/clients/apps/web/src/components/Payouts/ManagePayoutAccountModal.tsx
@@ -5,7 +5,6 @@ import { useHasPermission } from '@/hooks/permissions'
 import {
   useDeletePayoutAccount,
   usePayoutAccounts,
-  useSetOrganizationPayoutAccount,
 } from '@/hooks/queries/payout_accounts'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import { api } from '@/utils/client'
@@ -55,9 +54,6 @@ const ManagePayoutAccountModal: React.FC<ManagePayoutAccountModalProps> = ({
     refetch: refetchPayoutAccounts,
   } = usePayoutAccounts()
   const deletePayoutAccount = useDeletePayoutAccount()
-  const setOrganizationPayoutAccount = useSetOrganizationPayoutAccount(
-    _organization.id,
-  )
   const [loadingDashboardId, setLoadingDashboardId] = useState<string | null>(
     null,
   )
@@ -119,29 +115,6 @@ const ManagePayoutAccountModal: React.FC<ManagePayoutAccountModalProps> = ({
       }
     },
     [deletePayoutAccount, refetchOrganization, refetchPayoutAccounts],
-  )
-
-  const handleSwitch = useCallback(
-    async (payoutAccountId: string) => {
-      const { error } =
-        await setOrganizationPayoutAccount.mutateAsync(payoutAccountId)
-      if (error) {
-        toast({
-          title: 'Failed to switch payout account',
-          description: extractApiErrorMessage(
-            error,
-            'An error occurred while switching the payout account.',
-          ),
-        })
-      } else {
-        toast({
-          title: 'Payout account updated',
-          description: 'Your active payout account has been updated.',
-        })
-        refetchOrganization()
-      }
-    },
-    [setOrganizationPayoutAccount, refetchOrganization],
   )
 
   const accounts = [...(payoutAccountsList?.items ?? [])].sort((a, b) => {
@@ -230,16 +203,6 @@ const ManagePayoutAccountModal: React.FC<ManagePayoutAccountModalProps> = ({
                     )}
                     {!isActive && (
                       <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => handleSwitch(account.id)}
-                        loading={setOrganizationPayoutAccount.isPending}
-                      >
-                        Make Active
-                      </Button>
-                    )}
-                    {!isActive && (
-                      <Button
                         variant="destructive"
                         size="sm"
                         onClick={() => handleDelete(account.id)}
@@ -274,13 +237,6 @@ const ManagePayoutAccountModal: React.FC<ManagePayoutAccountModalProps> = ({
                           {account.is_payout_ready
                             ? 'Open in Stripe'
                             : 'Complete Setup'}
-                        </DropdownMenuItem>
-                      )}
-                      {!isActive && (
-                        <DropdownMenuItem
-                          onClick={() => handleSwitch(account.id)}
-                        >
-                          Make Active
                         </DropdownMenuItem>
                       )}
                       {!isActive && (

--- a/clients/apps/web/src/hooks/usePayoutAccountSetup.tsx
+++ b/clients/apps/web/src/hooks/usePayoutAccountSetup.tsx
@@ -2,19 +2,14 @@ import AccountCreateModal from '@/components/Accounts/AccountCreateModal'
 import { Modal } from '@polar-sh/orbit'
 import { useModal } from '@/components/Modal/useModal'
 import ManagePayoutAccountModal from '@/components/Payouts/ManagePayoutAccountModal'
-import {
-  usePayoutAccount,
-  usePayoutAccounts,
-} from '@/hooks/queries/payout_accounts'
+import { usePayoutAccount } from '@/hooks/queries/payout_accounts'
 import { schemas } from '@polar-sh/client'
 import { ReactNode, useCallback } from 'react'
 
 interface UsePayoutAccountSetupResult {
   payoutAccount: schemas['PayoutAccount'] | undefined
-  hasReusableAccounts: boolean
   openCreate: () => void
   openManage: () => void
-  openPrimary: () => void
   modals: ReactNode
 }
 
@@ -25,9 +20,6 @@ export const usePayoutAccountSetup = (
   const { data: payoutAccount } = usePayoutAccount(
     organization.payout_account_id ?? undefined,
   )
-  const { data: payoutAccountsList } = usePayoutAccounts()
-  const hasReusableAccounts = (payoutAccountsList?.items?.length ?? 0) > 0
-
   const {
     isShown: isCreateShown,
     show: openCreate,
@@ -43,14 +35,6 @@ export const usePayoutAccountSetup = (
     hideManage()
     openCreate()
   }, [hideManage, openCreate])
-
-  const openPrimary = useCallback(() => {
-    if (hasReusableAccounts) {
-      openManage()
-    } else {
-      openCreate()
-    }
-  }, [hasReusableAccounts, openManage, openCreate])
 
   const modals = (
     <>
@@ -84,10 +68,8 @@ export const usePayoutAccountSetup = (
 
   return {
     payoutAccount,
-    hasReusableAccounts,
     openCreate,
     openManage,
-    openPrimary,
     modals,
   }
 }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -31405,6 +31405,17 @@ export interface components {
       is_payout_ready: boolean
       status: components['schemas']['PayoutAccountStatus']
     }
+    /** PayoutAccountAlreadyLinked */
+    PayoutAccountAlreadyLinked: {
+      /**
+       * Error
+       * @example PayoutAccountAlreadyLinked
+       * @constant
+       */
+      error: 'PayoutAccountAlreadyLinked'
+      /** Detail */
+      detail: string
+    }
     /** PayoutAccountCreate */
     PayoutAccountCreate: {
       /**
@@ -41500,6 +41511,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Payout account already linked to another organization. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PayoutAccountAlreadyLinked']
         }
       }
       /** @description Validation Error */

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -239,9 +239,10 @@ async def set_payout_account(
     session: AsyncSession = Depends(get_db_session),
 ) -> Organization:
     """Set the payout account for an organization."""
-    # Resolve payout account and check admin ownership
+    # Resolve payout account and check admin ownership. Lock it so two
+    # concurrent requests can't link it to two organizations.
     pa_repo = PayoutAccountRepository.from_session(session)
-    payout_account = await pa_repo.get_by_id(body.payout_account_id)
+    payout_account = await pa_repo.get_by_id(body.payout_account_id, for_update=True)
     if (
         payout_account is None
         or payout_account.admin_id != authz.auth_subject.subject.id

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -135,6 +135,7 @@ from .schemas import (
 from .service import (
     CannotCreateOrganizationError,
     DisputeAutoAcceptNotEnabled,
+    PayoutAccountAlreadyLinked,
     SSOEnforcementRequiresConnection,
 )
 from .service import organization as organization_service
@@ -225,6 +226,10 @@ async def get_account(
     response_model=OrganizationSchema,
     responses={
         404: OrganizationNotFound,
+        409: {
+            "description": "Payout account already linked to another organization.",
+            "model": PayoutAccountAlreadyLinked.schema(),
+        },
     },
     tags=[APITag.private],
 )

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -886,9 +886,7 @@ class OrganizationService:
         organization_repository = OrganizationRepository.from_session(session)
 
         # Stripe requires one connected account per website, so a payout account
-        # serves a single organization. Lock the account so two concurrent
-        # requests can't both pass the check below.
-        await session.refresh(payout_account, with_for_update=True)
+        # serves a single organization.
         linked_organizations = await organization_repository.get_all_by_payout_account(
             payout_account.id
         )

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -279,6 +279,15 @@ class SSOEnforcementRequiresConnection(OrganizationError):
         )
 
 
+class PayoutAccountAlreadyLinked(OrganizationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "This payout account already belongs to another organization. "
+            "Each organization needs its own payout account.",
+            409,
+        )
+
+
 class OrganizationService:
     async def list(
         self,
@@ -874,9 +883,18 @@ class OrganizationService:
         organization: Organization,
         payout_account: PayoutAccount,
     ) -> Organization:
+        organization_repository = OrganizationRepository.from_session(session)
+
+        # Stripe requires one connected account per website, so a payout account
+        # serves a single organization.
+        linked_organizations = await organization_repository.get_all_by_payout_account(
+            payout_account.id
+        )
+        if any(linked.id != organization.id for linked in linked_organizations):
+            raise PayoutAccountAlreadyLinked()
+
         previous_payout_account_id = organization.payout_account_id
 
-        organization_repository = OrganizationRepository.from_session(session)
         await organization_repository.update(
             organization,
             update_dict={"payout_account_id": payout_account.id},

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -886,7 +886,9 @@ class OrganizationService:
         organization_repository = OrganizationRepository.from_session(session)
 
         # Stripe requires one connected account per website, so a payout account
-        # serves a single organization.
+        # serves a single organization. Lock the account so two concurrent
+        # requests can't both pass the check below.
+        await session.refresh(payout_account, with_for_update=True)
         linked_organizations = await organization_repository.get_all_by_payout_account(
             payout_account.id
         )

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -69,6 +69,7 @@ from polar.organization.schemas import (
 from polar.organization.service import (
     CannotCreateOrganizationError,
     OrganizationError,
+    PayoutAccountAlreadyLinked,
 )
 from polar.organization.service import organization as organization_service
 from polar.organization_review.appeal_case import appeal_case as appeal_case_service
@@ -85,11 +86,13 @@ from polar.user_organization.service import (
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
+    create_account,
     create_active_subscription,
     create_benefit,
     create_checkout_link,
     create_dispute,
     create_order,
+    create_organization,
     create_payment,
     create_payout_account,
     create_product,
@@ -4949,6 +4952,28 @@ class TestSetPayoutAccount:
         )
 
         assert updated_org.payout_account_id == payout_account.id
+
+    @pytest.mark.auth
+    async def test_rejects_account_linked_to_another_organization(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+
+        other_organization = await create_organization(
+            save_fixture, await create_account(save_fixture, user)
+        )
+
+        with pytest.raises(PayoutAccountAlreadyLinked):
+            await organization_service.set_payout_account(
+                session, other_organization, payout_account
+            )
 
     @pytest.mark.auth
     async def test_activates_when_all_gates_pass(


### PR DESCRIPTION
## Summary

Stripe requires one connected account per website. Rejects a payout account already linked to another organization, and stops the dashboard from steering merchants into reusing one. 

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

