### PR TITLE
perf: composite (user_id, created_at) index on notifications to fix /v1/notifications timeouts

### DIFF
--- a/server/migrations/versions/2026-09-09-1030_add_composite_index_on_notifications_.py
+++ b/server/migrations/versions/2026-09-09-1030_add_composite_index_on_notifications_.py
@@ -21,12 +21,6 @@ USER_ID_INDEX = "ix_notifications_user_id"
 
 
 def upgrade() -> None:
-    # GET /v1/notifications runs `WHERE user_id = ? ORDER BY created_at DESC LIMIT ?`.
-    # With only single-column indexes the planner scans ix_notifications_created_at
-    # backwards and filters by user_id, which degrades badly for users with many
-    # notifications. This composite lets the query jump straight to the user's rows
-    # already ordered by created_at (Postgres scans a plain btree backwards for the
-    # DESC LIMIT). Built CONCURRENTLY to avoid locking the table.
     with op.get_context().autocommit_block():
         # Drop any INVALID leftover from an interrupted concurrent build first.
         op.drop_index(

--- a/server/migrations/versions/2026-09-09-1030_add_composite_index_on_notifications_.py
+++ b/server/migrations/versions/2026-09-09-1030_add_composite_index_on_notifications_.py
@@ -1,0 +1,75 @@
+"""add composite index on notifications user_id created_at
+
+Revision ID: a0bc64d272f1
+Revises: f9cabfdff143
+Create Date: 2026-09-09 10:30:00.000000
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "a0bc64d272f1"
+down_revision = "f9cabfdff143"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+COMPOSITE_INDEX = "ix_notifications_user_id_created_at"
+USER_ID_INDEX = "ix_notifications_user_id"
+
+
+def upgrade() -> None:
+    # GET /v1/notifications runs `WHERE user_id = ? ORDER BY created_at DESC LIMIT ?`.
+    # With only single-column indexes the planner scans ix_notifications_created_at
+    # backwards and filters by user_id, which degrades badly for users with many
+    # notifications. This composite lets the query jump straight to the user's rows
+    # already ordered by created_at (Postgres scans a plain btree backwards for the
+    # DESC LIMIT). Built CONCURRENTLY to avoid locking the table.
+    with op.get_context().autocommit_block():
+        # Drop any INVALID leftover from an interrupted concurrent build first.
+        op.drop_index(
+            COMPOSITE_INDEX,
+            table_name="notifications",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            COMPOSITE_INDEX,
+            "notifications",
+            ["user_id", "created_at"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        # The composite covers `user_id = ?` lookups too, so the single-column index
+        # is now redundant; drop it to avoid the dead-index write overhead.
+        op.drop_index(
+            USER_ID_INDEX,
+            table_name="notifications",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            USER_ID_INDEX,
+            table_name="notifications",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            USER_ID_INDEX,
+            "notifications",
+            ["user_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            COMPOSITE_INDEX,
+            table_name="notifications",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )

--- a/server/polar/models/notification.py
+++ b/server/polar/models/notification.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, String, Uuid
+from sqlalchemy import ForeignKey, Index, String, Uuid
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -14,9 +14,12 @@ if TYPE_CHECKING:
 
 class Notification(RecordModel):
     __tablename__ = "notifications"
+    __table_args__ = (
+        Index("ix_notifications_user_id_created_at", "user_id", "created_at"),
+    )
 
     user_id: Mapped[UUID] = mapped_column(
-        Uuid, ForeignKey("users.id", ondelete="cascade"), nullable=False, index=True
+        Uuid, ForeignKey("users.id", ondelete="cascade"), nullable=False
     )
     type: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[JSONDict] = mapped_column(JSONB, nullable=False, default=dict)


### PR DESCRIPTION
Was poking Logfire for something else and Claude noticed that `/v1/notifications` is often slow or timing out, and this was an easy fix.

LLM generated PR description:

## Problem

`GET /v1/notifications` lists a user's notifications, running roughly:

```sql
SELECT ... FROM notifications WHERE user_id = $1 ORDER BY created_at DESC LIMIT $2
```

The `notifications` table only has single-column indexes (`user_id`, `created_at`, `deleted_at`, plus the PK). There is no composite `(user_id, created_at)` index.

Confirmed via production `EXPLAIN ANALYZE`: because the query is `ORDER BY created_at DESC LIMIT n`, the planner walks `ix_notifications_created_at` backwards (it's already in the right order) and filters by `user_id` row-by-row. For users with many notifications it has to scan through a large number of other users' rows before it collects enough matching rows, and this degrades badly as the table grows — bad enough to exceed asyncpg's command timeout, so the request errors out with a 500. This produces a steady stream of user-facing 500s that gets worse over time.

## Fix

Add a composite btree index on `notifications (user_id, created_at)`. This lets the query jump straight to the user's rows, already ordered by `created_at`, and read only the `LIMIT n` rows it needs — fast regardless of table size. A plain btree `(user_id, created_at)` already serves `ORDER BY created_at DESC LIMIT` efficiently (Postgres scans it backwards), so no descending column is needed.

The existing single-column `ix_notifications_user_id` becomes redundant — a leading-column `(user_id, created_at)` composite serves `user_id = ?` lookups too — so this drops it in the same migration to avoid carrying a dead index and its write overhead. Grepped the codebase: nothing references that index name outside the migrations, so nothing relies on it by name.

## Deploy safety

- The index is built with `CREATE INDEX CONCURRENTLY` inside an `autocommit_block()`, and the redundant index is dropped `CONCURRENTLY` too, so the migration doesn't take a blocking lock on the table.
- Interrupted-build cleanup (`DROP INDEX ... IF EXISTS` before the create) matches the repo's existing concurrent-index migrations.
- `downgrade` reverses both, recreating the single-column index and dropping the composite, all concurrent.
- Kept as its own standalone migration per the repo's ship-safety conventions.

The `Notification` model is updated to declare the composite index in `__table_args__` and drop `index=True` from `user_id`, so the model and migration agree.

## Verification note

Static checks (ruff + mypy on the changed files) pass. The migration was **not** run against a database locally: the shared dev database is currently occupied by another in-flight migration from a separate open PR, so a local `alembic upgrade` there isn't possible. DB verification (upgrade/downgrade round-trip, `alembic check`) is therefore pending CI/review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

