### PR TITLE
CLI: UI/DX improvements

### DIFF
--- a/clients/packages/cli/README.md
+++ b/clients/packages/cli/README.md
@@ -14,6 +14,9 @@ From `clients/`, install dependencies with `pnpm install`, then use
 `pnpm --filter polar-cli test`, `typecheck`, `format`, or `lint`.
 Bun `1.4.2` is the runtime, test runner, and binary compiler; pnpm manages dependencies.
 
+Run the CLI from source with `bun src/cli.ts <command>` in this directory, or
+compile the release binary with `pnpm build:binary` and run `./polar`.
+
 ## Releases
 
 Add a changeset from `clients/` with `pnpm exec changeset` and select `polar-cli`.

--- a/clients/packages/cli/package.json
+++ b/clients/packages/cli/package.json
@@ -34,7 +34,8 @@
     "@napi-rs/keyring": "2.0.0",
     "@polar-sh/sdk": "^0.47.0",
     "effect": "4.0.0-rc.112",
-    "open": "^10.2.0"
+    "open": "^10.2.0",
+    "picocolors": "^1.1.1"
   },
   "devDependencies": {
     "@effect/language-service": "^0.87.2",

--- a/clients/packages/cli/src/cli.ts
+++ b/clients/packages/cli/src/cli.ts
@@ -1,10 +1,11 @@
 import { BunRuntime, BunServices } from '@effect/platform-bun'
-import { Cause, Console, Effect, Layer, Runtime } from 'effect'
-import { Command } from 'effect/unstable/cli'
+import { Cause, Effect, Layer, Runtime } from 'effect'
+import { CliConfig, Command, GlobalFlag } from 'effect/unstable/cli'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { listen } from './commands/listen'
 import { auth } from './commands/auth'
 import { update } from './commands/update'
+import { describeError } from './errors'
 import * as Auth from './services/auth'
 import * as Credentials from './services/credentials'
 import * as Config from './services/config'
@@ -15,6 +16,7 @@ import {
   checkForUpdateInBackground,
   showUpdateNotice,
 } from './services/update-check'
+import * as ui from './ui'
 import { VERSION } from './version'
 
 const mainCommand = Command.make('polar').pipe(
@@ -39,20 +41,34 @@ const services = Layer.mergeAll(
   organizationsLayer,
   BunServices.layer,
   FetchHttpClient.layer,
+  CliConfig.layer({
+    builtIns: [
+      GlobalFlag.Help,
+      GlobalFlag.Version,
+      GlobalFlag.Completions,
+      GlobalFlag.LogLevel,
+    ],
+  }),
 )
+
+const reportError = (cause: Cause.Cause<unknown>) => {
+  if (Cause.hasInterruptsOnly(cause)) return Effect.void
+  const error = Cause.squash(cause)
+  if (!Runtime.getErrorReported(error)) return Effect.void
+  const { title, hint } = describeError(error)
+  return Effect.gen(function* () {
+    yield* Effect.sync(() => {
+      process.stderr.write(`\n${ui.failure(title, hint)}\n\n`)
+    })
+    yield* Effect.logDebug(cause)
+  })
+}
 
 showUpdateNotice()
 checkForUpdateInBackground()
 
 cli.pipe(
   Effect.provide(services),
-  Effect.tapCause((cause) => {
-    if (Cause.hasInterruptsOnly(cause)) return Effect.void
-    const error = Cause.squash(cause)
-    if (!Runtime.getErrorReported(error)) return Effect.void
-    return Console.error(
-      error instanceof Error ? error.message : 'An unexpected error occurred.',
-    )
-  }),
+  Effect.tapCause(reportError),
   BunRuntime.runMain({ disableErrorReporting: true }),
 )

--- a/clients/packages/cli/src/commands/auth.ts
+++ b/clients/packages/cli/src/commands/auth.ts
@@ -1,24 +1,43 @@
 import { Console, Effect } from 'effect'
 import { Command, Flag, Prompt } from 'effect/unstable/cli'
-import { AuthError, orgCommand, type PolarEnvironment } from '../schemas/Auth'
+import {
+  AuthError,
+  loginCommand,
+  orgCommand,
+  type PolarEnvironment,
+} from '../schemas/Auth'
 import { Auth } from '../services/auth'
 import { Organizations } from '../services/organizations'
+import * as ui from '../ui'
 import { environmentOf, production } from './flags'
+
+const dashboardUrl = (environment: PolarEnvironment) =>
+  `https://${environment === 'sandbox' ? 'sandbox.' : ''}polar.sh`
 
 const selectOrganization = (environment: PolarEnvironment) =>
   Effect.gen(function* () {
     const organizations = yield* Organizations
     const items = yield* organizations.list(environment)
     if (items.length === 0) {
+      yield* Console.log(ui.warning(`No organizations in ${environment} yet`))
       yield* Console.log(
-        `No organizations available. Create one at https://${environment === 'sandbox' ? 'sandbox.' : ''}polar.sh, then run ${orgCommand(environment)}.`,
+        ui.step(
+          `Create one at ${ui.cyan(dashboardUrl(environment))}, then run ${ui.command(orgCommand(environment))}`,
+        ),
       )
+      yield* Console.log(ui.blank)
       return
     }
     if (!process.stdin.isTTY || !process.stdout.isTTY) {
       yield* Console.log(
-        `Organization selection requires an interactive terminal. Run ${orgCommand(environment)} interactively; for CI use POLAR_ACCESS_TOKEN and --org <id>.`,
+        ui.warning('Organization selection requires an interactive terminal'),
       )
+      yield* Console.log(
+        ui.step(
+          `Run ${ui.command(orgCommand(environment))} interactively, or use POLAR_ACCESS_TOKEN with ${ui.command('--org <id>')} in CI`,
+        ),
+      )
+      yield* Console.log(ui.blank)
       return
     }
     const activeOrganizationId = yield* organizations.selected(environment)
@@ -28,21 +47,29 @@ const selectOrganization = (environment: PolarEnvironment) =>
         value: organization,
         title:
           organization.id === activeOrganizationId
-            ? `${organization.name} (active)`
+            ? `${organization.name} ${ui.dim('(active)')}`
             : organization.name,
+        description: organization.slug,
       })),
     })
     yield* organizations.select(environment, organization.id)
+    yield* Console.log(ui.blank)
     yield* Console.log(
-      `Active organization: ${organization.name} (${organization.slug}) — ${organization.id}`,
+      ui.success(
+        `Active organization ${ui.bold(organization.name)} ${ui.dim(organization.slug)}`,
+      ),
     )
+    yield* Console.log(ui.blank)
   })
 
 const login = Command.make(
   'login',
   {
     production,
-    newSession: Flag.boolean('new-session').pipe(Flag.withDefault(false)),
+    newSession: Flag.boolean('new-session').pipe(
+      Flag.withDefault(false),
+      Flag.withDescription('Sign in again even if a session is already saved'),
+    ),
   },
   ({ production, newSession }) =>
     Effect.gen(function* () {
@@ -50,15 +77,31 @@ const login = Command.make(
       const auth = yield* Auth
       const replaced = yield* auth.login(environment, newSession)
       if (!replaced) {
+        const other: PolarEnvironment = production ? 'sandbox' : 'production'
+        yield* Console.log(ui.blank)
         yield* Console.log(
-          `Already logged in to ${environment}. Use --new-session to log in again.`,
+          ui.warning(`Already logged in to ${ui.bold(environment)}`),
         )
+        yield* Console.log(
+          ui.step(
+            `Run ${ui.command(`${loginCommand(environment)} --new-session`)} to sign in again`,
+          ),
+        )
+        yield* Console.log(
+          ui.step(
+            `Run ${ui.command(loginCommand(other))} to sign in to ${other}`,
+          ),
+        )
+        yield* Console.log(ui.blank)
         return
       }
-      yield* Console.log(`Logged in to ${environment}.`)
+      yield* Console.log(
+        ui.success(`Logged in to Polar ${ui.bold(environment)}`),
+      )
+      yield* Console.log(ui.blank)
       yield* selectOrganization(environment)
     }),
-)
+).pipe(Command.withDescription('Sign in to Polar through your browser'))
 
 const whoami = Command.make('whoami', { production }, ({ production }) =>
   Effect.gen(function* () {
@@ -66,27 +109,41 @@ const whoami = Command.make('whoami', { production }, ({ production }) =>
     const auth = yield* Auth
     const organizations = yield* Organizations
     const credential = yield* auth.resolve(environment)
-    yield* Console.log(`Environment: ${environment}`)
+    const rows: Array<readonly [string, string]> = [
+      ['Environment', environment],
+    ]
     if (credential.source === 'override') {
+      rows.push(['Token', 'POLAR_ACCESS_TOKEN'])
       const items = yield* organizations.list(environment)
-      if (items.length !== 1) {
-        yield* Console.log(
-          'No active organization. Use --org <id> on organization-dependent commands.',
-        )
-        return
+      if (items.length === 1) {
+        const org = items[0]!
+        rows.push(['Organization', `${ui.bold(org.name)} ${ui.dim(org.slug)}`])
+        rows.push(['ID', ui.dim(org.id)])
       }
-      const org = items[0]!
-      yield* Console.log(`Organization: ${org.name} (${org.slug}) — ${org.id}`)
     } else if (yield* organizations.selected(environment)) {
       const org = yield* organizations.resolve(environment)
-      yield* Console.log(`Organization: ${org.name} (${org.slug}) — ${org.id}`)
-    } else {
+      rows.push(['Organization', `${ui.bold(org.name)} ${ui.dim(org.slug)}`])
+      rows.push(['ID', ui.dim(org.id)])
+    }
+    yield* Console.log(ui.blank)
+    yield* Console.log(ui.keyValue(rows))
+    if (
+      rows.length === 1 ||
+      (rows.length === 2 && credential.source === 'override')
+    ) {
+      yield* Console.log(ui.blank)
+      yield* Console.log(ui.warning('No active organization'))
       yield* Console.log(
-        `No active organization. Run ${orgCommand(environment)}.`,
+        ui.step(
+          credential.source === 'override'
+            ? `Use ${ui.command('--org <id>')} on organization-dependent commands`
+            : `Run ${ui.command(orgCommand(environment))} to choose one`,
+        ),
       )
     }
+    yield* Console.log(ui.blank)
   }),
-)
+).pipe(Command.withDescription('Show the active environment and organization'))
 
 const list = Command.make('list', { production }, ({ production }) =>
   Effect.gen(function* () {
@@ -96,17 +153,25 @@ const list = Command.make('list', { production }, ({ production }) =>
     const credential = yield* auth.resolve(environment)
     const items = yield* organizations.list(environment)
     const activeOrganizationId = yield* organizations.selected(environment)
+    yield* Console.log(ui.blank)
     yield* Console.log(
-      `Organizations in ${environment}${credential.source === 'override' ? ' (POLAR_ACCESS_TOKEN override)' : ''}:`,
+      `  ${ui.bold(`Organizations in ${environment}`)}${credential.source === 'override' ? ui.dim('  via POLAR_ACCESS_TOKEN') : ''}`,
     )
-    if (!items.length) yield* Console.log('No accessible organizations.')
+    yield* Console.log(ui.blank)
+    if (items.length === 0) {
+      yield* Console.log(ui.step('No accessible organizations'))
+    }
+    const width = Math.max(0, ...items.map((org) => org.name.length))
     for (const org of items) {
+      const marker =
+        org.id === activeOrganizationId ? ui.green('●') : ui.dim('○')
       yield* Console.log(
-        `${org.id === activeOrganizationId ? '*' : ' '} ${org.name} (${org.slug}) — ${org.id}`,
+        `  ${marker} ${org.name.padEnd(width)}  ${ui.dim(org.slug)}  ${ui.dim(org.id)}`,
       )
     }
+    yield* Console.log(ui.blank)
   }),
-)
+).pipe(Command.withDescription('List the organizations you have access to'))
 
 const org = Command.make('org', { production }, ({ production }) =>
   Effect.gen(function* () {
@@ -119,25 +184,32 @@ const org = Command.make('org', { production }, ({ production }) =>
     yield* auth.resolve(environmentOf(production))
     yield* selectOrganization(environmentOf(production))
   }),
-)
+).pipe(Command.withDescription('Choose the active organization'))
 
 const logout = Command.make('logout', { production }, ({ production }) =>
   Effect.gen(function* () {
     const auth = yield* Auth
     const environment = environmentOf(production)
-    if (yield* auth.override)
+    yield* Console.log(ui.blank)
+    if (yield* auth.override) {
+      yield* Console.log(ui.warning('POLAR_ACCESS_TOKEN remains active'))
       yield* Console.log(
-        'POLAR_ACCESS_TOKEN remains active. Unset it to stop using the override; only the saved session will be removed.',
+        ui.step(
+          'Unset it to stop using the override, only the saved session is removed',
+        ),
       )
+    }
     const deleted = yield* auth.logout(environment)
     yield* Console.log(
       deleted
-        ? `Logged out of ${environment}.`
-        : `Already logged out of ${environment}.`,
+        ? ui.success(`Logged out of Polar ${ui.bold(environment)}`)
+        : ui.step(`Already logged out of ${environment}`),
     )
+    yield* Console.log(ui.blank)
   }),
-)
+).pipe(Command.withDescription('Sign out and remove the saved session'))
 
 export const auth = Command.make('auth').pipe(
+  Command.withDescription('Manage your Polar sessions and active organization'),
   Command.withSubcommands([login, whoami, list, org, logout]),
 )

--- a/clients/packages/cli/src/commands/listen.test.ts
+++ b/clients/packages/cli/src/commands/listen.test.ts
@@ -150,7 +150,7 @@ describe('startListening', () => {
   })
 
   test('logs malformed JSON without terminating the stream', async () => {
-    const log = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const log = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
     run()
     await tick()
     connections[0]!.controller.enqueue(
@@ -158,7 +158,9 @@ describe('startListening', () => {
     )
     emit({ type: 'reconnect' })
     await tick()
-    expect(log).toHaveBeenCalledWith('>> Failed to decode event')
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('could not decode'),
+    )
     expect(connections).toHaveLength(2)
   })
 

--- a/clients/packages/cli/src/commands/listen.ts
+++ b/clients/packages/cli/src/commands/listen.ts
@@ -26,6 +26,7 @@ import {
   ListenReconnect,
   ListenWebhookEvent,
 } from '../schemas/Events'
+import * as ui from '../ui'
 
 export const LISTEN_BASE_URLS = {
   production: 'https://api.polar.sh/v1/cli/listen',
@@ -37,6 +38,48 @@ export class ListenError extends Data.TaggedError('ListenError')<{
   code: number
   cause?: unknown
 }> {}
+
+const EVENT_TYPE_WIDTH = 28
+
+const printError = (line: string) =>
+  Effect.sync(() => {
+    process.stderr.write(`${line}\n`)
+  })
+
+const describeForwardFailure = (error: unknown) => {
+  const cause =
+    error instanceof Error && error.cause instanceof Error ? error.cause : error
+  const message = cause instanceof Error ? cause.message : String(cause)
+  if (/ECONNREFUSED/i.test(message)) {
+    return 'connection refused, is your server running?'
+  }
+  return message
+}
+
+const eventLine = (eventType: string, outcome: string, startedAt: number) =>
+  `  ${ui.timestamp()}  ${ui.cyan(eventType.padEnd(EVENT_TYPE_WIDTH))}  ${outcome}  ${ui.duration(performance.now() - startedAt)}`
+
+const decodeFailure = (key: string | undefined) =>
+  ui.failure(
+    'Received an event the CLI could not decode',
+    `Event key: ${key ?? 'unknown'}. Run ${ui.command('polar update')} in case the format changed.`,
+  )
+
+const banner = (organizationName: string, secret: string, forwardUrl: string) =>
+  [
+    ui.blank,
+    `  ${ui.green('●')} ${ui.bold('Connected')}  ${ui.bold(organizationName)}`,
+    ui.keyValue([
+      ['Forwarding', forwardUrl],
+      [
+        'Secret',
+        `${secret}  ${ui.dim('use this to verify signatures locally')}`,
+      ],
+    ]),
+    ui.blank,
+    ui.step(`Waiting for events... press ${ui.bold('Ctrl+C')} to stop`),
+    ui.blank,
+  ].join('\n')
 
 export interface StartListeningOptions {
   listenUrl: string
@@ -134,7 +177,7 @@ export const startListening = ({
                 Schema.fromJsonString(Schema.Unknown),
               )(event.data)
               if (Exit.isFailure(decoded)) {
-                yield* Console.error('>> Failed to decode event')
+                yield* printError(decodeFailure(undefined))
                 return
               }
               const json = decoded.value
@@ -142,12 +185,8 @@ export const startListening = ({
               if (Exit.isSuccess(ack)) {
                 if (bannerShown) return
                 bannerShown = true
-                const dim = '\x1b[2m'
-                const bold = '\x1b[1m'
-                const cyan = '\x1b[36m'
-                const reset = '\x1b[0m'
                 yield* Console.log(
-                  `\n  ${bold}${cyan}Connected${reset}  ${bold}${organizationName}${reset}\n  ${dim}Secret${reset}     ${ack.value.secret}\n  ${dim}Forwarding${reset} ${forwardUrl}\n\n  ${dim}Waiting for events...${reset}\n`,
+                  banner(organizationName, ack.value.secret, forwardUrl),
                 )
                 return
               }
@@ -159,7 +198,11 @@ export const startListening = ({
               }
               const webhook = Schema.decodeUnknownExit(ListenWebhookEvent)(json)
               if (Exit.isFailure(webhook)) {
-                yield* Console.error('>> Failed to decode event')
+                const key =
+                  typeof json === 'object' && json !== null && 'key' in json
+                    ? String(json.key)
+                    : undefined
+                yield* printError(decodeFailure(key))
                 return
               }
               const rawPayload = webhook.value.payload.payload
@@ -171,6 +214,7 @@ export const startListening = ({
               const eventType = Exit.isSuccess(payload)
                 ? (payload.value.type ?? 'event')
                 : 'event'
+              const startedAt = performance.now()
               yield* Effect.tryPromise((signal) =>
                 forward(forwardUrl, {
                   method: 'POST',
@@ -185,13 +229,23 @@ export const startListening = ({
                   ).pipe(
                     Effect.andThen(
                       Console.log(
-                        `>> '\x1b[36m${eventType}\x1b[0m' >> ${result.status} ${result.statusText}`,
+                        eventLine(
+                          eventType,
+                          ui.statusCode(result.status, result.statusText),
+                          startedAt,
+                        ),
                       ),
                     ),
                   ),
                 ),
                 Effect.catch((error) =>
-                  Console.error(`>> Failed to forward event: ${error}`),
+                  printError(
+                    eventLine(
+                      eventType,
+                      ui.red(`failed  ${describeForwardFailure(error)}`),
+                      startedAt,
+                    ),
+                  ),
                 ),
               )
             }),
@@ -243,7 +297,11 @@ export const startListening = ({
     ),
   )
 
-const url = Argument.string('url')
+const url = Argument.string('url').pipe(
+  Argument.withDescription(
+    'Local URL to forward webhook events to, e.g. http://localhost:3000/api/webhooks',
+  ),
+)
 
 export const listen = Command.make(
   'listen',
@@ -273,4 +331,8 @@ export const listen = Command.make(
         ),
       )
     }),
+).pipe(
+  Command.withDescription(
+    'Forward webhook events for an organization to a local URL',
+  ),
 )

--- a/clients/packages/cli/src/commands/update.ts
+++ b/clients/packages/cli/src/commands/update.ts
@@ -10,6 +10,7 @@ import {
   getLatestRelease,
   isNewerVersion,
 } from '../services/github-releases'
+import * as ui from '../ui'
 import { VERSION } from '../version'
 
 export class UpdateError extends Data.TaggedError('UpdateError')<{
@@ -132,12 +133,6 @@ export function getArchiveExtractionCommand(
 
 const downloadAndUpdate = (release: CLIRelease, latestVersion: string) =>
   Effect.gen(function* () {
-    const bold = '\x1b[1m'
-    const cyan = '\x1b[36m'
-    const green = '\x1b[32m'
-    const dim = '\x1b[2m'
-    const reset = '\x1b[0m'
-
     const { os, arch } = detectPlatform()
     const platform = `${os}-${arch}`
     const archiveName = getReleaseArchiveName({ os, arch })
@@ -166,7 +161,7 @@ const downloadAndUpdate = (release: CLIRelease, latestVersion: string) =>
 
     yield* Effect.ensuring(
       Effect.gen(function* () {
-        yield* Console.log(`${dim}Downloading ${latestVersion}...${reset}`)
+        yield* Console.log(ui.step(`Downloading ${latestVersion}...`))
 
         const archiveBuffer = yield* Effect.tryPromise({
           try: () =>
@@ -194,7 +189,7 @@ const downloadAndUpdate = (release: CLIRelease, latestVersion: string) =>
             }),
         })
 
-        yield* Console.log(`${dim}Verifying checksum...${reset}`)
+        yield* Console.log(ui.step('Verifying checksum...'))
 
         const checksumsText = yield* Effect.tryPromise({
           try: () =>
@@ -243,7 +238,7 @@ const downloadAndUpdate = (release: CLIRelease, latestVersion: string) =>
           })
         }
 
-        yield* Console.log(`${dim}Extracting...${reset}`)
+        yield* Console.log(ui.step('Extracting...'))
 
         const extract = Bun.spawn(
           getArchiveExtractionCommand(archivePath, tempDir),
@@ -276,17 +271,19 @@ const downloadAndUpdate = (release: CLIRelease, latestVersion: string) =>
         const binaryPath = process.execPath
         const newBinaryPath = join(tempDir, 'polar')
 
-        yield* Console.log(`${dim}Replacing binary...${reset}`)
+        yield* Console.log(ui.step('Replacing binary...'))
 
         yield* replaceBinary(newBinaryPath, binaryPath).pipe(
           Effect.provide(BunFileSystem.layer),
         )
 
-        yield* Console.log('')
+        yield* Console.log(ui.blank)
         yield* Console.log(
-          `  ${bold}${green}Updated successfully!${reset} ${dim}${VERSION}${reset} -> ${bold}${cyan}${latestVersion}${reset}`,
+          ui.success(
+            `Updated ${ui.dim(VERSION)} ${ui.dim('→')} ${ui.bold(ui.cyan(latestVersion))}`,
+          ),
         )
-        yield* Console.log('')
+        yield* Console.log(ui.blank)
       }),
       Effect.promise(() =>
         rm(tempDir, { recursive: true, force: true }).catch(() => {}),
@@ -296,23 +293,19 @@ const downloadAndUpdate = (release: CLIRelease, latestVersion: string) =>
 
 export const update = Command.make('update', {}, () =>
   Effect.gen(function* () {
-    const green = '\x1b[32m'
-    const dim = '\x1b[2m'
-    const reset = '\x1b[0m'
-
-    yield* Console.log(`${dim}Checking for updates...${reset}`)
+    yield* Console.log(ui.blank)
+    yield* Console.log(ui.step('Checking for updates...'))
 
     const release = yield* getLatestRelease
 
     const latestVersion = release.version
 
     if (!isNewerVersion(latestVersion, VERSION)) {
-      yield* Console.log(
-        `${green}Already up to date${reset} ${dim}(${VERSION})${reset}`,
-      )
+      yield* Console.log(ui.success(`Already up to date ${ui.dim(VERSION)}`))
+      yield* Console.log(ui.blank)
       return
     }
 
     yield* downloadAndUpdate(release, latestVersion)
   }),
-)
+).pipe(Command.withDescription('Update the CLI to the latest release'))

--- a/clients/packages/cli/src/errors.ts
+++ b/clients/packages/cli/src/errors.ts
@@ -1,0 +1,63 @@
+import type { ListenError } from './commands/listen'
+import type { UpdateError } from './commands/update'
+import type { AuthError } from './schemas/Auth'
+import type { GitHubReleaseError } from './services/github-releases'
+
+export type CommandError =
+  | AuthError
+  | ListenError
+  | UpdateError
+  | GitHubReleaseError
+
+export interface ErrorDescription {
+  title: string
+  hint?: string
+}
+
+const releasesHint =
+  'Releases are published at https://github.com/polarsource/polar/releases'
+
+const listenHint = (code: number) => {
+  switch (code) {
+    case 403:
+      return 'You do not have access to this organization.'
+    case 404:
+      return 'The organization could not be found.'
+    default:
+      return code >= 500
+        ? 'The Polar API may be having issues, try again shortly.'
+        : undefined
+  }
+}
+
+const isCommandError = (error: unknown): error is CommandError =>
+  typeof error === 'object' &&
+  error !== null &&
+  '_tag' in error &&
+  ['AuthError', 'ListenError', 'UpdateError', 'GitHubReleaseError'].includes(
+    String(error._tag),
+  )
+
+export const describeError = (error: unknown): ErrorDescription => {
+  if (!isCommandError(error)) {
+    return {
+      title:
+        error instanceof Error ? error.message : 'An unexpected error occurred',
+    }
+  }
+  switch (error._tag) {
+    case 'AuthError':
+      return { title: error.message }
+    case 'ListenError': {
+      const hint = listenHint(error.code)
+      return hint ? { title: error.message, hint } : { title: error.message }
+    }
+    case 'UpdateError':
+      return { title: error.message, hint: releasesHint }
+    case 'GitHubReleaseError':
+      return {
+        title: `Could not check for updates: ${error.message}`,
+        hint: releasesHint,
+      }
+  }
+}

--- a/clients/packages/cli/src/services/oauth.ts
+++ b/clients/packages/cli/src/services/oauth.ts
@@ -1,6 +1,14 @@
 import { createHash, randomBytes } from 'node:crypto'
 import { createServer } from 'node:http'
-import { Context, DateTime, Effect, Layer, Redacted, Schema } from 'effect'
+import {
+  Console,
+  Context,
+  DateTime,
+  Effect,
+  Layer,
+  Redacted,
+  Schema,
+} from 'effect'
 import {
   FetchHttpClient,
   HttpClient,
@@ -14,6 +22,8 @@ import {
   type PolarEnvironment,
   type Session,
 } from '../schemas/Auth'
+import * as ui from '../ui'
+
 const SANDBOX_CLIENT_ID = 'polar_ci_AHVAKf9SDOaffma2auRGMXR3H8jg9QBgOfW7s1hYgW9'
 const PRODUCTION_CLIENT_ID = 'polar_ci_gBnJ_Yv_uSGm5mtoPa2cCA'
 
@@ -203,6 +213,15 @@ const login = (environment: PolarEnvironment) =>
       code_challenge_method: 'S256',
       sub_type: 'user',
     }).toString()
+    yield* Console.log(ui.blank)
+    yield* Console.log(
+      ui.step(`Opening your browser to sign in to Polar ${environment}...`),
+    )
+    yield* Console.log(ui.step('If it does not open, visit:'))
+    yield* Console.log(`    ${ui.cyan(authorization.toString())}`)
+    yield* Console.log(ui.blank)
+    yield* Console.log(ui.step('Waiting for you to authorize the CLI...'))
+    yield* Console.log(ui.blank)
     const server = createServer()
     const code = yield* Effect.callback<string, AuthError>((resume) => {
       let completed = false

--- a/clients/packages/cli/src/services/update-check.ts
+++ b/clients/packages/cli/src/services/update-check.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { Effect } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
+import * as ui from '../ui'
 import { VERSION } from '../version'
 import { getLatestRelease, isNewerVersion } from './github-releases'
 
@@ -26,14 +27,16 @@ export function showUpdateNotice(): void {
     if (!state.latestVersion || !isNewerVersion(state.latestVersion, VERSION))
       return
 
-    const dim = '\x1b[2m'
-    const cyan = '\x1b[36m'
-    const bold = '\x1b[1m'
-    const reset = '\x1b[0m'
-
     process.stderr.write(
-      `\n  ${dim}Update available:${reset} ${dim}${VERSION}${reset} ${dim}→${reset} ${bold}${cyan}${state.latestVersion}${reset}\n` +
-        `  ${dim}Run${reset} ${cyan}polar update${reset} ${dim}to update${reset}\n\n`,
+      [
+        ui.blank,
+        ui.warning(
+          `Update available ${ui.dim(VERSION)} ${ui.dim('→')} ${ui.bold(ui.cyan(state.latestVersion))}`,
+        ),
+        ui.step(`Run ${ui.command('polar update')} to install it`),
+        ui.blank,
+        ui.blank,
+      ].join('\n'),
     )
   } catch {
     // Silently ignore any errors

--- a/clients/packages/cli/src/ui.ts
+++ b/clients/packages/cli/src/ui.ts
@@ -1,0 +1,52 @@
+import pc from 'picocolors'
+
+const INDENT = '  '
+
+export const dim = pc.dim
+export const bold = pc.bold
+export const cyan = pc.cyan
+export const green = pc.green
+export const yellow = pc.yellow
+export const red = pc.red
+
+export const command = (text: string) => pc.cyan(text)
+
+export const success = (message: string) =>
+  `${INDENT}${pc.green('✔')} ${message}`
+
+export const failure = (title: string, hint?: string) => {
+  const lines = [`${INDENT}${pc.red('✖')} ${pc.bold(pc.red(title))}`]
+  if (hint) {
+    lines.push(`${INDENT}  ${pc.dim(hint)}`)
+  }
+  return lines.join('\n')
+}
+
+export const warning = (message: string) =>
+  `${INDENT}${pc.yellow('▲')} ${message}`
+
+export const step = (message: string) => `${INDENT}${pc.dim(message)}`
+
+export const keyValue = (rows: ReadonlyArray<readonly [string, string]>) => {
+  const width = Math.max(...rows.map(([label]) => label.length))
+  return rows
+    .map(
+      ([label, value]) => `${INDENT}${pc.dim(label.padEnd(width))}  ${value}`,
+    )
+    .join('\n')
+}
+
+export const blank = ''
+
+export const statusCode = (status: number, statusText: string) => {
+  const text = `${status} ${statusText}`.trim()
+  if (status >= 500) return pc.red(text)
+  if (status >= 400) return pc.yellow(text)
+  return pc.green(text)
+}
+
+export const timestamp = (date: Date = new Date()) =>
+  pc.dim(date.toTimeString().slice(0, 8))
+
+export const duration = (milliseconds: number) =>
+  pc.dim(`${Math.round(milliseconds)}ms`)

--- a/clients/pnpm-lock.yaml
+++ b/clients/pnpm-lock.yaml
@@ -1023,6 +1023,9 @@ importers:
       open:
         specifier: ^10.2.0
         version: 10.2.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
     devDependencies:
       '@effect/language-service':
         specifier: ^0.87.2


### PR DESCRIPTION
## Summary

This PR will add some UI improvements to the CLI:

* Improved error message (show what happened, and why it happened)
* Improved `--help` command (show descriptions)2
* Improved `auth login` (formatting, show the actual URL)
* Improved webhook output (add timestamps, formatting, timings)

Fixes [PLR-106](https://linear.app/polarsh/issue/PLR-106/improve-output)
Fixes [PLR-104](https://linear.app/polarsh/issue/PLR-104/improve-error-handling)

### Error message

<!-- linear:table-colwidths:400,400 -->
<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><img src="https://github.com/user-attachments/assets/20de919e-34cb-450b-9847-0c58bbb2dda8 " alt="Screenshot 2026-09-09 at 13 49 05" width="694" data-linear-height="662" /></td>
<td><img src="https://github.com/user-attachments/assets/1742ba64-06c1-4bfd-a1bc-1bd2641cab07 " alt="Screenshot 2026-09-09 at 13 48 57" width="801" data-linear-height="879" /></td>
</tr>
</tbody>
</table>

## Help

<img src="https://github.com/user-attachments/assets/98840710-1a29-4af0-9bd5-5614b4f627f7 " alt="Screenshot 2026-09-09 at 13 51 17" width="806" data-linear-height="314" />

## Auth login

<img src="https://github.com/user-attachments/assets/f2dd98fa-d214-42db-af9a-8b38e681d31d " alt="Screenshot 2026-09-09 at 13 52 56" width="1728" data-linear-height="466" />

## Webhook output

<!-- linear:table-colwidths:400,400 -->
<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><img src="https://github.com/user-attachments/assets/02f4a97a-e5f4-42ef-b03c-271259dff3cf " alt="Screenshot 2026-09-09 at 13 58 00" width="833" data-linear-height="345" /></td>
<td><img src="https://github.com/user-attachments/assets/0991c8b1-e4e7-4295-92db-0535a9774f41 " alt="Screenshot 2026-09-09 at 13 58 05" width="1037" data-linear-height="380" /></td>
</tr>
</tbody>
</table>

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)