### PR TITLE
CLI: Org implied environment

### DIFF
--- a/clients/packages/cli/src/commands/auth.test.ts
+++ b/clients/packages/cli/src/commands/auth.test.ts
@@ -11,8 +11,18 @@ import {
   overrideCredential,
 } from '@/utils/test-utils/services'
 
-const acme: ActiveOrganization = { id: 'org-1', name: 'Acme', slug: 'acme' }
-const beta: ActiveOrganization = { id: 'org-2', name: 'Beta', slug: 'beta' }
+const acme: ActiveOrganization = {
+  id: 'org-1',
+  name: 'Acme',
+  slug: 'acme',
+  environment: 'sandbox',
+}
+const beta: ActiveOrganization = {
+  id: 'org-2',
+  name: 'Beta',
+  slug: 'beta',
+  environment: 'production',
+}
 
 let auth: ReturnType<typeof fakeAuth>
 let organizations: ReturnType<typeof fakeOrganizations>
@@ -36,11 +46,11 @@ beforeEach(() => {
 describe('auth login', () => {
   test('explains how to replace an existing sandbox session', async () => {
     auth.state.replaced = false
-    const { promise, output } = run(['login'])
+    const { promise, output } = run(['login', '--sandbox'])
     await promise
 
     expect(output()).toContain('Already logged in to sandbox')
-    expect(output()).toContain('polar auth login --new-session')
+    expect(output()).toContain('polar auth login --sandbox --new-session')
     expect(output()).toContain('polar auth login --production to sign in')
   })
 
@@ -51,62 +61,81 @@ describe('auth login', () => {
 
     expect(output()).toContain('Already logged in to production')
     expect(output()).toContain('polar auth login --production --new-session')
-    expect(output()).toContain('polar auth login to sign in to sandbox')
+    expect(output()).toContain('polar auth login --sandbox to sign in')
   })
 
-  test('points at the dashboard when there are no organizations', async () => {
+  test('asks for the environment when no flag is given', async () => {
+    const { promise, output, terminal } = run(['login'], {
+      interactive: true,
+      input: [keys.down, keys.enter, keys.enter],
+    })
+    await promise
+
+    expect(terminal()).toContain('Which environment do you want to log in to?')
+    expect(output()).toContain('Logged in to Polar production')
+  })
+
+  test('requires a flag outside a terminal', async () => {
+    const { promise } = run(['login'])
+
+    await expect(promise).rejects.toThrow('Pass --sandbox or --production')
+  })
+
+  test('rejects both environment flags', async () => {
+    const { promise } = run(['login', '--sandbox', '--production'])
+
+    await expect(promise).rejects.toThrow('not both')
+  })
+
+  test('points at the dashboards when there are no organizations', async () => {
     organizations.state.items = []
-    const { promise, output } = run(['login'])
+    const { promise, output } = run(['login', '--sandbox'])
     await promise
 
     expect(output()).toContain('Logged in to Polar sandbox')
-    expect(output()).toContain('No organizations in sandbox yet')
+    expect(output()).toContain('No organizations yet')
+    expect(output()).toContain('https://polar.sh')
     expect(output()).toContain('https://sandbox.polar.sh')
     expect(output()).toContain('polar auth org')
   })
 
-  test('points at the production dashboard for production logins', async () => {
-    organizations.state.items = []
+  test('skips organization selection outside a terminal', async () => {
     const { promise, output } = run(['login', '--production'])
     await promise
 
-    expect(output()).toContain('No organizations in production yet')
-    expect(output()).toContain('https://polar.sh')
-    expect(output()).toContain('polar auth org --production')
-  })
-
-  test('skips organization selection outside a terminal', async () => {
-    const { promise, output } = run(['login'])
-    await promise
-
-    expect(output()).toContain('Logged in to Polar sandbox')
+    expect(output()).toContain('Logged in to Polar production')
     expect(output()).toContain(
       'Organization selection requires an interactive terminal',
     )
-    expect(organizations.state.selected).toEqual({})
+    expect(organizations.state.selected).toBeUndefined()
   })
 
-  test('selects an organization interactively', async () => {
-    const { promise, output, terminal } = run(['login'], {
+  test('offers organizations from every environment after login', async () => {
+    const { promise, output, terminal } = run(['login', '--sandbox'], {
       interactive: true,
       input: [keys.down, keys.enter],
     })
     await promise
 
-    expect(terminal()).toContain('Select sandbox organization')
-    expect(organizations.state.selected).toEqual({ sandbox: 'org-2' })
-    expect(output()).toContain('Active organization Beta beta')
+    expect(terminal()).toContain('Select organization')
+    expect(terminal()).toContain('Acme sandbox')
+    expect(terminal()).toContain('Beta production')
+    expect(organizations.state.selected).toEqual({
+      id: 'org-2',
+      environment: 'production',
+    })
+    expect(output()).toContain('Active organization Beta beta production')
   })
 })
 
 describe('auth whoami', () => {
-  test('shows the active organization of a saved session', async () => {
-    organizations.state.selected = { sandbox: 'org-2' }
+  test('shows the sessions and the active organization', async () => {
+    organizations.state.selected = { id: 'org-2', environment: 'production' }
     const { promise, output } = run(['whoami'])
     await promise
 
-    expect(output()).toContain('sandbox')
-    expect(output()).toContain('Beta beta')
+    expect(output()).toMatch(/Logged in\s+sandbox, production/)
+    expect(output()).toContain('Beta beta production')
     expect(output()).toContain('org-2')
     expect(output()).not.toContain('No active organization')
   })
@@ -119,13 +148,25 @@ describe('auth whoami', () => {
     expect(output()).toContain('polar auth org')
   })
 
+  test('explains how to log in when there are no sessions', async () => {
+    auth.state.sessions = []
+    const { promise, output } = run(['whoami'])
+    await promise
+
+    expect(output()).toContain('Not logged in')
+    expect(output()).toContain('polar auth login --sandbox')
+    expect(output()).toContain('polar auth login --production')
+  })
+
   test('shows the only organization of a token override', async () => {
     auth.state.credential = overrideCredential()
+    auth.state.environment = 'sandbox'
     organizations.state.items = [acme]
     const { promise, output } = run(['whoami'])
     await promise
 
     expect(output()).toContain('POLAR_ACCESS_TOKEN')
+    expect(output()).toMatch(/Environment\s+sandbox/)
     expect(output()).toContain('Acme acme')
     expect(output()).not.toContain('No active organization')
   })
@@ -135,29 +176,41 @@ describe('auth whoami', () => {
     const { promise, output } = run(['whoami'])
     await promise
 
+    expect(output()).toMatch(/Environment\s+production/)
     expect(output()).toContain('No active organization')
     expect(output()).toContain('--org <id>')
   })
 })
 
 describe('auth list', () => {
-  test('marks the active organization', async () => {
-    organizations.state.selected = { sandbox: 'org-1' }
+  test('groups organizations by environment and marks the active one', async () => {
+    organizations.state.selected = { id: 'org-1', environment: 'sandbox' }
     const { promise, output } = run(['list'])
     await promise
 
     expect(output()).toContain('Organizations in sandbox')
     expect(output()).toContain('● Acme  acme  org-1')
+    expect(output()).toContain('Organizations in production')
     expect(output()).toContain('○ Beta  beta  org-2')
+  })
+
+  test('only shows environments with a session', async () => {
+    auth.state.sessions = ['production']
+    const { promise, output } = run(['list'])
+    await promise
+
+    expect(output()).not.toContain('Organizations in sandbox')
+    expect(output()).toContain('Organizations in production')
   })
 
   test('mentions the token override', async () => {
     auth.state.credential = overrideCredential()
-    const { promise, output } = run(['list', '--production'])
+    const { promise, output } = run(['list'])
     await promise
 
     expect(output()).toContain('Organizations in production')
     expect(output()).toContain('via POLAR_ACCESS_TOKEN')
+    expect(output()).not.toContain('Organizations in sandbox')
   })
 
   test('reports when no organizations are accessible', async () => {
@@ -167,6 +220,14 @@ describe('auth list', () => {
 
     expect(output()).toContain('No accessible organizations')
   })
+
+  test('explains how to log in when there are no sessions', async () => {
+    auth.state.sessions = []
+    const { promise, output } = run(['list'])
+    await promise
+
+    expect(output()).toContain('Not logged in')
+  })
 })
 
 describe('auth org', () => {
@@ -175,6 +236,13 @@ describe('auth org', () => {
     const { promise } = run(['org'])
 
     await expect(promise).rejects.toThrow('Unset POLAR_ACCESS_TOKEN')
+  })
+
+  test('requires a session', async () => {
+    auth.state.sessions = []
+    const { promise } = run(['org'])
+
+    await expect(promise).rejects.toThrow('Not logged in')
   })
 
   test('requires a terminal to select an organization', async () => {
@@ -187,48 +255,91 @@ describe('auth org', () => {
   })
 
   test('marks the active organization in the prompt', async () => {
-    organizations.state.selected = { sandbox: 'org-1' }
+    organizations.state.selected = { id: 'org-1', environment: 'sandbox' }
     const { promise, output, terminal } = run(['org'], {
       interactive: true,
       input: [keys.enter],
     })
     await promise
 
-    expect(terminal()).toContain('Acme (active)')
-    expect(output()).toContain('Active organization Acme acme')
-    expect(organizations.state.selected).toEqual({ sandbox: 'org-1' })
+    expect(terminal()).toContain('Acme sandbox (active)')
+    expect(output()).toContain('Active organization Acme acme sandbox')
+    expect(organizations.state.selected).toEqual({
+      id: 'org-1',
+      environment: 'sandbox',
+    })
   })
 
   test('fails when the prompt is abandoned', async () => {
     const { promise } = run(['org'], { interactive: true })
 
     await expect(promise).rejects.toThrow()
-    expect(organizations.state.selected).toEqual({})
+    expect(organizations.state.selected).toBeUndefined()
   })
 })
 
 describe('auth logout', () => {
-  test('confirms the session was removed', async () => {
-    const { promise, output } = run(['logout'])
+  test('logs out of the flagged environment only', async () => {
+    const { promise, output } = run(['logout', '--production'])
+    await promise
+
+    expect(output()).toContain('Logged out of Polar production')
+    expect(output()).not.toContain('sandbox')
+    expect(auth.state.sessions).toEqual(['sandbox'])
+  })
+
+  test('logs out of everything with --all', async () => {
+    const { promise, output } = run(['logout', '--all'])
     await promise
 
     expect(output()).toContain('Logged out of Polar sandbox')
+    expect(output()).toContain('Logged out of Polar production')
+    expect(auth.state.sessions).toEqual([])
   })
 
-  test('reports when there was no session', async () => {
-    auth.state.deleted = false
+  test('reports environments that had no session', async () => {
+    auth.state.sessions = ['sandbox']
     const { promise, output } = run(['logout', '--production'])
     await promise
 
     expect(output()).toContain('Already logged out of production')
   })
 
+  test('asks which session to remove when no flag is given', async () => {
+    const { promise, output, terminal } = run(['logout'], {
+      interactive: true,
+      input: [keys.down, keys.down, keys.enter],
+    })
+    await promise
+
+    expect(terminal()).toContain('Which session do you want to log out of?')
+    expect(terminal()).toContain('All sessions')
+    expect(output()).toContain('Logged out of Polar sandbox')
+    expect(output()).toContain('Logged out of Polar production')
+  })
+
+  test('requires a flag outside a terminal', async () => {
+    const { promise } = run(['logout'])
+
+    await expect(promise).rejects.toThrow(
+      'Pass --sandbox, --production or --all',
+    )
+  })
+
+  test('reports when there is nothing to log out of', async () => {
+    auth.state.sessions = []
+    const { promise, output } = run(['logout'], { interactive: true })
+    await promise
+
+    expect(output()).toContain('Already logged out')
+  })
+
   test('warns that a token override stays active', async () => {
     auth.state.credential = overrideCredential()
-    const { promise, output } = run(['logout'])
+    const { promise, output } = run(['logout', '--all'])
     await promise
 
     expect(output()).toContain('POLAR_ACCESS_TOKEN remains active')
-    expect(output()).toContain('Logged out of Polar sandbox')
+    expect(output()).toContain('Logged out of Polar')
   })
 })

--- a/clients/packages/cli/src/commands/auth.ts
+++ b/clients/packages/cli/src/commands/auth.ts
@@ -2,83 +2,133 @@ import { Console, Effect, Stdio } from 'effect'
 import { Command, Flag, Prompt } from 'effect/unstable/cli'
 import {
   AuthError,
+  environments,
   loginCommand,
   orgCommand,
+  type ActiveOrganization,
+  type OrganizationSelection,
   type PolarEnvironment,
 } from '@/schemas/Auth'
 import { Auth } from '@/services/auth'
 import { Organizations } from '@/services/organizations'
 import * as ui from '@/utils/ui'
-import { environmentOf, production } from '@/commands/flags'
+import { production, sandbox } from '@/commands/flags'
 
-const dashboardUrl = (environment: PolarEnvironment) =>
-  `https://${environment === 'sandbox' ? 'sandbox.' : ''}polar.sh`
+const isSelected = (
+  organization: ActiveOrganization,
+  selection: OrganizationSelection | undefined,
+) =>
+  selection?.id === organization.id &&
+  selection.environment === organization.environment
 
-const selectOrganization = (environment: PolarEnvironment) =>
+const describe = (organization: ActiveOrganization) =>
+  `${ui.bold(organization.name)} ${ui.dim(organization.slug)} ${ui.dim(organization.environment)}`
+
+const notLoggedIn = Effect.gen(function* () {
+  yield* Console.log(ui.warning('Not logged in'))
+  yield* Console.log(
+    ui.step(
+      `Run ${ui.command(loginCommand('sandbox'))} or ${ui.command(loginCommand('production'))}`,
+    ),
+  )
+  yield* Console.log(ui.blank)
+})
+
+const environmentFlags = { sandbox, production }
+
+const interactive = Effect.gen(function* () {
+  const stdio = yield* Stdio.Stdio
+  return (yield* stdio.stdinIsTerminal) && (yield* stdio.stdoutIsTerminal)
+})
+
+const chooseEnvironment = (
+  flags: { sandbox: boolean; production: boolean },
+  action: string,
+) =>
   Effect.gen(function* () {
-    const organizations = yield* Organizations
-    const items = yield* organizations.list(environment)
-    if (items.length === 0) {
-      yield* Console.log(ui.warning(`No organizations in ${environment} yet`))
-      yield* Console.log(
-        ui.step(
-          `Create one at ${ui.cyan(dashboardUrl(environment))}, then run ${ui.command(orgCommand(environment))}`,
-        ),
-      )
-      yield* Console.log(ui.blank)
-      return
+    if (flags.sandbox && flags.production) {
+      return yield* new AuthError({
+        message: 'Pass either --sandbox or --production, not both.',
+      })
     }
-    const stdio = yield* Stdio.Stdio
-    if (!(yield* stdio.stdinIsTerminal) || !(yield* stdio.stdoutIsTerminal)) {
-      yield* Console.log(
-        ui.warning('Organization selection requires an interactive terminal'),
-      )
-      yield* Console.log(
-        ui.step(
-          `Run ${ui.command(orgCommand(environment))} interactively, or use POLAR_ACCESS_TOKEN with ${ui.command('--org <id>')} in CI`,
-        ),
-      )
-      yield* Console.log(ui.blank)
-      return
+    if (flags.production) return 'production' as const
+    if (flags.sandbox) return 'sandbox' as const
+    if (!(yield* interactive)) {
+      return yield* new AuthError({
+        message: `Pass --sandbox or --production to ${action} outside an interactive terminal.`,
+      })
     }
-    const activeOrganizationId = yield* organizations.selected(environment)
-    const organization = yield* Prompt.select({
-      message: `Select ${environment} organization`,
-      choices: items.map((organization) => ({
-        value: organization,
-        title:
-          organization.id === activeOrganizationId
-            ? `${organization.name} ${ui.dim('(active)')}`
-            : organization.name,
-        description: organization.slug,
-      })),
+    return yield* Prompt.select<PolarEnvironment>({
+      message: `Which environment do you want to ${action}?`,
+      choices: [
+        { title: 'Sandbox', value: 'sandbox', description: 'sandbox.polar.sh' },
+        { title: 'Production', value: 'production', description: 'polar.sh' },
+      ],
     })
-    yield* organizations.select(environment, organization.id)
-    yield* Console.log(ui.blank)
+  })
+
+const selectOrganization = Effect.gen(function* () {
+  const organizations = yield* Organizations
+  const items = yield* organizations.listAll
+  if (items.length === 0) {
+    yield* Console.log(ui.warning('No organizations yet'))
     yield* Console.log(
-      ui.success(
-        `Active organization ${ui.bold(organization.name)} ${ui.dim(organization.slug)}`,
+      ui.step(
+        `Create one at ${ui.cyan('https://polar.sh')} or ${ui.cyan('https://sandbox.polar.sh')}, then run ${ui.command(orgCommand)}`,
       ),
     )
     yield* Console.log(ui.blank)
+    return
+  }
+  if (!(yield* interactive)) {
+    yield* Console.log(
+      ui.warning('Organization selection requires an interactive terminal'),
+    )
+    yield* Console.log(
+      ui.step(
+        `Run ${ui.command(orgCommand)} interactively, or use POLAR_ACCESS_TOKEN with ${ui.command('--org <id>')} in CI`,
+      ),
+    )
+    yield* Console.log(ui.blank)
+    return
+  }
+  const selection = yield* organizations.selected
+  const organization = yield* Prompt.select({
+    message: 'Select organization',
+    choices: items.map((organization) => ({
+      value: organization,
+      title: `${organization.name} ${ui.dim(organization.environment)}${isSelected(organization, selection) ? ` ${ui.dim('(active)')}` : ''}`,
+      description: organization.slug,
+    })),
   })
+  yield* organizations.select({
+    id: organization.id,
+    environment: organization.environment,
+  })
+  yield* Console.log(ui.blank)
+  yield* Console.log(
+    ui.success(`Active organization ${describe(organization)}`),
+  )
+  yield* Console.log(ui.blank)
+})
 
 const login = Command.make(
   'login',
   {
-    production,
+    ...environmentFlags,
     newSession: Flag.boolean('new-session').pipe(
       Flag.withDefault(false),
       Flag.withDescription('Sign in again even if a session is already saved'),
     ),
   },
-  ({ production, newSession }) =>
+  ({ newSession, ...flags }) =>
     Effect.gen(function* () {
-      const environment = environmentOf(production)
+      const environment = yield* chooseEnvironment(flags, 'log in to')
       const auth = yield* Auth
       const replaced = yield* auth.login(environment, newSession)
       if (!replaced) {
-        const other: PolarEnvironment = production ? 'sandbox' : 'production'
+        const other: PolarEnvironment =
+          environment === 'production' ? 'sandbox' : 'production'
         yield* Console.log(ui.blank)
         yield* Console.log(
           ui.warning(`Already logged in to ${ui.bold(environment)}`),
@@ -100,81 +150,91 @@ const login = Command.make(
         ui.success(`Logged in to Polar ${ui.bold(environment)}`),
       )
       yield* Console.log(ui.blank)
-      yield* selectOrganization(environment)
+      yield* selectOrganization
     }),
 ).pipe(Command.withDescription('Sign in to Polar through your browser'))
 
-const whoami = Command.make('whoami', { production }, ({ production }) =>
+const whoami = Command.make('whoami', {}, () =>
   Effect.gen(function* () {
-    const environment = environmentOf(production)
     const auth = yield* Auth
     const organizations = yield* Organizations
-    const credential = yield* auth.resolve(environment)
-    const rows: Array<readonly [string, string]> = [
-      ['Environment', environment],
-    ]
-    if (credential.source === 'override') {
-      rows.push(['Token', 'POLAR_ACCESS_TOKEN'])
-      const items = yield* organizations.list(environment)
-      if (items.length === 1) {
-        const org = items[0]!
-        rows.push(['Organization', `${ui.bold(org.name)} ${ui.dim(org.slug)}`])
-        rows.push(['ID', ui.dim(org.id)])
-      }
-    } else if (yield* organizations.selected(environment)) {
-      const org = yield* organizations.resolve(environment)
-      rows.push(['Organization', `${ui.bold(org.name)} ${ui.dim(org.slug)}`])
-      rows.push(['ID', ui.dim(org.id)])
-    }
+    const environments = yield* auth.environments
     yield* Console.log(ui.blank)
+    if (yield* auth.override) {
+      const rows: Array<readonly [string, string]> = [
+        ['Token', 'POLAR_ACCESS_TOKEN'],
+        ['Environment', environments[0]!],
+      ]
+      const items = yield* organizations.listAll
+      const organization = items.length === 1 ? items[0] : undefined
+      if (organization) {
+        rows.push(['Organization', describe(organization)])
+        rows.push(['ID', ui.dim(organization.id)])
+      }
+      yield* Console.log(ui.keyValue(rows))
+      if (!organization) {
+        yield* Console.log(ui.blank)
+        yield* Console.log(ui.warning('No active organization'))
+        yield* Console.log(
+          ui.step(
+            `Use ${ui.command('--org <id>')} on organization-dependent commands`,
+          ),
+        )
+      }
+      yield* Console.log(ui.blank)
+      return
+    }
+    if (environments.length === 0) return yield* notLoggedIn
+    const rows: Array<readonly [string, string]> = [
+      ['Logged in', environments.join(', ')],
+    ]
+    const selection = yield* organizations.selected
+    if (selection) {
+      const organization = yield* organizations.resolve()
+      rows.push(['Organization', describe(organization)])
+      rows.push(['ID', ui.dim(organization.id)])
+    }
     yield* Console.log(ui.keyValue(rows))
-    if (
-      rows.length === 1 ||
-      (rows.length === 2 && credential.source === 'override')
-    ) {
+    if (!selection) {
       yield* Console.log(ui.blank)
       yield* Console.log(ui.warning('No active organization'))
-      yield* Console.log(
-        ui.step(
-          credential.source === 'override'
-            ? `Use ${ui.command('--org <id>')} on organization-dependent commands`
-            : `Run ${ui.command(orgCommand(environment))} to choose one`,
-        ),
-      )
+      yield* Console.log(ui.step(`Run ${ui.command(orgCommand)} to choose one`))
     }
     yield* Console.log(ui.blank)
   }),
-).pipe(Command.withDescription('Show the active environment and organization'))
+).pipe(Command.withDescription('Show your sessions and active organization'))
 
-const list = Command.make('list', { production }, ({ production }) =>
+const list = Command.make('list', {}, () =>
   Effect.gen(function* () {
-    const environment = environmentOf(production)
     const auth = yield* Auth
     const organizations = yield* Organizations
-    const credential = yield* auth.resolve(environment)
-    const items = yield* organizations.list(environment)
-    const activeOrganizationId = yield* organizations.selected(environment)
+    const environments = yield* auth.environments
+    const override = yield* auth.override
     yield* Console.log(ui.blank)
-    yield* Console.log(
-      `  ${ui.bold(`Organizations in ${environment}`)}${credential.source === 'override' ? ui.dim('  via POLAR_ACCESS_TOKEN') : ''}`,
-    )
-    yield* Console.log(ui.blank)
-    if (items.length === 0) {
-      yield* Console.log(ui.step('No accessible organizations'))
-    }
-    const width = Math.max(0, ...items.map((org) => org.name.length))
-    for (const org of items) {
-      const marker =
-        org.id === activeOrganizationId ? ui.green('●') : ui.dim('○')
+    if (environments.length === 0) return yield* notLoggedIn
+    const selection = yield* organizations.selected
+    for (const environment of environments) {
+      const items = yield* organizations.list(environment)
       yield* Console.log(
-        `  ${marker} ${org.name.padEnd(width)}  ${ui.dim(org.slug)}  ${ui.dim(org.id)}`,
+        `  ${ui.bold(`Organizations in ${environment}`)}${override ? ui.dim('  via POLAR_ACCESS_TOKEN') : ''}`,
       )
+      yield* Console.log(ui.blank)
+      if (items.length === 0) {
+        yield* Console.log(ui.step('No accessible organizations'))
+      }
+      const width = Math.max(0, ...items.map((org) => org.name.length))
+      for (const org of items) {
+        const marker = isSelected(org, selection) ? ui.green('●') : ui.dim('○')
+        yield* Console.log(
+          `  ${marker} ${org.name.padEnd(width)}  ${ui.dim(org.slug)}  ${ui.dim(org.id)}`,
+        )
+      }
+      yield* Console.log(ui.blank)
     }
-    yield* Console.log(ui.blank)
   }),
 ).pipe(Command.withDescription('List the organizations you have access to'))
 
-const org = Command.make('org', { production }, ({ production }) =>
+const org = Command.make('org', {}, () =>
   Effect.gen(function* () {
     const auth = yield* Auth
     if (yield* auth.override) {
@@ -182,33 +242,83 @@ const org = Command.make('org', { production }, ({ production }) =>
         message: 'Unset POLAR_ACCESS_TOKEN to manage saved sessions.',
       })
     }
-    yield* auth.resolve(environmentOf(production))
-    yield* selectOrganization(environmentOf(production))
+    if ((yield* auth.environments).length === 0) {
+      return yield* new AuthError({
+        message: `Not logged in. Run ${loginCommand('sandbox')} or ${loginCommand('production')}.`,
+      })
+    }
+    yield* selectOrganization
   }),
 ).pipe(Command.withDescription('Choose the active organization'))
 
-const logout = Command.make('logout', { production }, ({ production }) =>
+const logoutTargets = (flags: {
+  sandbox: boolean
+  production: boolean
+  all: boolean
+}) =>
   Effect.gen(function* () {
-    const auth = yield* Auth
-    const environment = environmentOf(production)
-    yield* Console.log(ui.blank)
-    if (yield* auth.override) {
-      yield* Console.log(ui.warning('POLAR_ACCESS_TOKEN remains active'))
-      yield* Console.log(
-        ui.step(
-          'Unset it to stop using the override, only the saved session is removed',
-        ),
-      )
+    if (flags.all) return [...environments]
+    if (flags.sandbox || flags.production) {
+      return environments.filter((environment) => flags[environment])
     }
-    const deleted = yield* auth.logout(environment)
-    yield* Console.log(
-      deleted
-        ? ui.success(`Logged out of Polar ${ui.bold(environment)}`)
-        : ui.step(`Already logged out of ${environment}`),
-    )
-    yield* Console.log(ui.blank)
-  }),
-).pipe(Command.withDescription('Sign out and remove the saved session'))
+    if (!(yield* interactive)) {
+      return yield* new AuthError({
+        message:
+          'Pass --sandbox, --production or --all to log out outside an interactive terminal.',
+      })
+    }
+    const auth = yield* Auth
+    const sessions = yield* auth.environments
+    if (sessions.length === 0) return []
+    const choices = sessions.map((environment) => ({
+      title: environment === 'production' ? 'Production' : 'Sandbox',
+      value: [environment] as PolarEnvironment[],
+    }))
+    if (sessions.length > 1) {
+      choices.push({ title: 'All sessions', value: [...sessions] })
+    }
+    return yield* Prompt.select({
+      message: 'Which session do you want to log out of?',
+      choices,
+    })
+  })
+
+const logout = Command.make(
+  'logout',
+  {
+    ...environmentFlags,
+    all: Flag.boolean('all').pipe(
+      Flag.withDefault(false),
+      Flag.withDescription('Remove every saved session'),
+    ),
+  },
+  (flags) =>
+    Effect.gen(function* () {
+      const auth = yield* Auth
+      yield* Console.log(ui.blank)
+      if (yield* auth.override) {
+        yield* Console.log(ui.warning('POLAR_ACCESS_TOKEN remains active'))
+        yield* Console.log(
+          ui.step(
+            'Unset it to stop using the override, only saved sessions are removed',
+          ),
+        )
+      }
+      const targets = yield* logoutTargets(flags)
+      const deleted = yield* auth.logout(targets)
+      for (const environment of targets) {
+        yield* Console.log(
+          deleted.includes(environment)
+            ? ui.success(`Logged out of Polar ${ui.bold(environment)}`)
+            : ui.step(`Already logged out of ${environment}`),
+        )
+      }
+      if (targets.length === 0) {
+        yield* Console.log(ui.step('Already logged out'))
+      }
+      yield* Console.log(ui.blank)
+    }),
+).pipe(Command.withDescription('Sign out and remove saved sessions'))
 
 export const auth = Command.make('auth').pipe(
   Command.withDescription('Manage your Polar sessions and active organization'),

--- a/clients/packages/cli/src/commands/flags.test.ts
+++ b/clients/packages/cli/src/commands/flags.test.ts
@@ -1,7 +1,0 @@
-import { expect, test } from 'vitest'
-import { environmentOf } from '@/commands/flags'
-
-test('maps the production flag to an environment', () => {
-  expect(environmentOf(true)).toBe('production')
-  expect(environmentOf(false)).toBe('sandbox')
-})

--- a/clients/packages/cli/src/commands/flags.ts
+++ b/clients/packages/cli/src/commands/flags.ts
@@ -1,13 +1,14 @@
 import { Flag } from 'effect/unstable/cli'
-import type { PolarEnvironment } from '@/schemas/Auth'
 
+export const sandbox = Flag.boolean('sandbox').pipe(
+  Flag.withDefault(false),
+  Flag.withDescription('Use the sandbox environment'),
+)
 export const production = Flag.boolean('production').pipe(
   Flag.withDefault(false),
-  Flag.withDescription('Use production instead of sandbox'),
+  Flag.withDescription('Use the production environment'),
 )
 export const org = Flag.string('org').pipe(
   Flag.optional,
   Flag.withDescription('Organization ID for this invocation only'),
 )
-export const environmentOf = (production: boolean): PolarEnvironment =>
-  production ? 'production' : 'sandbox'

--- a/clients/packages/cli/src/commands/listen.ts
+++ b/clients/packages/cli/src/commands/listen.ts
@@ -19,8 +19,8 @@ import {
 } from 'effect/unstable/http'
 import { Auth } from '@/services/auth'
 import { Organizations } from '@/services/organizations'
-import { environmentOf, org, production } from '@/commands/flags'
-import { type PolarEnvironment } from '@/schemas/Auth'
+import { org } from '@/commands/flags'
+import { loginCommand, type PolarEnvironment } from '@/schemas/Auth'
 import {
   ListenAck,
   ListenReconnect,
@@ -303,34 +303,30 @@ const url = Argument.string('url').pipe(
   ),
 )
 
-export const listen = Command.make(
-  'listen',
-  { url, production, org },
-  ({ url, production, org }) =>
-    Effect.gen(function* () {
-      const environment = environmentOf(production)
-      const organizations = yield* Organizations
-      const organization = yield* organizations.resolve(
-        environment,
-        Option.getOrUndefined(org),
-      )
-      return yield* startListening({
-        listenUrl: `${LISTEN_BASE_URLS[environment]}/${organization.id}`,
-        forwardUrl: url,
-        organizationName: organization.name,
-        environment,
-      }).pipe(
-        Effect.provide(FetchHttpClient.layer),
-        Effect.mapError((error) =>
-          error.code === 401
-            ? new ListenError({
-                code: 401,
-                message: `Authentication rejected for ${environment}. Check POLAR_ACCESS_TOKEN or run polar auth login${production ? ' --production' : ''} --new-session.`,
-              })
-            : error,
-        ),
-      )
-    }),
+export const listen = Command.make('listen', { url, org }, ({ url, org }) =>
+  Effect.gen(function* () {
+    const organizations = yield* Organizations
+    const organization = yield* organizations.resolve(
+      Option.getOrUndefined(org),
+    )
+    const { environment } = organization
+    return yield* startListening({
+      listenUrl: `${LISTEN_BASE_URLS[environment]}/${organization.id}`,
+      forwardUrl: url,
+      organizationName: organization.name,
+      environment,
+    }).pipe(
+      Effect.provide(FetchHttpClient.layer),
+      Effect.mapError((error) =>
+        error.code === 401
+          ? new ListenError({
+              code: 401,
+              message: `Authentication rejected for ${environment}. Check POLAR_ACCESS_TOKEN or run ${loginCommand(environment)} --new-session.`,
+            })
+          : error,
+      ),
+    )
+  }),
 ).pipe(
   Command.withDescription(
     'Forward webhook events for an organization to a local URL',

--- a/clients/packages/cli/src/schemas/Auth.ts
+++ b/clients/packages/cli/src/schemas/Auth.ts
@@ -1,13 +1,22 @@
 import { Data, Schema } from 'effect'
 
-export type PolarEnvironment = 'sandbox' | 'production'
+export const environments = ['sandbox', 'production'] as const
+export const PolarEnvironment = Schema.Literals(environments)
+export type PolarEnvironment = typeof PolarEnvironment.Type
 
 export const ActiveOrganization = Schema.Struct({
   id: Schema.String,
   name: Schema.String,
   slug: Schema.String,
+  environment: PolarEnvironment,
 })
 export type ActiveOrganization = typeof ActiveOrganization.Type
+
+export const OrganizationSelection = Schema.Struct({
+  id: Schema.String,
+  environment: PolarEnvironment,
+})
+export type OrganizationSelection = typeof OrganizationSelection.Type
 
 export const Session = Schema.Struct({
   version: Schema.Literal(1),
@@ -25,7 +34,6 @@ export class AuthError extends Data.TaggedError('AuthError')<{
 }> {}
 
 export const loginCommand = (environment: PolarEnvironment) =>
-  `polar auth login${environment === 'production' ? ' --production' : ''}`
+  `polar auth login --${environment}`
 
-export const orgCommand = (environment: PolarEnvironment) =>
-  `polar auth org${environment === 'production' ? ' --production' : ''}`
+export const orgCommand = 'polar auth org'

--- a/clients/packages/cli/src/services/auth.test.ts
+++ b/clients/packages/cli/src/services/auth.test.ts
@@ -12,15 +12,19 @@ import {
   session,
 } from '@/utils/test-utils/services'
 
-const organization = { id: 'org-1', name: 'First', slug: 'first' }
+const sandboxOrg = { id: 'org-1', environment: 'sandbox' as const }
 const saved = session()
 let credentials: ReturnType<typeof fakeCredentials>
 let oauth: ReturnType<typeof fakeOAuth>
 let config: ReturnType<typeof fakeConfig>
 let override: string | undefined
+let environment: string | undefined
 
 const authEffect = () =>
-  make(Effect.sync(() => override)).pipe(
+  make(
+    Effect.sync(() => override),
+    Effect.sync(() => environment),
+  ).pipe(
     Effect.provideService(Credentials, credentials.credentials),
     Effect.provideService(OAuth, oauth.oauth),
     Effect.provideService(CLIConfig, config.config),
@@ -37,32 +41,37 @@ beforeEach(() => {
     production: session('production'),
   })
   oauth = fakeOAuth()
-  config = fakeConfig({
-    sandbox: organization.id,
-    production: organization.id,
-  })
+  config = fakeConfig(sandboxOrg)
   override = undefined
+  environment = undefined
 })
 
 describe('saved sessions', () => {
-  test('usable login is a no-op; replacement clears the previous organization', async () => {
+  test('usable login is a no-op; replacement clears a selection in that environment', async () => {
     const auth = await Effect.runPromise(authEffect())
     expect(await Effect.runPromise(auth.login('sandbox', false))).toBe(false)
     expect(oauth.state.logins).toBe(0)
     expect(credentials.state.writes).toBe(0)
     expect(await Effect.runPromise(auth.login('sandbox', true))).toBe(true)
-    expect(config.state.activeOrganizations.sandbox).toBeUndefined()
+    expect(config.state.activeOrganization).toBeUndefined()
     expect(
       Redacted.value(credentials.state.sessions.sandbox!.accessToken),
     ).toBe('new-account')
-    expect(config.state.activeOrganizations.production).toBe(organization.id)
+  })
+
+  test('replacing the other environment keeps the selection', async () => {
+    const auth = await Effect.runPromise(authEffect())
+    expect(await Effect.runPromise(auth.login('production', true))).toBe(true)
+    expect(config.state.activeOrganization).toEqual(sandboxOrg)
+    expect(config.state.writes).toBe(0)
   })
 
   test('initial login persists credentials without requiring organizations', async () => {
     delete credentials.state.sessions.sandbox
+    config = fakeConfig()
     const auth = await Effect.runPromise(authEffect())
     expect(await Effect.runPromise(auth.login('sandbox', false))).toBe(true)
-    expect(config.state.activeOrganizations.sandbox).toBeUndefined()
+    expect(config.state.activeOrganization).toBeUndefined()
     expect(credentials.state.sessions.sandbox).toBeDefined()
     expect(oauth.state.logins).toBe(1)
   })
@@ -74,17 +83,40 @@ describe('saved sessions', () => {
       Effect.runPromise(auth.login('sandbox', true)),
     ).rejects.toThrow('denied')
     expect(credentials.state.sessions.sandbox).toBe(saved)
-    expect(config.state.activeOrganizations.sandbox).toBe(organization.id)
+    expect(config.state.activeOrganization).toEqual(sandboxOrg)
     expect(credentials.state.writes).toBe(0)
   })
 
-  test('idempotent logout clears selection only in its environment', async () => {
+  test('logout of one environment keeps the other session and an unrelated selection', async () => {
     const auth = await Effect.runPromise(authEffect())
-    expect(await Effect.runPromise(auth.logout('sandbox'))).toBe(true)
-    expect(await Effect.runPromise(auth.logout('sandbox'))).toBe(false)
-    expect(config.state.activeOrganizations.sandbox).toBeUndefined()
-    expect(config.state.activeOrganizations.production).toBe(organization.id)
-    expect(credentials.state.sessions.production).toBeDefined()
+    expect(await Effect.runPromise(auth.logout(['production']))).toEqual([
+      'production',
+    ])
+    expect(credentials.state.sessions.production).toBeUndefined()
+    expect(credentials.state.sessions.sandbox).toBe(saved)
+    expect(config.state.activeOrganization).toEqual(sandboxOrg)
+    expect(await Effect.runPromise(auth.logout(['production']))).toEqual([])
+  })
+
+  test('logout clears the selection that belonged to that environment', async () => {
+    const auth = await Effect.runPromise(authEffect())
+    expect(
+      await Effect.runPromise(auth.logout(['sandbox', 'production'])),
+    ).toEqual(['sandbox', 'production'])
+    expect(credentials.state.sessions).toEqual({})
+    expect(config.state.activeOrganization).toBeUndefined()
+  })
+
+  test('reports the environments with a saved session', async () => {
+    const auth = await Effect.runPromise(authEffect())
+    expect(await Effect.runPromise(auth.environments)).toEqual([
+      'sandbox',
+      'production',
+    ])
+    delete credentials.state.sessions.sandbox
+    expect(await Effect.runPromise(auth.environments)).toEqual(['production'])
+    delete credentials.state.sessions.production
+    expect(await Effect.runPromise(auth.environments)).toEqual([])
   })
 
   test('missing sessions provide environment-specific login guidance, never a browser', async () => {
@@ -100,6 +132,9 @@ describe('saved sessions', () => {
     credentials.state.failure = new AuthError({ message: 'keyring locked' })
     const auth = await Effect.runPromise(authEffect())
     await expect(Effect.runPromise(auth.resolve('sandbox'))).rejects.toThrow(
+      'keyring locked',
+    )
+    await expect(Effect.runPromise(auth.environments)).rejects.toThrow(
       'keyring locked',
     )
     expect(oauth.state.logins).toBe(0)
@@ -170,6 +205,19 @@ describe('token override', () => {
     expect(activity()).toBe(0)
   })
 
+  test('targets production unless POLAR_ENVIRONMENT says otherwise', async () => {
+    override = 'ci-secret'
+    const auth = await Effect.runPromise(authEffect())
+    expect(await Effect.runPromise(auth.environments)).toEqual(['production'])
+    environment = 'sandbox'
+    expect(await Effect.runPromise(auth.environments)).toEqual(['sandbox'])
+    environment = 'staging'
+    await expect(Effect.runPromise(auth.environments)).rejects.toThrow(
+      'POLAR_ENVIRONMENT must be "sandbox" or "production"',
+    )
+    expect(credentials.state.reads).toBe(0)
+  })
+
   test('rejects empty overrides and never falls back after rejection', async () => {
     const auth = await Effect.runPromise(authEffect())
     override = ''
@@ -183,16 +231,17 @@ describe('token override', () => {
     expect(activity()).toBe(0)
   })
 
-  test('blocks login but permits saved logout without unsetting the override', async () => {
+  test('blocks login but permits logout without unsetting the override', async () => {
     override = 'ci-secret'
     const auth = await Effect.runPromise(authEffect())
     await expect(
       Effect.runPromise(auth.login('sandbox', true)),
     ).rejects.toThrow('Unset POLAR_ACCESS_TOKEN')
-    await Effect.runPromise(auth.logout('sandbox'))
-    expect(credentials.state.sessions.sandbox).toBeUndefined()
-    expect(credentials.state.sessions.production).toBeDefined()
+    expect(
+      await Effect.runPromise(auth.logout(['sandbox', 'production'])),
+    ).toEqual(['sandbox', 'production'])
+    expect(credentials.state.sessions).toEqual({})
     expect(override).toBe('ci-secret')
-    expect(activity()).toBe(0)
+    expect(oauth.state.logins + oauth.state.refreshes).toBe(0)
   })
 })

--- a/clients/packages/cli/src/services/auth.ts
+++ b/clients/packages/cli/src/services/auth.ts
@@ -1,6 +1,7 @@
 import { Context, DateTime, Effect, Layer, Redacted, Semaphore } from 'effect'
 import {
   AuthError,
+  environments,
   loginCommand,
   type PolarEnvironment,
   type Session,
@@ -26,14 +27,23 @@ export class Auth extends Context.Service<
       environment: PolarEnvironment,
       newSession: boolean,
     ) => Effect.Effect<boolean, AuthError>
-    logout: (environment: PolarEnvironment) => Effect.Effect<boolean, AuthError>
+    logout: (
+      targets: ReadonlyArray<PolarEnvironment>,
+    ) => Effect.Effect<PolarEnvironment[], AuthError>
     override: Effect.Effect<boolean>
+    environments: Effect.Effect<PolarEnvironment[], AuthError>
   }
 >()('Auth') {}
+
+const isEnvironment = (value: string): value is PolarEnvironment =>
+  (environments as readonly string[]).includes(value)
 
 export const make = (
   tokenOverride: Effect.Effect<string | undefined> = Effect.sync(
     () => process.env['POLAR_ACCESS_TOKEN'],
+  ),
+  environmentOverride: Effect.Effect<string | undefined> = Effect.sync(
+    () => process.env['POLAR_ENVIRONMENT'],
   ),
 ) =>
   Effect.gen(function* () {
@@ -47,6 +57,14 @@ export const make = (
     const override = tokenOverride.pipe(
       Effect.map((token) => token !== undefined),
     )
+    const overrideEnvironment = Effect.gen(function* () {
+      const value = yield* environmentOverride
+      if (value === undefined) return 'production' as const
+      if (isEnvironment(value)) return value
+      return yield* new AuthError({
+        message: 'POLAR_ENVIRONMENT must be "sandbox" or "production".',
+      })
+    })
     const requireSavedMode = Effect.gen(function* () {
       if (yield* override)
         return yield* new AuthError({
@@ -108,6 +126,14 @@ export const make = (
     return Auth.of({
       override,
       resolve,
+      environments: Effect.gen(function* () {
+        if (yield* override) return [yield* overrideEnvironment]
+        const available: PolarEnvironment[] = []
+        for (const environment of environments) {
+          if (yield* store.read(environment)) available.push(environment)
+        }
+        return available
+      }),
       login: (environment, newSession) =>
         Effect.gen(function* () {
           yield* requireSavedMode
@@ -119,19 +145,27 @@ export const make = (
           yield* locks[environment].withPermit(
             Effect.gen(function* () {
               yield* store.write(environment, session)
-              yield* config.setActiveOrganization(environment, undefined)
+              const selection = yield* config.getActiveOrganization
+              if (selection?.environment === environment) {
+                yield* config.setActiveOrganization(undefined)
+              }
             }),
           )
           return true
         }),
-      logout: (environment) =>
-        locks[environment].withPermit(
-          Effect.gen(function* () {
-            const deleted = yield* store.delete(environment)
-            yield* config.setActiveOrganization(environment, undefined)
-            return deleted
-          }),
-        ),
+      logout: (targets) =>
+        Effect.gen(function* () {
+          const deleted: PolarEnvironment[] = []
+          for (const environment of targets) {
+            if (yield* locks[environment].withPermit(store.delete(environment)))
+              deleted.push(environment)
+          }
+          const selection = yield* config.getActiveOrganization
+          if (selection && targets.includes(selection.environment)) {
+            yield* config.setActiveOrganization(undefined)
+          }
+          return deleted
+        }),
     })
   })
 

--- a/clients/packages/cli/src/services/config.test.ts
+++ b/clients/packages/cli/src/services/config.test.ts
@@ -11,6 +11,11 @@ let file: string
 const configEffect = Effect.service(CLIConfig).pipe(
   Effect.provide(layer.pipe(Layer.provide(BunServices.layer))),
 )
+const sandboxOrg = { id: 'org_sandbox', environment: 'sandbox' as const }
+const productionOrg = {
+  id: 'org_production',
+  environment: 'production' as const,
+}
 
 beforeEach(async () => {
   directory = await mkdtemp(join(tmpdir(), 'polar-cli-config-'))
@@ -26,49 +31,37 @@ afterEach(async () => {
 
 test('missing config means no selection and clearing it creates no file', async () => {
   const config = await Effect.runPromise(configEffect)
-  expect(
-    await Effect.runPromise(config.getActiveOrganization('sandbox')),
-  ).toBeUndefined()
-  await Effect.runPromise(config.setActiveOrganization('sandbox', undefined))
+  expect(await Effect.runPromise(config.getActiveOrganization)).toBeUndefined()
+  await Effect.runPromise(config.setActiveOrganization(undefined))
   await expect(readFile(file)).rejects.toMatchObject({ code: 'ENOENT' })
 })
 
-test('persists only organization IDs and preserves the other environment when changing selection', async () => {
+test('persists the selected organization with its environment', async () => {
   const config = await Effect.runPromise(configEffect)
-  await Effect.runPromise(
-    config.setActiveOrganization('sandbox', 'org_sandbox'),
-  )
-  await Effect.runPromise(
-    config.setActiveOrganization('production', 'org_production'),
-  )
+  await Effect.runPromise(config.setActiveOrganization(sandboxOrg))
+  await Effect.runPromise(config.setActiveOrganization(productionOrg))
   const freshConfig = await Effect.runPromise(configEffect)
-  expect(
-    await Effect.runPromise(freshConfig.getActiveOrganization('sandbox')),
-  ).toBe('org_sandbox')
-  expect(JSON.parse(await readFile(file, 'utf8'))).toEqual({
-    sandbox: { activeOrganizationId: 'org_sandbox' },
-    production: { activeOrganizationId: 'org_production' },
-  })
-  await Effect.runPromise(
-    freshConfig.setActiveOrganization('sandbox', undefined),
+  expect(await Effect.runPromise(freshConfig.getActiveOrganization)).toEqual(
+    productionOrg,
   )
   expect(JSON.parse(await readFile(file, 'utf8'))).toEqual({
-    sandbox: {},
-    production: { activeOrganizationId: 'org_production' },
+    activeOrganization: productionOrg,
   })
+  await Effect.runPromise(freshConfig.setActiveOrganization(undefined))
+  expect(JSON.parse(await readFile(file, 'utf8'))).toEqual({})
 })
 
-test.each(['{invalid', '{"sandbox":{"activeOrganizationId":123}}'])(
+test.each(['{invalid', '{"activeOrganization":{"id":123}}'])(
   'does not overwrite invalid config: %s',
   async (content) => {
     const config = await Effect.runPromise(configEffect)
-    await Effect.runPromise(config.setActiveOrganization('sandbox', 'org'))
+    await Effect.runPromise(config.setActiveOrganization(sandboxOrg))
     await writeFile(file, content)
     await expect(
-      Effect.runPromise(config.getActiveOrganization('sandbox')),
+      Effect.runPromise(config.getActiveOrganization),
     ).rejects.toThrow('Invalid config')
     await expect(
-      Effect.runPromise(config.setActiveOrganization('production', 'other')),
+      Effect.runPromise(config.setActiveOrganization(productionOrg)),
     ).rejects.toThrow('Invalid config')
     expect(await readFile(file, 'utf8')).toBe(content)
   },

--- a/clients/packages/cli/src/services/config.ts
+++ b/clients/packages/cli/src/services/config.ts
@@ -1,27 +1,28 @@
 import { homedir } from 'node:os'
 import { Context, Effect, FileSystem, Layer, Path, Schema } from 'effect'
-import { AuthError, type PolarEnvironment } from '@/schemas/Auth'
+import { AuthError, OrganizationSelection } from '@/schemas/Auth'
 
-const EnvironmentConfig = Schema.Struct({
-  activeOrganizationId: Schema.optional(Schema.String),
-})
 const ConfigFile = Schema.Struct({
-  sandbox: Schema.optional(EnvironmentConfig),
-  production: Schema.optional(EnvironmentConfig),
+  activeOrganization: Schema.optional(OrganizationSelection),
 })
 
 export class CLIConfig extends Context.Service<
   CLIConfig,
   {
-    getActiveOrganization: (
-      environment: PolarEnvironment,
-    ) => Effect.Effect<string | undefined, AuthError>
+    getActiveOrganization: Effect.Effect<
+      OrganizationSelection | undefined,
+      AuthError
+    >
     setActiveOrganization: (
-      environment: PolarEnvironment,
-      id: string | undefined,
+      selection: OrganizationSelection | undefined,
     ) => Effect.Effect<void, AuthError>
   }
 >()('CLIConfig') {}
+
+const sameSelection = (
+  a: OrganizationSelection | undefined,
+  b: OrganizationSelection | undefined,
+) => a?.id === b?.id && a?.environment === b?.environment
 
 export const layer = Layer.effect(
   CLIConfig,
@@ -60,26 +61,23 @@ export const layer = Layer.effect(
       )
     })
     return CLIConfig.of({
-      getActiveOrganization: (environment) =>
+      getActiveOrganization: Effect.map(
+        read,
+        (config) => config?.activeOrganization,
+      ),
+      setActiveOrganization: (selection) =>
         Effect.gen(function* () {
           const config = yield* read
-          return config?.[environment]?.activeOrganizationId
-        }),
-      setActiveOrganization: (environment, id) =>
-        Effect.gen(function* () {
-          const config = yield* read
-          if (config?.[environment]?.activeOrganizationId === id) return
-          const updated = {
-            ...config,
-            [environment]: {
-              ...config?.[environment],
-              activeOrganizationId: id,
-            },
-          }
+          if (
+            config?.activeOrganization !== undefined &&
+            sameSelection(config.activeOrganization, selection)
+          )
+            return
+          if (config === undefined && selection === undefined) return
           yield* fs.makeDirectory(directory, { recursive: true })
           yield* fs.writeFileString(
             file,
-            `${JSON.stringify(updated, null, 2)}\n`,
+            `${JSON.stringify({ activeOrganization: selection }, null, 2)}\n`,
           )
         }).pipe(
           Effect.mapError((error) =>

--- a/clients/packages/cli/src/services/organizations.test.ts
+++ b/clients/packages/cli/src/services/organizations.test.ts
@@ -12,11 +12,21 @@ import {
   overrideCredential,
 } from '@/utils/test-utils/services'
 
-const first = { id: 'org-1', name: 'First', slug: 'first' }
-const second = { id: 'org-2', name: 'Second', slug: 'second' }
+const first = {
+  id: 'org-1',
+  name: 'First',
+  slug: 'first',
+  environment: 'sandbox' as const,
+}
+const second = {
+  id: 'org-2',
+  name: 'Second',
+  slug: 'second',
+  environment: 'production' as const,
+}
 let auth: ReturnType<typeof fakeAuth>
 let config: ReturnType<typeof fakeConfig>
-let pages: ActiveOrganization[][]
+let pages: Partial<Record<PolarEnvironment, ActiveOrganization[][]>>
 let requests: Array<{
   page?: number
   id?: string
@@ -24,19 +34,23 @@ let requests: Array<{
 }>
 let denied: boolean
 
+const environmentOf = () => polar.state.requests.at(-1)!
 const polar = fakePolar({
   organizations: {
     list: ({ page }: { page: number }) => {
-      requests.push({ page, environment: polar.state.requests.at(-1)! })
+      const environment = environmentOf()
+      requests.push({ page, environment })
       if (denied) throw new Error('forbidden')
+      const items = pages[environment] ?? [[]]
       return Promise.resolve({
-        items: pages[page - 1] ?? [],
-        pagination: { max_page: pages.length },
+        items: items[page - 1] ?? [],
+        pagination: { max_page: items.length },
       })
     },
     get: (id: string) => {
-      requests.push({ id, environment: polar.state.requests.at(-1)! })
-      const org = pages.flat().find((org) => org.id === id)
+      const environment = environmentOf()
+      requests.push({ id, environment })
+      const org = (pages[environment] ?? []).flat().find((org) => org.id === id)
       if (!org) throw new Error('missing')
       return Promise.resolve(org)
     },
@@ -62,97 +76,147 @@ const service = () =>
 
 beforeEach(() => {
   auth = fakeAuth()
-  config = fakeConfig({ sandbox: first.id, production: first.id })
-  pages = [[first], [second]]
+  config = fakeConfig({ id: first.id, environment: 'sandbox' })
+  pages = { sandbox: [[first]], production: [[second]] }
   requests = []
   denied = false
 })
 
-test('selection is stored in config separately for each environment', async () => {
+test('selection stores the organization with its environment', async () => {
   const organizations = await service()
-  await Effect.runPromise(organizations.select('sandbox', second.id))
-  expect(await Effect.runPromise(organizations.selected('sandbox'))).toBe(
-    second.id,
+  await Effect.runPromise(
+    organizations.select({ id: second.id, environment: 'production' }),
   )
-  expect(await Effect.runPromise(organizations.resolve('sandbox'))).toEqual(
-    second,
-  )
-  expect(config.state.activeOrganizations.production).toBe(first.id)
+  expect(await Effect.runPromise(organizations.selected)).toEqual({
+    id: second.id,
+    environment: 'production',
+  })
+  expect(await Effect.runPromise(organizations.resolve())).toEqual(second)
+  expect(requests).toEqual([{ id: second.id, environment: 'production' }])
+})
+
+test('selection requires a session in that environment', async () => {
+  auth.state.failure = new (await import('@/schemas/Auth')).AuthError({
+    message: 'Not logged in to production',
+  })
+  const organizations = await service()
+  await expect(
+    Effect.runPromise(
+      organizations.select({ id: second.id, environment: 'production' }),
+    ),
+  ).rejects.toThrow('Not logged in to production')
+  expect(config.state.writes).toBe(0)
 })
 
 test('token overrides ignore saved selection and cannot change it', async () => {
   auth.state.credential = overrideCredential()
   const organizations = await service()
-  expect(
-    await Effect.runPromise(organizations.selected('sandbox')),
-  ).toBeUndefined()
+  expect(await Effect.runPromise(organizations.selected)).toBeUndefined()
   await expect(
-    Effect.runPromise(organizations.select('sandbox', second.id)),
+    Effect.runPromise(
+      organizations.select({ id: second.id, environment: 'production' }),
+    ),
   ).rejects.toThrow('Unset POLAR_ACCESS_TOKEN')
-  expect(config.state.activeOrganizations.sandbox).toBe(first.id)
+  expect(config.state.activeOrganization?.id).toBe(first.id)
   expect(config.state.writes).toBe(0)
 })
 
-test('enumerates every page on the explicitly selected environment', async () => {
+test('lists every page of every logged-in environment', async () => {
+  pages = {
+    sandbox: [[first], [{ ...first, id: 'org-3' }]],
+    production: [[second]],
+  }
   const organizations = await service()
-  expect(await Effect.runPromise(organizations.list('production'))).toEqual([
+  expect(await Effect.runPromise(organizations.listAll)).toEqual([
     first,
+    { ...first, id: 'org-3' },
     second,
   ])
   expect(requests).toEqual([
+    { page: 1, environment: 'sandbox' },
+    { page: 2, environment: 'sandbox' },
     { page: 1, environment: 'production' },
-    { page: 2, environment: 'production' },
   ])
 })
 
-test('explicit organization overrides selection without persisting it', async () => {
+test('only lists environments with a session', async () => {
+  auth.state.sessions = ['production']
   const organizations = await service()
-  expect(
-    await Effect.runPromise(organizations.resolve('sandbox', second.id)),
-  ).toEqual(second)
-  expect(config.state.activeOrganizations.sandbox).toBe(first.id)
-  expect(config.state.writes).toBe(0)
-  expect(requests).toEqual([{ id: second.id, environment: 'sandbox' }])
+  expect(await Effect.runPromise(organizations.listAll)).toEqual([second])
 })
 
-test('explicit IDs work with no saved selection and without enumeration', async () => {
-  delete config.state.activeOrganizations.sandbox
-  denied = true
+test('an explicit id is looked up across logged-in environments without persisting it', async () => {
   const organizations = await service()
-  expect(
-    await Effect.runPromise(organizations.resolve('sandbox', first.id)),
-  ).toEqual(first)
-  await expect(
-    Effect.runPromise(organizations.resolve('sandbox')),
-  ).rejects.toThrow('polar auth org')
-})
-
-test('stale or unauthorized organization IDs fail rather than choosing another', async () => {
-  pages = [[second]]
-  const organizations = await service()
-  await expect(
-    Effect.runPromise(organizations.resolve('production')),
-  ).rejects.toThrow('missing')
-  await expect(
-    Effect.runPromise(organizations.resolve('production', 'missing')),
-  ).rejects.toThrow('missing')
-  expect(config.state.writes).toBe(0)
-})
-
-test('override uses its own permissions and only selects a sole accessible organization', async () => {
-  auth.state.credential = overrideCredential()
-  const organizations = await service()
-  await expect(
-    Effect.runPromise(organizations.resolve('sandbox')),
-  ).rejects.toThrow('--org <id>')
-  pages = [[second]]
-  expect(await Effect.runPromise(organizations.resolve('sandbox'))).toEqual(
+  expect(await Effect.runPromise(organizations.resolve(second.id))).toEqual(
     second,
   )
-  pages = [[]]
+  expect(config.state.activeOrganization?.id).toBe(first.id)
+  expect(config.state.writes).toBe(0)
+  expect(requests).toEqual([
+    { id: second.id, environment: 'sandbox' },
+    { id: second.id, environment: 'production' },
+  ])
+})
+
+test('an explicit id in a single environment surfaces the real error', async () => {
+  auth.state.sessions = ['sandbox']
+  const organizations = await service()
   await expect(
-    Effect.runPromise(organizations.resolve('sandbox')),
-  ).rejects.toThrow('--org <id>')
+    Effect.runPromise(organizations.resolve('missing')),
+  ).rejects.toThrow('missing')
+})
+
+test('an unknown explicit id names the environments that were searched', async () => {
+  const organizations = await service()
+  await expect(
+    Effect.runPromise(organizations.resolve('missing')),
+  ).rejects.toThrow('inaccessible in sandbox and production')
+})
+
+test('explicit IDs require a session', async () => {
+  auth.state.sessions = []
+  const organizations = await service()
+  await expect(
+    Effect.runPromise(organizations.resolve(first.id)),
+  ).rejects.toThrow('Not logged in')
+  expect(requests).toEqual([])
+})
+
+test('no selection fails with guidance instead of choosing an organization', async () => {
+  config = fakeConfig()
+  const organizations = await service()
+  await expect(Effect.runPromise(organizations.resolve())).rejects.toThrow(
+    'polar auth org',
+  )
+  expect(requests).toEqual([])
+})
+
+test('a stale selection fails rather than choosing another organization', async () => {
+  pages = { sandbox: [[]], production: [[second]] }
+  const organizations = await service()
+  await expect(Effect.runPromise(organizations.resolve())).rejects.toThrow(
+    'missing',
+  )
+  expect(config.state.writes).toBe(0)
+})
+
+test('override uses its own environment and only selects a sole accessible organization', async () => {
+  auth.state.credential = overrideCredential()
+  auth.state.environment = 'sandbox'
+  pages = { sandbox: [[first, { ...first, id: 'org-3' }]] }
+  const organizations = await service()
+  await expect(Effect.runPromise(organizations.resolve())).rejects.toThrow(
+    '--org <id>',
+  )
+  pages = { sandbox: [[first]] }
+  expect(await Effect.runPromise(organizations.resolve())).toEqual(first)
+  pages = { sandbox: [[]] }
+  await expect(Effect.runPromise(organizations.resolve())).rejects.toThrow(
+    '--org <id>',
+  )
+  expect(requests.every((request) => request.environment === 'sandbox')).toBe(
+    true,
+  )
   expect(config.state.writes).toBe(0)
 })
 
@@ -160,10 +224,10 @@ test('override enumeration reports permission errors but explicit accessible IDs
   auth.state.credential = overrideCredential()
   denied = true
   const organizations = await service()
-  await expect(
-    Effect.runPromise(organizations.list('sandbox')),
-  ).rejects.toThrow('forbidden')
-  expect(
-    await Effect.runPromise(organizations.resolve('sandbox', second.id)),
-  ).toEqual(second)
+  await expect(Effect.runPromise(organizations.listAll)).rejects.toThrow(
+    'forbidden',
+  )
+  expect(await Effect.runPromise(organizations.resolve(second.id))).toEqual(
+    second,
+  )
 })

--- a/clients/packages/cli/src/services/organizations.ts
+++ b/clients/packages/cli/src/services/organizations.ts
@@ -3,6 +3,7 @@ import {
   AuthError,
   orgCommand,
   type ActiveOrganization,
+  type OrganizationSelection,
   type PolarEnvironment,
 } from '@/schemas/Auth'
 import { Auth } from '@/services/auth'
@@ -12,20 +13,13 @@ import { Polar } from '@/services/polar'
 export class Organizations extends Context.Service<
   Organizations,
   {
-    selected: (
-      environment: PolarEnvironment,
-    ) => Effect.Effect<string | undefined, AuthError>
-    select: (
-      environment: PolarEnvironment,
-      id: string,
-    ) => Effect.Effect<void, AuthError>
     list: (
       environment: PolarEnvironment,
     ) => Effect.Effect<ActiveOrganization[], AuthError>
-    resolve: (
-      environment: PolarEnvironment,
-      id?: string,
-    ) => Effect.Effect<ActiveOrganization, AuthError>
+    listAll: Effect.Effect<ActiveOrganization[], AuthError>
+    selected: Effect.Effect<OrganizationSelection | undefined, AuthError>
+    select: (selection: OrganizationSelection) => Effect.Effect<void, AuthError>
+    resolve: (id?: string) => Effect.Effect<ActiveOrganization, AuthError>
   }
 >()('Organizations') {}
 
@@ -49,6 +43,7 @@ export const layer = Layer.effect(
               id,
               name,
               slug,
+              environment,
             })),
           )
           if (page >= response.pagination.max_page) break
@@ -56,52 +51,76 @@ export const layer = Layer.effect(
         }
         return organizations
       })
+    const listAll = Effect.gen(function* () {
+      const organizations: ActiveOrganization[] = []
+      for (const environment of yield* auth.environments) {
+        organizations.push(...(yield* list(environment)))
+      }
+      return organizations
+    })
+    const get = (id: string, environment: PolarEnvironment) =>
+      Effect.map(
+        polar.use((client) => client.organizations.get(id), environment),
+        (organization) => ({
+          id: organization.id,
+          name: organization.name,
+          slug: organization.slug,
+          environment,
+        }),
+      )
+    const find = (id: string) =>
+      Effect.gen(function* () {
+        const available = yield* auth.environments
+        if (available.length === 0) {
+          return yield* new AuthError({
+            message: 'Not logged in. Run polar auth login.',
+          })
+        }
+        if (available.length === 1) return yield* get(id, available[0]!)
+        for (const environment of available) {
+          const found = yield* get(id, environment).pipe(
+            Effect.catch(() => Effect.succeed(undefined)),
+          )
+          if (found) return found
+        }
+        return yield* new AuthError({
+          message: `Organization ${id} is missing or inaccessible in ${available.join(' and ')}. Check --org or run polar auth list.`,
+        })
+      })
     return Organizations.of({
       list,
-      selected: (environment) =>
-        Effect.gen(function* () {
-          if (yield* auth.override) return undefined
-          return yield* config.getActiveOrganization(environment)
-        }),
-      select: (environment, id) =>
+      listAll,
+      selected: Effect.gen(function* () {
+        if (yield* auth.override) return undefined
+        return yield* config.getActiveOrganization
+      }),
+      select: (selection) =>
         Effect.gen(function* () {
           if (yield* auth.override)
             return yield* new AuthError({
               message: 'Unset POLAR_ACCESS_TOKEN to manage saved sessions.',
             })
-          yield* auth.resolve(environment)
-          yield* config.setActiveOrganization(environment, id)
+          yield* auth.resolve(selection.environment)
+          yield* config.setActiveOrganization(selection)
         }),
-      resolve: (environment, id) =>
+      resolve: (id) =>
         Effect.gen(function* () {
-          const credential = yield* auth.resolve(environment)
-          const selected =
-            id ??
-            (credential.source === 'keyring'
-              ? yield* config.getActiveOrganization(environment)
-              : undefined)
-          if (selected) {
-            const organization = yield* polar.use(
-              (client) => client.organizations.get(selected),
-              environment,
-            )
-            return {
-              id: organization.id,
-              name: organization.name,
-              slug: organization.slug,
-            }
-          }
-          if (credential.source === 'override') {
-            const organizations = yield* list(environment)
+          if (id) return yield* find(id)
+          if (yield* auth.override) {
+            const organizations = yield* listAll
             if (organizations.length === 1) return organizations[0]!
             return yield* new AuthError({
               message:
                 'POLAR_ACCESS_TOKEN has no unique active organization. Supply --org <id> for an accessible organization.',
             })
           }
-          return yield* new AuthError({
-            message: `No active organization for ${environment}. Run ${orgCommand(environment)} or supply --org <id>.`,
-          })
+          const selection = yield* config.getActiveOrganization
+          if (!selection) {
+            return yield* new AuthError({
+              message: `No active organization. Run ${orgCommand} or supply --org <id>.`,
+            })
+          }
+          return yield* get(selection.id, selection.environment)
         }),
     })
   }),

--- a/clients/packages/cli/src/utils/test-utils/services.ts
+++ b/clients/packages/cli/src/utils/test-utils/services.ts
@@ -4,6 +4,7 @@ import {
   AuthError,
   loginCommand,
   type ActiveOrganization,
+  type OrganizationSelection,
   type PolarEnvironment,
   type Session,
 } from '@/schemas/Auth'
@@ -38,8 +39,9 @@ export const overrideCredential = (accessToken = 'ci-token'): Credential => ({
 
 interface AuthState {
   credential: Credential
+  environment: PolarEnvironment
+  sessions: PolarEnvironment[]
   replaced: boolean
-  deleted: boolean
   failure: AuthError | undefined
   resolutions: Array<{
     environment: PolarEnvironment
@@ -52,14 +54,24 @@ export const fakeAuth = (
 ) => {
   const state: AuthState = {
     credential: keyringCredential(),
+    environment: 'production',
+    sessions: ['sandbox', 'production'],
     replaced: true,
-    deleted: true,
     failure: undefined,
     resolutions: [],
     ...initial,
   }
   const auth = Auth.of({
     override: Effect.sync(() => state.credential.source === 'override'),
+    environments: Effect.suspend(() =>
+      state.failure
+        ? Effect.fail(state.failure)
+        : Effect.succeed(
+            state.credential.source === 'override'
+              ? [state.environment]
+              : [...state.sessions],
+          ),
+    ),
     resolve: (environment, rejected) =>
       Effect.suspend(() => {
         state.resolutions.push({ environment, rejected })
@@ -68,14 +80,23 @@ export const fakeAuth = (
           : Effect.succeed(state.credential)
       }),
     login: () => Effect.sync(() => state.replaced),
-    logout: () => Effect.sync(() => state.deleted),
+    logout: (targets) =>
+      Effect.sync(() => {
+        const deleted = targets.filter((target) =>
+          state.sessions.includes(target),
+        )
+        state.sessions = state.sessions.filter(
+          (session) => !targets.includes(session),
+        )
+        return deleted
+      }),
   })
   return { auth, state }
 }
 
 interface OrganizationsState {
   items: ActiveOrganization[]
-  selected: Partial<Record<PolarEnvironment, string>>
+  selected: OrganizationSelection | undefined
   failure: AuthError | undefined
 }
 
@@ -84,33 +105,34 @@ export const fakeOrganizations = (
 ) => {
   const state: OrganizationsState = {
     items: [],
-    selected: {},
+    selected: undefined,
     failure: undefined,
     ...initial,
   }
+  const available = () =>
+    state.failure ? Effect.fail(state.failure) : Effect.succeed(state.items)
   const organizations = Organizations.of({
-    list: () =>
-      Effect.suspend(() =>
-        state.failure
-          ? Effect.fail(state.failure)
-          : Effect.succeed(state.items),
+    list: (environment) =>
+      Effect.map(Effect.suspend(available), (items) =>
+        items.filter((item) => item.environment === environment),
       ),
-    selected: (environment) => Effect.sync(() => state.selected[environment]),
-    select: (environment, id) =>
+    listAll: Effect.suspend(available),
+    selected: Effect.sync(() => state.selected),
+    select: (selection) =>
       Effect.sync(() => {
-        state.selected[environment] = id
+        state.selected = selection
       }),
-    resolve: (environment, id) =>
+    resolve: (id) =>
       Effect.suspend(() => {
-        const target = id ?? state.selected[environment]
-        const found = state.items.find((item) => item.id === target)
+        const found = state.items.find((item) =>
+          id
+            ? item.id === id
+            : item.id === state.selected?.id &&
+              item.environment === state.selected.environment,
+        )
         return found
           ? Effect.succeed(found)
-          : Effect.fail(
-              new AuthError({
-                message: `No active organization for ${environment}.`,
-              }),
-            )
+          : Effect.fail(new AuthError({ message: 'No active organization.' }))
       }),
   })
   return { organizations, state }
@@ -156,22 +178,18 @@ export const fakeCredentials = (
 }
 
 interface ConfigState {
-  activeOrganizations: Partial<Record<PolarEnvironment, string>>
+  activeOrganization: OrganizationSelection | undefined
   writes: number
 }
 
-export const fakeConfig = (
-  activeOrganizations: ConfigState['activeOrganizations'] = {},
-) => {
-  const state: ConfigState = { activeOrganizations, writes: 0 }
+export const fakeConfig = (activeOrganization?: OrganizationSelection) => {
+  const state: ConfigState = { activeOrganization, writes: 0 }
   const config = CLIConfig.of({
-    getActiveOrganization: (environment) =>
-      Effect.sync(() => state.activeOrganizations[environment]),
-    setActiveOrganization: (environment, id) =>
+    getActiveOrganization: Effect.sync(() => state.activeOrganization),
+    setActiveOrganization: (selection) =>
       Effect.sync(() => {
         state.writes++
-        if (id === undefined) delete state.activeOrganizations[environment]
-        else state.activeOrganizations[environment] = id
+        state.activeOrganization = selection
       }),
   })
   return { config, state }


### PR DESCRIPTION
## Summary

Make the CLI's environment follow the active organization, so only login and logout needs  `--sandbox` or `--production`.


Fixes https://linear.app/polarsh/issue/PLR-112/make-organization-implied

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


