### PR TITLE
Fix N+1 product load in subscription charge-preview

### DIFF
--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -15,7 +15,7 @@ from polar.kit.math import non_negative_running_sum
 from polar.kit.utils import utc_now
 from polar.meter.aggregation import AggregationFunction
 from polar.meter.service import meter as meter_service
-from polar.models import BillingEntry, Event, OrderItem, Subscription
+from polar.models import BillingEntry, Event, OrderItem, Product, Subscription
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
 from polar.models.event import EventSource
 from polar.postgres import AsyncSession
@@ -170,6 +170,7 @@ class BillingEntryService:
         cutoff = cutoff or utc_now()
         repository = BillingEntryRepository.from_session(session)
 
+        products: dict[uuid.UUID, Product] = {}
         async for entry in repository.get_static_pending_by_subscription(
             subscription.id, cutoff=cutoff
         ):
@@ -180,6 +181,7 @@ class BillingEntryService:
                 entry,
                 seats=subscription.seats,
                 units=subscription.units,
+                products=products,
             )
             yield static_line_item, [entry.id]
 
@@ -306,13 +308,17 @@ class BillingEntryService:
         *,
         seats: int | None,
         units: int | None = None,
+        products: dict[uuid.UUID, Product],
     ) -> StaticLineItem:
         assert entry.amount is not None
         assert entry.currency is not None
 
-        product_repository = ProductRepository.from_session(session)
-        product = await product_repository.get_by_id(price.product_id)
-        assert product is not None
+        product = products.get(price.product_id)
+        if product is None:
+            product_repository = ProductRepository.from_session(session)
+            product = await product_repository.get_by_id(price.product_id)
+            assert product is not None
+            products[price.product_id] = product
 
         start = format_date(entry.start_timestamp.date(), locale="en_US")
         end = format_date(entry.end_timestamp.date(), locale="en_US")

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -39,7 +39,6 @@ from polar.product.guard import (
     is_metered_price,
     is_seat_price,
 )
-from polar.product.repository import ProductRepository
 from polar.product.tiers import Tiers, TierType
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -1078,53 +1077,6 @@ class TestCreateOrderItemsFromPending:
 
         await session.refresh(entries[2])
         assert entries[2].order_item_id == order_item_2.id
-
-    async def test_static_entries_load_product_once_per_computation(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        mocker: MockerFixture,
-        customer: Customer,
-        product: Product,
-    ) -> None:
-        subscription = await create_active_subscription(
-            save_fixture, product=product, customer=customer
-        )
-        price = product.prices[0]
-        assert is_fixed_price(price)
-
-        entries = [
-            await create_static_price_billing_entry(
-                save_fixture,
-                type=BillingEntryType.proration,
-                customer=customer,
-                price=price,
-                subscription=subscription,
-                pending=True,
-            )
-            for _ in range(5)
-        ]
-        for index, entry in enumerate(entries):
-            entry.start_timestamp -= timedelta(days=index + 1)
-            await save_fixture(entry)
-
-        get_by_id_spy = mocker.spy(ProductRepository, "get_by_id")
-
-        async with billing_entry_service.create_order_items_from_pending(
-            session, subscription
-        ) as order_items:
-            # Every entry shares the same product, so it is loaded exactly once
-            # regardless of how many static entries are prorated.
-            assert get_by_id_spy.call_count == 1
-            assert len(order_items) == len(entries)
-            for order_item in order_items:
-                assert product.name in order_item.label
-
-            await create_order(
-                save_fixture,
-                customer=customer,
-                order_items=list(order_items),
-            )
 
     async def test_static_entry_created_after_cutoff_is_included(
         self,

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -39,6 +39,7 @@ from polar.product.guard import (
     is_metered_price,
     is_seat_price,
 )
+from polar.product.repository import ProductRepository
 from polar.product.tiers import Tiers, TierType
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -1077,6 +1078,53 @@ class TestCreateOrderItemsFromPending:
 
         await session.refresh(entries[2])
         assert entries[2].order_item_id == order_item_2.id
+
+    async def test_static_entries_load_product_once_per_computation(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        mocker: MockerFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        price = product.prices[0]
+        assert is_fixed_price(price)
+
+        entries = [
+            await create_static_price_billing_entry(
+                save_fixture,
+                type=BillingEntryType.proration,
+                customer=customer,
+                price=price,
+                subscription=subscription,
+                pending=True,
+            )
+            for _ in range(5)
+        ]
+        for index, entry in enumerate(entries):
+            entry.start_timestamp -= timedelta(days=index + 1)
+            await save_fixture(entry)
+
+        get_by_id_spy = mocker.spy(ProductRepository, "get_by_id")
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, subscription
+        ) as order_items:
+            # Every entry shares the same product, so it is loaded exactly once
+            # regardless of how many static entries are prorated.
+            assert get_by_id_spy.call_count == 1
+            assert len(order_items) == len(entries)
+            for order_item in order_items:
+                assert product.name in order_item.label
+
+            await create_order(
+                save_fixture,
+                customer=customer,
+                order_items=list(order_items),
+            )
 
     async def test_static_entry_created_after_cutoff_is_included(
         self,


### PR DESCRIPTION
## The bug

`GET /v1/customer-portal/subscriptions/{id}/charge-preview` (and the dashboard equivalent) spent seconds re-loading the same product hundreds of times.

`compute_pending_subscription_line_items` iterates every static pending billing entry and calls `_get_static_price_line_item`, which did:

```python
product_repository = ProductRepository.from_session(session)
product = await product_repository.get_by_id(price.product_id)
```

once **per entry**. A subscription with N pending proration entries issued N product loads that almost all resolve to the *same* one or two products. The product is only read for `product.name` and `OrderItem.format_price_label(...)`.

## The fix

Memoize the product lookup in a per-computation `dict[UUID, Product]`, created in `compute_pending_subscription_line_items` and threaded into `_get_static_price_line_item`. Each distinct `product_id` is now fetched at most once per computation. The cache is request/computation-scoped (not a module-level global), so there is no cross-request/org correctness risk.

This path is shared with the **real** cycle-order / invoice generation (`order.service.build_subscription_order` also calls `compute_pending_subscription_line_items`), so it speeds those up too. Behavior is identical — same line items, labels and amounts, just fewer queries.

## Test

Added `test_static_entries_load_product_once_per_computation` in `tests/billing_entry/test_service.py`: creates a subscription with several static pending proration entries on the same product, spies on `ProductRepository.get_by_id`, and asserts it is called exactly once while the resulting line items are unchanged.

## Verification

- `uv run task lint` — passed
- `uv run task lint_types` — passed (no issues in 1648 files)
- `POLAR_ENV=testing uv run python -m pytest tests/billing_entry/ tests/subscription/` — 452 subscription + 18 billing_entry tests pass, including the new one and the charge-preview service tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

