### PR TITLE
feat(web): product mapping UI for merchant catalog import (PLR-116)

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingPanel.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import {
+  useProductMappings,
+  useUpdateProductMappings,
+} from '@/hooks/queries/merchantMigrations'
+import { Alert, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { useCallback } from 'react'
+import { ProductMappingTable } from './ProductMappingTable'
+import { mappingChoice, visibleMappingItems } from './productMapping'
+
+export function ProductMappingPanel({ migrationId }: { migrationId: string }) {
+  const mappings = useProductMappings(migrationId)
+  const updateMappings = useUpdateProductMappings(migrationId)
+  const visible = visibleMappingItems(mappings.data?.items ?? [])
+  const mutateMappings = updateMappings.mutate
+
+  const onChange = useCallback(
+    (sourceId: string, value: string) => {
+      mutateMappings([mappingChoice(sourceId, value)])
+    },
+    [mutateMappings],
+  )
+
+  if (visible.length === 0) {
+    return null
+  }
+
+  return (
+    <Box as="section" flexDirection="column" rowGap="s">
+      <Box flexDirection="column" rowGap="xs">
+        <Text variant="heading-xs" as="h3">
+          Product configuration
+        </Text>
+        <Text variant="caption" color="muted">
+          Map each Stripe product with subscribers onto a Polar product.
+          Imported subscribers keep their Stripe price if Polar&apos;s catalog
+          has moved on.
+        </Text>
+      </Box>
+      {updateMappings.isError ? (
+        <Alert
+          variant="danger"
+          title="We couldn't save that mapping"
+          description={
+            updateMappings.error?.message ||
+            'Something went wrong. Please try again.'
+          }
+        />
+      ) : null}
+      <ProductMappingTable
+        items={visible}
+        saving={updateMappings.isPending}
+        onChange={onChange}
+      />
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingRow.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Text,
+} from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import {
+  CREATE_NEW_VALUE,
+  mappingSelectValue,
+  type ProductMappingItem,
+} from './productMapping'
+
+export function ProductMappingRow({
+  item,
+  onChange,
+  saving,
+}: {
+  item: ProductMappingItem
+  onChange: (value: string) => void
+  saving?: boolean
+}) {
+  const locked = item.import_status !== 'pending'
+  const value = mappingSelectValue(item)
+  const candidates = item.candidates.filter((candidate) => candidate.compatible)
+
+  return (
+    <Box flexDirection="column" rowGap="xs" minWidth={0} width="100%">
+      <Select
+        value={value || undefined}
+        onValueChange={onChange}
+        disabled={locked || saving}
+      >
+        <SelectTrigger className="h-8 min-h-8 w-full min-w-0 py-0">
+          <SelectValue placeholder="Polar product" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={CREATE_NEW_VALUE}>
+            Create a new Polar product
+          </SelectItem>
+          {candidates.map((candidate) => (
+            <SelectItem key={candidate.id} value={candidate.id}>
+              {candidate.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {item.requires_choice ? (
+        <Text variant="caption" color="warning">
+          A Polar product already uses this name, but the billing interval
+          doesn&apos;t match. Map it, or create a new product before preparing.
+        </Text>
+      ) : null}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ProductMappingTable.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { Grid, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import type { ReactNode } from 'react'
+import { ProductMappingRow } from './ProductMappingRow'
+import {
+  formatMappingAmount,
+  formatMappingInterval,
+  type ProductMappingItem,
+} from './productMapping'
+
+const COLUMNS =
+  'minmax(0, 7.5rem) minmax(7rem, max-content) minmax(5.5rem, max-content) minmax(3.75rem, max-content) minmax(0, 1fr)'
+
+export function ProductMappingTable({
+  items,
+  saving,
+  onChange,
+}: {
+  items: ProductMappingItem[]
+  saving?: boolean
+  onChange: (sourceId: string, value: string) => void
+}) {
+  return (
+    <Grid
+      templateColumns={COLUMNS}
+      columnGap="xl"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+      borderRadius="l"
+      overflow="hidden"
+    >
+      <MappingGridRow header>
+        <Text variant="caption" color="muted">
+          Stripe product
+        </Text>
+        <Text variant="caption" color="muted">
+          Interval
+        </Text>
+        <Text variant="caption" color="muted">
+          Price
+        </Text>
+        <Text variant="caption" color="muted">
+          Subs
+        </Text>
+        <Text variant="caption" color="muted">
+          Polar product
+        </Text>
+      </MappingGridRow>
+      {items.map((item) => (
+        <ProductMappingTableRow
+          key={item.source_id}
+          item={item}
+          saving={saving}
+          onChange={onChange}
+        />
+      ))}
+    </Grid>
+  )
+}
+
+function MappingGridRow({
+  children,
+  header = false,
+}: {
+  children: ReactNode
+  header?: boolean
+}) {
+  return (
+    <Box
+      display="grid"
+      gridTemplateColumns="subgrid"
+      gridColumn="1 / -1"
+      alignItems="center"
+      paddingHorizontal="m"
+      paddingVertical="s"
+      backgroundColor={header ? 'background-secondary' : undefined}
+      borderTopWidth={header ? 0 : 1}
+      borderStyle="solid"
+      borderColor="border-primary"
+    >
+      {children}
+    </Box>
+  )
+}
+
+function ProductMappingTableRow({
+  item,
+  saving,
+  onChange,
+}: {
+  item: ProductMappingItem
+  saving?: boolean
+  onChange: (sourceId: string, value: string) => void
+}) {
+  return (
+    <MappingGridRow>
+      <Box minWidth={0}>
+        <Text variant="caption" truncate>
+          {item.name}
+        </Text>
+      </Box>
+      <Text variant="caption" color="muted">
+        {formatMappingInterval(
+          item.recurring_interval,
+          item.recurring_interval_count,
+        )}
+      </Text>
+      <Text variant="caption" monospace tabularNums>
+        {formatMappingAmount(item.prices)}
+      </Text>
+      <Text variant="caption" tabularNums>
+        {item.subscriber_count}
+      </Text>
+      <Box minWidth={0} width="100%">
+        <ProductMappingRow
+          item={item}
+          saving={saving}
+          onChange={(value) => onChange(item.source_id, value)}
+        />
+      </Box>
+    </MappingGridRow>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -6,11 +6,13 @@ import {
   useImportMerchantMigrationCatalog,
   useMerchantMigration,
   useMigrationRecords,
+  useProductMappings,
   useRunMerchantMigrationPrecheck,
 } from '@/hooks/queries/merchantMigrations'
 import { Alert, Spinner } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { ProductMappingPanel } from './ProductMappingPanel'
 import { useRecordSummary } from './recordSummary'
 import {
   selectionPayload,
@@ -22,6 +24,7 @@ import {
 } from '../selection'
 import { ReviewFilter } from './ReviewStatusTabs'
 import { ReviewTableView } from './ReviewTableView'
+import { mappingRequiresChoice } from './productMapping'
 
 export function ReviewTable({ migrationId }: { migrationId: string }) {
   const [filter, setFilter] = useState<ReviewFilter>('all')
@@ -67,6 +70,7 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
   } = useRecordSummary(migrationId, pollMs)
   const importCatalog = useImportMerchantMigrationCatalog(migrationId)
   const rerunPrecheck = useRunMerchantMigrationPrecheck(migrationId)
+  const productMappings = useProductMappings(migrationId)
   const wasRefreshing = useRef(false)
 
   useEffect(() => {
@@ -106,7 +110,7 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
         "We couldn't refresh from Stripe. Please try again."
       : undefined
 
-  if (records.isLoading || countsLoading) {
+  if (records.isLoading || countsLoading || productMappings.isLoading) {
     return (
       <Box padding="2xl" alignItems="center" justifyContent="center">
         <Spinner />
@@ -114,7 +118,7 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
     )
   }
 
-  if (records.isError || countsError) {
+  if (records.isError || countsError || productMappings.isError) {
     return (
       <Alert
         variant="danger"
@@ -157,6 +161,8 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
       onRerunPrecheck={() => rerunPrecheck.mutate()}
       rerunning={refreshing || rerunPrecheck.isPending}
       refreshError={refreshError}
+      prepareBlocked={mappingRequiresChoice(productMappings.data?.items ?? [])}
+      header={<ProductMappingPanel migrationId={migrationId} />}
     />
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -3,7 +3,7 @@
 import { Alert, Button, DataTable, InlineModal, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { OnChangeFn, PaginationState } from '@tanstack/react-table'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import { CatalogEmptyPanel } from './CatalogEmptyPanel'
 import { ReviewRecordModal } from './ReviewRecordModal'
 import {
@@ -48,6 +48,8 @@ interface Props {
   rerunning?: boolean
   refreshError?: string
   attentionCount: number
+  prepareBlocked?: boolean
+  header?: ReactNode
 }
 
 export function ReviewTableView({
@@ -71,6 +73,8 @@ export function ReviewTableView({
   rerunning = false,
   refreshError,
   attentionCount,
+  prepareBlocked = false,
+  header,
 }: Props) {
   const rowTotal = remainingSubscriptionCount(
     counts.subscriptions.total,
@@ -96,11 +100,8 @@ export function ReviewTableView({
     () =>
       buildReviewColumns({
         isSelected: (id) => isRowSelected(selection, id),
-        // The opt-out default reads as "all" even when no row can be picked,
-        // which would show as ticked-but-disabled.
         headerState:
           selectableTotal > 0 ? headerCheckState(selection) : 'unchecked',
-        // It flips every subscription, not this page, so gate it on the same scope.
         canSelectAll: selectableTotal > 0,
         onToggle,
         onToggleAll,
@@ -112,7 +113,6 @@ export function ReviewTableView({
   const onPaginationChange: OnChangeFn<PaginationState> = (updater) => {
     const next = typeof updater === 'function' ? updater(pagination) : updater
     if (next.pageSize !== pageSize) {
-      // Resets to the first page, so don't put the old one back.
       onPageSizeChange(next.pageSize)
       return
     }
@@ -145,8 +145,25 @@ export function ReviewTableView({
           description={importError}
         />
       )}
+      {prepareBlocked && (
+        <Alert
+          variant="warning"
+          title="Map existing Polar products first"
+          description="A Stripe product shares a name with a Polar product whose billing interval doesn't match. Choose a mapping or create a new product before preparing."
+        />
+      )}
+      {header}
 
-      <Box flexDirection="column" rowGap="m">
+      <Box flexDirection="column" rowGap="s">
+        <Box flexDirection="column" rowGap="xs">
+          <Text variant="heading-xs" as="h3">
+            Subscriptions
+          </Text>
+          <Text variant="caption" color="muted">
+            Preparing a subscription brings its customer and product to Polar.
+            Polar starts billing only when you switch.
+          </Text>
+        </Box>
         <Box
           alignItems="center"
           justifyContent="between"
@@ -182,18 +199,13 @@ export function ReviewTableView({
               <Button
                 size="sm"
                 onClick={onImport}
-                disabled={importing || importCount <= 0}
+                disabled={importing || importCount <= 0 || prepareBlocked}
               >
                 {prepareLabel}
               </Button>
             ) : null}
           </Box>
         </Box>
-
-        <Text variant="caption" color="muted">
-          Preparing a subscription brings its customer and product to Polar.
-          Polar starts billing only when you switch.
-        </Text>
 
         {rows.length === 0 ? (
           <Box

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/productMapping.ts
@@ -1,0 +1,80 @@
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+
+export type ProductMappingItem = schemas['MerchantMigrationProductMappingItem']
+export type ProductMappingChoice =
+  schemas['MerchantMigrationProductMappingChoice']
+
+export const CREATE_NEW_VALUE = 'create_new'
+
+const formatAmount = formatCurrency('accounting', 'en-US')
+
+const INTERVAL_LABEL: Record<string, [string, string]> = {
+  day: ['Daily', 'days'],
+  week: ['Weekly', 'weeks'],
+  month: ['Monthly', 'months'],
+  year: ['Yearly', 'years'],
+}
+
+export function mappingSelectValue(item: ProductMappingItem): string {
+  if (item.create_new) return CREATE_NEW_VALUE
+  if (item.polar_product_id) return item.polar_product_id
+  if (item.suggested_product_id) return item.suggested_product_id
+  if (!item.requires_choice) return CREATE_NEW_VALUE
+  return ''
+}
+
+export function visibleMappingItems(
+  items: ProductMappingItem[],
+): ProductMappingItem[] {
+  const hasCatalog = items.some((item) => item.candidates.length > 0)
+  if (!hasCatalog) {
+    return []
+  }
+  return items.filter((item) => item.subscriber_count > 0)
+}
+
+export function mappingChoice(
+  sourceId: string,
+  value: string,
+): ProductMappingChoice {
+  return {
+    source_id: sourceId,
+    polar_product_id: value === CREATE_NEW_VALUE || value === '' ? null : value,
+  }
+}
+
+export function mappingRequiresChoice(items: ProductMappingItem[]): boolean {
+  return items.some(
+    (item) =>
+      item.requires_choice &&
+      item.import_status === 'pending' &&
+      item.subscriber_count > 0,
+  )
+}
+
+export function formatMappingAmount(
+  prices: ProductMappingItem['prices'],
+): string {
+  if (prices.length === 0) {
+    return '—'
+  }
+  return prices
+    .map((price) => formatAmount(price.amount, price.currency))
+    .join(', ')
+}
+
+export function formatMappingInterval(
+  interval: string | null,
+  count: number,
+): string {
+  if (!interval) {
+    return '—'
+  }
+  const labels = INTERVAL_LABEL[interval]
+  if (!labels) {
+    return interval
+  }
+  const [once, plural] = labels
+  return count <= 1 ? once : `Every ${count} ${plural}`
+}

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -64,6 +64,9 @@ export const invalidateMigrationRecords = (id: string) => {
   client.invalidateQueries({
     queryKey: ['merchantMigrationRecordSummary', { id }],
   })
+  client.invalidateQueries({
+    queryKey: ['merchantMigrationProductMappings', { id }],
+  })
 }
 
 export const useRunMerchantMigrationPrecheck = (id: string) =>
@@ -299,4 +302,37 @@ export const useMerchantMigrationRecordSummary = (
     retry: defaultRetry,
     enabled: !!id,
     refetchInterval: refetchInterval ?? false,
+  })
+
+const productMappingsKey = (id: string) => [
+  'merchantMigrationProductMappings',
+  { id },
+]
+
+export const useProductMappings = (id: string) =>
+  useQuery({
+    queryKey: productMappingsKey(id),
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/merchant-migrations/{id}/product-mappings', {
+          params: { path: { id } },
+        }),
+      ),
+    retry: defaultRetry,
+    enabled: !!id,
+  })
+
+export const useUpdateProductMappings = (id: string) =>
+  useMutation({
+    mutationFn: (mappings: schemas['MerchantMigrationProductMappingChoice'][]) =>
+      dataOrThrow(
+        api.PUT('/v1/merchant-migrations/{id}/product-mappings', {
+          params: { path: { id } },
+          body: { mappings },
+        }),
+        "We couldn't save that mapping.",
+      ),
+    onSuccess: (listing) => {
+      getQueryClient().setQueryData(productMappingsKey(id), listing)
+    },
   })

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -324,7 +324,9 @@ export const useProductMappings = (id: string) =>
 
 export const useUpdateProductMappings = (id: string) =>
   useMutation({
-    mutationFn: (mappings: schemas['MerchantMigrationProductMappingChoice'][]) =>
+    mutationFn: (
+      mappings: schemas['MerchantMigrationProductMappingChoice'][],
+    ) =>
       dataOrThrow(
         api.PUT('/v1/merchant-migrations/{id}/product-mappings', {
           params: { path: { id } },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Related Issue**: [PLR-116](https://linear.app/polarsh/issue/PLR-116/allow-to-assign-existing-products-when-importing)

Dashboard UI for mapping Stripe products onto existing Polar products during merchant catalog review.

**Depends on** https://github.com/polarsource/polar/pull/14323 — retarget to `main` after that merges.

## What

- Product configuration table on catalog review: Stripe product, interval, price, subscriber count, Polar product select.
- Auto-suggest / create-new / requires-choice from the mappings API. PUT on change.
- All mapping rows visible (no pager). Subscriptions DataTable keeps its own pagination.
- Prepare is blocked until name-collision rows have an explicit mapping.

## Why

The mapping API is useless without a place to choose Polar products before Prepare. Empty for greenfield merchants (panel hidden when Polar has no catalog).

## How

`ProductMappingPanel` loads `GET .../product-mappings` and saves via `PUT`. Compatible Polar candidates only in the select. Imported subscribers keep the Stripe amount when Polar's catalog has moved on.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d72bd2a-24dd-46d4-8402-780b3e7e6c64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d72bd2a-24dd-46d4-8402-780b3e7e6c64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

