### PR TITLE
fix(payout): keep the connected account's website in sync

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -665,7 +665,15 @@ class OrganizationService:
                 OrganizationDetails, update_schema.details.model_dump()
             )
 
+        previous_website = organization.website
+
         organization = await repository.update(organization, update_dict=update_dict)
+
+        if organization.website != previous_website:
+            enqueue_job(
+                "organization.sync_payout_account_website",
+                organization_id=organization.id,
+            )
 
         if sso_newly_enforced:
             await oauth2_token_service.revoke_for_sso_enforcement(
@@ -1788,6 +1796,62 @@ class OrganizationService:
             enqueue_job("organization.under_review", organization_id=organization.id)
         return organization
 
+    async def sync_payout_account_website(
+        self, session: AsyncSession, organization: Organization
+    ) -> str | None:
+        """Put the organization's website on its Stripe connected account.
+
+        Stripe requires one connected account per website, and reads that
+        website from the account itself. Returns the Stripe account id the
+        website was pushed to.
+        """
+        if organization.payout_account_id is None:
+            log.info(
+                "organization.sync_payout_account_website.skipped",
+                reason="no_payout_account",
+                organization_id=str(organization.id),
+            )
+            return None
+
+        website = organization.website.strip() if organization.website else ""
+        if not website:
+            log.info(
+                "organization.sync_payout_account_website.skipped",
+                reason="no_website",
+                organization_id=str(organization.id),
+            )
+            return None
+
+        payout_account_repository = PayoutAccountRepository.from_session(session)
+        payout_account = await payout_account_repository.get_by_id(
+            organization.payout_account_id
+        )
+        if payout_account is None or payout_account.stripe_id is None:
+            log.info(
+                "organization.sync_payout_account_website.skipped",
+                reason="no_stripe_account",
+                organization_id=str(organization.id),
+            )
+            return None
+
+        # InvalidRequestError is a deterministic rejection (a URL Stripe won't
+        # accept, an account missing required fields): retrying can't succeed,
+        # so log instead of raising.
+        try:
+            await stripe_service.update_account_website(
+                payout_account.stripe_id, website
+            )
+        except stripe_lib.InvalidRequestError as e:
+            log.warning(
+                "organization.sync_payout_account_website.rejected",
+                organization_id=str(organization.id),
+                stripe_account_id=payout_account.stripe_id,
+                error=str(e),
+            )
+            return None
+
+        return payout_account.stripe_id
+
     async def evaluate_website_risk(
         self, session: AsyncSession, organization: Organization
     ) -> None:
@@ -1800,63 +1864,19 @@ class OrganizationService:
             )
             return
 
-        if organization.payout_account_id is None:
-            log.info(
-                "organization.evaluate_website_risk.skipped",
-                reason="no_payout_account",
-                organization_id=str(organization.id),
-            )
-            return
-
-        website = organization.website.strip() if organization.website else ""
-        if not website:
-            log.info(
-                "organization.evaluate_website_risk.skipped",
-                reason="no_website",
-                organization_id=str(organization.id),
-            )
-            return
-
-        payout_account_repository = PayoutAccountRepository.from_session(session)
-        payout_account = await payout_account_repository.get_by_id(
-            organization.payout_account_id
-        )
-        if payout_account is None or payout_account.stripe_id is None:
-            log.info(
-                "organization.evaluate_website_risk.skipped",
-                reason="no_stripe_account",
-                organization_id=str(organization.id),
-            )
-            return
-
-        # Stripe evaluates the website attached to the account, so sync it
-        # first. InvalidRequestError is a deterministic rejection (a URL
-        # Stripe won't accept, an account missing required fields): retrying
-        # can't succeed, so log instead of raising.
-        try:
-            await stripe_service.update_account_website(
-                payout_account.stripe_id, website
-            )
-        except stripe_lib.InvalidRequestError as e:
-            log.warning(
-                "organization.evaluate_website_risk.rejected",
-                step="sync_website",
-                organization_id=str(organization.id),
-                stripe_account_id=payout_account.stripe_id,
-                error=str(e),
-            )
+        # Stripe evaluates the website attached to the account, so sync it first.
+        stripe_id = await self.sync_payout_account_website(session, organization)
+        if stripe_id is None:
             return
 
         try:
-            await stripe_service.create_website_risk_evaluation(
-                payout_account.stripe_id
-            )
+            await stripe_service.create_website_risk_evaluation(stripe_id)
         except stripe_lib.InvalidRequestError as e:
             log.warning(
                 "organization.evaluate_website_risk.rejected",
                 step="create_evaluation",
                 organization_id=str(organization.id),
-                stripe_account_id=payout_account.stripe_id,
+                stripe_account_id=stripe_id,
                 error=str(e),
             )
 

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -1214,3 +1214,14 @@ async def evaluate_website_risk(organization_id: uuid.UUID) -> None:
             raise OrganizationDoesNotExist(organization_id)
 
         await organization_service.evaluate_website_risk(session, organization)
+
+
+@actor(actor_name="organization.sync_payout_account_website", priority=TaskPriority.LOW)
+async def sync_payout_account_website(organization_id: uuid.UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        repository = OrganizationRepository.from_session(session)
+        organization = await repository.get_by_id(organization_id)
+        if organization is None:
+            raise OrganizationDoesNotExist(organization_id)
+
+        await organization_service.sync_payout_account_website(session, organization)

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -15,6 +15,7 @@ from polar.organization.repository import OrganizationRepository
 from polar.organization.resolver import get_payload_organization
 from polar.payout.repository import PayoutRepository
 from polar.postgres import AsyncSession
+from polar.worker import enqueue_job
 
 from .repository import PayoutAccountRepository
 from .schemas import PayoutAccountCreate, PayoutAccountLink
@@ -134,6 +135,12 @@ class PayoutAccountService:
         organization_repository = OrganizationRepository.from_session(session)
         organization.payout_account = payout_account
         await organization_repository.update(organization)
+
+        # Stripe reads the organization's website off the connected account.
+        enqueue_job(
+            "organization.sync_payout_account_website",
+            organization_id=organization.id,
+        )
 
         return payout_account
 

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -22,6 +22,7 @@ from polar.models.organization_sso_connection import (
 from polar.models.subscription import SubscriptionStatus
 from polar.models.user_organization import OrganizationRole, UserOrganization
 from polar.organization.schemas import DISPUTE_AUTO_ACCEPT_MAX_AMOUNT
+from polar.organization_review.schemas import ReviewContext
 from polar.payout_account.service import PayoutAccountServiceError
 from polar.postgres import AsyncSession
 from polar.user_organization.service import (
@@ -604,7 +605,11 @@ class TestUpdateOrganization:
 
         assert response.status_code == 200
         assert response.json()["details_submitted_at"] is not None
-        enqueue_job_mock.assert_called_once()
+        enqueue_job_mock.assert_any_call(
+            "organization_review.run_agent",
+            organization_id=organization.id,
+            context=ReviewContext.SUBMISSION,
+        )
 
     @pytest.mark.auth
     async def test_submit_for_review_not_existing(self, client: AsyncClient) -> None:

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -403,7 +403,7 @@ class TestUpdateReviewSubmission:
         result = await organization_service.submit_for_review(session, organization)
 
         assert result.details_submitted_at is not None
-        enqueue_job_mock.assert_called_once_with(
+        enqueue_job_mock.assert_any_call(
             "organization_review.run_agent",
             organization_id=organization.id,
             context=ReviewContext.SUBMISSION,
@@ -664,6 +664,54 @@ async def test_get_next_invoice_number_multiple_customers(
     await session.refresh(customer2)
     assert customer.invoice_next_number == 3
     assert customer2.invoice_next_number == 2
+
+
+@pytest.mark.asyncio
+class TestUpdateWebsite:
+    @pytest.mark.auth
+    async def test_change_enqueues_payout_account_website_sync(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate(website=cast(HttpUrl, "https://example.com")),
+        )
+
+        enqueue_job_mock.assert_any_call(
+            "organization.sync_payout_account_website",
+            organization_id=organization.id,
+        )
+
+    @pytest.mark.auth
+    async def test_unchanged_website_does_not_enqueue_sync(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.website = "https://example.com/"
+        await save_fixture(organization)
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        await organization_service.update(
+            session,
+            organization,
+            OrganizationUpdate(website=cast(HttpUrl, "https://example.com")),
+        )
+
+        sync_calls = [
+            call
+            for call in enqueue_job_mock.call_args_list
+            if call.args and call.args[0] == "organization.sync_payout_account_website"
+        ]
+        assert sync_calls == []
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -16,6 +16,7 @@ from polar.organization.tasks import (
     organization_created,
     organization_offboarded,
     organization_under_review,
+    sync_payout_account_website,
 )
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_payout_account
@@ -151,6 +152,53 @@ class TestOrganizationCancelExpiredSubscriptions:
         await organization_cancel_expired_subscriptions()
 
         cancel_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestSyncPayoutAccountWebsite:
+    async def test_pushes_website_to_stripe(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        organization.website = "https://example.com"
+        await save_fixture(organization)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, stripe_id="acct_website_sync"
+        )
+        update_website_mock = mocker.patch(
+            "polar.organization.service.stripe_service.update_account_website",
+            new=AsyncMock(),
+        )
+
+        await sync_payout_account_website(organization.id)
+
+        update_website_mock.assert_awaited_once_with(
+            payout_account.stripe_id, "https://example.com"
+        )
+
+    async def test_rejection_does_not_raise(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        organization.website = "https://example.com"
+        await save_fixture(organization)
+        await create_payout_account(
+            save_fixture, organization, user, stripe_id="acct_website_sync"
+        )
+        mocker.patch(
+            "polar.organization.service.stripe_service.update_account_website",
+            new=AsyncMock(
+                side_effect=stripe_lib.InvalidRequestError("Invalid URL", None)
+            ),
+        )
+
+        await sync_payout_account_website(organization.id)
 
 
 @pytest.mark.asyncio

--- a/server/tests/payout_account/test_service.py
+++ b/server/tests/payout_account/test_service.py
@@ -5,8 +5,12 @@ from pytest_mock import MockerFixture
 from polar.auth.models import AuthSubject
 from polar.enums import PayoutAccountStatus, PayoutAccountType
 from polar.integrations.stripe.service import StripeService
-from polar.models import Organization, User
+from polar.models import Organization, User, UserOrganization
 from polar.models.payout_attempt import PayoutAttemptStatus
+from polar.payout_account.schemas import (
+    PayoutAccountCreate,
+    StripeAccountCountry,
+)
 from polar.payout_account.service import (
     PayoutAccountHasPendingPayouts,
     PayoutAccountLinkedToOrganization,
@@ -32,6 +36,51 @@ def stripe_service_mock(mocker: MockerFixture) -> StripeService:
     mock = mocker.MagicMock(spec=StripeService)
     mocker.patch("polar.payout_account.service.stripe", new=mock)
     return mock
+
+
+@pytest.mark.asyncio
+class TestCreate:
+    @pytest.mark.auth
+    async def test_enqueues_website_sync(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        stripe_service_mock.create_account.return_value = (  # type: ignore[attr-defined]
+            stripe_lib.Account.construct_from(
+                {
+                    "id": "acct_created",
+                    "email": "merchant@example.com",
+                    "country": "US",
+                    "default_currency": "usd",
+                    "details_submitted": False,
+                    "charges_enabled": False,
+                    "payouts_enabled": False,
+                    "business_type": None,
+                },
+                None,
+            )
+        )
+        enqueue_job_mock = mocker.patch("polar.payout_account.service.enqueue_job")
+
+        await payout_account_service.create(
+            auth_subject,
+            session,
+            PayoutAccountCreate(
+                type=PayoutAccountType.stripe,
+                organization_id=organization.id,
+                country=StripeAccountCountry.US,
+            ),
+        )
+
+        enqueue_job_mock.assert_any_call(
+            "organization.sync_payout_account_website",
+            organization_id=organization.id,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Stripe requires one connected account per website and reads that website off the account. We only pushed it when an organization entered review, so it went stale whenever a merchant changed their site, and a freshly created account had none at all.

Now pushed when the website changes and when a payout account is created.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

