### PR TITLE
webhooks: Dont re-enqueue task if event doesnt exist

### DIFF
--- a/server/polar/webhook/tasks.py
+++ b/server/polar/webhook/tasks.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 import httpx
 import idna
+import sentry_sdk
 import structlog
 from apscheduler.triggers.cron import CronTrigger
 from dramatiq import Retry
@@ -79,7 +80,10 @@ async def _webhook_event_send(
         webhook_event_id, options=repository.get_eager_options()
     )
     if event is None:
-        raise Exception(f"webhook event not found id={webhook_event_id}")
+        sentry_sdk.capture_exception(
+            Exception(f"webhook event not found id={webhook_event_id}")
+        )
+        return
 
     bound_log = log.bind(
         id=webhook_event_id,

--- a/server/tests/webhooks/test_tasks.py
+++ b/server/tests/webhooks/test_tasks.py
@@ -50,6 +50,9 @@ class TestWebhookEventSend:
         await session.refresh(event)
         assert event.succeeded is None
 
+    async def test_missing_event_skips_send(self, session: AsyncSession) -> None:
+        await _webhook_event_send(session, webhook_event_id=uuid.uuid4())
+
 
 @pytest.mark.asyncio
 class TestOnEventFailed:


### PR DESCRIPTION
Otherwise we continue retrying forever and ever


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

