### PR TITLE
fix(merchant-migration): keep the subscription switcher on the Switch tab

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationStepper.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationStepper.tsx
@@ -10,10 +10,12 @@ import { currentPosition, MIGRATION_STEPS } from './steps'
 // current step alone (its marker and its label).
 export function MigrationStepper({
   migration,
+  panCurrentStepKey,
 }: {
   migration: schemas['MerchantMigration']
+  panCurrentStepKey?: string | null
 }) {
-  const position = currentPosition(migration)
+  const position = currentPosition(migration, panCurrentStepKey)
   // A completed migration has every step behind it.
   const current =
     position.kind === 'completed' ? MIGRATION_STEPS.length : position.index

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
@@ -1,13 +1,17 @@
 'use client'
 
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
-import { useMerchantMigration } from '@/hooks/queries/merchantMigrations'
+import {
+  useMerchantMigration,
+  usePanTransfer,
+} from '@/hooks/queries/merchantMigrations'
 import { schemas } from '@polar-sh/client'
 import { Alert, Spinner, Status, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 import { PanTransferPanel } from '../cards/PanTransferPanel'
+import { isSwitchChecklistKey } from '../cards/panTransferCopy'
 import { ImportedStep } from '../ImportedStep'
 import { MigrationStepper } from '../MigrationStepper'
 import { PrecheckPanel } from '../PrecheckPanel'
@@ -62,11 +66,7 @@ export default function MigrationDetailPage({
         ) : !migration ? (
           <Text color="muted">This migration no longer exists.</Text>
         ) : (
-          <Box as="section" flexDirection="column" rowGap="xl">
-            <SourceHeader migration={migration} />
-            <MigrationStepper migration={migration} />
-            <StepContent migration={migration} />
-          </Box>
+          <MigrationLoaded migration={migration} />
         )}
       </Box>
     </DashboardBody>
@@ -103,10 +103,47 @@ function SourceHeader({
   )
 }
 
-function StepContent({
+function MigrationLoaded({
   migration,
 }: {
   migration: schemas['MerchantMigration']
+}) {
+  const needsPan = migration.step === 'copy_cards'
+  const pan = usePanTransfer(needsPan ? migration.id : '')
+  const panCurrentStepKey = pan.data?.current_step_key ?? null
+
+  if (needsPan && pan.isLoading) {
+    return (
+      <Box as="section" flexDirection="column" rowGap="xl">
+        <SourceHeader migration={migration} />
+        <Box padding="3xl" alignItems="center" justifyContent="center">
+          <Spinner />
+        </Box>
+      </Box>
+    )
+  }
+
+  return (
+    <Box as="section" flexDirection="column" rowGap="xl">
+      <SourceHeader migration={migration} />
+      <MigrationStepper
+        migration={migration}
+        panCurrentStepKey={panCurrentStepKey}
+      />
+      <StepContent
+        migration={migration}
+        panCurrentStepKey={panCurrentStepKey}
+      />
+    </Box>
+  )
+}
+
+function StepContent({
+  migration,
+  panCurrentStepKey,
+}: {
+  migration: schemas['MerchantMigration']
+  panCurrentStepKey: string | null
 }) {
   if (!migration.source_connected) {
     return (
@@ -115,7 +152,7 @@ function StepContent({
       </Text>
     )
   }
-  const def = currentStepDef(migration)
+  const def = currentStepDef(migration, panCurrentStepKey)
   switch (migration.step) {
     // The stepper shows a connected migration as assessing, but nothing is
     // staged until the first pre-check runs.
@@ -132,6 +169,14 @@ function StepContent({
     case 'create_catalog':
       return <ImportedStep migrationId={migration.id} />
     case 'copy_cards':
+      if (isSwitchChecklistKey(panCurrentStepKey)) {
+        return (
+          <Box flexDirection="column" rowGap="l">
+            <StepHeading def={def} />
+            <SwitchPanel migrationId={migration.id} />
+          </Box>
+        )
+      }
       return (
         <Box flexDirection="column" rowGap="l">
           <StepHeading def={def} />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
@@ -11,12 +11,16 @@ import { Box } from '@polar-sh/orbit/Box'
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
 import { PanTransferPanel } from '../cards/PanTransferPanel'
-import { isSwitchChecklistKey } from '../cards/panTransferCopy'
 import { ImportedStep } from '../ImportedStep'
 import { MigrationStepper } from '../MigrationStepper'
 import { PrecheckPanel } from '../PrecheckPanel'
 import { ReviewTable } from '../review/ReviewTable'
-import { currentStepDef, MigrationStepDef, OWNER_LABELS } from '../steps'
+import {
+  currentStepDef,
+  MigrationStepDef,
+  OWNER_LABELS,
+  visibleMigrationStep,
+} from '../steps'
 import { SwitchPanel } from '../switch/SwitchPanel'
 import { StripeMark } from '../StripeMark'
 
@@ -153,7 +157,7 @@ function StepContent({
     )
   }
   const def = currentStepDef(migration, panCurrentStepKey)
-  switch (migration.step) {
+  switch (visibleMigrationStep(migration, panCurrentStepKey)) {
     // The stepper shows a connected migration as assessing, but nothing is
     // staged until the first pre-check runs.
     case 'source_setup':
@@ -169,14 +173,6 @@ function StepContent({
     case 'create_catalog':
       return <ImportedStep migrationId={migration.id} />
     case 'copy_cards':
-      if (isSwitchChecklistKey(panCurrentStepKey)) {
-        return (
-          <Box flexDirection="column" rowGap="l">
-            <StepHeading def={def} />
-            <SwitchPanel migrationId={migration.id} />
-          </Box>
-        )
-      }
       return (
         <Box flexDirection="column" rowGap="l">
           <StepHeading def={def} />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
@@ -3,6 +3,7 @@
 import { usePanTransfer } from '@/hooks/queries/merchantMigrations'
 import { Alert, Spinner, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
+import { cardMovementSteps } from './panTransferCopy'
 import { PanTransferStepItem } from './PanTransferStepItem'
 
 export function PanTransferPanel({
@@ -40,12 +41,11 @@ export function PanTransferPanel({
     )
   }
 
-  const done = checklist.steps.filter(
-    (step) => step.status === 'completed',
-  ).length
+  const steps = cardMovementSteps(checklist.steps)
+  const done = steps.filter((step) => step.status === 'completed').length
   // Off the steps, not a null `current_step_key`: a checklist stuck with
   // nothing actionable would report that too.
-  const finished = done === checklist.steps.length
+  const finished = done === steps.length
 
   return (
     <Box flexDirection="column" rowGap="l">
@@ -55,12 +55,12 @@ export function PanTransferPanel({
         </Text>
       ) : (
         <Text variant="caption" color="muted">
-          {done} of {checklist.steps.length} complete
+          {done} of {steps.length} complete
         </Text>
       )}
 
       <Box as="ol" flexDirection="column" rowGap="l">
-        {checklist.steps.map((step) => (
+        {steps.map((step) => (
           <PanTransferStepItem
             // Migration-scoped: another migration lands on the same step key,
             // and a bare key would keep its unsaved form values alive.

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
@@ -3,13 +3,11 @@
 import { schemas } from '@polar-sh/client'
 import { Alert, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import { SwitchPanel } from '../switch/SwitchPanel'
 import { OpsUpdate } from './OpsUpdate'
 import { StepCopy } from './panTransferCopy'
 import { PanTransferStepForm } from './PanTransferStepForm'
 import { StartCopyStep } from './StartCopyStep'
 
-const SWITCH_STEP_KEY = 'cutover'
 const START_COPY_STEP_KEY = 'start_copy'
 
 interface Props {
@@ -70,10 +68,7 @@ export function PanTransferStepBody({
 
       <OpsUpdate step={step} />
 
-      {step.key === SWITCH_STEP_KEY ? (
-        <SwitchPanel migrationId={migrationId} />
-      ) : (
-        submittable &&
+      {submittable &&
         (fieldsUnknown || !copy.action ? (
           <Text variant="caption" color="muted">
             This step needs a newer version of this page. Please refresh.
@@ -84,8 +79,7 @@ export function PanTransferStepBody({
             migrationId={migrationId}
             stepKey={step.key}
           />
-        ))
-      )}
+        ))}
     </Box>
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
+  cardMovementSteps,
+  isSwitchChecklistKey,
   isValidStripeMigrationId,
   STEP_COPY,
   stripeCopyStatusUrl,
@@ -62,5 +64,25 @@ describe('provider export', () => {
       name: 'provider_contact',
       required: false,
     })
+  })
+})
+
+describe('card movement steps', () => {
+  it('hides switch and retired keys from the card list', () => {
+    const steps = cardMovementSteps([
+      { key: 'verify_cards' },
+      { key: 'resolve_uncovered' },
+      { key: 'cutover' },
+      { key: 'move_subscriptions' },
+    ])
+    expect(steps.map((step) => step.key)).toEqual(['verify_cards'])
+  })
+
+  it('treats the switch checklist keys as the switch tab', () => {
+    expect(isSwitchChecklistKey('cutover')).toBe(true)
+    expect(isSwitchChecklistKey('move_subscriptions')).toBe(true)
+    expect(isSwitchChecklistKey('resolve_uncovered')).toBe(true)
+    expect(isSwitchChecklistKey('verify_cards')).toBe(false)
+    expect(isSwitchChecklistKey(null)).toBe(false)
   })
 })

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
@@ -140,13 +140,7 @@ export const STEP_COPY: Record<string, StepCopy> = {
   verify_cards: {
     title: 'Polar checks the cards',
     description:
-      'We check that every imported subscription has a card it can charge, and tell you which ones do not.',
-  },
-  resolve_uncovered: {
-    title: 'Handle customers without a card',
-    description:
-      'Some customers have to add a card again. Ask them to do it, or run the copy again to pick up new cards.',
-    action: 'I handled these customers',
+      'We check that every imported subscription has a card it can charge.',
   },
   cutover: {
     title: 'Switch billing to Polar',
@@ -160,4 +154,18 @@ export const STEP_COPY: Record<string, StepCopy> = {
     description:
       'We start billing the subscriptions you picked. They are charged on their next renewal date.',
   },
+}
+
+const AFTER_CARD_MOVEMENT_KEYS = new Set([
+  'resolve_uncovered',
+  'cutover',
+  'move_subscriptions',
+])
+
+export function isSwitchChecklistKey(key: string | null | undefined): boolean {
+  return key != null && AFTER_CARD_MOVEMENT_KEYS.has(key)
+}
+
+export function cardMovementSteps<T extends { key: string }>(steps: T[]): T[] {
+  return steps.filter((step) => !AFTER_CARD_MOVEMENT_KEYS.has(step.key))
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
@@ -167,5 +167,5 @@ export function isSwitchChecklistKey(key: string | null | undefined): boolean {
 }
 
 export function cardMovementSteps<T extends { key: string }>(steps: T[]): T[] {
-  return steps.filter((step) => !AFTER_CARD_MOVEMENT_KEYS.has(step.key))
+  return steps.filter((step) => !isSwitchChecklistKey(step.key))
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.test.ts
@@ -31,10 +31,7 @@ describe('currentPosition', () => {
   it('surfaces Switch once cards are done, including a retired uncovered step', () => {
     expect(
       currentPosition(migration('copy_cards'), 'resolve_uncovered'),
-    ).toEqual({
-      kind: 'step',
-      index: 3,
-    })
+    ).toEqual(currentPosition(migration('activate_subscriptions')))
   })
 
   it('maps activate_subscriptions to Switch without a pan key', () => {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.test.ts
@@ -1,0 +1,46 @@
+import { schemas } from '@polar-sh/client'
+import { describe, expect, it } from 'vitest'
+import { currentPosition } from './steps'
+
+function migration(
+  step: schemas['MerchantMigrationStep'],
+  extras: Partial<schemas['MerchantMigration']> = {},
+): schemas['MerchantMigration'] {
+  return {
+    id: 'mig_1',
+    created_at: '2026-01-01T00:00:00Z',
+    modified_at: null,
+    organization_id: 'org_1',
+    source_platform: 'stripe',
+    step,
+    source_connected: true,
+    source: null,
+    operation: null,
+    ...extras,
+  } as schemas['MerchantMigration']
+}
+
+describe('currentPosition', () => {
+  it('keeps copy_cards on Card movement while cards are still moving', () => {
+    expect(currentPosition(migration('copy_cards'), 'verify_cards')).toEqual({
+      kind: 'step',
+      index: 2,
+    })
+  })
+
+  it('surfaces Switch once cards are done, including a retired uncovered step', () => {
+    expect(
+      currentPosition(migration('copy_cards'), 'resolve_uncovered'),
+    ).toEqual({
+      kind: 'step',
+      index: 3,
+    })
+  })
+
+  it('maps activate_subscriptions to Switch without a pan key', () => {
+    expect(currentPosition(migration('activate_subscriptions'))).toEqual({
+      kind: 'step',
+      index: 3,
+    })
+  })
+})

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.ts
@@ -1,4 +1,5 @@
 import { schemas } from '@polar-sh/client'
+import { isSwitchChecklistKey } from './cards/panTransferCopy'
 
 type Step = schemas['MerchantMigrationStep']
 
@@ -81,9 +82,18 @@ export type MigrationPosition =
 // fall through to `completed` below.
 export function currentPosition(
   migration: schemas['MerchantMigration'],
+  panCurrentStepKey?: string | null,
 ): MigrationPosition {
   if (!migration.source_connected) {
     return { kind: 'step', index: 0 }
+  }
+  // Card-checklist keys after the last card step belong on Switch, even if
+  // the backend still reports `copy_cards` for an in-progress migration.
+  if (
+    migration.step === 'copy_cards' &&
+    isSwitchChecklistKey(panCurrentStepKey)
+  ) {
+    return { kind: 'step', index: SWITCH_STEP_INDEX }
   }
   const step = migration.step === 'source_setup' ? 'pre_check' : migration.step
   const index = MIGRATION_STEPS.findIndex((def) => def.steps.includes(step))
@@ -92,7 +102,12 @@ export function currentPosition(
 
 export function currentStepDef(
   migration: schemas['MerchantMigration'],
+  panCurrentStepKey?: string | null,
 ): MigrationStepDef | null {
-  const position = currentPosition(migration)
+  const position = currentPosition(migration, panCurrentStepKey)
   return position.kind === 'completed' ? null : MIGRATION_STEPS[position.index]
 }
+
+const SWITCH_STEP_INDEX = MIGRATION_STEPS.findIndex(
+  (def) => def.key === 'cutover',
+)

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.ts
@@ -75,6 +75,21 @@ export type MigrationPosition =
   | { kind: 'step'; index: number }
   | { kind: 'completed' }
 
+// Card-checklist keys after the last card step belong on Switch, even if the
+// backend still reports `copy_cards` for an in-progress migration.
+export function visibleMigrationStep(
+  migration: schemas['MerchantMigration'],
+  panCurrentStepKey?: string | null,
+): Step {
+  if (
+    migration.step === 'copy_cards' &&
+    isSwitchChecklistKey(panCurrentStepKey)
+  ) {
+    return 'activate_subscriptions'
+  }
+  return migration.step
+}
+
 // Backend steps map to a visible step through `MIGRATION_STEPS`, with two
 // exceptions: `source_setup`, where connecting completes Connect even though
 // the backend still reads it, so once connected we surface Assessment; and the
@@ -87,15 +102,8 @@ export function currentPosition(
   if (!migration.source_connected) {
     return { kind: 'step', index: 0 }
   }
-  // Card-checklist keys after the last card step belong on Switch, even if
-  // the backend still reports `copy_cards` for an in-progress migration.
-  if (
-    migration.step === 'copy_cards' &&
-    isSwitchChecklistKey(panCurrentStepKey)
-  ) {
-    return { kind: 'step', index: SWITCH_STEP_INDEX }
-  }
-  const step = migration.step === 'source_setup' ? 'pre_check' : migration.step
+  const visible = visibleMigrationStep(migration, panCurrentStepKey)
+  const step = visible === 'source_setup' ? 'pre_check' : visible
   const index = MIGRATION_STEPS.findIndex((def) => def.steps.includes(step))
   return index === -1 ? { kind: 'completed' } : { kind: 'step', index }
 }
@@ -107,7 +115,3 @@ export function currentStepDef(
   const position = currentPosition(migration, panCurrentStepKey)
   return position.kind === 'completed' ? null : MIGRATION_STEPS[position.index]
 }
-
-const SWITCH_STEP_INDEX = MIGRATION_STEPS.findIndex(
-  (def) => def.key === 'cutover',
-)

--- a/server/polar/merchant_migration/pan_transfer.py
+++ b/server/polar/merchant_migration/pan_transfer.py
@@ -250,11 +250,6 @@ PAN_COPY_TEMPLATES: tuple[PanStepTemplate, ...] = (
         kind=PanStepKind.auto,
     ),
     PanStepTemplate(
-        key=STEP_RESOLVE_UNCOVERED,
-        owner=PanStepOwner.merchant,
-        kind=PanStepKind.confirm,
-    ),
-    PanStepTemplate(
         key=STEP_CUTOVER,
         owner=PanStepOwner.merchant,
         kind=PanStepKind.confirm,
@@ -310,11 +305,6 @@ PAN_IMPORT_TEMPLATES: tuple[PanStepTemplate, ...] = (
         key=STEP_VERIFY_CARDS,
         owner=PanStepOwner.polar_app,
         kind=PanStepKind.auto,
-    ),
-    PanStepTemplate(
-        key=STEP_RESOLVE_UNCOVERED,
-        owner=PanStepOwner.merchant,
-        kind=PanStepKind.confirm,
     ),
     PanStepTemplate(
         key=STEP_CUTOVER,
@@ -389,16 +379,29 @@ def _get(steps: Sequence[PanTransferStep], key: str) -> PanTransferStep:
     raise PanStepNotFound(key)
 
 
+def advance(
+    method: PanTransferMethod, steps: list[PanTransferStep]
+) -> list[PanTransferStep]:
+    """Make the next unfinished step actionable, walking past auto-completing
+    and retired keys."""
+    _advance(method, steps)
+    return steps
+
+
 def _advance(method: PanTransferMethod, steps: list[PanTransferStep]) -> None:
     """Make the first unfinished step actionable, walking past any that complete
     on their own."""
+    templates = _TEMPLATES_BY_KEY[method]
     for step in steps:
         if step.status == PanStepStatus.completed:
             continue
         if step.status == PanStepStatus.blocked:
             step.status = PanStepStatus.pending
             step.started_at = utc_now()
-        if not _template(method, step.key).auto_complete:
+        template = templates.get(step.key)
+        # No template: the step left the checklist. Complete it so stored
+        # migrations don't stall on a key Polar no longer asks anyone to do.
+        if template is not None and not template.auto_complete:
             return
         _settle(step, PanStepActor.system)
 

--- a/server/polar/merchant_migration/pan_transfer.py
+++ b/server/polar/merchant_migration/pan_transfer.py
@@ -360,8 +360,7 @@ def build(method: PanTransferMethod) -> list[PanTransferStep]:
         )
         for template in templates_for(method)
     ]
-    _advance(method, steps)
-    return steps
+    return advance(method, steps)
 
 
 def current(steps: Sequence[PanTransferStep]) -> PanTransferStep | None:
@@ -384,13 +383,6 @@ def advance(
 ) -> list[PanTransferStep]:
     """Make the next unfinished step actionable, walking past auto-completing
     and retired keys."""
-    _advance(method, steps)
-    return steps
-
-
-def _advance(method: PanTransferMethod, steps: list[PanTransferStep]) -> None:
-    """Make the first unfinished step actionable, walking past any that complete
-    on their own."""
     templates = _TEMPLATES_BY_KEY[method]
     for step in steps:
         if step.status == PanStepStatus.completed:
@@ -402,8 +394,9 @@ def _advance(method: PanTransferMethod, steps: list[PanTransferStep]) -> None:
         # No template: the step left the checklist. Complete it so stored
         # migrations don't stall on a key Polar no longer asks anyone to do.
         if template is not None and not template.auto_complete:
-            return
+            return steps
         _settle(step, PanStepActor.system)
+    return steps
 
 
 def _settle(step: PanTransferStep, actor: PanStepActor) -> None:
@@ -468,18 +461,21 @@ def complete(
     step = _get(steps, key)
     if step.status not in _ACTIONABLE:
         raise PanStepNotActionable(key)
+    template = _TEMPLATES_BY_KEY[method].get(key)
+    if template is None:
+        _settle(step, PanStepActor.system)
+        return advance(method, steps)
     if step.owner not in _ACTOR_OWNERS[actor]:
         raise PanStepNotOwned(key, step.owner)
 
     # Blank is the same as absent, so an untouched optional field doesn't get
     # stored and an all-whitespace required one still reads as missing.
     provided = {k: v.strip() for k, v in inputs.items() if v.strip()}
-    _validate_inputs(_template(method, key), provided)
+    _validate_inputs(template, provided)
 
     step.inputs = {**step.inputs, **provided}
     _settle(step, actor)
-    _advance(method, steps)
-    return steps
+    return advance(method, steps)
 
 
 def annotate(

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -1299,13 +1299,18 @@ class MerchantMigrationService:
         return None
 
     def _advance_retired_steps(
-        self, migration: MerchantMigration, steps: list[PanTransferStep]
+        self,
+        migration: MerchantMigration,
+        # `Sequence`, not `list`: this class defines a `list` method, which would
+        # shadow the builtin in an annotation evaluated in the class body.
+        steps: Sequence[PanTransferStep],
     ) -> bool:
         """Walk past keys Polar no longer asks anyone to complete. True if the
         current step moved, so the caller can persist."""
-        before = pan_transfer.current(steps)
-        pan_transfer.advance(migration.pan_transfer_method, steps)
-        after = pan_transfer.current(steps)
+        working = list(steps)
+        before = pan_transfer.current(working)
+        pan_transfer.advance(migration.pan_transfer_method, working)
+        after = pan_transfer.current(working)
         return (before.key if before else None) != (after.key if after else None)
 
     def _cutover_reachable(self, migration: MerchantMigration) -> bool:

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -126,6 +126,7 @@ _STEP_TASKS = {
 }
 
 _MIGRATION_STEP_BY_PAN_STEP = {
+    STEP_CUTOVER: MerchantMigrationStep.activate_subscriptions,
     STEP_MOVE_SUBSCRIPTIONS: MerchantMigrationStep.activate_subscriptions,
 }
 
@@ -674,7 +675,12 @@ class MerchantMigrationService:
         """The card-move checklist. Returns an empty one before it's started, so
         the client can show the method and the destination account up front."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
-        return self._checklist(migration)
+        steps = [step.model_copy() for step in migration.pan_transfer_steps]
+        if steps:
+            # Copies only: a GET must not persist, but stored checklists can
+            # still be sitting on a key Polar no longer asks anyone to complete.
+            pan_transfer.advance(migration.pan_transfer_method, steps)
+        return self._checklist(migration, steps)
 
     async def stream_imported_customer_source_ids(
         self,
@@ -1019,6 +1025,13 @@ class MerchantMigrationService:
         migration = await self._get_manageable(
             session, auth_subject, migration_id, for_update=True
         )
+        if migration.pan_transfer_steps:
+            steps = list(migration.pan_transfer_steps)
+            before = pan_transfer.current(steps)
+            pan_transfer.advance(migration.pan_transfer_method, steps)
+            after = pan_transfer.current(steps)
+            if (before.key if before else None) != (after.key if after else None):
+                await self._advance_checklist(session, migration, steps)
         if not self._cutover_reachable(migration):
             raise CutoverNotStarted()
 

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -679,7 +679,7 @@ class MerchantMigrationService:
         if steps:
             # Copies only: a GET must not persist, but stored checklists can
             # still be sitting on a key Polar no longer asks anyone to complete.
-            pan_transfer.advance(migration.pan_transfer_method, steps)
+            self._advance_retired_steps(migration, steps)
         return self._checklist(migration, steps)
 
     async def stream_imported_customer_source_ids(
@@ -1027,10 +1027,7 @@ class MerchantMigrationService:
         )
         if migration.pan_transfer_steps:
             steps = list(migration.pan_transfer_steps)
-            before = pan_transfer.current(steps)
-            pan_transfer.advance(migration.pan_transfer_method, steps)
-            after = pan_transfer.current(steps)
-            if (before.key if before else None) != (after.key if after else None):
+            if self._advance_retired_steps(migration, steps):
                 await self._advance_checklist(session, migration, steps)
         if not self._cutover_reachable(migration):
             raise CutoverNotStarted()
@@ -1300,6 +1297,16 @@ class MerchantMigrationService:
                 exclude_record_ids=list(exclude_record_ids)
             )
         return None
+
+    def _advance_retired_steps(
+        self, migration: MerchantMigration, steps: list[PanTransferStep]
+    ) -> bool:
+        """Walk past keys Polar no longer asks anyone to complete. True if the
+        current step moved, so the caller can persist."""
+        before = pan_transfer.current(steps)
+        pan_transfer.advance(migration.pan_transfer_method, steps)
+        after = pan_transfer.current(steps)
+        return (before.key if before else None) != (after.key if after else None)
 
     def _cutover_reachable(self, migration: MerchantMigration) -> bool:
         """The merchant may switch once the card checklist has reached the switch

--- a/server/tests/merchant_migration/test_pan_transfer.py
+++ b/server/tests/merchant_migration/test_pan_transfer.py
@@ -1,8 +1,12 @@
 import pytest
 
 from polar.exceptions import PolarRequestValidationError
+from polar.kit.utils import utc_now
 from polar.merchant_migration import pan_transfer
 from polar.merchant_migration.pan_transfer import (
+    STEP_CUTOVER,
+    STEP_RESOLVE_UNCOVERED,
+    STEP_VERIFY_CARDS,
     PanStepActor,
     PanStepKind,
     PanStepNotActionable,
@@ -124,6 +128,51 @@ class TestBuild:
         # Cutover is the last thing the merchant does before we take over billing.
         assert templates[-2].key == "cutover"
         assert templates[-2].owner == PanStepOwner.merchant
+
+
+class TestAdvance:
+    def test_completing_card_checks_lands_on_switch(self) -> None:
+        steps = pan_transfer.complete(
+            PanTransferMethod.pan_copy,
+            _advance_to(_copy_steps(), STEP_VERIFY_CARDS),
+            STEP_VERIFY_CARDS,
+            actor=PanStepActor.system,
+            inputs={},
+        )
+
+        current = pan_transfer.current(steps)
+        assert current is not None
+        assert current.key == STEP_CUTOVER
+
+    def test_walks_past_a_retired_uncovered_step(self) -> None:
+        steps = _advance_to(_copy_steps(), STEP_CUTOVER)
+        cutover = next(step for step in steps if step.key == STEP_CUTOVER)
+        cutover.status = PanStepStatus.blocked
+        cutover.started_at = None
+        steps.insert(
+            steps.index(cutover),
+            PanTransferStep(
+                key=STEP_RESOLVE_UNCOVERED,
+                owner=PanStepOwner.merchant,
+                kind=PanStepKind.confirm,
+                status=PanStepStatus.pending,
+                inputs={},
+                note=None,
+                expected_at=None,
+                started_at=utc_now(),
+                completed_at=None,
+                completed_by=None,
+            ),
+        )
+
+        pan_transfer.advance(PanTransferMethod.pan_copy, steps)
+
+        current = pan_transfer.current(steps)
+        assert current is not None
+        assert current.key == STEP_CUTOVER
+        retired = next(step for step in steps if step.key == STEP_RESOLVE_UNCOVERED)
+        assert retired.status == PanStepStatus.completed
+        assert retired.completed_by == PanStepActor.system
 
 
 class TestComplete:

--- a/server/tests/merchant_migration/test_pan_transfer.py
+++ b/server/tests/merchant_migration/test_pan_transfer.py
@@ -145,34 +145,54 @@ class TestAdvance:
         assert current.key == STEP_CUTOVER
 
     def test_walks_past_a_retired_uncovered_step(self) -> None:
-        steps = _advance_to(_copy_steps(), STEP_CUTOVER)
-        cutover = next(step for step in steps if step.key == STEP_CUTOVER)
-        cutover.status = PanStepStatus.blocked
-        cutover.started_at = None
-        steps.insert(
-            steps.index(cutover),
-            PanTransferStep(
-                key=STEP_RESOLVE_UNCOVERED,
-                owner=PanStepOwner.merchant,
-                kind=PanStepKind.confirm,
-                status=PanStepStatus.pending,
-                inputs={},
-                note=None,
-                expected_at=None,
-                started_at=utc_now(),
-                completed_at=None,
-                completed_by=None,
-            ),
-        )
+        steps = _stuck_on_uncovered()
 
         pan_transfer.advance(PanTransferMethod.pan_copy, steps)
 
-        current = pan_transfer.current(steps)
-        assert current is not None
-        assert current.key == STEP_CUTOVER
-        retired = next(step for step in steps if step.key == STEP_RESOLVE_UNCOVERED)
-        assert retired.status == PanStepStatus.completed
-        assert retired.completed_by == PanStepActor.system
+        _assert_skipped_uncovered(steps)
+
+    def test_completing_a_retired_uncovered_step_lands_on_switch(self) -> None:
+        steps = pan_transfer.complete(
+            PanTransferMethod.pan_copy,
+            _stuck_on_uncovered(),
+            STEP_RESOLVE_UNCOVERED,
+            actor=PanStepActor.merchant,
+            inputs={},
+        )
+
+        _assert_skipped_uncovered(steps)
+
+
+def _stuck_on_uncovered() -> list[PanTransferStep]:
+    steps = _advance_to(_copy_steps(), STEP_CUTOVER)
+    cutover = next(step for step in steps if step.key == STEP_CUTOVER)
+    cutover.status = PanStepStatus.blocked
+    cutover.started_at = None
+    steps.insert(
+        steps.index(cutover),
+        PanTransferStep(
+            key=STEP_RESOLVE_UNCOVERED,
+            owner=PanStepOwner.merchant,
+            kind=PanStepKind.confirm,
+            status=PanStepStatus.pending,
+            inputs={},
+            note=None,
+            expected_at=None,
+            started_at=utc_now(),
+            completed_at=None,
+            completed_by=None,
+        ),
+    )
+    return steps
+
+
+def _assert_skipped_uncovered(steps: list[PanTransferStep]) -> None:
+    current = pan_transfer.current(steps)
+    assert current is not None
+    assert current.key == STEP_CUTOVER
+    retired = next(step for step in steps if step.key == STEP_RESOLVE_UNCOVERED)
+    assert retired.status == PanStepStatus.completed
+    assert retired.completed_by == PanStepActor.system
 
 
 class TestComplete:

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -42,7 +42,6 @@ from polar.merchant_migration.cutover import CutoverOutcome, SubscriptionCutover
 from polar.merchant_migration.pan_transfer import (
     STEP_CUTOVER,
     STEP_MOVE_SUBSCRIPTIONS,
-    STEP_RESOLVE_UNCOVERED,
     STEP_VERIFY_CARDS,
 )
 from polar.merchant_migration.repository import (
@@ -2426,7 +2425,7 @@ class TestRunCardVerification:
         await service.run_card_verification(session, migration.id)
 
         checklist = service._checklist(migration)
-        assert checklist.current_step_key == STEP_RESOLVE_UNCOVERED
+        assert checklist.current_step_key == STEP_CUTOVER
 
     async def test_re_running_picks_up_only_what_arrived_since(
         self,
@@ -2608,7 +2607,7 @@ class TestRunCardVerification:
         await service.run_card_verification(session, migration.id)
 
         checklist = service._checklist(migration)
-        assert checklist.current_step_key == STEP_RESOLVE_UNCOVERED
+        assert checklist.current_step_key == STEP_CUTOVER
 
     async def test_lists_a_customer_once_however_many_subscriptions(
         self,
@@ -2676,6 +2675,32 @@ def _fake_cutover(
         service, "_build_adapter", new=mocker.AsyncMock(return_value=object())
     )
     return runner
+
+
+@pytest.mark.asyncio
+class TestFinishCardChecks:
+    async def test_moves_the_migration_onto_the_switch(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        migration = await build_connected_migration(save_fixture, organization)
+        migration.step = MerchantMigrationStep.copy_cards
+        migration.pan_transfer_steps = pan_steps_until(
+            migration.pan_transfer_method, STEP_VERIFY_CARDS
+        )
+        await save_fixture(migration)
+
+        await service._complete_step(session, migration, STEP_VERIFY_CARDS)
+
+        await session.flush()
+        await session.refresh(migration)
+        checklist = service._checklist(migration)
+        assert checklist.current_step_key == STEP_CUTOVER
+        assert migration.step == MerchantMigrationStep.activate_subscriptions
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Move the subscription switcher off Card movement and onto the Switch tab.
- Drop the retired “handle customers without a card” checklist step so finishing card verification lands on cutover / Switch.
- Skip stored checklists that are still sitting on that retired key, and map cutover onto `activate_subscriptions`.

## Test plan
- [ ] On a Stripe migration in Card movement, the card checklist no longer includes the switcher table, cutover, or the uncovered-customers step.
- [ ] After cards verify, the stepper highlights Switch and the switcher table is on that tab.
- [ ] A stored migration whose current pan step is `resolve_uncovered` still opens Switch rather than stalling on Card movement.
- [ ] Deploy API before web so the UI does not request cutover against an API that still expects the old uncovered step.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

