### PR TITLE
CLI: Add telemetry

### DIFF
--- a/clients/packages/cli/README.md
+++ b/clients/packages/cli/README.md
@@ -8,6 +8,22 @@ A Polar CLI for your terminal.
 
 Currently in development.
 
+## Telemetry
+
+Every command reports one anonymous `cli_command` event straight to PostHog when
+it finishes: the command path (for example `auth login`), the names of the flags
+used (never their values), whether it succeeded, failed or was interrupted, the
+error type, the duration, the CLI version, OS, architecture, Bun version, whether
+it ran in CI, and which AI coding agent (if any) invoked it. Events are keyed by a
+random install id stored in `~/.polar/telemetry.json`. Access tokens,
+organization IDs, URLs and payloads are never sent. The PostHog project key is a
+public write-only token, the same one the website uses.
+
+Telemetry is wired around the root command in `src/cli.ts`, so new commands are
+covered automatically. Only the compiled release binary sends events; running
+from source or from `bin/cli.js` sends nothing. Opt out with
+`POLAR_CLI_TELEMETRY_OPTOUT=1` (`DO_NOT_TRACK=1` is honoured too).
+
 ## Development
 
 From `clients/`, install dependencies with `pnpm install`, then use

--- a/clients/packages/cli/src/cli.ts
+++ b/clients/packages/cli/src/cli.ts
@@ -1,5 +1,5 @@
 import { BunRuntime, BunServices } from '@effect/platform-bun'
-import { Cause, Effect, Layer, Runtime } from 'effect'
+import { Cause, Effect, Layer, Runtime, Stdio } from 'effect'
 import { CliConfig, Command, GlobalFlag } from 'effect/unstable/cli'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { listen } from '@/commands/listen'
@@ -12,6 +12,7 @@ import * as Config from '@/services/config'
 import * as Organizations from '@/services/organizations'
 import * as OAuth from '@/services/oauth'
 import * as Polar from '@/services/polar'
+import * as Telemetry from '@/services/telemetry'
 import {
   checkForUpdateInBackground,
   showUpdateNotice,
@@ -36,10 +37,14 @@ const polarLayer = Polar.layer.pipe(Layer.provide(authLayer))
 const organizationsLayer = Organizations.layer.pipe(
   Layer.provide(Layer.mergeAll(authLayer, polarLayer, configLayer)),
 )
+const telemetryLayer = Telemetry.layer.pipe(
+  Layer.provide(Layer.mergeAll(BunServices.layer, Telemetry.detachedSender)),
+)
 const services = Layer.mergeAll(
   authLayer,
   polarLayer,
   organizationsLayer,
+  telemetryLayer,
   BunServices.layer,
   FetchHttpClient.layer,
   CliConfig.layer({
@@ -65,11 +70,33 @@ const reportError = (cause: Cause.Cause<unknown>) => {
   })
 }
 
-showUpdateNotice()
-checkForUpdateInBackground()
+const instrumented = Effect.gen(function* () {
+  const args = yield* (yield* Stdio.Stdio).args
+  const telemetry = yield* Telemetry.Telemetry
+  const startedAt = performance.now()
+  return yield* cli.pipe(
+    Effect.tapCause(reportError),
+    Effect.onExit((exit) =>
+      telemetry.record({
+        command: Telemetry.commandPath(mainCommand, args),
+        flags: Telemetry.flagNames(args),
+        ...Telemetry.outcomeOf(exit),
+        durationMs: performance.now() - startedAt,
+      }),
+    ),
+  )
+})
 
-cli.pipe(
-  Effect.provide(services),
-  Effect.tapCause(reportError),
-  BunRuntime.runMain({ disableErrorReporting: true }),
-)
+if (process.argv[2] === Telemetry.SENDER_COMMAND) {
+  Telemetry.sendFromStdin.pipe(
+    Effect.provide(FetchHttpClient.layer),
+    BunRuntime.runMain({ disableErrorReporting: true }),
+  )
+} else {
+  showUpdateNotice()
+  checkForUpdateInBackground()
+  instrumented.pipe(
+    Effect.provide(services),
+    BunRuntime.runMain({ disableErrorReporting: true }),
+  )
+}

--- a/clients/packages/cli/src/services/telemetry.test.ts
+++ b/clients/packages/cli/src/services/telemetry.test.ts
@@ -1,0 +1,579 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import { Cause, Effect, Exit, FileSystem, Layer, PlatformError } from 'effect'
+import { CliError, Command } from 'effect/unstable/cli'
+import { AuthError } from '@/schemas/Auth'
+import {
+  Build,
+  commandPath,
+  describeFailure,
+  detectAgent,
+  Environment,
+  flagNames,
+  isCI,
+  isOptedOut,
+  isCompiledBinary,
+  layer,
+  outcomeOf,
+  redact,
+  send,
+  Sender,
+  Telemetry,
+  type BuildKind,
+  type CommandOutcome,
+  type TelemetryEvent,
+} from '@/services/telemetry'
+import { fakeHttp } from '@/utils/test-utils/http'
+
+const outcome: CommandOutcome = {
+  command: ['polar', 'auth', 'login'],
+  flags: ['production'],
+  outcome: 'success',
+  durationMs: 42.6,
+}
+
+type Env = Record<string, string>
+
+const telemetry = (
+  env: Env = { POLAR_CLI_POSTHOG_KEY: 'phc_test' },
+  build: BuildKind = 'release',
+  { writable = true } = {},
+) => {
+  const files = new Map<string, string>()
+  const events: TelemetryEvent[] = []
+  const notFound = (method: string) =>
+    PlatformError.systemError({
+      _tag: 'NotFound',
+      module: 'FileSystem',
+      method,
+    })
+  const fs = FileSystem.layerNoop({
+    readFileString: (path) =>
+      files.has(path)
+        ? Effect.succeed(files.get(path)!)
+        : Effect.fail(notFound('readFileString')),
+    makeDirectory: () =>
+      writable ? Effect.void : Effect.fail(notFound('makeDirectory')),
+    writeFileString: (path, content) =>
+      Effect.sync(() => {
+        files.set(path, content)
+      }),
+  })
+  const sender = Layer.succeed(
+    Sender,
+    Sender.of({
+      dispatch: (event) =>
+        Effect.sync(() => {
+          events.push(event)
+        }),
+    }),
+  )
+  const live = layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        fs,
+        sender,
+        Layer.succeed(Environment, env),
+        Layer.succeed(Build, build),
+      ),
+    ),
+  )
+  const record = (result = outcome) =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        yield* (yield* Telemetry).record(result)
+      }).pipe(Effect.provide(live)),
+    )
+  return { record, events, files }
+}
+
+describe('opt out', () => {
+  test.each(['1', 'true', 'YES'])(
+    'honours POLAR_CLI_TELEMETRY_OPTOUT=%s',
+    (value) => {
+      expect(isOptedOut({ POLAR_CLI_TELEMETRY_OPTOUT: value })).toBe(true)
+    },
+  )
+
+  test('honours DO_NOT_TRACK and ignores other values', () => {
+    expect(isOptedOut({ DO_NOT_TRACK: '1' })).toBe(true)
+    expect(isOptedOut({ POLAR_CLI_TELEMETRY_OPTOUT: '0' })).toBe(false)
+    expect(isOptedOut({})).toBe(false)
+  })
+
+  test('records nothing when opted out', async () => {
+    const { record, events } = telemetry({
+      POLAR_CLI_POSTHOG_KEY: 'phc_test',
+      POLAR_CLI_TELEMETRY_OPTOUT: '1',
+    })
+    await record()
+    expect(events).toHaveLength(0)
+  })
+
+  test('records nothing from development builds unless forced', async () => {
+    const dev = telemetry({ POLAR_CLI_POSTHOG_KEY: 'phc_test' }, 'development')
+    await dev.record()
+    expect(dev.events).toHaveLength(0)
+
+    const forced = telemetry(
+      { POLAR_CLI_POSTHOG_KEY: 'phc_test', POLAR_CLI_TELEMETRY_FORCE: '1' },
+      'development',
+    )
+    await forced.record()
+    expect(forced.events[0]!.properties['build']).toBe('development')
+
+    const redirected = telemetry(
+      {
+        POLAR_CLI_POSTHOG_KEY: 'phc_test',
+        POLAR_CLI_TELEMETRY_URL: 'http://x',
+      },
+      'development',
+    )
+    await redirected.record()
+    expect(redirected.events).toHaveLength(1)
+  })
+
+  test('recognises compiled binaries', () => {
+    expect(isCompiledBinary('/$bunfs/root/polar')).toBe(true)
+    expect(isCompiledBinary('B:\\~BUN\\root\\polar.exe')).toBe(true)
+    expect(isCompiledBinary('/Users/dev/polar/src/cli.ts')).toBe(false)
+    expect(isCompiledBinary()).toBe(false)
+  })
+})
+
+describe('environment detection', () => {
+  test.each([
+    [{ CLAUDECODE: '1' }, 'claude-code'],
+    [{ CLAUDE_CODE_ENTRYPOINT: 'cli' }, 'claude-code'],
+    [{ CURSOR_TRACE_ID: 'abc' }, 'cursor'],
+    [{ CODEX_SANDBOX: 'seatbelt' }, 'codex'],
+    [{ OPENCODE_SESSION_ID: 'ses_1' }, 'opencode'],
+    [{ PI_CODING_AGENT: 'true', AI_AGENT: 'pi' }, 'pi'],
+    [{ AI_AGENT: 'SomeNewAgent' }, 'somenewagent'],
+    [{ GEMINI_CLI: '1' }, 'gemini-cli'],
+    [{ TERM_PROGRAM: 'iTerm.app' }, undefined],
+  ])('detects agents from %o', (env, agent) => {
+    expect(detectAgent(env)).toBe(agent)
+  })
+
+  test('ignores empty markers and detects CI', () => {
+    expect(detectAgent({ CLAUDECODE: '' })).toBeUndefined()
+    expect(isCI({ CI: 'true' })).toBe(true)
+    expect(isCI({ GITHUB_ACTIONS: 'true' })).toBe(true)
+    expect(isCI({})).toBe(false)
+  })
+})
+
+describe('command identification', () => {
+  const tree = Command.make('polar').pipe(
+    Command.withSubcommands([
+      Command.make('auth').pipe(
+        Command.withSubcommands([Command.make('login'), Command.make('org')]),
+      ),
+      Command.make('listen'),
+    ]),
+  )
+
+  test('walks the command tree past flags', () => {
+    expect(commandPath(tree, ['auth', 'login', '--production'])).toEqual([
+      'polar',
+      'auth',
+      'login',
+    ])
+    expect(
+      commandPath(tree, ['--log-level', 'debug', 'listen', 'http://x']),
+    ).toEqual(['polar', 'listen'])
+    expect(commandPath(tree, ['--help'])).toEqual(['polar'])
+    expect(commandPath(tree, ['bogus'])).toEqual(['polar'])
+  })
+
+  test('records flag names but never values', () => {
+    expect(
+      flagNames([
+        'listen',
+        'http://localhost',
+        '--org',
+        'org_secret',
+        '--org=x',
+        '-h',
+      ]),
+    ).toEqual(['org', 'h'])
+  })
+})
+
+describe('outcomes', () => {
+  test('classifies success, tagged failures, plain errors and interrupts', () => {
+    expect(outcomeOf(Exit.succeed(1))).toEqual({ outcome: 'success' })
+    expect(
+      outcomeOf(Exit.fail(new AuthError({ message: 'Not logged in' }))),
+    ).toEqual({
+      outcome: 'failure',
+      error: 'AuthError',
+      errorMessage: 'Not logged in',
+    })
+    expect(
+      outcomeOf(
+        Exit.fail(
+          new CliError.ShowHelp({ commandPath: ['polar'], errors: [] }),
+        ),
+      ),
+    ).toEqual({ outcome: 'success' })
+    expect(
+      outcomeOf(
+        Exit.fail(
+          new CliError.ShowHelp({
+            commandPath: ['polar'],
+            errors: [
+              new CliError.UnknownSubcommand({
+                subcommand: 'bogus',
+                parent: ['polar'],
+                suggestions: [],
+              }),
+            ],
+          }),
+        ),
+      ),
+    ).toMatchObject({ outcome: 'failure', error: 'ShowHelp' })
+    expect(outcomeOf(Exit.die(new TypeError('boom')))).toEqual({
+      outcome: 'failure',
+      error: 'TypeError',
+      errorMessage: 'boom',
+    })
+    expect(outcomeOf(Exit.failCause(Cause.interrupt()))).toEqual({
+      outcome: 'interrupted',
+    })
+  })
+
+  test('extracts status codes from listen and HTTP errors', () => {
+    expect(
+      describeFailure({
+        _tag: 'ListenError',
+        message: 'Event stream error',
+        code: 403,
+      }),
+    ).toEqual({
+      error: 'ListenError',
+      errorMessage: 'Event stream error',
+      errorCode: 403,
+    })
+    expect(
+      describeFailure({
+        _tag: 'HttpClientError',
+        message: 'StatusCode: 429',
+        reason: { _tag: 'StatusCodeError', response: { status: 429 } },
+      }),
+    ).toEqual({
+      error: 'HttpClientError:StatusCodeError',
+      errorMessage: 'StatusCode: 429',
+      errorCode: 429,
+    })
+  })
+})
+
+describe('redact', () => {
+  test.each([
+    [
+      'lowercase UUIDs',
+      'Organization 342c8722-fcad-416b-8232-8877dcf8f90e is missing',
+      'Organization <redacted> is missing',
+    ],
+    [
+      'uppercase UUIDs',
+      'id 342C8722-FCAD-416B-8232-8877DCF8F90E',
+      'id <redacted>',
+    ],
+    [
+      'Polar tokens of every kind',
+      'polar_oat_AbC123 polar_pat_x-y.z polar_at_q polar_ci_gBnJ',
+      '<redacted> <redacted> <redacted> <redacted>',
+    ],
+    [
+      'Stripe style keys',
+      'sk_live_abc pk_test_def whsec_ghi rk_live_x',
+      '<redacted> <redacted> <redacted> <redacted>',
+    ],
+    [
+      'GitHub and GitLab tokens',
+      'ghp_a gho_b ghu_c ghs_d ghr_e github_pat_f glpat-g',
+      '<redacted> <redacted> <redacted> <redacted> <redacted> <redacted> <redacted>',
+    ],
+    [
+      'Slack, AWS and Google credentials',
+      'xoxb-1-2 AKIAIOSFODNN7EXAMPLE AIzaSyAbc ya29.a0Af',
+      '<redacted> <redacted> <redacted> <redacted>',
+    ],
+    [
+      'JWTs',
+      'session eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc expired',
+      'session <redacted> expired',
+    ],
+    [
+      'bearer headers',
+      'Authorization: Bearer short rejected',
+      'Authorization: <redacted> rejected',
+    ],
+    [
+      'URLs including localhost and query strings',
+      'see https://api.polar.sh/v1/x?token=abc then http://localhost:3000/hook.',
+      'see <redacted> then <redacted>',
+    ],
+    [
+      'other URL schemes',
+      'open file:///tmp/x or ws://h/p',
+      'open <redacted> or <redacted>',
+    ],
+    [
+      'home directories',
+      '/Users/seb/.config/polar-cli/config.json and /home/seb/x and /root/y',
+      '<redacted> and <redacted> and <redacted>',
+    ],
+    [
+      'temporary directories',
+      'tar: /var/folders/ab/T/polar-update-x/polar: Cannot open, see /tmp/log and /private/var/x',
+      'tar: <redacted> Cannot open, see <redacted> and <redacted>',
+    ],
+    [
+      'Windows home directories',
+      'Unable to read C:\\Users\\seb\\AppData\\Roaming\\polar-cli\\config.json.',
+      'Unable to read <redacted>',
+    ],
+    ['email addresses', 'user me@polar.sh failed', 'user <redacted> failed'],
+    [
+      'long hashes and opaque tokens',
+      'sha 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08 ok',
+      'sha <redacted> ok',
+    ],
+    [
+      'IPv4 addresses',
+      'ECONNREFUSED 10.0.0.5:443',
+      'ECONNREFUSED <redacted>:443',
+    ],
+    [
+      'tokens wrapped in punctuation',
+      '(polar_oat_abc) token=polar_oat_def, "ghp_x".',
+      '(<redacted>) token=<redacted>, "<redacted>".',
+    ],
+    [
+      'several categories in one message',
+      'Org 342c8722-fcad-416b-8232-8877dcf8f90e rejected polar_oat_A at https://api.polar.sh/v1 for me@polar.sh in /Users/seb/.config',
+      'Org <redacted> rejected <redacted> at <redacted> for <redacted> in <redacted>',
+    ],
+  ])('redacts %s', (_label, input, expected) => {
+    expect(redact(input)).toBe(expected)
+  })
+
+  test.each([
+    'Not logged in to sandbox. Run polar auth login --sandbox.',
+    'Organization org_123 is missing or inaccessible. Check --org.',
+    'Received unknown argument: --production',
+    '/opt/homebrew/bin/polar: permission denied',
+    'ENOENT /rootfs/etc/x',
+    'ASIA-Pacific region unsupported',
+    'Event stream error (403)',
+    'Checksum mismatch! Expected: a1b2 Got: c3d4',
+    'page 2 of 4, retry in 30s',
+    'polar update',
+    '',
+  ])('leaves ordinary messages untouched: %s', (message) => {
+    expect(redact(message)).toBe(message)
+  })
+
+  test('truncates to 200 characters after redacting', () => {
+    const long = `${'try again '.repeat(30)}polar_oat_secret ${'x '.repeat(50)}`
+    const result = redact(long)
+    expect(result).toHaveLength(200)
+    expect(result).not.toContain('polar_oat')
+  })
+
+  test('stays fast on very long messages', () => {
+    const started = performance.now()
+    redact('a'.repeat(200_000))
+    expect(performance.now() - started).toBeLessThan(50)
+  })
+
+  test('is idempotent', () => {
+    const once = redact('me@polar.sh at https://x.y/z with polar_oat_a')
+    expect(redact(once)).toBe(once)
+  })
+
+  test('never lets a secret survive inside a URL or path', () => {
+    expect(redact('https://polar.sh/?t=polar_oat_a')).toBe('<redacted>')
+    expect(redact('/Users/seb/polar_oat_a')).toBe('<redacted>')
+  })
+
+  test('applies to failure messages and ignores non-numeric codes', () => {
+    expect(
+      describeFailure(
+        new AuthError({
+          message:
+            'Organization 342c8722-fcad-416b-8232-8877dcf8f90e is missing.',
+        }),
+      ),
+    ).toEqual({
+      error: 'AuthError',
+      errorMessage: 'Organization <redacted> is missing.',
+    })
+    const notFound = Object.assign(
+      new Error("ENOENT: no such file '/Users/seb/.polar/x'"),
+      { code: 'ENOENT' },
+    )
+    expect(describeFailure(notFound)).toEqual({
+      error: 'Error',
+      errorMessage: "ENOENT: no such file '<redacted>",
+    })
+  })
+})
+
+describe('Telemetry.record', () => {
+  test('dispatches one event with a stable install id and no secrets', async () => {
+    const { record, events, files } = telemetry({
+      POLAR_CLI_POSTHOG_KEY: 'phc_test',
+      CLAUDECODE: '1',
+      CI: 'true',
+    })
+    await record({ ...outcome, outcome: 'failure', error: 'AuthError' })
+    await record()
+
+    expect(events).toHaveLength(2)
+    const [first, second] = events as [TelemetryEvent, TelemetryEvent]
+    expect(first).toMatchObject({
+      api_key: 'phc_test',
+      event: 'cli_command',
+      properties: {
+        command: 'polar auth login',
+        flags: ['production'],
+        outcome: 'failure',
+        error: 'AuthError',
+        duration_ms: 43,
+        os: process.platform,
+        arch: process.arch,
+        agent: 'claude-code',
+        ci: true,
+        build: 'release',
+        $process_person_profile: false,
+      },
+    })
+    expect(first.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(first.properties['runtime']).toMatch(/^bun \d/)
+    expect(first.properties['cli_version']).toMatch(/^\d+\.\d+\.\d+/)
+    expect(first.distinct_id).toMatch(/^cli:[0-9a-f-]{36}$/)
+    expect(second.distinct_id).toBe(first.distinct_id)
+    expect(second.properties['error']).toBeNull()
+    expect(second.properties['error_message']).toBeNull()
+    expect(second.properties['error_code']).toBeNull()
+    const [stored] = [...files.values()]
+    expect(JSON.parse(stored!).installId).toBe(first.distinct_id.slice(4))
+  })
+
+  test('reports no agent outside an AI coding tool', async () => {
+    const { record, events } = telemetry({ POLAR_CLI_POSTHOG_KEY: 'phc_test' })
+    await record()
+    expect(events[0]!.properties['agent']).toBeNull()
+    expect(events[0]!.properties['ci']).toBe(false)
+  })
+
+  test('reuses an install id that is already on disk', async () => {
+    const { record, events, files } = telemetry()
+    files.set([...files.keys()][0] ?? '', '')
+    await record()
+    const id = events[0]!.distinct_id
+    const path = [...files.keys()].find((key) =>
+      key.endsWith('telemetry.json'),
+    )!
+    files.set(path, JSON.stringify({ installId: 'existing-id' }))
+    await record()
+    expect(events[1]!.distinct_id).toBe('cli:existing-id')
+    expect(id).not.toBe('cli:existing-id')
+  })
+
+  test('recovers when the state file holds null', async () => {
+    const { record, events, files } = telemetry()
+    await record()
+    const path = [...files.keys()].find((key) =>
+      key.endsWith('telemetry.json'),
+    )!
+    files.set(path, 'null')
+    await record()
+    expect(events).toHaveLength(2)
+    expect(JSON.parse(files.get(path)!).installId).toBe(
+      events[1]!.distinct_id.slice(4),
+    )
+  })
+
+  test('still dispatches when the state directory cannot be written', async () => {
+    const { record, events, files } = telemetry(undefined, 'release', {
+      writable: false,
+    })
+    await record()
+    expect(events).toHaveLength(1)
+    expect(files.size).toBe(0)
+  })
+
+  test('never fails the command when dispatch throws', async () => {
+    const exploding = layer.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          FileSystem.layerNoop({}),
+          Layer.succeed(
+            Sender,
+            Sender.of({ dispatch: () => Effect.die(new Error('boom')) }),
+          ),
+          Layer.succeed(Environment, { POLAR_CLI_POSTHOG_KEY: 'phc_test' }),
+          Layer.succeed(Build, 'release' as const),
+        ),
+      ),
+    )
+    await expect(
+      Effect.runPromise(
+        Effect.gen(function* () {
+          yield* (yield* Telemetry).record(outcome)
+        }).pipe(Effect.provide(exploding)),
+      ),
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('send', () => {
+  const event: TelemetryEvent = {
+    api_key: 'phc_test',
+    event: 'cli_command',
+    distinct_id: 'cli:x',
+    timestamp: '2026-09-10T00:00:00.000Z',
+    properties: { command: 'polar' },
+  }
+  const posthog = 'https://us.i.posthog.com/capture/'
+  let http: ReturnType<typeof fakeHttp>
+
+  beforeEach(() => {
+    http = fakeHttp({ [`POST ${posthog}`]: () => Response.json({ status: 1 }) })
+  })
+
+  const run = (env: Env = {}) =>
+    Effect.runPromise(
+      send(event).pipe(
+        Effect.provide(http.layer),
+        Effect.provideService(Environment, env),
+      ),
+    )
+
+  test('posts the event to PostHog', async () => {
+    await run()
+    expect(http.urls()).toEqual([posthog])
+    expect(JSON.parse(await http.requests[0]!.text())).toEqual(event)
+  })
+
+  test('honours POLAR_CLI_TELEMETRY_URL', async () => {
+    const local = 'http://127.0.0.1:9/capture/'
+    http.routes[`POST ${local}`] = () => new Response(null, { status: 202 })
+    await run({ POLAR_CLI_TELEMETRY_URL: local })
+    expect(http.urls()).toEqual([local])
+  })
+
+  test('never fails when the endpoint is down', async () => {
+    http.routes[`POST ${posthog}`] = () => {
+      throw new Error('offline')
+    }
+    await expect(run()).resolves.toBeUndefined()
+    http.routes[`POST ${posthog}`] = () => new Response(null, { status: 500 })
+    await expect(run()).resolves.toBeUndefined()
+  })
+})

--- a/clients/packages/cli/src/services/telemetry.ts
+++ b/clients/packages/cli/src/services/telemetry.ts
@@ -1,0 +1,321 @@
+import { randomUUID } from 'node:crypto'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import {
+  Cause,
+  Context,
+  Effect,
+  Exit,
+  FileSystem,
+  Layer,
+  Runtime,
+} from 'effect'
+import { HttpClient, HttpClientRequest } from 'effect/unstable/http'
+import { VERSION } from '@/version'
+
+export const OPT_OUT_VARIABLE = 'POLAR_CLI_TELEMETRY_OPTOUT'
+export const ENDPOINT_VARIABLE = 'POLAR_CLI_TELEMETRY_URL'
+export const PROJECT_KEY_VARIABLE = 'POLAR_CLI_POSTHOG_KEY'
+export const FORCE_VARIABLE = 'POLAR_CLI_TELEMETRY_FORCE'
+export const SENDER_COMMAND = '__telemetry'
+const ENDPOINT = 'https://us.i.posthog.com/capture/'
+const PROJECT_KEY = 'phc_H2ajVAY4cy0uQpcgN5fzpv8JC3yP8VZOjx2EXiFBbgz'
+const EVENT = 'cli_command'
+const SEND_TIMEOUT = '5 seconds'
+
+declare const POLAR_CLI_BUILD: string | undefined
+
+type Env = Record<string, string | undefined>
+
+export const Environment = Context.Reference<Env>(
+  'polar/Telemetry/Environment',
+  { defaultValue: () => process.env },
+)
+
+export type BuildKind = 'release' | 'development'
+
+export const Build = Context.Reference<BuildKind>('polar/Telemetry/Build', {
+  defaultValue: () =>
+    typeof POLAR_CLI_BUILD !== 'undefined' && POLAR_CLI_BUILD === 'release'
+      ? 'release'
+      : 'development',
+})
+
+const agents: ReadonlyArray<readonly [string, RegExp]> = [
+  ['claude-code', /^CLAUDECODE$|^CLAUDE_CODE_/],
+  ['cursor', /^CURSOR_/],
+  ['codex', /^CODEX_/],
+  ['opencode', /^OPENCODE_/],
+  ['pi', /^PI_CODING_AGENT$/],
+  ['gemini-cli', /^GEMINI_CLI$/],
+  ['copilot', /^(GITHUB_)?COPILOT_/],
+  ['aider', /^AIDER_/],
+  ['windsurf', /^WINDSURF_/],
+]
+
+const enabled = (value: string | undefined) =>
+  value !== undefined && ['1', 'true', 'yes'].includes(value.toLowerCase())
+
+export const isOptedOut = (env: Env) =>
+  enabled(env[OPT_OUT_VARIABLE]) || enabled(env['DO_NOT_TRACK'])
+
+export const isCI = (env: Env) =>
+  enabled(env['CI']) || env['GITHUB_ACTIONS'] !== undefined
+
+export const isCompiledBinary = (main = Bun.main) =>
+  main.startsWith('/$bunfs/') || /^[A-Za-z]:\\~BUN\\/.test(main)
+
+export const detectAgent = (env: Env) => {
+  const names = Object.keys(env).filter((name) => env[name])
+  const known = agents.find(([, pattern]) =>
+    names.some((name) => pattern.test(name)),
+  )?.[0]
+  return known ?? env['AI_AGENT']?.toLowerCase() ?? undefined
+}
+
+interface CommandTree {
+  readonly name: string
+  readonly subcommands: ReadonlyArray<{
+    readonly commands: ReadonlyArray<CommandTree>
+  }>
+}
+
+export const commandPath = (
+  command: CommandTree,
+  args: ReadonlyArray<string>,
+) => {
+  const path = [command.name]
+  let current = command
+  for (const token of args) {
+    const candidates = current.subcommands.flatMap((group) => group.commands)
+    if (candidates.length === 0) break
+    const next = candidates.find((child) => child.name === token)
+    if (!next) continue
+    path.push(next.name)
+    current = next
+  }
+  return path
+}
+
+export const flagNames = (args: ReadonlyArray<string>) => [
+  ...new Set(
+    args
+      .filter((arg) => arg.startsWith('-') && arg !== '-' && arg !== '--')
+      .map((arg) => arg.replace(/^-+/, '').split('=')[0]!),
+  ),
+]
+
+export interface Failure {
+  error: string
+  errorMessage?: string
+  errorCode?: number
+}
+
+export interface CommandOutcome extends Partial<Failure> {
+  command: string[]
+  flags: string[]
+  outcome: 'success' | 'failure' | 'interrupted'
+  durationMs: number
+}
+
+const redactions: ReadonlyArray<RegExp> = [
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+  /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+  /\bBearer\s+\S+/gi,
+  /\b(?:polar_|sk_|pk_|rk_|whsec_|ghp_|gho_|ghu_|ghs_|ghr_|github_pat_|glpat-|xox[baprs]-|AIza|ya29\.)[A-Za-z0-9_.-]+/g,
+  /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g,
+  /\b[a-z][a-z0-9+.-]*:\/\/\S+/gi,
+  /(?:\/Users|\/home|\/root|\/tmp|\/var|\/private|[A-Za-z]:\\Users)(?:[\\/]\S*|\b)/g,
+  /\S+@\S+\.\S+/g,
+  /\b\d{1,3}(?:\.\d{1,3}){3}\b/g,
+  /\b[A-Za-z0-9_-]{32,}\b/g,
+]
+
+export const redact = (text: string) =>
+  redactions
+    .reduce(
+      (result, pattern) => result.replace(pattern, '<redacted>'),
+      text.slice(0, 1000),
+    )
+    .slice(0, 200)
+
+const field = (value: unknown, key: string): unknown =>
+  typeof value === 'object' && value !== null && key in value
+    ? (value as Record<string, unknown>)[key]
+    : undefined
+
+export const describeFailure = (error: unknown): Failure => {
+  const tag = field(error, '_tag')
+  const reason = field(error, 'reason')
+  const reasonTag = field(reason, '_tag')
+  const name =
+    tag !== undefined
+      ? `${String(tag)}${reasonTag !== undefined ? `:${String(reasonTag)}` : ''}`
+      : error instanceof Error
+        ? error.name
+        : 'Unknown'
+  const message = field(error, 'message')
+  const code =
+    field(error, 'code') ?? field(field(reason, 'response'), 'status')
+  return {
+    error: name,
+    ...(typeof message === 'string' && message
+      ? { errorMessage: redact(message) }
+      : {}),
+    ...(typeof code === 'number' ? { errorCode: code } : {}),
+  }
+}
+
+export const outcomeOf = (
+  exit: Exit.Exit<unknown, unknown>,
+): Pick<CommandOutcome, 'outcome' | 'error' | 'errorMessage' | 'errorCode'> => {
+  if (Exit.isSuccess(exit)) return { outcome: 'success' }
+  if (Cause.hasInterruptsOnly(exit.cause)) return { outcome: 'interrupted' }
+  const error = Cause.squash(exit.cause)
+  if (Runtime.getErrorExitCode(error) === 0) return { outcome: 'success' }
+  return { outcome: 'failure', ...describeFailure(error) }
+}
+
+export interface TelemetryEvent {
+  api_key: string
+  event: string
+  distinct_id: string
+  timestamp: string
+  properties: Record<string, unknown>
+}
+
+export class Sender extends Context.Service<
+  Sender,
+  { dispatch: (event: TelemetryEvent) => Effect.Effect<void> }
+>()('polar/Telemetry/Sender') {}
+
+export class Telemetry extends Context.Service<
+  Telemetry,
+  { record: (outcome: CommandOutcome) => Effect.Effect<void> }
+>()('polar/Telemetry') {}
+
+const stateFile = join(homedir(), '.polar', 'telemetry.json')
+
+const installId = (fs: FileSystem.FileSystem) =>
+  Effect.gen(function* () {
+    const stored = yield* fs.readFileString(stateFile).pipe(
+      Effect.flatMap((raw) =>
+        Effect.try(() => JSON.parse(raw) as { installId?: unknown }),
+      ),
+      Effect.orElseSucceed(() => ({}) as { installId?: unknown }),
+    )
+    const existing = field(stored, 'installId')
+    if (typeof existing === 'string') return existing
+    const id = randomUUID()
+    yield* fs
+      .makeDirectory(dirname(stateFile), { recursive: true })
+      .pipe(
+        Effect.andThen(
+          fs.writeFileString(
+            stateFile,
+            `${JSON.stringify({ installId: id }, null, 2)}\n`,
+          ),
+        ),
+        Effect.ignore,
+      )
+    return id
+  })
+
+export const layer = Layer.effect(
+  Telemetry,
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const sender = yield* Sender
+    const env = yield* Environment
+    const build = yield* Build
+    const projectKey = env[PROJECT_KEY_VARIABLE] || PROJECT_KEY
+    const active =
+      !isOptedOut(env) &&
+      (build === 'release' ||
+        !!env[ENDPOINT_VARIABLE] ||
+        enabled(env[FORCE_VARIABLE]))
+    return Telemetry.of({
+      record: (result) =>
+        Effect.gen(function* () {
+          if (!active) return
+          const id = yield* installId(fs)
+          yield* sender.dispatch({
+            api_key: projectKey,
+            event: EVENT,
+            distinct_id: `cli:${id}`,
+            timestamp: new Date().toISOString(),
+            properties: {
+              command: result.command.join(' '),
+              flags: result.flags,
+              outcome: result.outcome,
+              error: result.error ?? null,
+              error_message: result.errorMessage ?? null,
+              error_code: result.errorCode ?? null,
+              duration_ms: Math.round(result.durationMs),
+              cli_version: VERSION.replace(/^v/, ''),
+              os: process.platform,
+              arch: process.arch,
+              runtime: `bun ${Bun.version}`,
+              agent: detectAgent(env) ?? null,
+              ci: isCI(env),
+              build,
+              $process_person_profile: false,
+            },
+          })
+        }).pipe(Effect.ignoreCause),
+    })
+  }),
+)
+
+export const send = (event: TelemetryEvent) =>
+  Effect.gen(function* () {
+    const env = yield* Environment
+    const client = yield* HttpClient.HttpClient
+    const request = yield* HttpClientRequest.post(
+      env[ENDPOINT_VARIABLE] || ENDPOINT,
+    ).pipe(HttpClientRequest.bodyJson(event))
+    yield* client.execute(request)
+  }).pipe(Effect.scoped, Effect.timeout(SEND_TIMEOUT), Effect.ignoreCause)
+
+export const httpSender = Layer.effect(
+  Sender,
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient
+    const env = yield* Environment
+    return Sender.of({
+      dispatch: (event) =>
+        send(event).pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+          Effect.provideService(Environment, env),
+        ),
+    })
+  }),
+)
+
+export const detachedSender = Layer.succeed(
+  Sender,
+  Sender.of({
+    dispatch: (event) =>
+      Effect.try(() => {
+        const command = isCompiledBinary()
+          ? [process.execPath, SENDER_COMMAND]
+          : [process.execPath, Bun.main, SENDER_COMMAND]
+        const child = Bun.spawn(command, {
+          stdin: 'pipe',
+          stdout: 'ignore',
+          stderr: 'ignore',
+        })
+        child.stdin.write(JSON.stringify(event))
+        child.stdin.end()
+        child.unref()
+      }).pipe(Effect.ignoreCause),
+  }),
+)
+
+export const sendFromStdin = Effect.gen(function* () {
+  const raw = yield* Effect.tryPromise(() =>
+    new Response(Bun.stdin.stream()).text(),
+  )
+  const event = yield* Effect.try(() => JSON.parse(raw) as TelemetryEvent)
+  yield* send(event)
+}).pipe(Effect.ignoreCause)


### PR DESCRIPTION
## Summary

Add (anonymous) telemetry so we can analyze the usage of the CLI. For each command we now pass:

* Command
* Flags
* Errors
* Duration
* OS
* Agent
* CI

to PostHog. These can be opted out of with either the `POLAR_CLI_TELEMETRY_OPTOUT` or `DO_NOT_TRACK` environment variable.

<img width="640" height="421" alt="Screenshot 2026-09-09 at 17 07 43" src="https://github.com/user-attachments/assets/a683c663-dc7d-4ee6-8273-a4112e2cb5e2" />

<img width="906" height="295" alt="Screenshot 2026-09-09 at 17 07 49" src="https://github.com/user-attachments/assets/810c94ef-5efb-453b-a3db-74b1e91ecd9a" />



Fixes https://linear.app/polarsh/issue/PLR-109/add-basic-telemetry