### PR TITLE
server/integrations/resend: no-op sync task as it clutters the low prio queue

### DIFF
--- a/server/polar/integrations/resend/tasks.py
+++ b/server/polar/integrations/resend/tasks.py
@@ -7,5 +7,6 @@ from .service import resend as resend_service
 
 @actor(actor_name="resend.sync_user", priority=TaskPriority.LOW)
 async def sync_user(user_id: UUID, previous_email: str | None = None) -> None:
+    return
     async with AsyncSessionMaker() as session:
         await resend_service.sync_user(session, user_id, previous_email=previous_email)

--- a/server/scripts/backfill_resend_id.py
+++ b/server/scripts/backfill_resend_id.py
@@ -1,79 +1,24 @@
-"""Sync all users to Resend and save their contact IDs.
-
-uv run python -m scripts.backfill_resend_id --concurrency 16
-"""
-
-import asyncio
-from uuid import UUID
-
+import dramatiq
 import typer
 from rich.progress import Progress
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select
 
+from polar import tasks  # noqa: F401
 from polar.config import settings
-from polar.integrations.resend.service import resend as resend_service
-from polar.kit.db.postgres import AsyncSessionMaker, create_async_sessionmaker
+from polar.kit.db.postgres import create_async_sessionmaker
 from polar.models import User
 from polar.postgres import create_async_engine
+from polar.redis import create_redis
+from polar.worker import JobQueueManager, enqueue_job
 
 from .helper import configure_script_logging, typer_async
 
 cli = typer.Typer()
 
 
-async def run_backfill(
-    sessionmaker: AsyncSessionMaker,
-    *,
-    concurrency: int = 16,
-) -> int:
-    last_id: UUID | None = None
-    total = 0
-    semaphore = asyncio.Semaphore(concurrency)
-
-    with Progress() as progress:
-        task = progress.add_task("[cyan]Syncing users...", total=None)
-
-        async def sync_user(user_id: UUID) -> None:
-            nonlocal total
-            try:
-                async with sessionmaker.begin() as session:
-                    await resend_service.sync_user(session, user_id)
-                total += 1
-                progress.advance(task)
-            finally:
-                semaphore.release()
-
-        async with asyncio.TaskGroup() as group:
-            while True:
-                statement = (
-                    select(User.id)
-                    .where(or_(User.is_deleted, User.blocked_at.is_(None)))
-                    .order_by(User.id)
-                    .limit(1000)
-                )
-                if last_id is not None:
-                    statement = statement.where(User.id > last_id)
-                async with sessionmaker() as session:
-                    user_ids = (await session.scalars(statement)).all()
-                if not user_ids:
-                    break
-
-                for user_id in user_ids:
-                    await semaphore.acquire()
-                    group.create_task(sync_user(user_id))
-
-                last_id = user_ids[-1]
-
-    return total
-
-
 @cli.command()
 @typer_async
-async def backfill(
-    concurrency: int = typer.Option(
-        16, min=1, help="Number of users to sync in parallel"
-    ),
-) -> None:
+async def backfill() -> None:
     configure_script_logging()
     if settings.RESEND_ACTIVE_USERS_SEGMENT_ID is None or not settings.RESEND_API_KEY:
         typer.echo(
@@ -83,11 +28,33 @@ async def backfill(
 
     engine = create_async_engine("script")
     sessionmaker = create_async_sessionmaker(engine)
-    try:
-        total = await run_backfill(sessionmaker, concurrency=concurrency)
-        typer.echo(f"Done: {total} users synced.")
-    finally:
-        await engine.dispose()
+    redis = create_redis("script")
+
+    async with sessionmaker() as session:
+        async with JobQueueManager.open(dramatiq.get_broker(), redis):
+            with Progress() as progress:
+                task_id = progress.add_task("[cyan]Enqueuing user sync...", total=None)
+
+                statement = (
+                    select(User.id)
+                    .where(or_(User.is_deleted, User.blocked_at.is_(None)))
+                    .order_by(User.id)
+                )
+                count_statement = statement.with_only_columns(func.count()).order_by(
+                    None
+                )
+                count_result = await session.execute(count_statement)
+                progress.update(task_id, total=count_result.scalar_one())
+
+                stream_result = await session.stream_scalars(
+                    statement,
+                    execution_options={"yield_per": settings.DATABASE_STREAM_YIELD_PER},
+                )
+                async for user_id in stream_result:
+                    enqueue_job("resend.sync_user", user_id)
+                    progress.advance(task_id)
+
+    await engine.dispose()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

