### PR TITLE
CLI: Make callback page more pretty

### DIFF
--- a/clients/packages/cli/src/services/oauth.test.ts
+++ b/clients/packages/cli/src/services/oauth.test.ts
@@ -33,6 +33,10 @@ beforeEach(() => {
 test.each([true, false])(
   'closes the callback server after OAuth completion (authorized: %s)',
   async (authorized) => {
+    let callbackResponse:
+      | { status: number | undefined; type: string | undefined; body: string }
+      | undefined
+    let browserDone: Promise<void> | undefined
     const server = http.createServer()
     const nativeListen = server.listen.bind(server)
     const listen = vi
@@ -56,15 +60,23 @@ test.each([true, false])(
           authorized ? 'code' : 'error',
           authorized ? 'test-code' : 'access_denied',
         )
-        await new Promise<void>((resolve, reject) => {
+        browserDone = new Promise<void>((resolve, reject) => {
           http
             .get(callback, (response) => {
-              response.resume()
+              callbackResponse = {
+                status: response.statusCode,
+                type: response.headers['content-type'],
+                body: '',
+              }
+              response.on('data', (chunk) => {
+                callbackResponse!.body += chunk
+              })
               response.on('end', resolve)
               response.on('error', reject)
             })
             .on('error', reject)
         })
+        await browserDone
         return new ChildProcess()
       })
     respond(() => Response.json({ access_token: 'test-token', expires_in: 60 }))
@@ -81,6 +93,14 @@ test.each([true, false])(
       )
       expect(result._tag).toBe(authorized ? 'Success' : 'Failure')
       expect(server.listening).toBe(false)
+      await browserDone
+      expect(callbackResponse).toMatchObject({
+        status: 200,
+        type: 'text/html; charset=utf-8',
+      })
+      expect(callbackResponse!.body).toContain(
+        authorized ? 'You are signed in' : 'Sign-in canceled',
+      )
     } finally {
       server.closeAllConnections()
       server.close()

--- a/clients/packages/cli/src/services/oauth.ts
+++ b/clients/packages/cli/src/services/oauth.ts
@@ -21,6 +21,7 @@ import {
   type PolarEnvironment,
   type Session,
 } from '@/schemas/Auth'
+import { callbackPage, type CallbackOutcome } from '@/utils/callback-page'
 import * as ui from '@/utils/ui'
 
 const SANDBOX_CLIENT_ID = 'polar_ci_AHVAKf9SDOaffma2auRGMXR3H8jg9QBgOfW7s1hYgW9'
@@ -171,25 +172,37 @@ export const exchange = (
     }
   }).pipe(Effect.scoped)
 
-export const validateCallback = (url: URL, expectedState: string) => {
+export type CallbackResult =
+  | { outcome: 'success'; code: string }
+  | { outcome: Exclude<CallbackOutcome, 'success'>; message: string }
+
+export const parseCallback = (
+  url: URL,
+  expectedState: string,
+): CallbackResult => {
   if (url.searchParams.get('state') !== expectedState) {
-    return Effect.fail(
-      new AuthError({ message: 'Invalid OAuth callback state.' }),
-    )
+    return { outcome: 'invalid', message: 'Invalid OAuth callback state.' }
   }
   if (url.searchParams.has('error')) {
-    return Effect.fail(
-      new AuthError({ message: 'OAuth authorization was denied or canceled.' }),
-    )
+    return {
+      outcome: 'denied',
+      message: 'OAuth authorization was denied or canceled.',
+    }
   }
   const code = url.searchParams.get('code')
   return code
-    ? Effect.succeed(code)
-    : Effect.fail(
-        new AuthError({
-          message: 'OAuth callback is missing its authorization code.',
-        }),
-      )
+    ? { outcome: 'success', code }
+    : {
+        outcome: 'invalid',
+        message: 'OAuth callback is missing its authorization code.',
+      }
+}
+
+export const validateCallback = (url: URL, expectedState: string) => {
+  const result = parseCallback(url, expectedState)
+  return result.outcome === 'success'
+    ? Effect.succeed(result.code)
+    : Effect.fail(new AuthError({ message: result.message }))
 }
 
 const login = (environment: PolarEnvironment) =>
@@ -236,9 +249,12 @@ const login = (environment: PolarEnvironment) =>
           response.writeHead(404).end()
           return
         }
+        const result = parseCallback(url, state)
         response
-          .writeHead(200, { 'Content-Type': 'text/plain' })
-          .end('Return to the Polar CLI to complete login.')
+          .writeHead(result.outcome === 'invalid' ? 400 : 200, {
+            'Content-Type': 'text/html; charset=utf-8',
+          })
+          .end(callbackPage(result.outcome))
         finish(validateCallback(url, state))
       })
       server.on('error', () =>

--- a/clients/packages/cli/src/utils/callback-page.test.ts
+++ b/clients/packages/cli/src/utils/callback-page.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'vitest'
+import { callbackPage } from '@/utils/callback-page'
+
+describe('callbackPage', () => {
+  test.each([
+    ['success', 'You are signed in', 'close this tab'],
+    ['denied', 'Sign-in canceled', '<code>polar auth login</code>'],
+    ['invalid', 'Something went wrong', 'invalid or has expired'],
+  ] as const)('renders the %s page', (outcome, title, hint) => {
+    const html = callbackPage(outcome)
+    expect(html).toContain(`<h1>${title}</h1>`)
+    expect(html).toContain(hint)
+  })
+})

--- a/clients/packages/cli/src/utils/callback-page.ts
+++ b/clients/packages/cli/src/utils/callback-page.ts
@@ -1,0 +1,64 @@
+export type CallbackOutcome = 'success' | 'denied' | 'invalid'
+
+const copy: Record<CallbackOutcome, { title: string; message: string }> = {
+  success: {
+    title: 'You are signed in',
+    message: 'Return to your terminal to continue. You can close this tab.',
+  },
+  denied: {
+    title: 'Sign-in canceled',
+    message:
+      'Authorization was denied. Return to your terminal and run <code>polar auth login</code> to try again.',
+  },
+  invalid: {
+    title: 'Something went wrong',
+    message:
+      'This sign-in link is invalid or has expired. Return to your terminal and run <code>polar auth login</code> again.',
+  },
+}
+
+const logo = `<svg width="88" height="88" viewBox="0 0 29 29" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M9.07727 23.0572C13.8782 26.307 20.4046 25.0496 23.6545 20.2487C26.9043 15.4478 25.6469 8.92133 20.846 5.67149C16.0451 2.42165 9.51862 3.67905 6.26878 8.47998C3.01894 13.2809 4.27634 19.8073 9.07727 23.0572ZM10.4703 23.1428C14.862 25.3897 20.433 23.2807 22.9135 18.4322C25.394 13.5838 23.8447 7.83194 19.4531 5.58511C15.0614 3.33829 9.49042 5.4473 7.00991 10.2957C4.52939 15.1442 6.07867 20.896 10.4703 23.1428Z" fill="currentColor"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11.7222 24.2898C15.6865 25.58 20.35 22.1715 22.1385 16.6765C23.927 11.1815 22.1632 5.68099 18.1989 4.39071C14.2346 3.10043 9.5711 6.509 7.78261 12.004C5.99412 17.4989 7.75793 22.9995 11.7222 24.2898ZM12.9347 23.872C16.2897 24.5876 19.9174 20.9108 21.0374 15.6596C22.1574 10.4084 20.3457 5.57134 16.9907 4.85575C13.6357 4.14016 10.008 7.817 8.88797 13.0682C7.76793 18.3194 9.57971 23.1564 12.9347 23.872Z" fill="currentColor"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.8537 24.7382C16.5062 25.0215 19.1534 20.5972 19.7664 14.8563C20.3794 9.1155 18.7261 4.23202 16.0736 3.94879C13.4211 3.66556 10.7739 8.08983 10.1609 13.8307C9.54788 19.5715 11.2012 24.455 13.8537 24.7382ZM15.0953 22.9906C17.015 22.9603 18.5101 19.0742 18.4349 14.3108C18.3596 9.54747 16.7424 5.71058 14.8228 5.7409C12.9032 5.77123 11.408 9.6573 11.4833 14.4207C11.5585 19.184 13.1757 23.0209 15.0953 22.9906Z" fill="currentColor"/>
+</svg>`
+
+export const callbackPage = (outcome: CallbackOutcome) => {
+  const { title, message } = copy[outcome]
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark">
+<title>Polar CLI</title>
+<style>
+  html, body { height: 100%; margin: 0; }
+  body {
+    display: flex; align-items: center; justify-content: center;
+    background: #000; color: #fff;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  main { display: flex; flex-direction: column; align-items: center; text-align: center; padding: 32px; max-width: 28rem; }
+  svg { display: block; margin-bottom: 32px; }
+  h1 { font-size: 20px; font-weight: 500; margin: 0 0 12px; letter-spacing: -0.01em; }
+  p { font-size: 15px; line-height: 1.6; margin: 0; color: rgba(255, 255, 255, 0.6); }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 13px; color: rgba(255, 255, 255, 0.85);
+    background: rgba(255, 255, 255, 0.08); border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 6px; padding: 1px 6px; white-space: nowrap;
+  }
+</style>
+</head>
+<body>
+<main>
+${logo}
+<h1>${title}</h1>
+<p>${message}</p>
+</main>
+</body>
+</html>
+`
+}


### PR DESCRIPTION
## Summary

When running `polar auth login` we auth and show a status message in the browser (http://127.0.0.1:3333/oauth/callback?code=polar_ac_ouX&state=423ed09b4&iss=https%3A%2F%2Fapi.polar.sh). This PR will make that more pretty

| Before | After (success) | After (failure) |
|--------|--------|--------|
| <img width="473" height="558" alt="bef-" src="https://github.com/user-attachments/assets/f66d52d2-8562-436b-bf48-bd74ed1f714c" /> | <img width="473" height="558" alt="af-succ" src="https://github.com/user-attachments/assets/cab5c6d8-cbbc-4ef0-83fa-b95abc8fc401" /> | <img width="473" height="558" alt="af-canceled" src="https://github.com/user-attachments/assets/37795bc2-c0e9-4d98-bb1f-259760d08614" /> |








<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

