### PR TITLE
fix(merchant-migration): allow same org to reuse a Stripe account

### DIFF
--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -61,7 +61,9 @@ class MerchantMigrationRepository(
             self.session, "merchant_migration.stripe_account", stripe_account_id
         )
 
-    async def stripe_account_id_exists(self, stripe_account_id: str) -> bool:
+    async def stripe_account_id_exists(
+        self, stripe_account_id: str, *, exclude_organization_id: UUID
+    ) -> bool:
         statement = select(
             self.get_base_statement()
             .where(
@@ -69,6 +71,7 @@ class MerchantMigrationRepository(
                 == MerchantMigrationSourcePlatform.stripe,
                 MerchantMigration.source_credentials["stripe_user_id"].astext
                 == stripe_account_id,
+                MerchantMigration.organization_id != exclude_organization_id,
             )
             .exists()
         )

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -198,7 +198,8 @@ class SourceVerificationUnavailable(MerchantMigrationError):
 class SourceAccountAlreadyMigrated(MerchantMigrationError):
     def __init__(self) -> None:
         super().__init__(
-            "This Stripe account is already used by another merchant migration.",
+            "This Stripe account is already used by another organization's "
+            "merchant migration.",
             409,
         )
 
@@ -448,7 +449,10 @@ class MerchantMigrationService:
         if stripe_account_id is None:
             raise SourceVerificationUnavailable()
         await repository.lock_stripe_account(stripe_account_id)
-        if await repository.stripe_account_id_exists(stripe_account_id):
+        if await repository.stripe_account_id_exists(
+            stripe_account_id,
+            exclude_organization_id=create_schema.organization_id,
+        ):
             raise SourceAccountAlreadyMigrated()
         return await repository.create(migration, flush=True)
 

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -248,7 +248,32 @@ class TestCreate:
         )
 
         assert response.status_code == 409
-        assert "already used by another merchant migration" in response.text
+        assert (
+            "already used by another organization's merchant migration"
+            in response.text
+        )
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_same_organization_can_reuse_stripe_account(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        await _enable_feature(save_fixture, organization)
+        existing = await build_connected_migration(save_fixture, organization)
+        _mock_stripe_adapter(mocker)
+
+        response = await client.post(
+            "/v1/merchant-migrations/", json=_body(organization)
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["id"] != str(existing.id)
+        assert body["source"]["stripe_user_id"] == "acct_test"
 
 
 @pytest.mark.asyncio

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -249,8 +249,7 @@ class TestCreate:
 
         assert response.status_code == 409
         assert (
-            "already used by another organization's merchant migration"
-            in response.text
+            "already used by another organization's merchant migration" in response.text
         )
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -251,6 +251,30 @@ class TestCreate:
         await assert_no_migrations(session, organization)
 
     @pytest.mark.auth
+    async def test_allows_stripe_account_from_same_organization_migration(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _enable_feature(save_fixture, organization)
+        existing = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(account_id="acct_test"),
+        )
+
+        migration = await service.create(
+            session, auth_subject, _create_schema(organization)
+        )
+
+        assert migration.id != existing.id
+        assert migration.source_credentials["stripe_user_id"] == "acct_test"
+
+    @pytest.mark.auth
     async def test_allows_stripe_account_from_soft_deleted_migration(
         self,
         mocker: MockerFixture,


### PR DESCRIPTION
## Summary

We should allow to create a new migration for the same stripe account. We should only block a different org trying to create it for the same account.
