### PR TITLE
Fix HTTPX instrumentation in Lambda workers

### DIFF
--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -19,7 +19,6 @@ from redis.backoff import default_backoff
 from redis.retry import Retry
 
 from polar.config import settings
-from polar.logfire import instrument_httpx
 from polar.logging import CorrelationID, Logger
 from polar.operational_errors import handle_operational_error
 from polar.redis import REDIS_RETRY_ON_ERRROR, SyncFailoverRedis
@@ -135,11 +134,6 @@ class LogfireMiddleware(dramatiq.Middleware):
     @property
     def ephemeral_options(self) -> set[str]:
         return {"logfire_stack"}
-
-    def before_worker_boot(
-        self, broker: dramatiq.Broker, worker: dramatiq.Worker
-    ) -> None:
-        instrument_httpx()
 
     def before_process_message(
         self, broker: dramatiq.Broker, message: dramatiq.MessageProxy

--- a/server/polar/worker/_httpx.py
+++ b/server/polar/worker/_httpx.py
@@ -3,6 +3,7 @@ import httpx
 import structlog
 from dramatiq.asyncio import get_event_loop_thread
 
+from polar.logfire import instrument_httpx
 from polar.logging import Logger
 
 log: Logger = structlog.get_logger()
@@ -21,6 +22,7 @@ async def _close_client() -> None:
 
 def setup_httpx() -> None:
     global _httpx
+    instrument_httpx()
     _httpx = httpx.AsyncClient()
     log.info("Created HTTPX client")
 


### PR DESCRIPTION
## Summary

Fixes [PLR-114](https://linear.app/polarsh/issue/PLR-114/httpx-is-not-instrumented-in-aws-lambda). HTTPX requests from Lambda tasks now emit tracing spans through the same instrumentation as classic workers.

## What

Move `instrument_httpx()` from `LogfireMiddleware.before_worker_boot()` into `setup_httpx()`.

## Why

Lambda and local SQS runners bypass Dramatiq's worker boot hooks, so they never enabled global HTTPX instrumentation.

## How

Enable instrumentation in the HTTPX setup function shared by all worker entry points, before creating the shared client.

Validation: 18 existing worker-runner and instrumentation smoke tests pass. Ruff checks and formatting pass for both changed files; targeted mypy checks also passed. A temporary regression test verified shared, async, and sync clients emit request spans and was removed as requested.

## Checklist

- [x] This PR addresses a single concern
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests — no new test retained
- [x] Targeted linting and type checking pass
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

