### PR TITLE
Index members on (organization_id, lower(email))

### DIFF
--- a/server/migrations/versions/2026-09-10-1302_index_members_on_organization_id_lower_.py
+++ b/server/migrations/versions/2026-09-10-1302_index_members_on_organization_id_lower_.py
@@ -1,0 +1,69 @@
+"""index members on organization_id lower(email), drop redundant case-sensitive index
+
+Revision ID: 382c4661fdb2
+Revises: a0bc64d272f1
+Create Date: 2026-09-10 13:02:04.903463
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "382c4661fdb2"
+down_revision = "a0bc64d272f1"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+NEW_INDEX_NAME = "ix_members_organization_id_lower_email_active"
+REDUNDANT_INDEX_NAME = "members_customer_id_email_active_key"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Support customer-portal lookups by organization + case-insensitive
+        # email. Existing indexes are all customer_id-leading, so a query
+        # filtering on (organization_id, lower(email)) can't use them and falls
+        # back to scanning every active member in the org.
+        # Drop any INVALID leftover from an interrupted concurrent build first.
+        op.drop_index(
+            NEW_INDEX_NAME,
+            table_name="members",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.create_index(
+            NEW_INDEX_NAME,
+            "members",
+            ["organization_id", sa.text("lower(email)")],
+            unique=False,
+            postgresql_where=sa.text("deleted_at IS NULL"),
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        # Drop the redundant case-sensitive (customer_id, email) unique index.
+        # It only exists on databases predating the June 2026 squash (the squash
+        # creates only the case-insensitive variant), and the case-insensitive
+        # unique index enforces a strictly stronger constraint. if_exists keeps
+        # this a no-op on databases that never had it.
+        op.drop_index(
+            REDUNDANT_INDEX_NAME,
+            table_name="members",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            NEW_INDEX_NAME,
+            table_name="members",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        # The case-sensitive index was a legacy, prod-only artifact not
+        # represented in the schema, so it is intentionally not recreated here.

--- a/server/polar/models/member.py
+++ b/server/polar/models/member.py
@@ -44,6 +44,15 @@ class Member(RecordModel):
             unique=True,
             postgresql_where=text("deleted_at IS NULL AND role = 'owner'"),
         ),
+        # Lookup by organization + case-insensitive email (customer portal email
+        # disambiguation). Non-unique: the same email can belong to multiple
+        # customers within an organization.
+        Index(
+            "ix_members_organization_id_lower_email_active",
+            "organization_id",
+            func.lower(Column("email")),
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
     )
 
     customer_id: Mapped[UUID] = mapped_column(


### PR DESCRIPTION
## Summary

Fixes a persistent latency problem on `POST /v1/customer-portal/customer-session/request` (steady p95 **3–9s** in Logfire over the last 24h, load-independent).

All the endpoint's time is one `SELECT` — `MemberRepository.list_by_email_and_organization` — which filters on `organization_id + lower(email)` and **never** on `customer_id`. Every existing `members` index is `customer_id`-leading, so none apply; Postgres falls back to the `ix_members_organization_id` btree and post-filters `lower(email)` across every active member in the org.

## Changes

- **Add** a non-unique partial index `ix_members_organization_id_lower_email_active` on `(organization_id, lower(email)) WHERE deleted_at IS NULL`. Non-unique on purpose — the same email can be a member of multiple customers within one org (exactly the disambiguation case this query serves).
- **Drop** the redundant case-sensitive `members_customer_id_email_active_key` index:
  - It exists **only on databases predating the June 2026 squash** (the squash creates just the case-insensitive variant).
  - Every `Member` email query uses `func.lower(...)`, so nothing reads it.
  - The case-insensitive unique index `members_customer_id_email_case_insensitive_active_key` enforces a strictly stronger constraint.
  - Guarded with `IF EXISTS` → no-op on fresh/test/sandbox DBs that never had it.

## Testing

- Migration SQL verified via offline `alembic upgrade … --sql`:
  ```sql
  DROP INDEX CONCURRENTLY IF EXISTS ix_members_organization_id_lower_email_active;
  CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_members_organization_id_lower_email_active
      ON members (organization_id, lower(email)) WHERE deleted_at IS NULL;
  DROP INDEX CONCURRENTLY IF EXISTS members_customer_id_email_active_key;
  ```
- `ruff` passes on both changed files.
- Could not run `alembic upgrade` end-to-end locally: the shared dev DB is stamped at a revision from another branch/worktree (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

