### PR TITLE
fix(merchant-migration): allow same org to reuse a Stripe account

### DIFF
--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -61,7 +61,9 @@ class MerchantMigrationRepository(
             self.session, "merchant_migration.stripe_account", stripe_account_id
         )
 
-    async def stripe_account_id_exists(self, stripe_account_id: str) -> bool:
+    async def stripe_account_id_exists(
+        self, stripe_account_id: str, *, exclude_organization_id: UUID
+    ) -> bool:
         statement = select(
             self.get_base_statement()
             .where(
@@ -69,6 +71,7 @@ class MerchantMigrationRepository(
                 == MerchantMigrationSourcePlatform.stripe,
                 MerchantMigration.source_credentials["stripe_user_id"].astext
                 == stripe_account_id,
+                MerchantMigration.organization_id != exclude_organization_id,
             )
             .exists()
         )

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -198,7 +198,8 @@ class SourceVerificationUnavailable(MerchantMigrationError):
 class SourceAccountAlreadyMigrated(MerchantMigrationError):
     def __init__(self) -> None:
         super().__init__(
-            "This Stripe account is already used by another merchant migration.",
+            "This Stripe account is already used by another organization's "
+            "merchant migration.",
             409,
         )
 
@@ -448,7 +449,10 @@ class MerchantMigrationService:
         if stripe_account_id is None:
             raise SourceVerificationUnavailable()
         await repository.lock_stripe_account(stripe_account_id)
-        if await repository.stripe_account_id_exists(stripe_account_id):
+        if await repository.stripe_account_id_exists(
+            stripe_account_id,
+            exclude_organization_id=create_schema.organization_id,
+        ):
             raise SourceAccountAlreadyMigrated()
         return await repository.create(migration, flush=True)
 

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -248,7 +248,32 @@ class TestCreate:
         )
 
         assert response.status_code == 409
-        assert "already used by another merchant migration" in response.text
+        assert (
+            "already used by another organization's merchant migration"
+            in response.text
+        )
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_same_organization_can_reuse_stripe_account(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        await _enable_feature(save_fixture, organization)
+        existing = await build_connected_migration(save_fixture, organization)
+        _mock_stripe_adapter(mocker)
+
+        response = await client.post(
+            "/v1/merchant-migrations/", json=_body(organization)
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["id"] != str(existing.id)
+        assert body["source"]["stripe_user_id"] == "acct_test"
 
 
 @pytest.mark.asyncio

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -249,8 +249,7 @@ class TestCreate:
 
         assert response.status_code == 409
         assert (
-            "already used by another organization's merchant migration"
-            in response.text
+            "already used by another organization's merchant migration" in response.text
         )
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -251,6 +251,30 @@ class TestCreate:
         await assert_no_migrations(session, organization)
 
     @pytest.mark.auth
+    async def test_allows_stripe_account_from_same_organization_migration(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _enable_feature(save_fixture, organization)
+        existing = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(account_id="acct_test"),
+        )
+
+        migration = await service.create(
+            session, auth_subject, _create_schema(organization)
+        )
+
+        assert migration.id != existing.id
+        assert migration.source_credentials["stripe_user_id"] == "acct_test"
+
+    @pytest.mark.auth
     async def test_allows_stripe_account_from_soft_deleted_migration(
         self,
         mocker: MockerFixture,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Connecting a Stripe source for a **second migration on the same organization** no longer fails with "This Stripe account is already used by another merchant migration."

That uniqueness check still applies across organizations: another merchant cannot claim a Stripe account that already has a Polar migration.

## What

- Scope `stripe_account_id_exists` to migrations on **other** organizations.
- Keep the global advisory lock so two organizations cannot race to claim the same Stripe account.
- Allow a follow-up migration on the same org (pilot / single run, then full rollout).
- Clarify the 409 error copy so it names the other-organization case.

## Why

Merchant migration already keys the catalog ledger per organization, so a later run can reuse products and customers imported by an earlier one. The Stripe-account uniqueness check was global, which blocked that same-org rollout path.

## How

When creating a migration, look up existing Stripe `stripe_user_id` values excluding the current `organization_id`. Same-org reuse succeeds; a different org still gets `SourceAccountAlreadyMigrated` (409).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d45c24c-09ae-4337-9e9a-d36ed6bede6b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d45c24c-09ae-4337-9e9a-d36ed6bede6b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

