### PR TITLE
feat(merchant-migration): map Stripe products onto existing Polar catalog

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
@@ -4,13 +4,23 @@ import {
   useProductMappings,
   useUpdateProductMappings,
 } from '@/hooks/queries/merchantMigrations'
-import { Alert, Spinner } from '@polar-sh/orbit'
+import {
+  Alert,
+  DataTable,
+  Spinner,
+  Text,
+  type DataTableColumnDef,
+} from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
+import { useCallback, useMemo } from 'react'
 import { ProductMappingRow } from './ProductMappingRow'
 import {
+  formatMappingAmount,
+  formatMappingInterval,
   mappingChoice,
   shouldShowProductMappingPanel,
   visibleMappingItems,
+  type ProductMappingItem,
 } from './productMapping'
 
 export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
@@ -18,6 +28,20 @@ export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
   const updateMappings = useUpdateProductMappings(migrationId)
   const items = mappings.data?.items ?? []
   const visible = visibleMappingItems(items)
+  const saving = updateMappings.isPending
+  const mutateMappings = updateMappings.mutate
+
+  const onChange = useCallback(
+    (sourceId: string, value: string) => {
+      mutateMappings([mappingChoice(sourceId, value)])
+    },
+    [mutateMappings],
+  )
+
+  const columns = useMemo(
+    () => buildProductMappingColumns({ saving, onChange }),
+    [saving, onChange],
+  )
 
   if (mappings.isLoading) {
     return (
@@ -42,7 +66,18 @@ export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
   }
 
   return (
-    <Box flexDirection="column" rowGap="s">
+    <Box as="section" flexDirection="column" rowGap="m">
+      <Box flexDirection="column" rowGap="xs">
+        <Text variant="heading-xs" as="h3">
+          Product configuration
+        </Text>
+        <Text variant="caption" color="muted">
+          Map each Stripe product that still has subscribers onto a Polar
+          product so they keep the same benefits. Choose an existing Polar
+          product, or create a new one. Imported subscribers keep their Stripe
+          price if Polar&apos;s catalog has moved on.
+        </Text>
+      </Box>
       {updateMappings.isError ? (
         <Alert
           variant="danger"
@@ -53,16 +88,76 @@ export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
           }
         />
       ) : null}
-      {visible.map((item) => (
-        <ProductMappingRow
-          key={item.source_id}
-          item={item}
-          saving={updateMappings.isPending}
-          onChange={(value) =>
-            updateMappings.mutate([mappingChoice(item.source_id, value)])
-          }
-        />
-      ))}
+      <DataTable
+        columns={columns}
+        data={visible}
+        isLoading={false}
+        getRowId={(row) => row.source_id}
+      />
     </Box>
   )
+}
+
+function buildProductMappingColumns({
+  onChange,
+  saving,
+}: {
+  onChange: (sourceId: string, value: string) => void
+  saving: boolean
+}): DataTableColumnDef<ProductMappingItem>[] {
+  return [
+    {
+      id: 'name',
+      size: 220,
+      header: 'Stripe product',
+      cell: ({ row }) => (
+        <Box minWidth={0}>
+          <Text truncate>{row.original.name}</Text>
+        </Box>
+      ),
+    },
+    {
+      id: 'interval',
+      size: 120,
+      header: 'Interval',
+      cell: ({ row }) => (
+        <Text color="muted">
+          {formatMappingInterval(
+            row.original.recurring_interval,
+            row.original.recurring_interval_count,
+          )}
+        </Text>
+      ),
+    },
+    {
+      id: 'price',
+      size: 120,
+      header: 'Price',
+      cell: ({ row }) => (
+        <Text monospace tabularNums>
+          {formatMappingAmount(row.original.prices)}
+        </Text>
+      ),
+    },
+    {
+      id: 'subscriptions',
+      size: 120,
+      header: 'Subscriptions',
+      cell: ({ row }) => (
+        <Text tabularNums>{row.original.subscriber_count}</Text>
+      ),
+    },
+    {
+      id: 'action',
+      size: 280,
+      header: 'Polar product',
+      cell: ({ row }) => (
+        <ProductMappingRow
+          item={row.original}
+          saving={saving}
+          onChange={(value) => onChange(row.original.source_id, value)}
+        />
+      ),
+    },
+  ]
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
@@ -4,15 +4,20 @@ import {
   useProductMappings,
   useUpdateProductMappings,
 } from '@/hooks/queries/merchantMigrations'
-import { Alert, Spinner, Text } from '@polar-sh/orbit'
+import { Alert, Spinner } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { ProductMappingRow } from './ProductMappingRow'
-import { mappingChoice, shouldShowProductMappingPanel } from './productMapping'
+import {
+  mappingChoice,
+  shouldShowProductMappingPanel,
+  visibleMappingItems,
+} from './productMapping'
 
 export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
   const mappings = useProductMappings(migrationId)
   const updateMappings = useUpdateProductMappings(migrationId)
   const items = mappings.data?.items ?? []
+  const visible = visibleMappingItems(items)
 
   if (mappings.isLoading) {
     return (
@@ -37,17 +42,7 @@ export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
   }
 
   return (
-    <Box flexDirection="column" rowGap="m">
-      <Box flexDirection="column" rowGap="xs">
-        <Text variant="heading-xs">Map existing Polar products</Text>
-        <Text variant="caption" color="muted">
-          If you already sell these plans on Polar, map each Stripe product onto
-          the matching Polar product so subscribers keep the same benefits.
-          Polar suggests a match when the name is unique, or when amount,
-          currency, and billing interval uniquely match. Imported subscribers
-          keep their Stripe price if Polar&apos;s catalog has moved on.
-        </Text>
-      </Box>
+    <Box flexDirection="column" rowGap="s">
       {updateMappings.isError ? (
         <Alert
           variant="danger"
@@ -58,7 +53,7 @@ export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
           }
         />
       ) : null}
-      {items.map((item) => (
+      {visible.map((item) => (
         <ProductMappingRow
           key={item.source_id}
           item={item}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
@@ -4,23 +4,14 @@ import {
   useProductMappings,
   useUpdateProductMappings,
 } from '@/hooks/queries/merchantMigrations'
-import {
-  Alert,
-  DataTable,
-  Spinner,
-  Text,
-  type DataTableColumnDef,
-} from '@polar-sh/orbit'
+import { Alert, Spinner, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import { useCallback, useMemo } from 'react'
-import { ProductMappingRow } from './ProductMappingRow'
+import { useCallback } from 'react'
+import { ProductMappingTable } from './ProductMappingTable'
 import {
-  formatMappingAmount,
-  formatMappingInterval,
   mappingChoice,
   shouldShowProductMappingPanel,
   visibleMappingItems,
-  type ProductMappingItem,
 } from './productMapping'
 
 export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
@@ -28,7 +19,6 @@ export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
   const updateMappings = useUpdateProductMappings(migrationId)
   const items = mappings.data?.items ?? []
   const visible = visibleMappingItems(items)
-  const saving = updateMappings.isPending
   const mutateMappings = updateMappings.mutate
 
   const onChange = useCallback(
@@ -36,11 +26,6 @@ export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
       mutateMappings([mappingChoice(sourceId, value)])
     },
     [mutateMappings],
-  )
-
-  const columns = useMemo(
-    () => buildProductMappingColumns({ saving, onChange }),
-    [saving, onChange],
   )
 
   if (mappings.isLoading) {
@@ -66,16 +51,15 @@ export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
   }
 
   return (
-    <Box as="section" flexDirection="column" rowGap="m">
+    <Box as="section" flexDirection="column" rowGap="s">
       <Box flexDirection="column" rowGap="xs">
         <Text variant="heading-xs" as="h3">
           Product configuration
         </Text>
         <Text variant="caption" color="muted">
-          Map each Stripe product that still has subscribers onto a Polar
-          product so they keep the same benefits. Choose an existing Polar
-          product, or create a new one. Imported subscribers keep their Stripe
-          price if Polar&apos;s catalog has moved on.
+          Map each Stripe product with subscribers onto a Polar product.
+          Imported subscribers keep their Stripe price if Polar&apos;s catalog
+          has moved on.
         </Text>
       </Box>
       {updateMappings.isError ? (
@@ -88,76 +72,11 @@ export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
           }
         />
       ) : null}
-      <DataTable
-        columns={columns}
-        data={visible}
-        isLoading={false}
-        getRowId={(row) => row.source_id}
+      <ProductMappingTable
+        items={visible}
+        saving={updateMappings.isPending}
+        onChange={onChange}
       />
     </Box>
   )
-}
-
-function buildProductMappingColumns({
-  onChange,
-  saving,
-}: {
-  onChange: (sourceId: string, value: string) => void
-  saving: boolean
-}): DataTableColumnDef<ProductMappingItem>[] {
-  return [
-    {
-      id: 'name',
-      size: 220,
-      header: 'Stripe product',
-      cell: ({ row }) => (
-        <Box minWidth={0}>
-          <Text truncate>{row.original.name}</Text>
-        </Box>
-      ),
-    },
-    {
-      id: 'interval',
-      size: 120,
-      header: 'Interval',
-      cell: ({ row }) => (
-        <Text color="muted">
-          {formatMappingInterval(
-            row.original.recurring_interval,
-            row.original.recurring_interval_count,
-          )}
-        </Text>
-      ),
-    },
-    {
-      id: 'price',
-      size: 120,
-      header: 'Price',
-      cell: ({ row }) => (
-        <Text monospace tabularNums>
-          {formatMappingAmount(row.original.prices)}
-        </Text>
-      ),
-    },
-    {
-      id: 'subscriptions',
-      size: 120,
-      header: 'Subscriptions',
-      cell: ({ row }) => (
-        <Text tabularNums>{row.original.subscriber_count}</Text>
-      ),
-    },
-    {
-      id: 'action',
-      size: 280,
-      header: 'Polar product',
-      cell: ({ row }) => (
-        <ProductMappingRow
-          item={row.original}
-          saving={saving}
-          onChange={(value) => onChange(row.original.source_id, value)}
-        />
-      ),
-    },
-  ]
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
@@ -43,8 +43,9 @@ export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
         <Text variant="caption" color="muted">
           If you already sell these plans on Polar, map each Stripe product onto
           the matching Polar product so subscribers keep the same benefits.
-          Polar suggests a match when amount, currency, and billing interval are
-          unique.
+          Polar suggests a match when the name is unique, or when amount,
+          currency, and billing interval uniquely match. Imported subscribers
+          keep their Stripe price if Polar&apos;s catalog has moved on.
         </Text>
       </Box>
       {updateMappings.isError ? (

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import {
+  useProductMappings,
+  useUpdateProductMappings,
+} from '@/hooks/queries/merchantMigrations'
+import { Alert, Spinner, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { ProductMappingRow } from './ProductMappingRow'
+import { mappingChoice, shouldShowProductMappingPanel } from './productMapping'
+
+export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
+  const mappings = useProductMappings(migrationId)
+  const updateMappings = useUpdateProductMappings(migrationId)
+  const items = mappings.data?.items ?? []
+
+  if (mappings.isLoading) {
+    return (
+      <Box padding="l" alignItems="center" justifyContent="center">
+        <Spinner />
+      </Box>
+    )
+  }
+
+  if (mappings.isError) {
+    return (
+      <Alert
+        variant="danger"
+        title="We couldn't load product mappings"
+        description="Something went wrong. Please refresh and try again."
+      />
+    )
+  }
+
+  if (!shouldShowProductMappingPanel(items)) {
+    return null
+  }
+
+  return (
+    <Box flexDirection="column" rowGap="m">
+      <Box flexDirection="column" rowGap="xs">
+        <Text variant="heading-xs">Map existing Polar products</Text>
+        <Text variant="caption" color="muted">
+          If you already sell these plans on Polar, map each Stripe product onto
+          the matching Polar product so subscribers keep the same benefits.
+          Polar suggests a match when amount, currency, and billing interval are
+          unique.
+        </Text>
+      </Box>
+      {updateMappings.isError ? (
+        <Alert
+          variant="danger"
+          title="We couldn't save that mapping"
+          description={
+            updateMappings.error?.message ||
+            'Something went wrong. Please try again.'
+          }
+        />
+      ) : null}
+      {items.map((item) => (
+        <ProductMappingRow
+          key={item.source_id}
+          item={item}
+          saving={updateMappings.isPending}
+          onChange={(value) =>
+            updateMappings.mutate([mappingChoice(item.source_id, value)])
+          }
+        />
+      ))}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
@@ -11,7 +11,6 @@ import {
 import { Box } from '@polar-sh/orbit/Box'
 import {
   CREATE_NEW_VALUE,
-  catalogPriceNote,
   compatibleCandidates,
   mappingSelectValue,
   type ProductMappingItem,
@@ -29,7 +28,6 @@ export function ProductMappingRow({
   const locked = item.import_status !== 'pending'
   const value = mappingSelectValue(item)
   const candidates = compatibleCandidates(item)
-  const catalogNote = catalogPriceNote(item)
 
   return (
     <Box flexDirection="column" rowGap="xs" minWidth={0}>
@@ -52,11 +50,6 @@ export function ProductMappingRow({
           ))}
         </SelectContent>
       </Select>
-      {catalogNote ? (
-        <Text variant="caption" color="muted">
-          {catalogNote}
-        </Text>
-      ) : null}
       {item.requires_choice ? (
         <Text variant="caption" color="warning">
           A Polar product already uses this name, but the billing interval

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
@@ -30,7 +30,7 @@ export function ProductMappingRow({
   const candidates = compatibleCandidates(item)
 
   return (
-    <Box flexDirection="column" rowGap="xs" minWidth={0}>
+    <Box flexDirection="column" rowGap="xs" minWidth={0} width="100%">
       <Select
         value={value || undefined}
         onValueChange={onChange}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Text,
+} from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import {
+  CREATE_NEW_VALUE,
+  compatibleCandidates,
+  formatMappingPrices,
+  mappingSelectValue,
+  type ProductMappingItem,
+} from './productMapping'
+
+export function ProductMappingRow({
+  item,
+  onChange,
+  saving,
+}: {
+  item: ProductMappingItem
+  onChange: (value: string) => void
+  saving?: boolean
+}) {
+  const locked = item.import_status !== 'pending'
+  const value = mappingSelectValue(item)
+  const candidates = compatibleCandidates(item)
+  const subscriberLabel =
+    item.subscriber_count === 1
+      ? '1 subscription'
+      : `${item.subscriber_count} subscriptions`
+
+  return (
+    <Box
+      flexDirection="column"
+      rowGap="s"
+      padding="l"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+      borderRadius="l"
+    >
+      <Box
+        alignItems="center"
+        justifyContent="between"
+        columnGap="m"
+        rowGap="s"
+        flexWrap="wrap"
+      >
+        <Box flexDirection="column" rowGap="xs" minWidth={0} flex={1}>
+          <Text variant="body">{item.name}</Text>
+          <Text variant="caption" color="muted">
+            {formatMappingPrices(item.prices, item.recurring_interval)} ·{' '}
+            {subscriberLabel}
+          </Text>
+        </Box>
+        <Box minWidth={220} flex={1}>
+          <Select
+            value={value || undefined}
+            onValueChange={onChange}
+            disabled={locked || saving}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Choose a Polar product" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={CREATE_NEW_VALUE}>
+                Create a new Polar product
+              </SelectItem>
+              {candidates.map((candidate) => (
+                <SelectItem key={candidate.id} value={candidate.id}>
+                  {candidate.name}
+                  {candidate.id === item.suggested_product_id
+                    ? ' (suggested)'
+                    : ''}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Box>
+      </Box>
+      {item.requires_choice ? (
+        <Text variant="caption" color="warning">
+          A Polar product already uses this name, but the price or billing
+          interval doesn&apos;t match. Map it, or create a new product before
+          preparing.
+        </Text>
+      ) : null}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
@@ -13,6 +13,7 @@ import {
   CREATE_NEW_VALUE,
   compatibleCandidates,
   formatMappingPrices,
+  grandfatheredPriceWarning,
   mappingSelectValue,
   type ProductMappingItem,
 } from './productMapping'
@@ -29,6 +30,7 @@ export function ProductMappingRow({
   const locked = item.import_status !== 'pending'
   const value = mappingSelectValue(item)
   const candidates = compatibleCandidates(item)
+  const grandfatherWarning = grandfatheredPriceWarning(item)
   const subscriberLabel =
     item.subscriber_count === 1
       ? '1 subscription'
@@ -83,11 +85,15 @@ export function ProductMappingRow({
           </Select>
         </Box>
       </Box>
+      {grandfatherWarning ? (
+        <Text variant="caption" color="warning">
+          {grandfatherWarning}
+        </Text>
+      ) : null}
       {item.requires_choice ? (
         <Text variant="caption" color="warning">
-          A Polar product already uses this name, but the price or billing
-          interval doesn&apos;t match. Map it, or create a new product before
-          preparing.
+          A Polar product already uses this name, but the billing interval
+          doesn&apos;t match. Map it, or create a new product before preparing.
         </Text>
       ) : null}
     </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
@@ -38,8 +38,8 @@ export function ProductMappingRow({
         onValueChange={onChange}
         disabled={locked || saving}
       >
-        <SelectTrigger className="w-full">
-          <SelectValue placeholder="Choose a Polar product" />
+        <SelectTrigger className="h-8 min-h-8 w-full min-w-0 py-0">
+          <SelectValue placeholder="Polar product" />
         </SelectTrigger>
         <SelectContent>
           <SelectItem value={CREATE_NEW_VALUE}>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
@@ -13,7 +13,6 @@ import {
   CREATE_NEW_VALUE,
   catalogPriceNote,
   compatibleCandidates,
-  formatMappingPrices,
   mappingSelectValue,
   type ProductMappingItem,
 } from './productMapping'
@@ -31,50 +30,33 @@ export function ProductMappingRow({
   const value = mappingSelectValue(item)
   const candidates = compatibleCandidates(item)
   const catalogNote = catalogPriceNote(item)
-  const subscriberLabel =
-    item.subscriber_count === 1 ? '1 sub' : `${item.subscriber_count} subs`
 
   return (
-    <Box flexDirection="column" rowGap="xs">
-      <Box
-        alignItems="center"
-        justifyContent="between"
-        columnGap="m"
-        rowGap="xs"
-        flexWrap="wrap"
+    <Box flexDirection="column" rowGap="xs" minWidth={0}>
+      <Select
+        value={value || undefined}
+        onValueChange={onChange}
+        disabled={locked || saving}
       >
-        <Text variant="body">
-          {item.name} ·{' '}
-          {formatMappingPrices(item.prices, item.recurring_interval)} ·{' '}
-          {subscriberLabel}
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="Choose a Polar product" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={CREATE_NEW_VALUE}>
+            Create a new Polar product
+          </SelectItem>
+          {candidates.map((candidate) => (
+            <SelectItem key={candidate.id} value={candidate.id}>
+              {candidate.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {catalogNote ? (
+        <Text variant="caption" color="muted">
+          {catalogNote}
         </Text>
-        <Box alignItems="center" columnGap="s" minWidth={0}>
-          <Select
-            value={value || undefined}
-            onValueChange={onChange}
-            disabled={locked || saving}
-          >
-            <SelectTrigger className="w-auto min-w-40">
-              <SelectValue placeholder="Polar product" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={CREATE_NEW_VALUE}>
-                Create a new Polar product
-              </SelectItem>
-              {candidates.map((candidate) => (
-                <SelectItem key={candidate.id} value={candidate.id}>
-                  {candidate.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {catalogNote ? (
-            <Text variant="caption" color="muted">
-              {catalogNote}
-            </Text>
-          ) : null}
-        </Box>
-      </Box>
+      ) : null}
       {item.requires_choice ? (
         <Text variant="caption" color="warning">
           A Polar product already uses this name, but the billing interval

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
@@ -11,9 +11,9 @@ import {
 import { Box } from '@polar-sh/orbit/Box'
 import {
   CREATE_NEW_VALUE,
+  catalogPriceNote,
   compatibleCandidates,
   formatMappingPrices,
-  grandfatheredPriceWarning,
   mappingSelectValue,
   type ProductMappingItem,
 } from './productMapping'
@@ -30,44 +30,32 @@ export function ProductMappingRow({
   const locked = item.import_status !== 'pending'
   const value = mappingSelectValue(item)
   const candidates = compatibleCandidates(item)
-  const grandfatherWarning = grandfatheredPriceWarning(item)
+  const catalogNote = catalogPriceNote(item)
   const subscriberLabel =
-    item.subscriber_count === 1
-      ? '1 subscription'
-      : `${item.subscriber_count} subscriptions`
+    item.subscriber_count === 1 ? '1 sub' : `${item.subscriber_count} subs`
 
   return (
-    <Box
-      flexDirection="column"
-      rowGap="s"
-      padding="l"
-      borderWidth={1}
-      borderStyle="solid"
-      borderColor="border-primary"
-      borderRadius="l"
-    >
+    <Box flexDirection="column" rowGap="xs">
       <Box
         alignItems="center"
         justifyContent="between"
         columnGap="m"
-        rowGap="s"
+        rowGap="xs"
         flexWrap="wrap"
       >
-        <Box flexDirection="column" rowGap="xs" minWidth={0} flex={1}>
-          <Text variant="body">{item.name}</Text>
-          <Text variant="caption" color="muted">
-            {formatMappingPrices(item.prices, item.recurring_interval)} ·{' '}
-            {subscriberLabel}
-          </Text>
-        </Box>
-        <Box minWidth={220} flex={1}>
+        <Text variant="body">
+          {item.name} ·{' '}
+          {formatMappingPrices(item.prices, item.recurring_interval)} ·{' '}
+          {subscriberLabel}
+        </Text>
+        <Box alignItems="center" columnGap="s" minWidth={0}>
           <Select
             value={value || undefined}
             onValueChange={onChange}
             disabled={locked || saving}
           >
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="Choose a Polar product" />
+            <SelectTrigger className="w-auto min-w-40">
+              <SelectValue placeholder="Polar product" />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value={CREATE_NEW_VALUE}>
@@ -76,20 +64,17 @@ export function ProductMappingRow({
               {candidates.map((candidate) => (
                 <SelectItem key={candidate.id} value={candidate.id}>
                   {candidate.name}
-                  {candidate.id === item.suggested_product_id
-                    ? ' (suggested)'
-                    : ''}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
+          {catalogNote ? (
+            <Text variant="caption" color="muted">
+              {catalogNote}
+            </Text>
+          ) : null}
         </Box>
       </Box>
-      {grandfatherWarning ? (
-        <Text variant="caption" color="warning">
-          {grandfatherWarning}
-        </Text>
-      ) : null}
       {item.requires_choice ? (
         <Text variant="caption" color="warning">
           A Polar product already uses this name, but the billing interval

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingTable.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { useState } from 'react'
+import { ProductMappingRow } from './ProductMappingRow'
+import {
+  formatMappingAmount,
+  formatMappingInterval,
+  paginateMappingItems,
+  type ProductMappingItem,
+} from './productMapping'
+
+const COLUMNS =
+  'minmax(0, 1.4fr) max-content max-content max-content minmax(140px, 1.2fr)'
+
+export function ProductMappingTable({
+  items,
+  saving,
+  onChange,
+}: {
+  items: ProductMappingItem[]
+  saving?: boolean
+  onChange: (sourceId: string, value: string) => void
+}) {
+  const [page, setPage] = useState(1)
+  const paged = paginateMappingItems(items, page)
+
+  return (
+    <Box flexDirection="column" rowGap="s">
+      <Box
+        borderWidth={1}
+        borderStyle="solid"
+        borderColor="border-primary"
+        borderRadius="l"
+        overflow="hidden"
+        flexDirection="column"
+      >
+        <ProductMappingTableHeader />
+        {paged.items.map((item) => (
+          <ProductMappingTableRow
+            key={item.source_id}
+            item={item}
+            saving={saving}
+            onChange={onChange}
+          />
+        ))}
+      </Box>
+      {paged.showPagination ? (
+        <Box alignItems="center" justifyContent="end" columnGap="s">
+          <Text variant="caption" color="muted">
+            {paged.rangeStart}–{paged.rangeEnd} of {paged.total}
+          </Text>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={paged.page <= 1}
+            onClick={() => setPage(paged.page - 1)}
+          >
+            Previous
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={paged.page >= paged.pageCount}
+            onClick={() => setPage(paged.page + 1)}
+          >
+            Next
+          </Button>
+        </Box>
+      ) : null}
+    </Box>
+  )
+}
+
+function ProductMappingTableHeader() {
+  return (
+    <Box
+      display="grid"
+      gridTemplateColumns={COLUMNS}
+      columnGap="m"
+      alignItems="center"
+      paddingHorizontal="m"
+      paddingVertical="s"
+      backgroundColor="background-secondary"
+    >
+      <Text variant="caption" color="muted">
+        Stripe product
+      </Text>
+      <Text variant="caption" color="muted">
+        Interval
+      </Text>
+      <Text variant="caption" color="muted">
+        Price
+      </Text>
+      <Text variant="caption" color="muted">
+        Subs
+      </Text>
+      <Text variant="caption" color="muted">
+        Polar product
+      </Text>
+    </Box>
+  )
+}
+
+function ProductMappingTableRow({
+  item,
+  saving,
+  onChange,
+}: {
+  item: ProductMappingItem
+  saving?: boolean
+  onChange: (sourceId: string, value: string) => void
+}) {
+  return (
+    <Box
+      display="grid"
+      gridTemplateColumns={COLUMNS}
+      columnGap="m"
+      alignItems="center"
+      paddingHorizontal="m"
+      paddingVertical="s"
+      borderTopWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+    >
+      <Box minWidth={0}>
+        <Text variant="caption" truncate>
+          {item.name}
+        </Text>
+      </Box>
+      <Text variant="caption" color="muted">
+        {formatMappingInterval(
+          item.recurring_interval,
+          item.recurring_interval_count,
+        )}
+      </Text>
+      <Text variant="caption" monospace tabularNums>
+        {formatMappingAmount(item.prices)}
+      </Text>
+      <Text variant="caption" tabularNums>
+        {item.subscriber_count}
+      </Text>
+      <ProductMappingRow
+        item={item}
+        saving={saving}
+        onChange={(value) => onChange(item.source_id, value)}
+      />
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingTable.tsx
@@ -12,7 +12,7 @@ import {
 } from './productMapping'
 
 const COLUMNS =
-  'minmax(0, 1.4fr) max-content max-content max-content minmax(140px, 1.2fr)'
+  'minmax(0, 7.5rem) max-content max-content max-content minmax(0, 1fr)'
 
 export function ProductMappingTable({
   items,

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingTable.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { Button, Text } from '@polar-sh/orbit'
+import { Button, Grid, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { ProductMappingRow } from './ProductMappingRow'
 import {
   formatMappingAmount,
@@ -28,15 +28,32 @@ export function ProductMappingTable({
 
   return (
     <Box flexDirection="column" rowGap="s">
-      <Box
+      <Grid
+        templateColumns={COLUMNS}
+        columnGap="m"
         borderWidth={1}
         borderStyle="solid"
         borderColor="border-primary"
         borderRadius="l"
         overflow="hidden"
-        flexDirection="column"
       >
-        <ProductMappingTableHeader />
+        <MappingGridRow header>
+          <Text variant="caption" color="muted">
+            Stripe product
+          </Text>
+          <Text variant="caption" color="muted">
+            Interval
+          </Text>
+          <Text variant="caption" color="muted">
+            Price
+          </Text>
+          <Text variant="caption" color="muted">
+            Subs
+          </Text>
+          <Text variant="caption" color="muted">
+            Polar product
+          </Text>
+        </MappingGridRow>
         {paged.items.map((item) => (
           <ProductMappingTableRow
             key={item.source_id}
@@ -45,7 +62,7 @@ export function ProductMappingTable({
             onChange={onChange}
           />
         ))}
-      </Box>
+      </Grid>
       {paged.showPagination ? (
         <Box alignItems="center" justifyContent="end" columnGap="s">
           <Text variant="caption" color="muted">
@@ -73,32 +90,27 @@ export function ProductMappingTable({
   )
 }
 
-function ProductMappingTableHeader() {
+function MappingGridRow({
+  children,
+  header = false,
+}: {
+  children: ReactNode
+  header?: boolean
+}) {
   return (
     <Box
       display="grid"
-      gridTemplateColumns={COLUMNS}
-      columnGap="m"
+      gridTemplateColumns="subgrid"
+      gridColumn="1 / -1"
       alignItems="center"
       paddingHorizontal="m"
       paddingVertical="s"
-      backgroundColor="background-secondary"
+      backgroundColor={header ? 'background-secondary' : undefined}
+      borderTopWidth={header ? 0 : 1}
+      borderStyle="solid"
+      borderColor="border-primary"
     >
-      <Text variant="caption" color="muted">
-        Stripe product
-      </Text>
-      <Text variant="caption" color="muted">
-        Interval
-      </Text>
-      <Text variant="caption" color="muted">
-        Price
-      </Text>
-      <Text variant="caption" color="muted">
-        Subs
-      </Text>
-      <Text variant="caption" color="muted">
-        Polar product
-      </Text>
+      {children}
     </Box>
   )
 }
@@ -113,17 +125,7 @@ function ProductMappingTableRow({
   onChange: (sourceId: string, value: string) => void
 }) {
   return (
-    <Box
-      display="grid"
-      gridTemplateColumns={COLUMNS}
-      columnGap="m"
-      alignItems="center"
-      paddingHorizontal="m"
-      paddingVertical="s"
-      borderTopWidth={1}
-      borderStyle="solid"
-      borderColor="border-primary"
-    >
+    <MappingGridRow>
       <Box minWidth={0}>
         <Text variant="caption" truncate>
           {item.name}
@@ -141,11 +143,13 @@ function ProductMappingTableRow({
       <Text variant="caption" tabularNums>
         {item.subscriber_count}
       </Text>
-      <ProductMappingRow
-        item={item}
-        saving={saving}
-        onChange={(value) => onChange(item.source_id, value)}
-      />
-    </Box>
+      <Box minWidth={0} width="100%">
+        <ProductMappingRow
+          item={item}
+          saving={saving}
+          onChange={(value) => onChange(item.source_id, value)}
+        />
+      </Box>
+    </MappingGridRow>
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -6,11 +6,13 @@ import {
   useImportMerchantMigrationCatalog,
   useMerchantMigration,
   useMigrationRecords,
+  useProductMappings,
   useRunMerchantMigrationPrecheck,
 } from '@/hooks/queries/merchantMigrations'
 import { Alert, Spinner } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { ProductMappingPanel } from './ProductMappingPanel'
 import { useRecordSummary } from './recordSummary'
 import {
   selectionPayload,
@@ -22,6 +24,7 @@ import {
 } from '../selection'
 import { ReviewFilter } from './ReviewStatusTabs'
 import { ReviewTableView } from './ReviewTableView'
+import { mappingRequiresChoice } from './productMapping'
 
 export function ReviewTable({ migrationId }: { migrationId: string }) {
   const [filter, setFilter] = useState<ReviewFilter>('all')
@@ -67,6 +70,7 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
   } = useRecordSummary(migrationId, pollMs)
   const importCatalog = useImportMerchantMigrationCatalog(migrationId)
   const rerunPrecheck = useRunMerchantMigrationPrecheck(migrationId)
+  const productMappings = useProductMappings(migrationId)
   const wasRefreshing = useRef(false)
 
   useEffect(() => {
@@ -106,7 +110,7 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
         "We couldn't refresh from Stripe. Please try again."
       : undefined
 
-  if (records.isLoading || countsLoading) {
+  if (records.isLoading || countsLoading || productMappings.isLoading) {
     return (
       <Box padding="2xl" alignItems="center" justifyContent="center">
         <Spinner />
@@ -114,7 +118,7 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
     )
   }
 
-  if (records.isError || countsError) {
+  if (records.isError || countsError || productMappings.isError) {
     return (
       <Alert
         variant="danger"
@@ -157,6 +161,8 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
       onRerunPrecheck={() => rerunPrecheck.mutate()}
       rerunning={refreshing || rerunPrecheck.isPending}
       refreshError={refreshError}
+      prepareBlocked={mappingRequiresChoice(productMappings.data?.items ?? [])}
+      header={<ProductMappingPanel migrationId={migrationId} />}
     />
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -3,7 +3,7 @@
 import { Alert, Button, DataTable, InlineModal, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { OnChangeFn, PaginationState } from '@tanstack/react-table'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import { CatalogEmptyPanel } from './CatalogEmptyPanel'
 import { ReviewRecordModal } from './ReviewRecordModal'
 import {
@@ -48,6 +48,8 @@ interface Props {
   rerunning?: boolean
   refreshError?: string
   attentionCount: number
+  prepareBlocked?: boolean
+  header?: ReactNode
 }
 
 export function ReviewTableView({
@@ -71,6 +73,8 @@ export function ReviewTableView({
   rerunning = false,
   refreshError,
   attentionCount,
+  prepareBlocked = false,
+  header,
 }: Props) {
   const rowTotal = remainingSubscriptionCount(
     counts.subscriptions.total,
@@ -96,11 +100,8 @@ export function ReviewTableView({
     () =>
       buildReviewColumns({
         isSelected: (id) => isRowSelected(selection, id),
-        // The opt-out default reads as "all" even when no row can be picked,
-        // which would show as ticked-but-disabled.
         headerState:
           selectableTotal > 0 ? headerCheckState(selection) : 'unchecked',
-        // It flips every subscription, not this page, so gate it on the same scope.
         canSelectAll: selectableTotal > 0,
         onToggle,
         onToggleAll,
@@ -112,7 +113,6 @@ export function ReviewTableView({
   const onPaginationChange: OnChangeFn<PaginationState> = (updater) => {
     const next = typeof updater === 'function' ? updater(pagination) : updater
     if (next.pageSize !== pageSize) {
-      // Resets to the first page, so don't put the old one back.
       onPageSizeChange(next.pageSize)
       return
     }
@@ -145,6 +145,14 @@ export function ReviewTableView({
           description={importError}
         />
       )}
+      {prepareBlocked && (
+        <Alert
+          variant="warning"
+          title="Map existing Polar products first"
+          description="A Stripe product shares a name with a Polar product whose price doesn't match. Choose a mapping or create a new product before preparing."
+        />
+      )}
+      {header}
 
       <Box flexDirection="column" rowGap="m">
         <Box
@@ -182,7 +190,7 @@ export function ReviewTableView({
               <Button
                 size="sm"
                 onClick={onImport}
-                disabled={importing || importCount <= 0}
+                disabled={importing || importCount <= 0 || prepareBlocked}
               >
                 {prepareLabel}
               </Button>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -149,7 +149,7 @@ export function ReviewTableView({
         <Alert
           variant="warning"
           title="Map existing Polar products first"
-          description="A Stripe product shares a name with a Polar product whose price doesn't match. Choose a mapping or create a new product before preparing."
+          description="A Stripe product shares a name with a Polar product whose billing interval doesn't match. Choose a mapping or create a new product before preparing."
         />
       )}
       {header}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -154,7 +154,16 @@ export function ReviewTableView({
       )}
       {header}
 
-      <Box flexDirection="column" rowGap="m">
+      <Box flexDirection="column" rowGap="s">
+        <Box flexDirection="column" rowGap="xs">
+          <Text variant="heading-xs" as="h3">
+            Subscriptions
+          </Text>
+          <Text variant="caption" color="muted">
+            Preparing a subscription brings its customer and product to Polar.
+            Polar starts billing only when you switch.
+          </Text>
+        </Box>
         <Box
           alignItems="center"
           justifyContent="between"
@@ -197,11 +206,6 @@ export function ReviewTableView({
             ) : null}
           </Box>
         </Box>
-
-        <Text variant="caption" color="muted">
-          Preparing a subscription brings its customer and product to Polar.
-          Polar starts billing only when you switch.
-        </Text>
 
         {rows.length === 0 ? (
           <Box

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
@@ -3,6 +3,7 @@ import {
   CREATE_NEW_VALUE,
   catalogPriceNote,
   compatibleCandidates,
+  formatMappingInterval,
   mappingChoice,
   mappingRequiresChoice,
   mappingSelectValue,
@@ -87,6 +88,11 @@ describe('mappingRequiresChoice', () => {
         item({ requires_choice: true, import_status: 'imported' }),
       ]),
     ).toBe(false)
+    expect(
+      mappingRequiresChoice([
+        item({ requires_choice: true, subscriber_count: 0 }),
+      ]),
+    ).toBe(false)
   })
 })
 
@@ -97,29 +103,17 @@ describe('shouldShowProductMappingPanel', () => {
     )
   })
 
-  it('hides a unique same-price match', () => {
+  it('hides Stripe products with no subscribers', () => {
+    expect(shouldShowProductMappingPanel([item({ subscriber_count: 0 })])).toBe(
+      false,
+    )
+  })
+
+  it('shows products that still have subscribers', () => {
     expect(
       shouldShowProductMappingPanel([
         item({ suggested_product_id: 'prod_polar' }),
       ]),
-    ).toBe(false)
-  })
-
-  it('shows when the catalog price differs', () => {
-    expect(
-      shouldShowProductMappingPanel([
-        item({
-          prices: [{ amount: 500, currency: 'usd' }],
-          suggested_product_id: 'prod_polar',
-          candidates: [candidate({ incompatibilities: ['amount_mismatch'] })],
-        }),
-      ]),
-    ).toBe(true)
-  })
-
-  it('shows when the merchant must choose', () => {
-    expect(
-      shouldShowProductMappingPanel([item({ requires_choice: true })]),
     ).toBe(true)
   })
 })
@@ -165,5 +159,13 @@ describe('catalogPriceNote', () => {
 
   it('is silent when creating a new Polar product', () => {
     expect(catalogPriceNote(item({ create_new: true }))).toBeNull()
+  })
+})
+
+describe('formatMappingInterval', () => {
+  it('labels a monthly and a multi-month cadence', () => {
+    expect(formatMappingInterval('month', 1)).toBe('Monthly')
+    expect(formatMappingInterval('month', 3)).toBe('Every 3 months')
+    expect(formatMappingInterval(null, 1)).toBe('—')
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   CREATE_NEW_VALUE,
-  catalogPriceNote,
   compatibleCandidates,
   formatMappingInterval,
   mappingChoice,
@@ -137,29 +136,6 @@ describe('compatibleCandidates', () => {
         }),
       ),
     ).toEqual([mismatched])
-  })
-})
-
-describe('catalogPriceNote', () => {
-  it('notes the Polar catalog price when it differs from Stripe', () => {
-    expect(
-      catalogPriceNote(
-        item({
-          prices: [{ amount: 500, currency: 'usd' }],
-          suggested_product_id: 'prod_polar',
-          candidates: [
-            candidate({
-              prices: [{ amount: 1000, currency: 'usd' }],
-              incompatibilities: ['amount_mismatch'],
-            }),
-          ],
-        }),
-      ),
-    ).toBe('catalog $10.00/mo')
-  })
-
-  it('is silent when creating a new Polar product', () => {
-    expect(catalogPriceNote(item({ create_new: true }))).toBeNull()
   })
 })
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   CREATE_NEW_VALUE,
   compatibleCandidates,
+  grandfatheredPriceWarning,
   mappingChoice,
   mappingRequiresChoice,
   mappingSelectValue,
@@ -102,16 +103,47 @@ describe('shouldShowProductMappingPanel', () => {
 })
 
 describe('compatibleCandidates', () => {
-  it('drops Polar products whose amount or interval do not match', () => {
+  it('keeps Polar products whose amount differs but are still compatible', () => {
+    const mismatched = candidate({
+      id: 'raised',
+      compatible: true,
+      incompatibilities: ['amount_mismatch'],
+      prices: [{ amount: 1000, currency: 'usd' }],
+    })
     expect(
       compatibleCandidates(
         item({
           candidates: [
-            candidate({ compatible: true }),
+            mismatched,
             candidate({ id: 'other', compatible: false }),
           ],
         }),
       ),
-    ).toEqual([candidate({ compatible: true })])
+    ).toEqual([mismatched])
+  })
+})
+
+describe('grandfatheredPriceWarning', () => {
+  it('warns when the selected Polar catalog price is higher than Stripe', () => {
+    expect(
+      grandfatheredPriceWarning(
+        item({
+          prices: [{ amount: 500, currency: 'usd' }],
+          suggested_product_id: 'prod_polar',
+          candidates: [
+            candidate({
+              prices: [{ amount: 1000, currency: 'usd' }],
+              incompatibilities: ['amount_mismatch'],
+            }),
+          ],
+        }),
+      ),
+    ).toMatch(
+      /Imported subscribers keep .* Polar currently sells this product at/,
+    )
+  })
+
+  it('is silent when creating a new Polar product', () => {
+    expect(grandfatheredPriceWarning(item({ create_new: true }))).toBeNull()
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
@@ -7,6 +7,7 @@ import {
   mappingChoice,
   mappingRequiresChoice,
   mappingSelectValue,
+  paginateMappingItems,
   shouldShowProductMappingPanel,
   type ProductMappingItem,
 } from './productMapping'
@@ -167,5 +168,31 @@ describe('formatMappingInterval', () => {
     expect(formatMappingInterval('month', 1)).toBe('Monthly')
     expect(formatMappingInterval('month', 3)).toBe('Every 3 months')
     expect(formatMappingInterval(null, 1)).toBe('—')
+  })
+})
+
+describe('paginateMappingItems', () => {
+  const items = Array.from({ length: 6 }, (_, index) =>
+    item({ source_id: `prod_${index}:month:1` }),
+  )
+
+  it('hides pagination when every product fits on one page', () => {
+    const paged = paginateMappingItems(items.slice(0, 5), 1)
+    expect(paged.showPagination).toBe(false)
+    expect(paged.items).toHaveLength(5)
+  })
+
+  it('pages five at a time and clamps out-of-range pages', () => {
+    const first = paginateMappingItems(items, 1)
+    expect(first.showPagination).toBe(true)
+    expect(first.items).toHaveLength(5)
+    expect(first.rangeEnd).toBe(5)
+
+    const second = paginateMappingItems(items, 2)
+    expect(second.items).toHaveLength(1)
+    expect(second.rangeStart).toBe(6)
+    expect(second.rangeEnd).toBe(6)
+
+    expect(paginateMappingItems(items, 99).page).toBe(2)
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   CREATE_NEW_VALUE,
+  catalogPriceNote,
   compatibleCandidates,
-  grandfatheredPriceWarning,
   mappingChoice,
   mappingRequiresChoice,
   mappingSelectValue,
@@ -97,8 +97,30 @@ describe('shouldShowProductMappingPanel', () => {
     )
   })
 
-  it('shows when Polar already has a catalog', () => {
-    expect(shouldShowProductMappingPanel([item()])).toBe(true)
+  it('hides a unique same-price match', () => {
+    expect(
+      shouldShowProductMappingPanel([
+        item({ suggested_product_id: 'prod_polar' }),
+      ]),
+    ).toBe(false)
+  })
+
+  it('shows when the catalog price differs', () => {
+    expect(
+      shouldShowProductMappingPanel([
+        item({
+          prices: [{ amount: 500, currency: 'usd' }],
+          suggested_product_id: 'prod_polar',
+          candidates: [candidate({ incompatibilities: ['amount_mismatch'] })],
+        }),
+      ]),
+    ).toBe(true)
+  })
+
+  it('shows when the merchant must choose', () => {
+    expect(
+      shouldShowProductMappingPanel([item({ requires_choice: true })]),
+    ).toBe(true)
   })
 })
 
@@ -123,10 +145,10 @@ describe('compatibleCandidates', () => {
   })
 })
 
-describe('grandfatheredPriceWarning', () => {
-  it('warns when the selected Polar catalog price is higher than Stripe', () => {
+describe('catalogPriceNote', () => {
+  it('notes the Polar catalog price when it differs from Stripe', () => {
     expect(
-      grandfatheredPriceWarning(
+      catalogPriceNote(
         item({
           prices: [{ amount: 500, currency: 'usd' }],
           suggested_product_id: 'prod_polar',
@@ -138,12 +160,10 @@ describe('grandfatheredPriceWarning', () => {
           ],
         }),
       ),
-    ).toMatch(
-      /Imported subscribers keep .* Polar currently sells this product at/,
-    )
+    ).toBe('catalog $10.00/mo')
   })
 
   it('is silent when creating a new Polar product', () => {
-    expect(grandfatheredPriceWarning(item({ create_new: true }))).toBeNull()
+    expect(catalogPriceNote(item({ create_new: true }))).toBeNull()
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CREATE_NEW_VALUE,
+  compatibleCandidates,
+  mappingChoice,
+  mappingRequiresChoice,
+  mappingSelectValue,
+  shouldShowProductMappingPanel,
+  type ProductMappingItem,
+} from './productMapping'
+
+const candidate = (
+  overrides: Partial<ProductMappingItem['candidates'][number]> = {},
+): ProductMappingItem['candidates'][number] => ({
+  id: 'prod_polar',
+  name: 'Pro',
+  recurring_interval: 'month',
+  recurring_interval_count: 1,
+  prices: [{ amount: 1000, currency: 'usd' }],
+  compatible: true,
+  incompatibilities: [],
+  ...overrides,
+})
+
+function item(overrides: Partial<ProductMappingItem> = {}): ProductMappingItem {
+  return {
+    source_id: 'prod_1:month:1',
+    product_source_id: 'prod_1',
+    name: 'Pro',
+    recurring_interval: 'month',
+    recurring_interval_count: 1,
+    prices: [{ amount: 1000, currency: 'usd' }],
+    subscriber_count: 3,
+    import_status: 'pending',
+    mapped_product_id: null,
+    create_new: false,
+    suggested_product_id: null,
+    name_collision: false,
+    requires_choice: false,
+    candidates: [candidate()],
+    ...overrides,
+  }
+}
+
+describe('mappingSelectValue', () => {
+  it('prefers an explicit create-new choice', () => {
+    expect(
+      mappingSelectValue(item({ create_new: true, suggested_product_id: 'p' })),
+    ).toBe(CREATE_NEW_VALUE)
+  })
+
+  it('uses a saved mapping, then a suggestion', () => {
+    expect(mappingSelectValue(item({ mapped_product_id: 'saved' }))).toBe(
+      'saved',
+    )
+    expect(mappingSelectValue(item({ suggested_product_id: 'hint' }))).toBe(
+      'hint',
+    )
+  })
+
+  it('defaults to create-new when import would create a Polar product', () => {
+    expect(mappingSelectValue(item({ candidates: [] }))).toBe(CREATE_NEW_VALUE)
+  })
+
+  it('stays empty until the merchant chooses a colliding product', () => {
+    expect(
+      mappingSelectValue(item({ requires_choice: true, candidates: [] })),
+    ).toBe('')
+  })
+})
+
+describe('mappingChoice', () => {
+  it('sends null when creating a new Polar product', () => {
+    expect(mappingChoice('prod_1:month:1', CREATE_NEW_VALUE)).toEqual({
+      source_id: 'prod_1:month:1',
+      polar_product_id: null,
+    })
+  })
+})
+
+describe('mappingRequiresChoice', () => {
+  it('blocks prepare only for pending rows that still need a choice', () => {
+    expect(mappingRequiresChoice([item({ requires_choice: true })])).toBe(true)
+    expect(
+      mappingRequiresChoice([
+        item({ requires_choice: true, import_status: 'imported' }),
+      ]),
+    ).toBe(false)
+  })
+})
+
+describe('shouldShowProductMappingPanel', () => {
+  it('hides when Polar has no products to map onto', () => {
+    expect(shouldShowProductMappingPanel([item({ candidates: [] })])).toBe(
+      false,
+    )
+  })
+
+  it('shows when Polar already has a catalog', () => {
+    expect(shouldShowProductMappingPanel([item()])).toBe(true)
+  })
+})
+
+describe('compatibleCandidates', () => {
+  it('drops Polar products whose amount or interval do not match', () => {
+    expect(
+      compatibleCandidates(
+        item({
+          candidates: [
+            candidate({ compatible: true }),
+            candidate({ id: 'other', compatible: false }),
+          ],
+        }),
+      ),
+    ).toEqual([candidate({ compatible: true })])
+  })
+})

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
@@ -16,6 +16,13 @@ const INTERVAL_ABBREVIATION: Record<string, string> = {
   year: '/yr',
 }
 
+const INTERVAL_LABEL: Record<string, [string, string]> = {
+  day: ['Daily', 'days'],
+  week: ['Weekly', 'weeks'],
+  month: ['Monthly', 'months'],
+  year: ['Yearly', 'years'],
+}
+
 export function compatibleCandidates(item: ProductMappingItem) {
   return item.candidates.filter((candidate) => candidate.compatible)
 }
@@ -28,23 +35,14 @@ export function mappingSelectValue(item: ProductMappingItem): string {
   return ''
 }
 
-export function isSilentAutoMap(item: ProductMappingItem): boolean {
-  if (item.requires_choice || item.create_new) {
-    return false
-  }
-  const candidate = selectedMappingCandidate(item)
-  if (!candidate) {
-    return false
-  }
-  return !candidate.incompatibilities.includes('amount_mismatch')
-}
-
 export function visibleMappingItems(
   items: ProductMappingItem[],
 ): ProductMappingItem[] {
-  return items.filter(
-    (item) => item.candidates.length > 0 && !isSilentAutoMap(item),
-  )
+  const hasCatalog = items.some((item) => item.candidates.length > 0)
+  if (!hasCatalog) {
+    return []
+  }
+  return items.filter((item) => item.subscriber_count > 0)
 }
 
 export function shouldShowProductMappingPanel(
@@ -65,7 +63,10 @@ export function mappingChoice(
 
 export function mappingRequiresChoice(items: ProductMappingItem[]): boolean {
   return items.some(
-    (item) => item.requires_choice && item.import_status === 'pending',
+    (item) =>
+      item.requires_choice &&
+      item.import_status === 'pending' &&
+      item.subscriber_count > 0,
   )
 }
 
@@ -86,13 +87,40 @@ export function catalogPriceNote(item: ProductMappingItem): string | null {
   )}`
 }
 
+export function formatMappingAmount(
+  prices: ProductMappingItem['prices'],
+): string {
+  if (prices.length === 0) {
+    return '—'
+  }
+  return prices
+    .map((price) => formatAmount(price.amount, price.currency))
+    .join(', ')
+}
+
+export function formatMappingInterval(
+  interval: string | null,
+  count: number,
+): string {
+  if (!interval) {
+    return '—'
+  }
+  const labels = INTERVAL_LABEL[interval]
+  if (!labels) {
+    return interval
+  }
+  const [once, plural] = labels
+  return count <= 1 ? once : `Every ${count} ${plural}`
+}
+
 export function formatMappingPrices(
   prices: ProductMappingItem['prices'],
   interval: string | null,
 ): string {
-  const money = prices
-    .map((price) => formatAmount(price.amount, price.currency))
-    .join(', ')
+  const money = formatMappingAmount(prices)
+  if (money === '—') {
+    return money
+  }
   const suffix = interval ? (INTERVAL_ABBREVIATION[interval] ?? '') : ''
   return `${money}${suffix}`
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
@@ -51,6 +51,28 @@ export function shouldShowProductMappingPanel(
   return visibleMappingItems(items).length > 0
 }
 
+export const PRODUCT_MAPPING_PAGE_SIZE = 5
+
+export function paginateMappingItems(
+  items: ProductMappingItem[],
+  page: number,
+) {
+  const total = items.length
+  const pageCount = Math.max(1, Math.ceil(total / PRODUCT_MAPPING_PAGE_SIZE))
+  const currentPage = Math.min(Math.max(page, 1), pageCount)
+  const start = (currentPage - 1) * PRODUCT_MAPPING_PAGE_SIZE
+  const pageItems = items.slice(start, start + PRODUCT_MAPPING_PAGE_SIZE)
+  return {
+    page: currentPage,
+    pageCount,
+    items: pageItems,
+    showPagination: total > PRODUCT_MAPPING_PAGE_SIZE,
+    rangeStart: total === 0 ? 0 : start + 1,
+    rangeEnd: start + pageItems.length,
+    total,
+  }
+}
+
 export function mappingChoice(
   sourceId: string,
   value: string,

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
@@ -28,10 +28,29 @@ export function mappingSelectValue(item: ProductMappingItem): string {
   return ''
 }
 
+export function isSilentAutoMap(item: ProductMappingItem): boolean {
+  if (item.requires_choice || item.create_new) {
+    return false
+  }
+  const candidate = selectedMappingCandidate(item)
+  if (!candidate) {
+    return false
+  }
+  return !candidate.incompatibilities.includes('amount_mismatch')
+}
+
+export function visibleMappingItems(
+  items: ProductMappingItem[],
+): ProductMappingItem[] {
+  return items.filter(
+    (item) => item.candidates.length > 0 && !isSilentAutoMap(item),
+  )
+}
+
 export function shouldShowProductMappingPanel(
   items: ProductMappingItem[],
 ): boolean {
-  return items.some((item) => item.candidates.length > 0)
+  return visibleMappingItems(items).length > 0
 }
 
 export function mappingChoice(
@@ -56,19 +75,15 @@ export function selectedMappingCandidate(item: ProductMappingItem) {
   return item.candidates.find((candidate) => candidate.id === value)
 }
 
-export function grandfatheredPriceWarning(
-  item: ProductMappingItem,
-): string | null {
+export function catalogPriceNote(item: ProductMappingItem): string | null {
   const candidate = selectedMappingCandidate(item)
   if (!candidate?.incompatibilities.includes('amount_mismatch')) {
     return null
   }
-  const stripe = formatMappingPrices(item.prices, item.recurring_interval)
-  const polar = formatMappingPrices(
+  return `catalog ${formatMappingPrices(
     candidate.prices,
     candidate.recurring_interval,
-  )
-  return `Imported subscribers keep ${stripe}. Polar currently sells this product at ${polar}.`
+  )}`
 }
 
 export function formatMappingPrices(

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
@@ -9,13 +9,6 @@ export const CREATE_NEW_VALUE = 'create_new'
 
 const formatAmount = formatCurrency('accounting', 'en-US')
 
-const INTERVAL_ABBREVIATION: Record<string, string> = {
-  day: '/day',
-  week: '/wk',
-  month: '/mo',
-  year: '/yr',
-}
-
 const INTERVAL_LABEL: Record<string, [string, string]> = {
   day: ['Daily', 'days'],
   week: ['Weekly', 'weeks'],
@@ -92,23 +85,6 @@ export function mappingRequiresChoice(items: ProductMappingItem[]): boolean {
   )
 }
 
-export function selectedMappingCandidate(item: ProductMappingItem) {
-  const value = mappingSelectValue(item)
-  if (!value || value === CREATE_NEW_VALUE) return undefined
-  return item.candidates.find((candidate) => candidate.id === value)
-}
-
-export function catalogPriceNote(item: ProductMappingItem): string | null {
-  const candidate = selectedMappingCandidate(item)
-  if (!candidate?.incompatibilities.includes('amount_mismatch')) {
-    return null
-  }
-  return `catalog ${formatMappingPrices(
-    candidate.prices,
-    candidate.recurring_interval,
-  )}`
-}
-
 export function formatMappingAmount(
   prices: ProductMappingItem['prices'],
 ): string {
@@ -133,16 +109,4 @@ export function formatMappingInterval(
   }
   const [once, plural] = labels
   return count <= 1 ? once : `Every ${count} ${plural}`
-}
-
-export function formatMappingPrices(
-  prices: ProductMappingItem['prices'],
-  interval: string | null,
-): string {
-  const money = formatMappingAmount(prices)
-  if (money === '—') {
-    return money
-  }
-  const suffix = interval ? (INTERVAL_ABBREVIATION[interval] ?? '') : ''
-  return `${money}${suffix}`
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
@@ -2,7 +2,8 @@ import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 
 export type ProductMappingItem = schemas['MerchantMigrationProductMappingItem']
-export type ProductMappingChoice = schemas['MerchantMigrationProductMappingChoice']
+export type ProductMappingChoice =
+  schemas['MerchantMigrationProductMappingChoice']
 
 export const CREATE_NEW_VALUE = 'create_new'
 
@@ -39,8 +40,7 @@ export function mappingChoice(
 ): ProductMappingChoice {
   return {
     source_id: sourceId,
-    polar_product_id:
-      value === CREATE_NEW_VALUE || value === '' ? null : value,
+    polar_product_id: value === CREATE_NEW_VALUE || value === '' ? null : value,
   }
 }
 
@@ -48,6 +48,27 @@ export function mappingRequiresChoice(items: ProductMappingItem[]): boolean {
   return items.some(
     (item) => item.requires_choice && item.import_status === 'pending',
   )
+}
+
+export function selectedMappingCandidate(item: ProductMappingItem) {
+  const value = mappingSelectValue(item)
+  if (!value || value === CREATE_NEW_VALUE) return undefined
+  return item.candidates.find((candidate) => candidate.id === value)
+}
+
+export function grandfatheredPriceWarning(
+  item: ProductMappingItem,
+): string | null {
+  const candidate = selectedMappingCandidate(item)
+  if (!candidate?.incompatibilities.includes('amount_mismatch')) {
+    return null
+  }
+  const stripe = formatMappingPrices(item.prices, item.recurring_interval)
+  const polar = formatMappingPrices(
+    candidate.prices,
+    candidate.recurring_interval,
+  )
+  return `Imported subscribers keep ${stripe}. Polar currently sells this product at ${polar}.`
 }
 
 export function formatMappingPrices(

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
@@ -1,0 +1,62 @@
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+
+export type ProductMappingItem = schemas['MerchantMigrationProductMappingItem']
+export type ProductMappingChoice = schemas['MerchantMigrationProductMappingChoice']
+
+export const CREATE_NEW_VALUE = 'create_new'
+
+const formatAmount = formatCurrency('accounting', 'en-US')
+
+const INTERVAL_ABBREVIATION: Record<string, string> = {
+  day: '/day',
+  week: '/wk',
+  month: '/mo',
+  year: '/yr',
+}
+
+export function compatibleCandidates(item: ProductMappingItem) {
+  return item.candidates.filter((candidate) => candidate.compatible)
+}
+
+export function mappingSelectValue(item: ProductMappingItem): string {
+  if (item.create_new) return CREATE_NEW_VALUE
+  if (item.mapped_product_id) return item.mapped_product_id
+  if (item.suggested_product_id) return item.suggested_product_id
+  if (!item.requires_choice) return CREATE_NEW_VALUE
+  return ''
+}
+
+export function shouldShowProductMappingPanel(
+  items: ProductMappingItem[],
+): boolean {
+  return items.some((item) => item.candidates.length > 0)
+}
+
+export function mappingChoice(
+  sourceId: string,
+  value: string,
+): ProductMappingChoice {
+  return {
+    source_id: sourceId,
+    polar_product_id:
+      value === CREATE_NEW_VALUE || value === '' ? null : value,
+  }
+}
+
+export function mappingRequiresChoice(items: ProductMappingItem[]): boolean {
+  return items.some(
+    (item) => item.requires_choice && item.import_status === 'pending',
+  )
+}
+
+export function formatMappingPrices(
+  prices: ProductMappingItem['prices'],
+  interval: string | null,
+): string {
+  const money = prices
+    .map((price) => formatAmount(price.amount, price.currency))
+    .join(', ')
+  const suffix = interval ? (INTERVAL_ABBREVIATION[interval] ?? '') : ''
+  return `${money}${suffix}`
+}

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -64,6 +64,9 @@ export const invalidateMigrationRecords = (id: string) => {
   client.invalidateQueries({
     queryKey: ['merchantMigrationRecordSummary', { id }],
   })
+  client.invalidateQueries({
+    queryKey: ['merchantMigrationProductMappings', { id }],
+  })
 }
 
 export const useRunMerchantMigrationPrecheck = (id: string) =>
@@ -299,4 +302,37 @@ export const useMerchantMigrationRecordSummary = (
     retry: defaultRetry,
     enabled: !!id,
     refetchInterval: refetchInterval ?? false,
+  })
+
+const productMappingsKey = (id: string) => [
+  'merchantMigrationProductMappings',
+  { id },
+]
+
+export const useProductMappings = (id: string) =>
+  useQuery({
+    queryKey: productMappingsKey(id),
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/merchant-migrations/{id}/product-mappings', {
+          params: { path: { id } },
+        }),
+      ),
+    retry: defaultRetry,
+    enabled: !!id,
+  })
+
+export const useUpdateProductMappings = (id: string) =>
+  useMutation({
+    mutationFn: (mappings: schemas['MerchantMigrationProductMappingChoice'][]) =>
+      dataOrThrow(
+        api.PUT('/v1/merchant-migrations/{id}/product-mappings', {
+          params: { path: { id } },
+          body: { mappings },
+        }),
+        "We couldn't save that mapping.",
+      ),
+    onSuccess: (listing) => {
+      getQueryClient().setQueryData(productMappingsKey(id), listing)
+    },
   })

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5381,6 +5381,30 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/merchant-migrations/{id}/product-mappings': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Merchant Migration Product Mappings
+     * @description **Scopes**: `organizations:read` `organizations:write`
+     */
+    get: operations['merchant-migrations:list_product_mappings']
+    /**
+     * Update Merchant Migration Product Mappings
+     * @description **Scopes**: `organizations:write`
+     */
+    put: operations['merchant-migrations:update_product_mappings']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/merchant-migrations/{id}/customer-ids.csv': {
     parameters: {
       query?: never
@@ -24963,6 +24987,13 @@ export interface components {
        * @description Prepare every importable subscription except these — the opt-out selection for large catalogs. Ignored when `record_ids` is set.
        */
       exclude_record_ids?: string[] | null
+      /**
+       * Product Mappings
+       * @description Stripe product → existing Polar product mappings to apply before import. Omitted mappings keep whatever was saved earlier; a null `polar_product_id` creates a new Polar product.
+       */
+      product_mappings?:
+        | components['schemas']['MerchantMigrationProductMappingChoice'][]
+        | null
     }
     /** MerchantMigrationImportResult */
     MerchantMigrationImportResult: {
@@ -24978,6 +25009,19 @@ export interface components {
        * @description How many were left on the source (not importable).
        */
       skipped: number
+    }
+    /** MerchantMigrationMappedPrice */
+    MerchantMigrationMappedPrice: {
+      /**
+       * Amount
+       * @description Price in the currency's smallest unit (cents for USD).
+       */
+      amount: number
+      /**
+       * Currency
+       * @description ISO currency code.
+       */
+      currency: string
     }
     /** MerchantMigrationNotEnabled */
     MerchantMigrationNotEnabled: {
@@ -25024,6 +25068,144 @@ export interface components {
      * @enum {string}
      */
     MerchantMigrationOperationStatus: 'pending' | 'running' | 'done' | 'failed'
+    /** MerchantMigrationPolarProductOption */
+    MerchantMigrationPolarProductOption: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The Polar product id.
+       */
+      id: string
+      /**
+       * Name
+       * @description The Polar product name.
+       */
+      name: string
+      /**
+       * Recurring Interval
+       * @description Billing interval (`month`, `year`). None for one-time products.
+       */
+      recurring_interval: string | null
+      /**
+       * Recurring Interval Count
+       * @description How many `recurring_interval` units each period spans.
+       */
+      recurring_interval_count: number | null
+      /**
+       * Prices
+       * @description Active fixed catalog prices.
+       */
+      prices: components['schemas']['MerchantMigrationMappedPrice'][]
+      /**
+       * Compatible
+       * @description Whether amount, currency, and billing interval match the Stripe product.
+       */
+      compatible: boolean
+      /**
+       * Incompatibilities
+       * @description Why this Polar product can't be mapped, when `compatible` is false.
+       */
+      incompatibilities: components['schemas']['ProductMappingIncompatibility'][]
+    }
+    /** MerchantMigrationProductMappingChoice */
+    MerchantMigrationProductMappingChoice: {
+      /**
+       * Source Id
+       * @description The staged catalog product id (`prod_…:month:1`). One Polar product per source interval.
+       */
+      source_id: string
+      /**
+       * Polar Product Id
+       * @description The Polar product to reuse. None creates a new Polar product for this source product.
+       */
+      polar_product_id: string | null
+    }
+    /** MerchantMigrationProductMappingItem */
+    MerchantMigrationProductMappingItem: {
+      /**
+       * Source Id
+       * @description The staged catalog product id (`prod_…:month:1`).
+       */
+      source_id: string
+      /**
+       * Product Source Id
+       * @description The Stripe product id (`prod_…`).
+       */
+      product_source_id: string
+      /**
+       * Name
+       * @description The Stripe product name.
+       */
+      name: string
+      /**
+       * Recurring Interval
+       * @description Billing interval on the source.
+       */
+      recurring_interval: string | null
+      /**
+       * Recurring Interval Count
+       * @description How many `recurring_interval` units each period spans.
+       */
+      recurring_interval_count: number
+      /**
+       * Prices
+       * @description Importable fixed prices on this source product.
+       */
+      prices: components['schemas']['MerchantMigrationMappedPrice'][]
+      /**
+       * Subscriber Count
+       * @description How many staged subscriptions bill this product.
+       */
+      subscriber_count: number
+      /** @description Whether this product has already been imported or skipped. */
+      import_status: components['schemas']['MerchantMigrationRecordStatus']
+      /**
+       * Mapped Product Id
+       * @description The Polar product chosen for this source product. None when creating a new Polar product or when no choice has been saved yet.
+       */
+      mapped_product_id: string | null
+      /**
+       * Create New
+       * @description The merchant chose to create a new Polar product instead of mapping.
+       */
+      create_new: boolean
+      /**
+       * Suggested Product Id
+       * @description The unique Polar product that matches amount, currency, and interval. None when there is no unique match.
+       */
+      suggested_product_id: string | null
+      /**
+       * Name Collision
+       * @description A Polar product already uses this name.
+       */
+      name_collision: boolean
+      /**
+       * Requires Choice
+       * @description The merchant must map or explicitly create a new product before import. True when a Polar product shares the name but isn't a unique compatible match, and no mapping has been saved.
+       */
+      requires_choice: boolean
+      /**
+       * Candidates
+       * @description Active Polar products the merchant can map onto.
+       */
+      candidates: components['schemas']['MerchantMigrationPolarProductOption'][]
+    }
+    /** MerchantMigrationProductMappingList */
+    MerchantMigrationProductMappingList: {
+      /**
+       * Items
+       * @description Importable source products and how they map onto Polar.
+       */
+      items: components['schemas']['MerchantMigrationProductMappingItem'][]
+    }
+    /** MerchantMigrationProductMappingUpdate */
+    MerchantMigrationProductMappingUpdate: {
+      /**
+       * Mappings
+       * @description Replaces the saved mappings for the listed source products. A null `polar_product_id` creates a new Polar product.
+       */
+      mappings: components['schemas']['MerchantMigrationProductMappingChoice'][]
+    }
     /** MerchantMigrationRecordItem */
     MerchantMigrationRecordItem: {
       /**
@@ -32169,6 +32351,38 @@ export interface components {
        * @description Number of meter interval units. Defaults to 1 when `meter_interval` is set. Ignored when `meter_interval` is `None`.
        */
       meter_interval_count?: number | null
+    }
+    /**
+     * ProductMappingIncompatibility
+     * @enum {string}
+     */
+    ProductMappingIncompatibility:
+      | 'not_recurring'
+      | 'interval_mismatch'
+      | 'currency_mismatch'
+      | 'amount_mismatch'
+      | 'missing_fixed_price'
+    /** ProductMappingInvalid */
+    ProductMappingInvalid: {
+      /**
+       * Error
+       * @example ProductMappingInvalid
+       * @constant
+       */
+      error: 'ProductMappingInvalid'
+      /** Detail */
+      detail: string
+    }
+    /** ProductMappingLocked */
+    ProductMappingLocked: {
+      /**
+       * Error
+       * @example ProductMappingLocked
+       * @constant
+       */
+      error: 'ProductMappingLocked'
+      /** Detail */
+      detail: string
     }
     /**
      * ProductMediaFileCreate
@@ -55753,7 +55967,7 @@ export interface operations {
           'application/json': components['schemas']['MerchantMigrationImportReport']
         }
       }
-      /** @description The source is not connected or isn't supported. */
+      /** @description The source is not connected, isn't supported, or a product mapping is invalid. */
       400: {
         headers: {
           [name: string]: unknown
@@ -55762,6 +55976,7 @@ export interface operations {
           'application/json':
             | components['schemas']['SourceNotConnected']
             | components['schemas']['UnsupportedMigrationSource']
+            | components['schemas']['ProductMappingInvalid']
         }
       }
       /** @description Not allowed to manage this organization. */
@@ -55782,7 +55997,7 @@ export interface operations {
           'application/json': components['schemas']['MerchantMigrationNotFound']
         }
       }
-      /** @description The pre-check hasn't run yet, it reports a blocker, or another job is still running. */
+      /** @description The pre-check hasn't run yet, it reports a blocker, another job is still running, or an imported product mapping can't change. */
       409: {
         headers: {
           [name: string]: unknown
@@ -55792,6 +56007,127 @@ export interface operations {
             | components['schemas']['CatalogImportNotReady']
             | components['schemas']['CatalogImportBlocked']
             | components['schemas']['MigrationOperationInProgress']
+            | components['schemas']['ProductMappingLocked']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'merchant-migrations:list_product_mappings': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationProductMappingList']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'merchant-migrations:update_product_mappings': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MerchantMigrationProductMappingUpdate']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationProductMappingList']
+        }
+      }
+      /** @description A mapping is invalid. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ProductMappingInvalid']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description An already-imported product can't be remapped. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ProductMappingLocked']
         }
       }
       /** @description Validation Error */
@@ -71412,6 +71748,15 @@ export const processorValues: ReadonlyArray<
 export const productBillingTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['ProductBillingType']
 > = ['one_time', 'recurring']
+export const productMappingIncompatibilityValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['ProductMappingIncompatibility']
+> = [
+  'not_recurring',
+  'interval_mismatch',
+  'currency_mismatch',
+  'amount_mismatch',
+  'missing_fixed_price',
+]
 export const productMediaFileCreateServiceValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['ProductMediaFileCreate']['service']
 > = ['product_media']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -25098,12 +25098,12 @@ export interface components {
       prices: components['schemas']['MerchantMigrationMappedPrice'][]
       /**
        * Compatible
-       * @description Whether amount, currency, and billing interval match the Stripe product.
+       * @description Whether currency and billing interval match the Stripe product. Amount may differ: imported subscribers keep the Stripe price.
        */
       compatible: boolean
       /**
        * Incompatibilities
-       * @description Why this Polar product can't be mapped, when `compatible` is false.
+       * @description Differences from the Stripe product. `amount_mismatch` is informational and does not block mapping; other values make `compatible` false.
        */
       incompatibilities: components['schemas']['ProductMappingIncompatibility'][]
     }
@@ -25171,7 +25171,7 @@ export interface components {
       create_new: boolean
       /**
        * Suggested Product Id
-       * @description The unique Polar product that matches amount, currency, and interval. None when there is no unique match.
+       * @description The unique Polar product to map onto: a unique name among interval-compatible products, or else a unique amount, currency, and interval match. None when there is no unique match.
        */
       suggested_product_id: string | null
       /**
@@ -25181,7 +25181,7 @@ export interface components {
       name_collision: boolean
       /**
        * Requires Choice
-       * @description The merchant must map or explicitly create a new product before import. True when a Polar product shares the name but isn't a unique compatible match, and no mapping has been saved.
+       * @description The merchant must map or explicitly create a new product before import. True when a Polar product shares the name but there is no unique interval-compatible match, and no mapping has been saved.
        */
       requires_choice: boolean
       /**

--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -179,17 +179,21 @@ The UI should treat this as leave-and-return background work (poll while `pendin
 
 Merchants who already sell on Polar (new checkouts) while still billing a legacy cohort on Stripe must map Stripe products onto the **existing** Polar products. Creating a duplicate Polar product would split benefits and plan resolution: subscribers would land on a new product ID that the merchant's app does not recognize.
 
-Grain is one Polar product = one source product + interval (`CanonicalProduct.source_id`, e.g. `prod_…:month:1`). A mapping is valid only when amount, currency, and cadence match; otherwise the first Polar renewal would charge a different price. Quantity, tax, and trial stay on the subscription / pre-check: Polar products don't carry per-subscription quantity, and cutover already preserves period and trial dates.
+Grain is one Polar product = one source product + interval (`CanonicalProduct.source_id`, e.g. `prod_…:month:1`). Interval and currency must match to map. Amount need not: Polar's catalog can have moved on (Stripe still $5, Polar now sells $10). Imported subscribers keep the Stripe amount via an archived catalog price on that product; checkout keeps offering the active catalog price. Do not add a new currency onto the Polar product.
+
+Quantity, tax, and trial stay on the subscription / pre-check: Polar products don't carry per-subscription quantity, and cutover already preserves period and trial dates.
 
 UI options considered:
 
 1. **Dedicated wizard step** — rejected. Empty for greenfield merchants, and an extra click for everyone else.
 2. **Assessment panel on catalog review** — chosen. Mapping sits above the subscription table, hidden when Polar has no catalog.
-3. **Auto-suggest** — also chosen, as the default. A unique amount+currency+interval match is reused at import without a click; a case-insensitive name match wins when several are compatible. Name collision without a unique compatible match blocks Prepare until the merchant maps or explicitly creates a new product.
+3. **Auto-suggest** — also chosen, as the default. A unique case-insensitive name among interval-compatible products is reused even when amount differs. Otherwise a unique amount+currency+interval match. A unique compatible product that differs in both name and amount is not auto-mapped. Name collision with an interval mismatch blocks Prepare until the merchant maps or explicitly creates a new product.
 
-- Missing mapping + unique compatible Polar product (amount, currency, interval) → reuse it at import.
-- Missing mapping + name collision without a unique compatible match → the merchant must choose map-or-create before import.
+- Missing mapping + unique name among interval-compatible Polar products → reuse it at import (grandfather the Stripe amount).
+- Missing mapping + unique amount+currency+interval match → reuse it at import.
+- Missing mapping + name collision without a unique interval-compatible match → the merchant must choose map-or-create before import.
 - Explicit `null` → create a new Polar product even when a match exists.
+- On reuse, import attaches (or creates) an archived catalog `ProductPriceFixed` at the Stripe amount so cutover can bill that price. The active catalog price is left alone.
 - Mappings persist on `MerchantMigration.source_credentials.product_mappings` (no new column: precheck deletes pending records, and a dedicated column would fail isolation CI if shipped with app code).
 
 ## Testing and rollout
@@ -219,7 +223,7 @@ Before importing, we should run the following checks.
 - **Pricing**
 	- Blocker: only fixed prices are supported for now (tiered/dynamic pricing isn't - we can still import the rest).
 - **Catalog**
-	- Warning: a Polar product already uses this name. Map the Stripe product onto it, or Polar creates a duplicate. Amount/currency/interval must match to reuse.
+	- Warning: a Polar product already uses this name. Map the Stripe product onto it, or Polar creates a duplicate. Interval and currency must match to reuse; imported subscribers keep the Stripe amount if Polar's catalog price has changed.
 - **Customers**
 	- Warning: duplicate emails (in case of manual creation), we will reuse the existing ones.
 	- Warning: if we reuse a Polar customer by email but PAN copy preserves the source `cus_…`, the copied card lands under a different customer. We should reconcile `stripe_customer_id` on reuse.

--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -3,7 +3,7 @@
 
 **Created**: 2026-06-15
 
-**Last Updated**: 2026-08-12
+**Last Updated**: 2026-09-09
 </Info>
 
 # Merchant Migrations to Polar
@@ -175,6 +175,23 @@ Precheck and catalog import run as **Dramatiq background jobs** (batched self-re
 
 The UI should treat this as leave-and-return background work (poll while `pending`/`running`; retry on `failed`). Details are out of scope here.
 
+## Product mapping
+
+Merchants who already sell on Polar (new checkouts) while still billing a legacy cohort on Stripe must map Stripe products onto the **existing** Polar products. Creating a duplicate Polar product would split benefits and plan resolution: subscribers would land on a new product ID that the merchant's app does not recognize.
+
+Grain is one Polar product = one source product + interval (`CanonicalProduct.source_id`, e.g. `prod_…:month:1`). A mapping is valid only when amount, currency, and cadence match; otherwise the first Polar renewal would charge a different price. Quantity, tax, and trial stay on the subscription / pre-check: Polar products don't carry per-subscription quantity, and cutover already preserves period and trial dates.
+
+UI options considered:
+
+1. **Dedicated wizard step** — rejected. Empty for greenfield merchants, and an extra click for everyone else.
+2. **Assessment panel on catalog review** — chosen. Mapping sits above the subscription table, hidden when Polar has no catalog.
+3. **Auto-suggest** — also chosen, as the default. A unique amount+currency+interval match is reused at import without a click; a case-insensitive name match wins when several are compatible. Name collision without a unique compatible match blocks Prepare until the merchant maps or explicitly creates a new product.
+
+- Missing mapping + unique compatible Polar product (amount, currency, interval) → reuse it at import.
+- Missing mapping + name collision without a unique compatible match → the merchant must choose map-or-create before import.
+- Explicit `null` → create a new Polar product even when a match exists.
+- Mappings persist on `MerchantMigration.source_credentials.product_mappings` (no new column: precheck deletes pending records, and a dedicated column would fail isolation CI if shipped with app code).
+
 ## Testing and rollout
 
 We can't test this on sandbox: PAN Copy and PAN Import only run on Stripe live, so we validate against live production. (love the YOLO mode with money)
@@ -202,7 +219,7 @@ Before importing, we should run the following checks.
 - **Pricing**
 	- Blocker: only fixed prices are supported for now (tiered/dynamic pricing isn't - we can still import the rest).
 - **Catalog**
-	- Blocker: duplicate product names (in case of manual creation).
+	- Warning: a Polar product already uses this name. Map the Stripe product onto it, or Polar creates a duplicate. Amount/currency/interval must match to reuse.
 - **Customers**
 	- Warning: duplicate emails (in case of manual creation), we will reuse the existing ones.
 	- Warning: if we reuse a Polar customer by email but PAN copy preserves the source `cus_…`, the copied card lands under a different customer. We should reconcile `stripe_customer_id` on reuse.

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -43,6 +43,7 @@ from .canonical import (
 from .cards import AmbiguousCopiedCard, link_payment_method
 from .importer import (
     _CUSTOMER_ALREADY_SUBSCRIBED,
+    POLAR_PRODUCT_PRICE_OPTIONS,
     create_imported_subscription,
     find_imported_price,
 )
@@ -304,7 +305,7 @@ class SubscriptionCutover:
             product_record.target_id,
             self.migration.organization_id,
             options=(
-                selectinload(Product.prices),
+                *POLAR_PRODUCT_PRICE_OPTIONS,
                 joinedload(Product.organization),
             ),
         )

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -19,6 +19,10 @@ from polar.postgres import AsyncReadSession, get_db_read_session, get_db_session
 from polar.routing import APIRouter
 
 from .auth import MerchantMigrationRead, MerchantMigrationWrite
+from .errors import (
+    ProductMappingInvalid,
+    ProductMappingLocked,
+)
 from .pan_transfer import (
     PanStepNotActionable,
     PanStepNotFound,
@@ -35,6 +39,8 @@ from .schemas import (
     MerchantMigrationCutoverRequest,
     MerchantMigrationImportReport,
     MerchantMigrationImportRequest,
+    MerchantMigrationProductMappingList,
+    MerchantMigrationProductMappingUpdate,
     MerchantMigrationRecordItem,
     MerchantMigrationRecordSummary,
     PanTransferChecklist,
@@ -185,8 +191,11 @@ async def precheck(
     summary="Import Merchant Migration Catalog",
     responses={
         400: {
-            "description": "The source is not connected or isn't supported.",
-            "model": SourceNotConnected.schema() | UnsupportedMigrationSource.schema(),
+            "description": "The source is not connected, isn't supported, or a "
+            "product mapping is invalid.",
+            "model": SourceNotConnected.schema()
+            | UnsupportedMigrationSource.schema()
+            | ProductMappingInvalid.schema(),
         },
         403: {
             "description": "Not allowed to manage this organization.",
@@ -198,10 +207,12 @@ async def precheck(
         },
         409: {
             "description": "The pre-check hasn't run yet, it reports a blocker, "
-            "or another job is still running.",
+            "another job is still running, or an imported product mapping "
+            "can't change.",
             "model": CatalogImportNotReady.schema()
             | CatalogImportBlocked.schema()
-            | MigrationOperationInProgress.schema(),
+            | MigrationOperationInProgress.schema()
+            | ProductMappingLocked.schema(),
         },
     },
 )
@@ -217,6 +228,66 @@ async def import_catalog(
         id,
         record_ids=body.record_ids if body is not None else None,
         exclude_record_ids=body.exclude_record_ids if body is not None else None,
+        product_mappings=body.product_mappings if body is not None else None,
+    )
+
+
+@router.get(
+    "/{id}/product-mappings",
+    response_model=MerchantMigrationProductMappingList,
+    summary="List Merchant Migration Product Mappings",
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+    },
+)
+async def list_product_mappings(
+    id: UUID4,
+    auth_subject: MerchantMigrationRead,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> MerchantMigrationProductMappingList:
+    return await merchant_migration_service.list_product_mappings(
+        session, auth_subject, id
+    )
+
+
+@router.put(
+    "/{id}/product-mappings",
+    response_model=MerchantMigrationProductMappingList,
+    summary="Update Merchant Migration Product Mappings",
+    responses={
+        400: {
+            "description": "A mapping is invalid.",
+            "model": ProductMappingInvalid.schema(),
+        },
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+        409: {
+            "description": "An already-imported product can't be remapped.",
+            "model": ProductMappingLocked.schema(),
+        },
+    },
+)
+async def update_product_mappings(
+    id: UUID4,
+    body: MerchantMigrationProductMappingUpdate,
+    auth_subject: MerchantMigrationWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> MerchantMigrationProductMappingList:
+    return await merchant_migration_service.update_product_mappings(
+        session, auth_subject, id, body.mappings
     )
 
 

--- a/server/polar/merchant_migration/errors.py
+++ b/server/polar/merchant_migration/errors.py
@@ -4,3 +4,16 @@ from polar.exceptions import PolarError
 class MerchantMigrationError(PolarError):
     """Base for everything this module raises, so a caller can catch the whole
     feature in one clause."""
+
+
+class ProductMappingInvalid(MerchantMigrationError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message, 400)
+
+
+class ProductMappingLocked(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "This product has already been imported, so its mapping can't change.",
+            409,
+        )

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from typing import TypeVar
 from uuid import UUID
 
+from sqlalchemy.orm import selectinload
+
 from polar.auth.models import AuthSubject
 from polar.customer.repository import CustomerRepository
 from polar.customer.service import customer as customer_service
@@ -28,8 +30,12 @@ from polar.models.merchant_migration_record import (
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
-from polar.models.product_price import ProductPriceAmountType, ProductPriceFixed
-from polar.product.repository import ProductRepository
+from polar.models.product_price import (
+    ProductPriceAmountType,
+    ProductPriceFixed,
+    ProductPriceSource,
+)
+from polar.product.repository import ProductPriceRepository, ProductRepository
 from polar.product.schemas import (
     ProductCreateRecurring,
     ProductPriceCreate,
@@ -42,6 +48,7 @@ from .canonical import (
     CanonicalCustomer,
     CanonicalProduct,
     CanonicalSubscription,
+    PriceKey,
     canonical_price_key,
     deserialize,
     subscription_price_key,
@@ -77,6 +84,9 @@ _CUSTOMER_STRIPE_ID_CONFLICT = Reason(
 )
 
 
+POLAR_PRODUCT_PRICE_OPTIONS = (selectinload(Product.all_prices),)
+
+
 def find_imported_price(
     product: Product,
     canonical_product: CanonicalProduct,
@@ -96,16 +106,56 @@ def find_imported_price(
     if canonical_price is None:
         return None
     currency = canonical_price.currency.lower()
-    return next(
-        (
-            price
-            for price in product.prices
-            if isinstance(price, ProductPriceFixed)
-            and price.price_currency.lower() == currency
-            and price.price_amount == canonical_price.amount
-        ),
-        None,
+    matches = [
+        price
+        for price in product.all_prices
+        if isinstance(price, ProductPriceFixed)
+        and price.price_currency.lower() == currency
+        and price.price_amount == canonical_price.amount
+    ]
+    return next((price for price in matches if not price.is_archived), None) or (
+        matches[0] if matches else None
     )
+
+
+async def ensure_mapped_prices(
+    session: AsyncSession,
+    product: Product,
+    canonical: CanonicalProduct,
+    importable_price_keys: set[PriceKey],
+) -> None:
+    """Keep Stripe amounts as archived catalog prices when Polar's catalog moved on."""
+    existing = {
+        (price.price_currency.lower(), price.price_amount)
+        for price in product.all_prices
+        if isinstance(price, ProductPriceFixed)
+    }
+    catalog_tax = {
+        price.price_currency.lower(): price.tax_behavior
+        for price in product.prices
+        if isinstance(price, ProductPriceFixed)
+    }
+    repository = ProductPriceRepository.from_session(session)
+    for price in canonical.prices:
+        if price.amount is None:
+            continue
+        if canonical_price_key(price) not in importable_price_keys:
+            continue
+        key = (price.currency.lower(), price.amount)
+        if key in existing:
+            continue
+        existing.add(key)
+        await repository.create(
+            ProductPriceFixed(
+                price_amount=price.amount,
+                price_currency=price.currency.lower(),
+                product=product,
+                is_archived=True,
+                source=ProductPriceSource.catalog,
+                tax_behavior=catalog_tax.get(price.currency.lower()),
+            ),
+            flush=True,
+        )
 
 
 async def create_imported_subscription(
@@ -303,7 +353,9 @@ class CatalogImporter:
         )
         polar_products = await ProductRepository.from_session(
             self.session
-        ).get_all_by_organization(self.organization.id)
+        ).get_all_by_organization(
+            self.organization.id, options=POLAR_PRODUCT_PRICE_OPTIONS
+        )
 
         counts = ImportCounts()
         for record, product in zip(records, products, strict=True):
@@ -326,6 +378,12 @@ class CatalogImporter:
                 # Leave the ledger pending so a corrected mapping can retry.
                 raise ProductMappingInvalid(decision.skip.message)
             if decision.product is not None:
+                await ensure_mapped_prices(
+                    self.session,
+                    decision.product,
+                    product,
+                    plan.importable_prices,
+                )
                 await self._mark_imported(record, decision.product.id)
                 counts.imported += 1
                 continue

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -29,6 +29,7 @@ from polar.models.merchant_migration_record import (
     MerchantMigrationRecordType,
 )
 from polar.models.product_price import ProductPriceAmountType, ProductPriceFixed
+from polar.product.repository import ProductRepository
 from polar.product.schemas import (
     ProductCreateRecurring,
     ProductPriceCreate,
@@ -45,6 +46,7 @@ from .canonical import (
     deserialize,
     subscription_price_key,
 )
+from .errors import ProductMappingInvalid
 from .precheck import (
     ProductImportPlan,
     Reason,
@@ -52,6 +54,7 @@ from .precheck import (
     plan_product_imports,
     plan_subscription_imports,
 )
+from .product_mapping import UNSET, decide_mapping, read_product_mappings
 from .repository import MerchantMigrationRecordRepository
 from .schemas import (
     MerchantMigrationImportReport,
@@ -97,7 +100,9 @@ def find_imported_price(
         (
             price
             for price in product.prices
-            if isinstance(price, ProductPriceFixed) and price.price_currency == currency
+            if isinstance(price, ProductPriceFixed)
+            and price.price_currency.lower() == currency
+            and price.price_amount == canonical_price.amount
         ),
         None,
     )
@@ -164,6 +169,7 @@ class CatalogImporter:
         self.exclude_record_ids = exclude_record_ids
         self.record_repository = MerchantMigrationRecordRepository.from_session(session)
         self.customer_repository = CustomerRepository.from_session(session)
+        self.product_mappings = read_product_mappings(migration)
 
     async def run(self) -> MerchantMigrationImportReport:
         records = await self.record_repository.list_by_migration(self.migration.id)
@@ -295,6 +301,9 @@ class CatalogImporter:
         plans = plan_product_imports(
             products, self.organization.default_presentment_currency
         )
+        polar_products = await ProductRepository.from_session(
+            self.session
+        ).get_all_by_organization(self.organization.id)
 
         counts = ImportCounts()
         for record, product in zip(records, products, strict=True):
@@ -307,6 +316,18 @@ class CatalogImporter:
             if plan.skip is not None:
                 await self._mark_skipped(record, plan.skip)
                 counts.skipped += 1
+                continue
+            decision = decide_mapping(
+                product,
+                polar_products,
+                self.product_mappings.get(product.source_id, UNSET),
+            )
+            if decision.skip is not None:
+                # Leave the ledger pending so a corrected mapping can retry.
+                raise ProductMappingInvalid(decision.skip.message)
+            if decision.product is not None:
+                await self._mark_imported(record, decision.product.id)
+                counts.imported += 1
                 continue
             polar_product = await self._create_product(product, plan)
             await self._mark_imported(record, polar_product.id)

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -97,7 +97,8 @@ _DUPLICATE_PRODUCT_NAME_REASON = (
     "Another source product uses this name. Both import and share it in Polar."
 )
 _EXISTING_PRODUCT_NAME_REASON = (
-    "A Polar product already uses this name. Importing adds a second one."
+    "A Polar product already uses this name. Map this Stripe product onto it "
+    "so subscribers keep the same Polar product and benefits."
 )
 _DUPLICATE_CUSTOMER_EMAIL_REASON = (
     "Another source customer uses this email, and a Polar customer can only carry "
@@ -437,16 +438,17 @@ class PrecheckEngine:
         products_by_name: dict[str, set[str]],
         existing_product_names: set[str],
     ) -> Iterable[PrecheckIssue]:
-        # Warn, don't block: the product still imports, as a new Polar product next
-        # to the existing one. Mapping onto it is a later, merchant-driven step.
+        # Warn, don't block: without an explicit mapping Polar still imports a
+        # new product. Compatible name+price matches are reused at import.
         for name in products_by_name:
             if name.lower() in existing_product_names:
                 yield PrecheckIssue(
                     level=PrecheckIssueLevel.warning,
                     code="product_exists_in_polar",
                     message=(
-                        f"A Polar product named '{name}' already exists; importing "
-                        "will create a duplicate."
+                        f"A Polar product named '{name}' already exists; map "
+                        "this Stripe product onto it, or Polar will create a "
+                        "duplicate."
                     ),
                     source_id=None,
                 )

--- a/server/polar/merchant_migration/product_mapping.py
+++ b/server/polar/merchant_migration/product_mapping.py
@@ -1,8 +1,9 @@
 """Match a staged Stripe product onto an existing Polar product.
 
 Polar recurrence lives on the product, so the grain is one CanonicalProduct
-(source product + interval). A mapping is valid only when amount, currency, and
-cadence match: otherwise the first Polar renewal would charge a different price.
+(source product + interval). Interval and currency must match to map; amount
+need not. Imported subscribers keep the Stripe amount (an archived catalog
+price) when Polar's active catalog has moved on.
 """
 
 from collections import Counter
@@ -28,18 +29,27 @@ PRODUCT_MAPPINGS_KEY = "product_mappings"
 
 MAPPING_REQUIRED = Reason(
     "product_mapping_required",
-    "A Polar product already uses this name, but amount or billing interval "
-    "don't match. Map it to an existing product, or choose to create a new one.",
+    "A Polar product already uses this name, but the billing interval "
+    "doesn't match. Map it to an existing product, or choose to create a new one.",
 )
 MAPPING_INCOMPATIBLE = Reason(
     "product_mapping_incompatible",
-    "The chosen Polar product doesn't match this Stripe product's amount, "
-    "currency, or billing interval.",
+    "The chosen Polar product doesn't match this Stripe product's currency "
+    "or billing interval.",
 )
 MAPPING_NOT_FOUND = Reason(
     "product_mapping_not_found",
     "The chosen Polar product is missing, archived, or belongs to another "
     "organization.",
+)
+
+_BLOCKING = frozenset(
+    {
+        ProductMappingIncompatibility.not_recurring,
+        ProductMappingIncompatibility.interval_mismatch,
+        ProductMappingIncompatibility.currency_mismatch,
+        ProductMappingIncompatibility.missing_fixed_price,
+    }
 )
 
 
@@ -100,7 +110,15 @@ def incompatibilities(
 
 
 def is_compatible(canonical: CanonicalProduct, product: Product) -> bool:
-    return not incompatibilities(canonical, product)
+    return not _BLOCKING.intersection(incompatibilities(canonical, product))
+
+
+def catalog_amounts_match(canonical: CanonicalProduct, product: Product) -> bool:
+    codes = incompatibilities(canonical, product)
+    return (
+        ProductMappingIncompatibility.amount_mismatch not in codes
+        and ProductMappingIncompatibility.currency_mismatch not in codes
+    )
 
 
 def name_collision(canonical: CanonicalProduct, product: Product) -> bool:
@@ -110,19 +128,25 @@ def name_collision(canonical: CanonicalProduct, product: Product) -> bool:
 def suggest_product(
     canonical: CanonicalProduct, products: Sequence[Product]
 ) -> Product | None:
-    """The unique Polar product that matches cadence, amount, and currency.
+    """The unique Polar product this Stripe product should map onto.
 
-    Prefer a case-insensitive name match when several are compatible. Ambiguous
-    matches (two Polar products at the same price and interval) return None.
+    Prefer a unique case-insensitive name among interval-compatible products,
+    even when Polar's catalog amount has moved on. Otherwise a unique
+    amount+currency+interval match. Do not auto-map a unique compatible product
+    that differs in both name and amount.
     """
     compatible = [product for product in products if is_compatible(canonical, product)]
-    if not compatible:
-        return None
     named = [product for product in compatible if name_collision(canonical, product)]
-    pool = named or compatible
-    if len(pool) != 1:
+    if len(named) == 1:
+        return named[0]
+    if len(named) > 1:
         return None
-    return pool[0]
+    amount_matches = [
+        product for product in compatible if catalog_amounts_match(canonical, product)
+    ]
+    if len(amount_matches) == 1:
+        return amount_matches[0]
+    return None
 
 
 def has_name_collision(

--- a/server/polar/merchant_migration/product_mapping.py
+++ b/server/polar/merchant_migration/product_mapping.py
@@ -1,0 +1,200 @@
+"""Match a staged Stripe product onto an existing Polar product.
+
+Polar recurrence lives on the product, so the grain is one CanonicalProduct
+(source product + interval). A mapping is valid only when amount, currency, and
+cadence match: otherwise the first Polar renewal would charge a different price.
+"""
+
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass
+from uuid import UUID
+
+from polar.models import MerchantMigration, Product
+from polar.models.product_price import ProductPriceFixed
+
+from .canonical import (
+    CanonicalProduct,
+    CanonicalSubscription,
+    price_key,
+    subscription_price_key,
+)
+from .precheck import Reason
+from .schemas import ProductMappingIncompatibility
+
+UNSET = object()
+
+PRODUCT_MAPPINGS_KEY = "product_mappings"
+
+MAPPING_REQUIRED = Reason(
+    "product_mapping_required",
+    "A Polar product already uses this name, but amount or billing interval "
+    "don't match. Map it to an existing product, or choose to create a new one.",
+)
+MAPPING_INCOMPATIBLE = Reason(
+    "product_mapping_incompatible",
+    "The chosen Polar product doesn't match this Stripe product's amount, "
+    "currency, or billing interval.",
+)
+MAPPING_NOT_FOUND = Reason(
+    "product_mapping_not_found",
+    "The chosen Polar product is missing, archived, or belongs to another "
+    "organization.",
+)
+
+
+@dataclass(frozen=True)
+class MappingDecision:
+    """What import should do with one staged product."""
+
+    product: Product | None = None
+    skip: Reason | None = None
+    create_new: bool = False
+
+
+def polar_interval(product: Product) -> str | None:
+    if product.recurring_interval is None:
+        return None
+    return product.recurring_interval.value
+
+
+def polar_interval_count(product: Product) -> int:
+    return product.recurring_interval_count or 1
+
+
+def fixed_prices(product: Product) -> dict[str, ProductPriceFixed]:
+    return {
+        price.price_currency.lower(): price
+        for price in product.prices
+        if isinstance(price, ProductPriceFixed)
+    }
+
+
+def incompatibilities(
+    canonical: CanonicalProduct, product: Product
+) -> list[ProductMappingIncompatibility]:
+    if product.is_archived or polar_interval(product) is None:
+        return [ProductMappingIncompatibility.not_recurring]
+    found: list[ProductMappingIncompatibility] = []
+    if (
+        polar_interval(product) != canonical.recurring_interval
+        or polar_interval_count(product) != canonical.recurring_interval_count
+    ):
+        found.append(ProductMappingIncompatibility.interval_mismatch)
+    polar_by_currency = fixed_prices(product)
+    for price in canonical.prices:
+        if price.amount is None:
+            continue
+        currency = price.currency.lower()
+        polar_price = polar_by_currency.get(currency)
+        if polar_price is None:
+            found.append(
+                ProductMappingIncompatibility.currency_mismatch
+                if polar_by_currency
+                else ProductMappingIncompatibility.missing_fixed_price
+            )
+            continue
+        if polar_price.price_amount != price.amount:
+            found.append(ProductMappingIncompatibility.amount_mismatch)
+    return list(dict.fromkeys(found))
+
+
+def is_compatible(canonical: CanonicalProduct, product: Product) -> bool:
+    return not incompatibilities(canonical, product)
+
+
+def name_collision(canonical: CanonicalProduct, product: Product) -> bool:
+    return product.name.lower() == canonical.name.lower()
+
+
+def suggest_product(
+    canonical: CanonicalProduct, products: Sequence[Product]
+) -> Product | None:
+    """The unique Polar product that matches cadence, amount, and currency.
+
+    Prefer a case-insensitive name match when several are compatible. Ambiguous
+    matches (two Polar products at the same price and interval) return None.
+    """
+    compatible = [product for product in products if is_compatible(canonical, product)]
+    if not compatible:
+        return None
+    named = [product for product in compatible if name_collision(canonical, product)]
+    pool = named or compatible
+    if len(pool) != 1:
+        return None
+    return pool[0]
+
+
+def has_name_collision(
+    canonical: CanonicalProduct, products: Sequence[Product]
+) -> bool:
+    return any(name_collision(canonical, product) for product in products)
+
+
+def subscriber_counts(
+    products: Sequence[CanonicalProduct],
+    subscriptions: Sequence[CanonicalSubscription],
+) -> dict[str, int]:
+    product_by_price = {
+        price_key(price.source_id, price.currency): product.source_id
+        for product in products
+        for price in product.prices
+    }
+    counts: Counter[str] = Counter()
+    for subscription in subscriptions:
+        key = subscription_price_key(subscription)
+        source_id = product_by_price.get(key) if key is not None else None
+        if source_id is not None:
+            counts[source_id] += 1
+    return dict(counts)
+
+
+def read_product_mappings(migration: MerchantMigration) -> dict[str, UUID | None]:
+    raw = migration.source_credentials.get(PRODUCT_MAPPINGS_KEY)
+    if not isinstance(raw, dict):
+        return {}
+    mappings: dict[str, UUID | None] = {}
+    for source_id, value in raw.items():
+        if not isinstance(source_id, str):
+            continue
+        if value is None:
+            mappings[source_id] = None
+            continue
+        try:
+            mappings[source_id] = UUID(str(value))
+        except ValueError:
+            continue
+    return mappings
+
+
+def serialize_product_mappings(
+    mappings: dict[str, UUID | None],
+) -> dict[str, str | None]:
+    return {
+        source_id: str(product_id) if product_id is not None else None
+        for source_id, product_id in mappings.items()
+    }
+
+
+def decide_mapping(
+    canonical: CanonicalProduct,
+    products: Sequence[Product],
+    chosen: UUID | None | object = UNSET,
+) -> MappingDecision:
+    """Resolve one staged product against stored choice, suggestion, and collisions."""
+    if chosen is not UNSET:
+        if chosen is None:
+            return MappingDecision(create_new=True)
+        product = next((item for item in products if item.id == chosen), None)
+        if product is None:
+            return MappingDecision(skip=MAPPING_NOT_FOUND)
+        if not is_compatible(canonical, product):
+            return MappingDecision(skip=MAPPING_INCOMPATIBLE)
+        return MappingDecision(product=product)
+
+    suggested = suggest_product(canonical, products)
+    if suggested is not None:
+        return MappingDecision(product=suggested)
+    if has_name_collision(canonical, products):
+        return MappingDecision(skip=MAPPING_REQUIRED)
+    return MappingDecision(create_new=True)

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -66,6 +66,14 @@ class PrecheckReasonLevel(StrEnum):
     info = "info"
 
 
+class ProductMappingIncompatibility(StrEnum):
+    not_recurring = "not_recurring"
+    interval_mismatch = "interval_mismatch"
+    currency_mismatch = "currency_mismatch"
+    amount_mismatch = "amount_mismatch"
+    missing_fixed_price = "missing_fixed_price"
+
+
 class PrecheckEntitySummary(Schema):
     entity: PrecheckEntity = Field(description="The source entity type.")
     total: int = Field(description="How many were read from the source.")
@@ -238,6 +246,21 @@ class MerchantMigrationRecordSummary(Schema):
     )
 
 
+class MerchantMigrationProductMappingChoice(Schema):
+    source_id: str = Field(
+        description=(
+            "The staged catalog product id (`prod_…:month:1`). One Polar product "
+            "per source interval."
+        ),
+    )
+    polar_product_id: UUID4 | None = Field(
+        description=(
+            "The Polar product to reuse. None creates a new Polar product for "
+            "this source product."
+        ),
+    )
+
+
 class MerchantMigrationImportRequest(Schema):
     record_ids: list[UUID4] | None = Field(
         default=None,
@@ -253,6 +276,14 @@ class MerchantMigrationImportRequest(Schema):
         description=(
             "Prepare every importable subscription except these — the opt-out "
             "selection for large catalogs. Ignored when `record_ids` is set."
+        ),
+    )
+    product_mappings: list[MerchantMigrationProductMappingChoice] | None = Field(
+        default=None,
+        description=(
+            "Stripe product → existing Polar product mappings to apply before "
+            "import. Omitted mappings keep whatever was saved earlier; a null "
+            "`polar_product_id` creates a new Polar product."
         ),
     )
 
@@ -376,5 +407,100 @@ class MerchantMigration(IDSchema, TimestampedSchema):
     operation: MerchantMigrationOperation | None = Field(
         description=(
             "Background work for the current step, if any. None until a run starts."
+        ),
+    )
+
+
+class MerchantMigrationMappedPrice(Schema):
+    amount: int = Field(
+        description="Price in the currency's smallest unit (cents for USD)."
+    )
+    currency: str = Field(description="ISO currency code.")
+
+
+class MerchantMigrationPolarProductOption(Schema):
+    id: UUID4 = Field(description="The Polar product id.")
+    name: str = Field(description="The Polar product name.")
+    recurring_interval: str | None = Field(
+        description="Billing interval (`month`, `year`). None for one-time products."
+    )
+    recurring_interval_count: int | None = Field(
+        description="How many `recurring_interval` units each period spans."
+    )
+    prices: list[MerchantMigrationMappedPrice] = Field(
+        description="Active fixed catalog prices."
+    )
+    compatible: bool = Field(
+        description=(
+            "Whether amount, currency, and billing interval match the Stripe product."
+        )
+    )
+    incompatibilities: list[ProductMappingIncompatibility] = Field(
+        description="Why this Polar product can't be mapped, when `compatible` is false."
+    )
+
+
+class MerchantMigrationProductMappingItem(Schema):
+    source_id: str = Field(
+        description="The staged catalog product id (`prod_…:month:1`)."
+    )
+    product_source_id: str = Field(description="The Stripe product id (`prod_…`).")
+    name: str = Field(description="The Stripe product name.")
+    recurring_interval: str | None = Field(
+        description="Billing interval on the source."
+    )
+    recurring_interval_count: int = Field(
+        description="How many `recurring_interval` units each period spans."
+    )
+    prices: list[MerchantMigrationMappedPrice] = Field(
+        description="Importable fixed prices on this source product."
+    )
+    subscriber_count: int = Field(
+        description="How many staged subscriptions bill this product."
+    )
+    import_status: MerchantMigrationRecordStatus = Field(
+        description="Whether this product has already been imported or skipped."
+    )
+    mapped_product_id: UUID4 | None = Field(
+        description=(
+            "The Polar product chosen for this source product. None when creating "
+            "a new Polar product or when no choice has been saved yet."
+        )
+    )
+    create_new: bool = Field(
+        description=(
+            "The merchant chose to create a new Polar product instead of mapping."
+        )
+    )
+    suggested_product_id: UUID4 | None = Field(
+        description=(
+            "The unique Polar product that matches amount, currency, and interval. "
+            "None when there is no unique match."
+        )
+    )
+    name_collision: bool = Field(description="A Polar product already uses this name.")
+    requires_choice: bool = Field(
+        description=(
+            "The merchant must map or explicitly create a new product before "
+            "import. True when a Polar product shares the name but isn't a unique "
+            "compatible match, and no mapping has been saved."
+        )
+    )
+    candidates: list[MerchantMigrationPolarProductOption] = Field(
+        description="Active Polar products the merchant can map onto."
+    )
+
+
+class MerchantMigrationProductMappingList(Schema):
+    items: list[MerchantMigrationProductMappingItem] = Field(
+        description="Importable source products and how they map onto Polar."
+    )
+
+
+class MerchantMigrationProductMappingUpdate(Schema):
+    mappings: list[MerchantMigrationProductMappingChoice] = Field(
+        description=(
+            "Replaces the saved mappings for the listed source products. A null "
+            "`polar_product_id` creates a new Polar product."
         ),
     )

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -432,11 +432,15 @@ class MerchantMigrationPolarProductOption(Schema):
     )
     compatible: bool = Field(
         description=(
-            "Whether amount, currency, and billing interval match the Stripe product."
+            "Whether currency and billing interval match the Stripe product. "
+            "Amount may differ: imported subscribers keep the Stripe price."
         )
     )
     incompatibilities: list[ProductMappingIncompatibility] = Field(
-        description="Why this Polar product can't be mapped, when `compatible` is false."
+        description=(
+            "Differences from the Stripe product. `amount_mismatch` is informational "
+            "and does not block mapping; other values make `compatible` false."
+        )
     )
 
 
@@ -474,16 +478,17 @@ class MerchantMigrationProductMappingItem(Schema):
     )
     suggested_product_id: UUID4 | None = Field(
         description=(
-            "The unique Polar product that matches amount, currency, and interval. "
-            "None when there is no unique match."
+            "The unique Polar product to map onto: a unique name among interval-"
+            "compatible products, or else a unique amount, currency, and interval "
+            "match. None when there is no unique match."
         )
     )
     name_collision: bool = Field(description="A Polar product already uses this name.")
     requires_choice: bool = Field(
         description=(
             "The merchant must map or explicitly create a new product before "
-            "import. True when a Polar product shares the name but isn't a unique "
-            "compatible match, and no mapping has been saved."
+            "import. True when a Polar product shares the name but there is no "
+            "unique interval-compatible match, and no mapping has been saved."
         )
     )
     candidates: list[MerchantMigrationPolarProductOption] = Field(

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -85,6 +85,7 @@ from .product_mapping import (
     decide_mapping,
     has_name_collision,
     incompatibilities,
+    is_compatible,
     polar_interval,
     polar_interval_count,
     read_product_mappings,
@@ -292,7 +293,7 @@ def _polar_option(
             for price in product.prices
             if isinstance(price, ProductPriceFixed)
         ],
-        compatible=not codes,
+        compatible=is_compatible(canonical, product),
         incompatibilities=codes,
     )
 
@@ -793,7 +794,7 @@ class MerchantMigrationService:
             if decision.product is None:
                 raise ProductMappingInvalid(
                     f"'{canonical.name}' can't map onto that Polar product: "
-                    "amount, currency, or billing interval don't match."
+                    "currency or billing interval don't match."
                 )
             stored[choice.source_id] = choice.polar_product_id
         credentials = dict(migration.source_credentials)

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -21,6 +21,7 @@ from polar.models import (
     MerchantMigration,
     MerchantMigrationRecord,
     PaymentMethod,
+    Product,
 )
 from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
@@ -36,6 +37,7 @@ from polar.models.merchant_migration_record import (
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
+from polar.models.product_price import ProductPriceFixed
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
 from polar.product.repository import ProductRepository
@@ -52,7 +54,11 @@ from .canonical import (
 )
 from .cards import AmbiguousCopiedCard, link_payment_method
 from .cutover import SubscriptionCutover
-from .errors import MerchantMigrationError
+from .errors import (
+    MerchantMigrationError,
+    ProductMappingInvalid,
+    ProductMappingLocked,
+)
 from .importer import CatalogImporter
 from .pan_transfer import (
     STEP_CUTOVER,
@@ -70,7 +76,21 @@ from .precheck import (
     account_blockers,
     classify_records,
     import_blockers,
+    plan_product_imports,
     precheck_engine,
+)
+from .product_mapping import (
+    PRODUCT_MAPPINGS_KEY,
+    UNSET,
+    decide_mapping,
+    has_name_collision,
+    incompatibilities,
+    polar_interval,
+    polar_interval_count,
+    read_product_mappings,
+    serialize_product_mappings,
+    subscriber_counts,
+    suggest_product,
 )
 from .repository import (
     MerchantMigrationRecordRepository,
@@ -80,6 +100,11 @@ from .schemas import (
     MerchantMigrationCreate,
     MerchantMigrationCutoverReport,
     MerchantMigrationImportReport,
+    MerchantMigrationMappedPrice,
+    MerchantMigrationPolarProductOption,
+    MerchantMigrationProductMappingChoice,
+    MerchantMigrationProductMappingItem,
+    MerchantMigrationProductMappingList,
     MerchantMigrationRecordItem,
     MerchantMigrationRecordSummary,
     MerchantMigrationRecordSummaryEntity,
@@ -235,6 +260,41 @@ class BlockedByPrecheck(MerchantMigrationError):
 class CatalogImportBlocked(BlockedByPrecheck):
     def __init__(self, blockers: list[PrecheckIssue]) -> None:
         super().__init__("The migration can't be imported:", blockers, 409)
+
+
+def _canonical_prices(
+    product: CanonicalProduct,
+) -> list[MerchantMigrationMappedPrice]:
+    return [
+        MerchantMigrationMappedPrice(
+            amount=price.amount, currency=price.currency.lower()
+        )
+        for price in product.prices
+        if price.amount is not None
+    ]
+
+
+def _polar_option(
+    canonical: CanonicalProduct, product: Product
+) -> MerchantMigrationPolarProductOption:
+    codes = incompatibilities(canonical, product)
+    return MerchantMigrationPolarProductOption(
+        id=product.id,
+        name=product.name,
+        recurring_interval=polar_interval(product),
+        recurring_interval_count=(
+            polar_interval_count(product) if product.recurring_interval else None
+        ),
+        prices=[
+            MerchantMigrationMappedPrice(
+                amount=price.price_amount, currency=price.price_currency.lower()
+            )
+            for price in product.prices
+            if isinstance(price, ProductPriceFixed)
+        ],
+        compatible=not codes,
+        incompatibilities=codes,
+    )
 
 
 class SourceAccountNotMigratable(BlockedByPrecheck):
@@ -617,6 +677,7 @@ class MerchantMigrationService:
         *,
         record_ids: Sequence[UUID] | None = None,
         exclude_record_ids: Sequence[UUID] | None = None,
+        product_mappings: Sequence[MerchantMigrationProductMappingChoice] | None = None,
     ) -> MerchantMigrationImportReport:
         """Create the Polar catalog from the staged importable records, then
         advance the migration to the create-catalog step. Idempotent: re-running
@@ -638,6 +699,11 @@ class MerchantMigrationService:
         if blockers:
             raise CatalogImportBlocked(blockers)
 
+        if product_mappings is not None:
+            await self._save_product_mappings(
+                session, migration, organization, product_mappings
+            )
+
         report = await CatalogImporter(
             session,
             migration,
@@ -655,6 +721,161 @@ class MerchantMigrationService:
         )
         report.step = MerchantMigrationStep.create_catalog
         return report
+
+    async def list_product_mappings(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> MerchantMigrationProductMappingList:
+        migration = await self._get_manageable(session, auth_subject, migration_id)
+        organization = await self._get_organization(session, migration)
+        return await self._product_mapping_list(session, migration, organization)
+
+    async def update_product_mappings(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+        mappings: Sequence[MerchantMigrationProductMappingChoice],
+    ) -> MerchantMigrationProductMappingList:
+        migration = await self._get_manageable(
+            session, auth_subject, migration_id, for_update=True
+        )
+        organization = await self._get_organization(session, migration)
+        await self._save_product_mappings(session, migration, organization, mappings)
+        return await self._product_mapping_list(session, migration, organization)
+
+    async def _save_product_mappings(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        organization: Organization,
+        choices: Sequence[MerchantMigrationProductMappingChoice],
+    ) -> None:
+        records = await MerchantMigrationRecordRepository.from_session(
+            session
+        ).list_by_migration(migration.id)
+        polar_products = await ProductRepository.from_session(
+            session
+        ).get_all_by_organization(organization.id)
+        product_records = {
+            record.source_id: record
+            for record in records
+            if record.type == MerchantMigrationRecordType.product
+        }
+        canonical_products = [
+            self._as_canonical_product(record) for record in product_records.values()
+        ]
+        plans = plan_product_imports(
+            canonical_products, organization.default_presentment_currency
+        )
+        stored = read_product_mappings(migration)
+        for choice in choices:
+            record = product_records.get(choice.source_id)
+            if record is None:
+                raise ProductMappingInvalid(
+                    f"Unknown source product '{choice.source_id}'."
+                )
+            if record.status != MerchantMigrationRecordStatus.pending:
+                raise ProductMappingLocked()
+            canonical = self._as_canonical_product(record)
+            if plans[canonical.source_id].skip is not None:
+                raise ProductMappingInvalid(
+                    f"'{canonical.name}' can't be imported, so it can't be mapped."
+                )
+            if choice.polar_product_id is None:
+                stored[choice.source_id] = None
+                continue
+            decision = decide_mapping(
+                canonical, polar_products, choice.polar_product_id
+            )
+            if decision.product is None:
+                raise ProductMappingInvalid(
+                    f"'{canonical.name}' can't map onto that Polar product: "
+                    "amount, currency, or billing interval don't match."
+                )
+            stored[choice.source_id] = choice.polar_product_id
+        credentials = dict(migration.source_credentials)
+        credentials[PRODUCT_MAPPINGS_KEY] = serialize_product_mappings(stored)
+        await MerchantMigrationRepository.from_session(session).update(
+            migration, update_dict={"source_credentials": credentials}
+        )
+
+    async def _product_mapping_list(
+        self,
+        session: AsyncReadSession,
+        migration: MerchantMigration,
+        organization: Organization,
+    ) -> MerchantMigrationProductMappingList:
+        records = await MerchantMigrationRecordRepository.from_session(
+            session
+        ).list_by_migration(migration.id)
+        polar_products = list(
+            await ProductRepository.from_session(session).get_all_by_organization(
+                organization.id
+            )
+        )
+        product_records = [
+            record
+            for record in records
+            if record.type == MerchantMigrationRecordType.product
+        ]
+        canonical_products = [
+            self._as_canonical_product(record) for record in product_records
+        ]
+        subscriptions = [
+            deserialize(record.type, record.canonical)
+            for record in records
+            if record.type == MerchantMigrationRecordType.subscription
+        ]
+        plans = plan_product_imports(
+            canonical_products, organization.default_presentment_currency
+        )
+        stored = read_product_mappings(migration)
+        counts = subscriber_counts(
+            canonical_products,
+            [item for item in subscriptions if isinstance(item, CanonicalSubscription)],
+        )
+        items: list[MerchantMigrationProductMappingItem] = []
+        for record, canonical in zip(product_records, canonical_products, strict=True):
+            if plans[canonical.source_id].skip is not None:
+                continue
+            chosen = stored.get(canonical.source_id, UNSET)
+            suggested = suggest_product(canonical, polar_products)
+            collision = has_name_collision(canonical, polar_products)
+            create_new = chosen is None
+            mapped_id = chosen if isinstance(chosen, UUID) else None
+            items.append(
+                MerchantMigrationProductMappingItem(
+                    source_id=canonical.source_id,
+                    product_source_id=canonical.product_source_id,
+                    name=canonical.name,
+                    recurring_interval=canonical.recurring_interval,
+                    recurring_interval_count=canonical.recurring_interval_count,
+                    prices=_canonical_prices(canonical),
+                    subscriber_count=counts.get(canonical.source_id, 0),
+                    import_status=record.status,
+                    mapped_product_id=mapped_id,
+                    create_new=create_new,
+                    suggested_product_id=suggested.id
+                    if suggested is not None
+                    else None,
+                    name_collision=collision,
+                    requires_choice=chosen is UNSET and collision and suggested is None,
+                    candidates=[
+                        _polar_option(canonical, product) for product in polar_products
+                    ],
+                )
+            )
+        return MerchantMigrationProductMappingList(items=items)
+
+    def _as_canonical_product(
+        self, record: MerchantMigrationRecord
+    ) -> CanonicalProduct:
+        canonical = deserialize(record.type, record.canonical)
+        assert isinstance(canonical, CanonicalProduct)
+        return canonical
 
     async def get_pan_transfer(
         self,

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 
 from polar.auth.scope import Scope
 from polar.config import settings
+from polar.enums import SubscriptionRecurringInterval
 from polar.kit.utils import utc_now
 from polar.merchant_migration.adapters.base import ExtractionPage
 from polar.merchant_migration.canonical import (
@@ -47,6 +48,7 @@ from polar.models.merchant_migration_record import (
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_product
 from tests.merchant_migration._helpers import (
     assert_no_migrations,
     build_connected_migration,
@@ -585,6 +587,110 @@ class TestImport:
         results = {r["entity"]: r for r in response.json()["results"]}
         assert results["customers"]["imported"] == 1
         assert results["products"]["imported"] == 1
+
+
+@pytest.mark.asyncio
+class TestProductMappings:
+    async def test_anonymous(
+        self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        response = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/product-mappings"
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_lists_and_saves_create_new(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+        start_and_execute_precheck: StartAndExecutePrecheck,
+    ) -> None:
+        await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(5000, "usd")],
+        )
+        migration = await build_connected_migration(save_fixture, organization)
+        adapter = mocker.MagicMock()
+        adapter.extract_page = mocker.AsyncMock(
+            return_value=ExtractionPage(_catalog(), None)
+        )
+        adapter.get_source_account = mocker.AsyncMock(
+            return_value=CanonicalAccount(country="US", has_connected_accounts=False)
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+        await start_and_execute_precheck(migration)
+
+        listed = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/product-mappings"
+        )
+        assert listed.status_code == 200
+        item = listed.json()["items"][0]
+        assert item["source_id"] == "prod_1:month:1"
+        assert item["requires_choice"] is True
+
+        updated = await client.put(
+            f"/v1/merchant-migrations/{migration.id}/product-mappings",
+            json={
+                "mappings": [{"source_id": "prod_1:month:1", "polar_product_id": None}]
+            },
+        )
+        assert updated.status_code == 200
+        saved = updated.json()["items"][0]
+        assert saved["create_new"] is True
+        assert saved["requires_choice"] is False
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_rejects_amount_mismatch(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+        start_and_execute_precheck: StartAndExecutePrecheck,
+    ) -> None:
+        existing = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(5000, "usd")],
+        )
+        migration = await build_connected_migration(save_fixture, organization)
+        adapter = mocker.MagicMock()
+        adapter.extract_page = mocker.AsyncMock(
+            return_value=ExtractionPage(_catalog(), None)
+        )
+        adapter.get_source_account = mocker.AsyncMock(
+            return_value=CanonicalAccount(country="US", has_connected_accounts=False)
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+        await start_and_execute_precheck(migration)
+
+        response = await client.put(
+            f"/v1/merchant-migrations/{migration.id}/product-mappings",
+            json={
+                "mappings": [
+                    {
+                        "source_id": "prod_1:month:1",
+                        "polar_product_id": str(existing.id),
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 400
 
 
 def _configure_destination(mocker: MockerFixture) -> None:

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -614,7 +614,7 @@ class TestProductMappings:
             save_fixture,
             organization=organization,
             name="Pro",
-            recurring_interval=SubscriptionRecurringInterval.month,
+            recurring_interval=SubscriptionRecurringInterval.year,
             prices=[(5000, "usd")],
         )
         migration = await build_connected_migration(save_fixture, organization)
@@ -650,7 +650,50 @@ class TestProductMappings:
         assert saved["requires_choice"] is False
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
-    async def test_rejects_amount_mismatch(
+    async def test_rejects_interval_mismatch(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+        start_and_execute_precheck: StartAndExecutePrecheck,
+    ) -> None:
+        existing = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.year,
+            prices=[(5000, "usd")],
+        )
+        migration = await build_connected_migration(save_fixture, organization)
+        adapter = mocker.MagicMock()
+        adapter.extract_page = mocker.AsyncMock(
+            return_value=ExtractionPage(_catalog(), None)
+        )
+        adapter.get_source_account = mocker.AsyncMock(
+            return_value=CanonicalAccount(country="US", has_connected_accounts=False)
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+        await start_and_execute_precheck(migration)
+
+        response = await client.put(
+            f"/v1/merchant-migrations/{migration.id}/product-mappings",
+            json={
+                "mappings": [
+                    {
+                        "source_id": "prod_1:month:1",
+                        "polar_product_id": str(existing.id),
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_saves_amount_mismatch_mapping(
         self,
         client: AsyncClient,
         save_fixture: SaveFixture,
@@ -690,7 +733,12 @@ class TestProductMappings:
                 ]
             },
         )
-        assert response.status_code == 400
+        assert response.status_code == 200
+        item = response.json()["items"][0]
+        assert item["mapped_product_id"] == str(existing.id)
+        candidate = next(c for c in item["candidates"] if c["id"] == str(existing.id))
+        assert candidate["compatible"] is True
+        assert "amount_mismatch" in candidate["incompatibilities"]
 
 
 def _configure_destination(mocker: MockerFixture) -> None:

--- a/server/tests/merchant_migration/test_product_mapping.py
+++ b/server/tests/merchant_migration/test_product_mapping.py
@@ -14,6 +14,7 @@ from polar.merchant_migration.canonical import (
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
 )
+from polar.merchant_migration.importer import find_imported_price
 from polar.merchant_migration.product_mapping import (
     UNSET,
     decide_mapping,
@@ -27,7 +28,7 @@ from polar.merchant_migration.product_mapping import (
 from polar.merchant_migration.schemas import ProductMappingIncompatibility
 from polar.models import Organization, Product
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_product
+from tests.fixtures.random_objects import create_product, create_product_price_fixed
 
 
 def _price(
@@ -135,9 +136,11 @@ class TestIncompatibilities:
         self, save_fixture: SaveFixture, organization: Organization
     ) -> None:
         polar = await _polar_product(save_fixture, organization, amount=5000)
-        assert incompatibilities(_canonical(), polar) == [
+        canonical = _canonical()
+        assert incompatibilities(canonical, polar) == [
             ProductMappingIncompatibility.amount_mismatch
         ]
+        assert is_compatible(canonical, polar)
 
     async def test_currency_mismatch(
         self, save_fixture: SaveFixture, organization: Organization
@@ -161,6 +164,14 @@ class TestSuggestProduct:
         self, save_fixture: SaveFixture, organization: Organization
     ) -> None:
         polar = await _polar_product(save_fixture, organization, name="Pro")
+        assert suggest_product(_canonical(name="Pro"), [polar]) is polar
+
+    async def test_unique_name_despite_amount_mismatch(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(
+            save_fixture, organization, name="Pro", amount=5000
+        )
         assert suggest_product(_canonical(name="Pro"), [polar]) is polar
 
     async def test_unique_compatible_different_name(
@@ -187,6 +198,14 @@ class TestSuggestProduct:
             prices=[(2000, "usd")],
         )
         assert suggest_product(_canonical(name="Pro"), [first, second]) is None
+
+    async def test_does_not_suggest_different_name_and_amount(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(
+            save_fixture, organization, name="Starter", amount=5000
+        )
+        assert suggest_product(_canonical(name="Pro"), [polar]) is None
 
     async def test_prefers_name_among_compatible(
         self, save_fixture: SaveFixture, organization: Organization
@@ -227,10 +246,22 @@ class TestDecideMapping:
         assert decision.create_new is True
         assert decision.skip is None
 
-    async def test_incompatible_explicit_map(
+    async def test_explicit_map_amount_mismatch(
         self, save_fixture: SaveFixture, organization: Organization
     ) -> None:
         polar = await _polar_product(save_fixture, organization, amount=5000)
+        decision = decide_mapping(_canonical(), [polar], polar.id)
+        assert decision.product is polar
+        assert decision.skip is None
+
+    async def test_incompatible_explicit_map(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(
+            save_fixture,
+            organization,
+            interval=SubscriptionRecurringInterval.year,
+        )
         decision = decide_mapping(_canonical(), [polar], polar.id)
         assert decision.product is None
         assert decision.skip is not None
@@ -253,16 +284,29 @@ class TestDecideMapping:
         assert decision.product is polar
         assert decision.skip is None
 
-    async def test_name_collision_requires_choice(
+    async def test_name_collision_interval_mismatch_requires_choice(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(
+            save_fixture,
+            organization,
+            name="Pro",
+            interval=SubscriptionRecurringInterval.year,
+        )
+        decision = decide_mapping(_canonical(name="Pro"), [polar], UNSET)
+        assert decision.product is None
+        assert decision.skip is not None
+        assert decision.skip.code == "product_mapping_required"
+
+    async def test_name_collision_amount_mismatch_maps(
         self, save_fixture: SaveFixture, organization: Organization
     ) -> None:
         polar = await _polar_product(
             save_fixture, organization, name="Pro", amount=5000
         )
         decision = decide_mapping(_canonical(name="Pro"), [polar], UNSET)
-        assert decision.product is None
-        assert decision.skip is not None
-        assert decision.skip.code == "product_mapping_required"
+        assert decision.product is polar
+        assert decision.skip is None
 
     async def test_no_collision_creates_new(
         self, save_fixture: SaveFixture, organization: Organization
@@ -308,3 +352,47 @@ class TestHelpers:
             ],
         )
         assert counts[product.source_id] == 1
+
+
+def _subscription() -> CanonicalSubscription:
+    return CanonicalSubscription(
+        source_id="sub_1",
+        customer_source_id="cus_1",
+        price_source_id="price_1",
+        status=CanonicalSubscriptionStatus.active,
+        collection_method=CanonicalCollectionMethod.charge_automatically,
+        current_period_start=None,
+        current_period_end=None,
+        trialing=False,
+        paused_collection=False,
+        line_item_count=1,
+        quantity=1,
+        payment_method=None,
+        currency="usd",
+    )
+
+
+@pytest.mark.asyncio
+class TestFindImportedPrice:
+    async def test_finds_archived_grandfathered_amount(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization, amount=1000)
+        archived = await create_product_price_fixed(
+            save_fixture, product=polar, amount=500, is_archived=True
+        )
+        found = find_imported_price(
+            polar, _canonical(prices=[_price(amount=500)]), _subscription()
+        )
+        assert found is not None
+        assert found.id == archived.id
+        assert found.is_archived is True
+
+    async def test_prefers_active_catalog_when_amounts_match(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization, amount=2000)
+        found = find_imported_price(polar, _canonical(), _subscription())
+        assert found is not None
+        assert found.price_amount == 2000
+        assert found.is_archived is False

--- a/server/tests/merchant_migration/test_product_mapping.py
+++ b/server/tests/merchant_migration/test_product_mapping.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from polar.enums import SubscriptionRecurringInterval
+from polar.merchant_migration.canonical import (
+    CanonicalCollectionMethod,
+    CanonicalPrice,
+    CanonicalPricingScheme,
+    CanonicalProduct,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+)
+from polar.merchant_migration.product_mapping import (
+    UNSET,
+    decide_mapping,
+    incompatibilities,
+    is_compatible,
+    read_product_mappings,
+    serialize_product_mappings,
+    subscriber_counts,
+    suggest_product,
+)
+from polar.merchant_migration.schemas import ProductMappingIncompatibility
+from polar.models import Organization, Product
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_product
+
+
+def _price(
+    *,
+    amount: int = 2000,
+    currency: str = "usd",
+) -> CanonicalPrice:
+    return CanonicalPrice(
+        source_id="price_1",
+        currency=currency,
+        amount=amount,
+        pricing_scheme=CanonicalPricingScheme.fixed,
+    )
+
+
+def _canonical(
+    *,
+    name: str = "Pro",
+    prices: list[CanonicalPrice] | None = None,
+    recurring_interval: str | None = "month",
+    recurring_interval_count: int = 1,
+) -> CanonicalProduct:
+    return CanonicalProduct(
+        source_id="prod_1:month:1",
+        product_source_id="prod_1",
+        name=name,
+        recurring_interval=recurring_interval,
+        recurring_interval_count=recurring_interval_count,
+        prices=prices or [_price()],
+    )
+
+
+async def _polar_product(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    *,
+    name: str = "Pro",
+    amount: int = 2000,
+    interval: SubscriptionRecurringInterval | None = (
+        SubscriptionRecurringInterval.month
+    ),
+    interval_count: int = 1,
+    is_archived: bool = False,
+    extra_prices: list[tuple[int, str]] | None = None,
+) -> Product:
+    prices: list[tuple[int, str]] = [(amount, "usd")]
+    if extra_prices:
+        prices.extend(extra_prices)
+    return await create_product(
+        save_fixture,
+        organization=organization,
+        name=name,
+        recurring_interval=interval,
+        recurring_interval_count=interval_count,
+        is_archived=is_archived,
+        prices=prices,
+    )
+
+
+@pytest.mark.asyncio
+class TestIncompatibilities:
+    async def test_compatible(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization)
+        assert incompatibilities(_canonical(), polar) == []
+
+    async def test_archived(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization, is_archived=True)
+        assert incompatibilities(_canonical(), polar) == [
+            ProductMappingIncompatibility.not_recurring
+        ]
+
+    async def test_one_time_product(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization, interval=None)
+        assert incompatibilities(_canonical(), polar) == [
+            ProductMappingIncompatibility.not_recurring
+        ]
+
+    async def test_interval_mismatch(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(
+            save_fixture,
+            organization,
+            interval=SubscriptionRecurringInterval.year,
+        )
+        assert ProductMappingIncompatibility.interval_mismatch in incompatibilities(
+            _canonical(), polar
+        )
+
+    async def test_interval_count_mismatch(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization, interval_count=3)
+        assert ProductMappingIncompatibility.interval_mismatch in incompatibilities(
+            _canonical(), polar
+        )
+
+    async def test_amount_mismatch(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization, amount=5000)
+        assert incompatibilities(_canonical(), polar) == [
+            ProductMappingIncompatibility.amount_mismatch
+        ]
+
+    async def test_currency_mismatch(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization)
+        reasons = incompatibilities(_canonical(prices=[_price(currency="eur")]), polar)
+        assert ProductMappingIncompatibility.currency_mismatch in reasons
+
+    async def test_extra_polar_currency_is_ok(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(
+            save_fixture, organization, extra_prices=[(1800, "eur")]
+        )
+        assert is_compatible(_canonical(), polar)
+
+
+@pytest.mark.asyncio
+class TestSuggestProduct:
+    async def test_unique_name_and_price(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization, name="Pro")
+        assert suggest_product(_canonical(name="Pro"), [polar]) is polar
+
+    async def test_unique_compatible_different_name(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization, name="Polar Pro")
+        assert suggest_product(_canonical(name="Stripe Pro"), [polar]) is polar
+
+    async def test_ambiguous_compatible_set(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        first = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Alpha",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(2000, "usd")],
+        )
+        second = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Beta",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(2000, "usd")],
+        )
+        assert suggest_product(_canonical(name="Pro"), [first, second]) is None
+
+    async def test_prefers_name_among_compatible(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        other = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Other",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(2000, "usd")],
+        )
+        named = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(2000, "usd")],
+        )
+        assert suggest_product(_canonical(name="Pro"), [other, named]) is named
+
+
+@pytest.mark.asyncio
+class TestDecideMapping:
+    async def test_explicit_map(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization)
+        decision = decide_mapping(_canonical(), [polar], polar.id)
+        assert decision.product is polar
+        assert decision.skip is None
+
+    async def test_explicit_create_new(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization)
+        decision = decide_mapping(_canonical(), [polar], None)
+        assert decision.product is None
+        assert decision.create_new is True
+        assert decision.skip is None
+
+    async def test_incompatible_explicit_map(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization, amount=5000)
+        decision = decide_mapping(_canonical(), [polar], polar.id)
+        assert decision.product is None
+        assert decision.skip is not None
+        assert decision.skip.code == "product_mapping_incompatible"
+
+    async def test_missing_explicit_map(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization)
+        decision = decide_mapping(_canonical(), [polar], uuid4())
+        assert decision.product is None
+        assert decision.skip is not None
+        assert decision.skip.code == "product_mapping_not_found"
+
+    async def test_auto_suggest(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(save_fixture, organization, name="Pro")
+        decision = decide_mapping(_canonical(name="Pro"), [polar], UNSET)
+        assert decision.product is polar
+        assert decision.skip is None
+
+    async def test_name_collision_requires_choice(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(
+            save_fixture, organization, name="Pro", amount=5000
+        )
+        decision = decide_mapping(_canonical(name="Pro"), [polar], UNSET)
+        assert decision.product is None
+        assert decision.skip is not None
+        assert decision.skip.code == "product_mapping_required"
+
+    async def test_no_collision_creates_new(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        polar = await _polar_product(
+            save_fixture, organization, name="Starter", amount=5000
+        )
+        decision = decide_mapping(_canonical(name="Pro"), [polar], UNSET)
+        assert decision.product is None
+        assert decision.create_new is True
+        assert decision.skip is None
+
+
+class TestHelpers:
+    def test_read_and_serialize_mappings(self) -> None:
+        mapped_id = uuid4()
+        stored = serialize_product_mappings({"a": mapped_id, "b": None})
+        migration = SimpleNamespace(source_credentials={"product_mappings": stored})
+        parsed = read_product_mappings(migration)  # type: ignore[arg-type]
+        assert parsed["a"] == mapped_id
+        assert parsed["b"] is None
+
+    def test_subscriber_counts(self) -> None:
+        product = _canonical()
+        counts = subscriber_counts(
+            [product],
+            [
+                CanonicalSubscription(
+                    source_id="sub_1",
+                    customer_source_id="cus_1",
+                    price_source_id="price_1",
+                    status=CanonicalSubscriptionStatus.active,
+                    collection_method=CanonicalCollectionMethod.charge_automatically,
+                    current_period_start=None,
+                    current_period_end=None,
+                    trialing=False,
+                    paused_collection=False,
+                    line_item_count=1,
+                    quantity=1,
+                    payment_method=None,
+                    currency="usd",
+                )
+            ],
+        )
+        assert counts[product.source_id] == 1

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -14,6 +14,7 @@ from polar.auth.models import AuthSubject
 from polar.config import settings
 from polar.customer.repository import CustomerRepository
 from polar.customer.service import customer as customer_service
+from polar.enums import SubscriptionRecurringInterval
 from polar.kit import encryption
 from polar.kit.encryption import LocalKeyProvider
 from polar.kit.pagination import PaginationParams
@@ -36,6 +37,10 @@ from polar.merchant_migration.canonical import (
 )
 from polar.merchant_migration.cards import AmbiguousCopiedCard
 from polar.merchant_migration.cutover import CutoverOutcome, SubscriptionCutover
+from polar.merchant_migration.errors import (
+    ProductMappingInvalid,
+    ProductMappingLocked,
+)
 from polar.merchant_migration.pan_transfer import (
     STEP_CUTOVER,
     STEP_MOVE_SUBSCRIPTIONS,
@@ -48,6 +53,7 @@ from polar.merchant_migration.repository import (
 )
 from polar.merchant_migration.schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationProductMappingChoice,
     PrecheckEntity,
     PrecheckReasonLevel,
     PrecheckRecordStatus,
@@ -103,6 +109,7 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_customer,
     create_payment_method,
+    create_product,
 )
 from tests.fixtures.stripe import build_stripe_payment_method
 from tests.merchant_migration._helpers import (
@@ -2028,6 +2035,244 @@ class TestImportCatalog:
             for price in products[0].prices
             if isinstance(price, ProductPriceFixed)
         } == {("eur", 900), ("usd", 1000)}
+
+
+@pytest.mark.asyncio
+class TestProductMappings:
+    @pytest.mark.auth
+    async def test_lists_suggested_match(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(1000, "usd")],
+        )
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        listing = await service.list_product_mappings(
+            session, auth_subject, migration.id
+        )
+
+        assert len(listing.items) == 1
+        item = listing.items[0]
+        assert item.source_id == "prod_1:month:1"
+        assert item.suggested_product_id == existing.id
+        assert item.requires_choice is False
+        assert item.mapped_product_id is None
+        assert item.create_new is False
+
+    @pytest.mark.auth
+    async def test_name_collision_without_match_requires_choice(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(5000, "usd")],
+        )
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        listing = await service.list_product_mappings(
+            session, auth_subject, migration.id
+        )
+
+        item = listing.items[0]
+        assert item.name_collision is True
+        assert item.suggested_product_id is None
+        assert item.requires_choice is True
+
+    @pytest.mark.auth
+    async def test_rejects_incompatible_mapping(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(5000, "usd")],
+        )
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        with pytest.raises(ProductMappingInvalid):
+            await service.update_product_mappings(
+                session,
+                auth_subject,
+                migration.id,
+                [
+                    MerchantMigrationProductMappingChoice(
+                        source_id="prod_1:month:1", polar_product_id=existing.id
+                    )
+                ],
+            )
+
+    @pytest.mark.auth
+    async def test_import_reuses_matching_polar_product(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(1000, "usd")],
+        )
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.products].imported == 1
+        products = await _products(session, organization)
+        assert len(products) == 1
+        assert products[0].id == existing.id
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        records = await record_repository.list_by_migration(migration.id)
+        imported = next(
+            record
+            for record in records
+            if record.type == MerchantMigrationRecordType.product
+            and record.source_id == "prod_1:month:1"
+        )
+        assert imported.status == MerchantMigrationRecordStatus.imported
+        assert imported.target_id == existing.id
+
+    @pytest.mark.auth
+    async def test_explicit_create_new_duplicates_existing_product(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(1000, "usd")],
+        )
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        await service.update_product_mappings(
+            session,
+            auth_subject,
+            migration.id,
+            [
+                MerchantMigrationProductMappingChoice(
+                    source_id="prod_1:month:1", polar_product_id=None
+                )
+            ],
+        )
+
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        products = await _products(session, organization)
+        ids = {product.id for product in products}
+        assert existing.id in ids
+        assert len(products) == 2
+
+    @pytest.mark.auth
+    async def test_import_blocks_when_mapping_is_required(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(5000, "usd")],
+        )
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        with pytest.raises(ProductMappingInvalid):
+            await service.import_catalog(session, auth_subject, migration.id)
+
+        products = await _products(session, organization)
+        assert len(products) == 1
+
+    @pytest.mark.auth
+    async def test_imported_mapping_is_locked(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(1000, "usd")],
+        )
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        with pytest.raises(ProductMappingLocked):
+            await service.update_product_mappings(
+                session,
+                auth_subject,
+                migration.id,
+                [
+                    MerchantMigrationProductMappingChoice(
+                        source_id="prod_1:month:1", polar_product_id=existing.id
+                    )
+                ],
+            )
 
 
 @pytest.mark.asyncio

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -57,6 +57,7 @@ from polar.merchant_migration.schemas import (
     PrecheckEntity,
     PrecheckReasonLevel,
     PrecheckRecordStatus,
+    ProductMappingIncompatibility,
 )
 from polar.merchant_migration.service import (
     CatalogImportBlocked,
@@ -110,6 +111,7 @@ from tests.fixtures.random_objects import (
     create_customer,
     create_payment_method,
     create_product,
+    create_product_price_fixed,
 )
 from tests.fixtures.stripe import build_stripe_payment_method
 from tests.merchant_migration._helpers import (
@@ -1188,6 +1190,48 @@ def _catalog_with_subscription() -> list[CanonicalRecord]:
     ]
 
 
+def _legacy_amount_catalog(*, amount: int = 500) -> list[CanonicalRecord]:
+    """Stripe still bills `amount` for Pro; Polar's catalog may have moved on."""
+    return [
+        CanonicalProduct(
+            source_id="prod_1:month:1",
+            product_source_id="prod_1",
+            name="Pro",
+            recurring_interval="month",
+            recurring_interval_count=1,
+            prices=[
+                CanonicalPrice(
+                    source_id="price_1",
+                    currency="usd",
+                    amount=amount,
+                    pricing_scheme=CanonicalPricingScheme.fixed,
+                )
+            ],
+        ),
+        CanonicalCustomer(
+            source_id="cus_1",
+            email="alice@example.com",
+            name="Alice",
+            country="US",
+        ),
+        CanonicalSubscription(
+            source_id="sub_1",
+            customer_source_id="cus_1",
+            price_source_id="price_1",
+            status=CanonicalSubscriptionStatus.active,
+            collection_method=CanonicalCollectionMethod.charge_automatically,
+            current_period_start=None,
+            current_period_end=None,
+            trialing=False,
+            paused_collection=False,
+            line_item_count=1,
+            quantity=1,
+            payment_method=None,
+            currency="usd",
+        ),
+    ]
+
+
 def _multi_currency_catalog() -> list[CanonicalRecord]:
     return [
         CanonicalProduct(
@@ -1239,7 +1283,7 @@ async def _products(session: AsyncSession, organization: Organization) -> list[P
     result = await session.execute(
         select(Product)
         .where(Product.organization_id == organization.id)
-        .options(selectinload(Product.prices))
+        .options(selectinload(Product.all_prices), selectinload(Product.prices))
     )
     return list(result.scalars().unique().all())
 
@@ -2086,8 +2130,8 @@ class TestProductMappings:
             save_fixture,
             organization=organization,
             name="Pro",
-            recurring_interval=SubscriptionRecurringInterval.month,
-            prices=[(5000, "usd")],
+            recurring_interval=SubscriptionRecurringInterval.year,
+            prices=[(1000, "usd")],
         )
         migration = await _staged_migration(
             mocker, session, save_fixture, auth_subject, organization
@@ -2101,6 +2145,45 @@ class TestProductMappings:
         assert item.name_collision is True
         assert item.suggested_product_id is None
         assert item.requires_choice is True
+        assert item.candidates[0].compatible is False
+        assert (
+            ProductMappingIncompatibility.interval_mismatch
+            in item.candidates[0].incompatibilities
+        )
+
+    @pytest.mark.auth
+    async def test_suggests_unique_name_despite_amount_mismatch(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(5000, "usd")],
+        )
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        listing = await service.list_product_mappings(
+            session, auth_subject, migration.id
+        )
+
+        item = listing.items[0]
+        assert item.suggested_product_id == existing.id
+        assert item.requires_choice is False
+        candidate = next(c for c in item.candidates if c.id == existing.id)
+        assert candidate.compatible is True
+        assert (
+            ProductMappingIncompatibility.amount_mismatch in candidate.incompatibilities
+        )
 
     @pytest.mark.auth
     async def test_rejects_incompatible_mapping(
@@ -2116,8 +2199,8 @@ class TestProductMappings:
             save_fixture,
             organization=organization,
             name="Pro",
-            recurring_interval=SubscriptionRecurringInterval.month,
-            prices=[(5000, "usd")],
+            recurring_interval=SubscriptionRecurringInterval.year,
+            prices=[(1000, "usd")],
         )
         migration = await _staged_migration(
             mocker, session, save_fixture, auth_subject, organization
@@ -2176,6 +2259,111 @@ class TestProductMappings:
         assert imported.target_id == existing.id
 
     @pytest.mark.auth
+    async def test_import_grandfathers_stripe_amount_on_mapped_product(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(1000, "usd")],
+        )
+        migration = await _staged_migration(
+            mocker,
+            session,
+            save_fixture,
+            auth_subject,
+            organization,
+            records=_legacy_amount_catalog(),
+        )
+
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.products].imported == 1
+        products = await _products(session, organization)
+        assert len(products) == 1
+        assert products[0].id == existing.id
+        catalog = {
+            (price.price_currency, price.price_amount)
+            for price in products[0].prices
+            if isinstance(price, ProductPriceFixed)
+        }
+        assert catalog == {("usd", 1000)}
+        all_fixed = {
+            (price.price_currency, price.price_amount, price.is_archived)
+            for price in products[0].all_prices
+            if isinstance(price, ProductPriceFixed)
+        }
+        assert ("usd", 1000, False) in all_fixed
+        assert ("usd", 500, True) in all_fixed
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        records = await record_repository.list_by_migration(migration.id)
+        imported = next(
+            record
+            for record in records
+            if record.type == MerchantMigrationRecordType.product
+        )
+        assert imported.target_id == existing.id
+
+    @pytest.mark.auth
+    async def test_import_reuses_archived_price_instead_of_duplicating(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = await create_product(
+            save_fixture,
+            organization=organization,
+            name="Pro",
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(1000, "usd")],
+        )
+        archived = await create_product_price_fixed(
+            save_fixture, product=existing, amount=500, is_archived=True
+        )
+        migration = await _staged_migration(
+            mocker,
+            session,
+            save_fixture,
+            auth_subject,
+            organization,
+            records=_legacy_amount_catalog(),
+        )
+
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        products = await _products(session, organization)
+        assert len(products) == 1
+        archived_fives = [
+            price
+            for price in products[0].all_prices
+            if isinstance(price, ProductPriceFixed)
+            and price.price_amount == 500
+            and price.is_archived
+        ]
+        assert len(archived_fives) == 1
+        assert archived_fives[0].id == archived.id
+        catalog = {
+            (price.price_currency, price.price_amount)
+            for price in products[0].prices
+            if isinstance(price, ProductPriceFixed)
+        }
+        assert catalog == {("usd", 1000)}
+
+    @pytest.mark.auth
     async def test_explicit_create_new_duplicates_existing_product(
         self,
         mocker: MockerFixture,
@@ -2227,8 +2415,8 @@ class TestProductMappings:
             save_fixture,
             organization=organization,
             name="Pro",
-            recurring_interval=SubscriptionRecurringInterval.month,
-            prices=[(5000, "usd")],
+            recurring_interval=SubscriptionRecurringInterval.year,
+            prices=[(1000, "usd")],
         )
         migration = await _staged_migration(
             mocker, session, save_fixture, auth_subject, organization


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Merchants who already sell on Polar (new checkouts) while still billing a legacy cohort on Stripe can map Stripe products onto **existing** Polar products, instead of Polar always creating a duplicate catalog.

This is the Pepy-shaped cutover: Polar product IDs already drive benefits and plan resolution, so importing a second "Pro" would split entitlements. Polar's catalog can also have moved on (Stripe still $5, Polar now sells $10). Imported subscribers keep the Stripe amount; checkout keeps the current catalog price.

## What

- Persist `Stripe product+interval → Polar product` mappings on `MerchantMigration.source_credentials.product_mappings` (no new column; ADR-0006 isolation).
- `GET/PUT /v1/merchant-migrations/{id}/product-mappings` plus an optional `product_mappings` field on catalog import.
- Compatibility gate: same cadence and a Polar **fixed** catalog price in the same currency. Amount may differ (`amount_mismatch` is informational). Extra Polar currencies are allowed. Mapping does not add a new currency onto the Polar product.
- Auto-suggest a unique case-insensitive name among interval-compatible products, even when amount differs. Otherwise a unique amount+currency+interval match. A unique compatible product that differs in both name and amount is not auto-mapped.
- Name collision without a unique interval-compatible match blocks Prepare until the merchant maps or explicitly creates a new product.
- On reuse, import attaches (or creates) an archived catalog `ProductPriceFixed` at the Stripe amount so cutover bills that price. The active catalog price is left alone.
- Assessment panel on the catalog review step. Hidden when Polar has no catalog (greenfield). Warns when the selected Polar catalog price differs from Stripe.

## Why

Creating duplicate Polar products is dangerous for merchants whose app resolves plans/benefits from Polar product IDs. Email-based customer reuse already existed; products were always created new. Requiring the Polar catalog amount to match Stripe would also block the common "we raised the price, legacy subs stay on the old one" case.

## How

Three UI options considered:

1. Dedicated wizard step — rejected (empty for greenfield).
2. Assessment panel on catalog review — chosen.
3. Auto-suggest — chosen as the default (unique name among interval-compatible products, else unique amount/currency/interval).

Import decision: explicit UUID (validate interval/currency) → explicit create-new → unique suggestion → name-collision requires choice → otherwise create new. Mapping failures raise `400` and leave the ledger pending so a corrected mapping can retry.

Quantity, tax, and trial stay on the subscription / pre-check. Polar products do not carry per-subscription quantity, and cutover already preserves period and trial dates.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

## Test plan

- Backend: `POLAR_ENV=testing uv run python -m pytest tests/merchant_migration/test_product_mapping.py tests/merchant_migration/test_service.py::TestProductMappings tests/merchant_migration/test_endpoints.py::TestProductMappings tests/merchant_migration/test_service.py::TestImportCatalog tests/merchant_migration/test_cutover.py`
- Frontend: `pnpm exec vitest run …/productMapping.test.ts`
- Covered: Stripe $5 mapped onto Polar Pro catalog $10 creates an archived $5 price and leaves catalog at $10; already-archived $5 is reused; unique name auto-suggests despite amount mismatch; yearly Polar vs monthly Stripe still requires a choice / 400.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d72bd2a-24dd-46d4-8402-780b3e7e6c64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d72bd2a-24dd-46d4-8402-780b3e7e6c64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

