### PR TITLE
server/worker: set idle transaction timeout in AWS Lamdba runner

### DIFF
--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -288,9 +288,17 @@ async def run_task(
         )
 
 
-def bootstrap(*, pool_pre_ping: bool = False) -> None:
+def bootstrap(
+    *,
+    pool_pre_ping: bool = False,
+    idle_in_transaction_session_timeout_seconds: int | None = None,
+) -> None:
     """Initialize worker resources (DB engine + Redis + HTTPX) for the SQS runner."""
-    setup_sqlalchemy(pool_name="worker-sqs", pool_pre_ping=pool_pre_ping)
+    setup_sqlalchemy(
+        pool_name="worker-sqs",
+        pool_pre_ping=pool_pre_ping,
+        idle_in_transaction_session_timeout_seconds=idle_in_transaction_session_timeout_seconds,
+    )
     setup_redis()
     setup_httpx()
     validate_allowlist()

--- a/server/polar/worker/_sqlalchemy.py
+++ b/server/polar/worker/_sqlalchemy.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncIterator
 import dramatiq
 import structlog
 from dramatiq.asyncio import get_event_loop_thread
+from sqlalchemy import Connection, event
 
 from polar.config import settings
 from polar.kit.db.postgres import AsyncSessionMaker as AsyncSessionMakerType
@@ -51,7 +52,10 @@ async def dispose_sqlalchemy_engine() -> None:
 
 
 def setup_sqlalchemy(
-    pool_name: str | None = None, *, pool_pre_ping: bool = False
+    pool_name: str | None = None,
+    *,
+    pool_pre_ping: bool = False,
+    idle_in_transaction_session_timeout_seconds: int | None = None,
 ) -> None:
     global \
         _sqlalchemy_engine, \
@@ -76,6 +80,17 @@ def setup_sqlalchemy(
         instrument_engines.append(_sqlalchemy_read_engine.sync_engine)
     else:
         _sqlalchemy_async_read_sessionmaker = _sqlalchemy_async_sessionmaker
+
+    if idle_in_transaction_session_timeout_seconds is not None:
+
+        def set_idle_transaction_timeout(connection: Connection) -> None:
+            connection.exec_driver_sql(
+                "SET LOCAL idle_in_transaction_session_timeout = "
+                f"'{idle_in_transaction_session_timeout_seconds}s'"
+            )
+
+        for engine in instrument_engines:
+            event.listen(engine, "begin", set_idle_transaction_timeout)
 
     instrument_sqlalchemy(instrument_engines)
     log.info("Created database engine", pool_name=pool_name)

--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -36,7 +36,7 @@ log: Logger = structlog.get_logger()
 # must run on the same loop (a fresh asyncio.run() per record would break it).
 _loop = asyncio.new_event_loop()
 asyncio.set_event_loop(_loop)
-bootstrap(pool_pre_ping=True)
+bootstrap(pool_pre_ping=True, idle_in_transaction_session_timeout_seconds=60)
 
 consumer_sqs_client = get_consumer_sqs_client()
 consumer_scheduler_client = get_consumer_scheduler_client()


### PR DESCRIPTION

We apparently have a networking issue between AWS Lambda and Render external database endpoint: the client cancellation sent by asyncpg seems to be lost in the void, leading to the task timing out and transactions stuck in `idle in transaction` state in the database. Until we find the root cause, this change will force Postgres to kill idle transactions after 60 seconds.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

