### PR TITLE
CLI: Backend support for triggering webhook events

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -2953,6 +2953,46 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/cli/events': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Events
+     * @description **Scopes**: `webhooks:read` `webhooks:write`
+     */
+    get: operations['cli:events']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/cli/trigger/{id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Trigger
+     * @description **Scopes**: `webhooks:read` `webhooks:write`
+     */
+    post: operations['cli:trigger']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/files/': {
     parameters: {
       query?: never
@@ -26156,6 +26196,17 @@ export interface components {
       /** Detail */
       detail: string
     }
+    /** NoActiveListener */
+    NoActiveListener: {
+      /**
+       * Error
+       * @example NoActiveListener
+       * @constant
+       */
+      error: 'NoActiveListener'
+      /** Detail */
+      detail: string
+    }
     /** NotOpenCheckout */
     NotOpenCheckout: {
       /**
@@ -37917,6 +37968,52 @@ export interface components {
      * @enum {string}
      */
     TrialInterval: 'day' | 'week' | 'month' | 'year'
+    /** TriggerEvent */
+    TriggerEvent: {
+      type: components['schemas']['WebhookEventType']
+      /**
+       * Description
+       * @description One-line description of when Polar sends this event.
+       */
+      description: string
+    }
+    /** TriggerRequest */
+    TriggerRequest: {
+      event: components['schemas']['WebhookEventType']
+      /**
+       * Overrides
+       * @description Payload fields to override, keyed by dotted path relative to the payload root, e.g. `data.amount`.
+       */
+      overrides?: {
+        [key: string]: unknown
+      }
+      /**
+       * Seed
+       * @description Seed for generated IDs and numbers, for reproducible payloads.
+       */
+      seed?: number | null
+      /**
+       * Deliver
+       * @description Send the event to the organization's active CLI listener.
+       * @default true
+       */
+      deliver: boolean
+    }
+    /** TriggerResponse */
+    TriggerResponse: {
+      /**
+       * Webhook Event Id
+       * Format: uuid
+       */
+      webhook_event_id: string
+      event: components['schemas']['WebhookEventType']
+      /** Delivered */
+      delivered: boolean
+      /** Payload */
+      payload: {
+        [key: string]: unknown
+      }
+    }
     /** Unauthorized */
     Unauthorized: {
       /**
@@ -47556,6 +47653,79 @@ export interface operations {
         }
         content: {
           'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'cli:events': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['TriggerEvent'][]
+        }
+      }
+    }
+  }
+  'cli:trigger': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['TriggerRequest']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['TriggerResponse']
+        }
+      }
+      /** @description Organization not found or not accessible. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description No CLI is listening for this organization. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NoActiveListener']
         }
       }
       /** @description Validation Error */

--- a/server/polar/cli/endpoints.py
+++ b/server/polar/cli/endpoints.py
@@ -10,6 +10,8 @@ from standardwebhooks.webhooks import Webhook as StandardWebhook
 
 from polar.cli import auth
 from polar.cli.listener import mark_active, mark_inactive
+from polar.cli.schemas import TriggerEvent, TriggerRequest, TriggerResponse
+from polar.cli.service import NoActiveListener, list_trigger_events, trigger_event
 from polar.eventstream.endpoints import subscribe
 from polar.eventstream.service import Receivers
 from polar.exceptions import ResourceNotFound
@@ -63,6 +65,8 @@ async def transform_webhook_events(
                         "webhook-timestamp": str(int(ts.timestamp())),
                         "webhook-signature": signature,
                     }
+                    if payload_data.get("triggered"):
+                        event["headers"]["x-polar-triggered"] = "true"
                     yield json.dumps(event)
                     continue
         except (json.JSONDecodeError, KeyError) as e:
@@ -118,3 +122,35 @@ async def listen(
             await mark_inactive(redis, org.id)
 
     return EventSourceResponse(first_event_wrapper())
+
+
+@router.get("/events")
+async def events(auth_subject: auth.CLIRead) -> list[TriggerEvent]:
+    return list(list_trigger_events())
+
+
+OrganizationNotFound = {
+    "description": "Organization not found or not accessible.",
+    "model": ResourceNotFound.schema(),
+}
+ListenerNotActive = {
+    "description": "No CLI is listening for this organization.",
+    "model": NoActiveListener.schema(),
+}
+
+
+@router.post(
+    "/trigger/{id}",
+    responses={404: OrganizationNotFound, 409: ListenerNotActive},
+)
+async def trigger(
+    id: OrganizationID,
+    trigger_request: TriggerRequest,
+    auth_subject: auth.CLIRead,
+    redis: Redis = Depends(get_redis),
+    session: AsyncSession = Depends(get_db_session),
+) -> TriggerResponse:
+    organization = await organization_service.get(session, auth_subject, id)
+    if organization is None:
+        raise ResourceNotFound()
+    return await trigger_event(redis, organization, trigger_request)

--- a/server/polar/cli/fixtures.py
+++ b/server/polar/cli/fixtures.py
@@ -1,0 +1,579 @@
+import random
+import uuid
+from datetime import datetime, timedelta
+from functools import cached_property
+from typing import Any
+
+from pydantic import TypeAdapter
+from sqlalchemy import Column, ColumnDefault
+from sqlalchemy.orm import class_mapper
+
+from polar.customer.schemas.state import CustomerState
+from polar.enums import PaymentProcessor, SubscriptionRecurringInterval, TaxBehavior
+from polar.kit.address import Address
+from polar.kit.utils import utc_now
+from polar.kit.visibility import Visibility
+from polar.models import (
+    Benefit,
+    BenefitGrant,
+    Checkout,
+    CheckoutProduct,
+    Customer,
+    CustomerSeat,
+    Member,
+    Order,
+    OrderItem,
+    Organization,
+    Payment,
+    Product,
+    ProductPriceFixed,
+    Refund,
+    Subscription,
+    SubscriptionProductPrice,
+)
+from polar.models.benefit import BenefitType
+from polar.models.checkout import CheckoutStatus
+from polar.models.customer_seat import SeatStatus
+from polar.models.discount import DiscountDuration, DiscountPercentage, DiscountType
+from polar.models.member import MemberRole
+from polar.models.order import OrderBillingReasonInternal, OrderStatus
+from polar.models.payment import PaymentStatus
+from polar.models.product_price import ProductPriceSource
+from polar.models.refund import RefundReason, RefundStatus
+from polar.models.subscription import SubscriptionStatus
+from polar.models.webhook_endpoint import WebhookEventType
+from polar.version import CURRENT_API_VERSION
+from polar.webhook.webhooks import BaseWebhookPayload, WebhookPayloadTypeAdapter
+
+_CustomerStateAdapter: TypeAdapter[CustomerState] = TypeAdapter(CustomerState)
+
+SUPPORTED_EVENTS: tuple[WebhookEventType, ...] = tuple(WebhookEventType)
+
+PERSONAS: tuple[str, ...] = (
+    "Astrid Lindgren",
+    "Selma Lagerlöf",
+    "Greta Garbo",
+    "Karin Boye",
+    "Elsa Beskow",
+    "Monica Zetterlund",
+    "Hilma af Klint",
+    "Alfred Nobel",
+    "Anders Celsius",
+    "Anders Ångström",
+    "August Strindberg",
+    "Tomas Tranströmer",
+)
+
+ADDRESSES: tuple[dict[str, str], ...] = (
+    {"line1": "Drottninggatan 12", "postal_code": "111 51", "city": "Stockholm"},
+    {"line1": "Kungsportsavenyen 7", "postal_code": "411 36", "city": "Göteborg"},
+    {"line1": "Södergatan 3", "postal_code": "211 34", "city": "Malmö"},
+    {"line1": "Fyristorg 4", "postal_code": "753 10", "city": "Uppsala"},
+    {"line1": "Storgatan 28", "postal_code": "903 26", "city": "Umeå"},
+    {"line1": "Stora Torget 1", "postal_code": "582 19", "city": "Linköping"},
+    {"line1": "Kyrkogatan 9", "postal_code": "222 22", "city": "Lund"},
+    {"line1": "Hamngatan 15", "postal_code": "831 30", "city": "Östersund"},
+)
+
+TRANSLITERATIONS = str.maketrans({"å": "a", "ä": "a", "ö": "o", "é": "e", " ": "."})
+
+
+def email_for(name: str) -> str:
+    handle = "".join(
+        character
+        for character in name.lower().translate(TRANSLITERATIONS)
+        if character.isalnum() or character in ".-"
+    )
+    return f"{handle}@polar.sh"
+
+
+def with_column_defaults[ModelT](instance: ModelT) -> ModelT:
+    """
+    Transient objects never go through an INSERT, so column defaults are not
+    applied. Apply the Python-side ones so the schemas see complete objects.
+    """
+    mapper = class_mapper(type(instance))
+    for attribute in mapper.column_attrs:
+        column = attribute.columns[0]
+        if not isinstance(column, Column):
+            continue
+        default = column.default
+        if not isinstance(default, ColumnDefault):
+            continue
+        if getattr(instance, attribute.key, None) is not None:
+            continue
+        if default.is_scalar:
+            setattr(instance, attribute.key, default.arg)
+        elif default.is_callable:
+            setattr(instance, attribute.key, default.arg(None))
+    return instance
+
+
+class TriggerFixtures:
+    """
+    Builds an in-memory, mutually consistent set of objects for a triggered
+    webhook event. Nothing is persisted: the objects only exist to be
+    serialized into a payload.
+    """
+
+    def __init__(self, organization: Organization, seed: int | None = None) -> None:
+        self.organization = organization
+        self.random = random.Random(seed)
+        self.now = utc_now()
+        self.personas = self.random.sample(PERSONAS, 2)
+
+    def build(self, event: WebhookEventType) -> BaseWebhookPayload:
+        return WebhookPayloadTypeAdapter.validate_python(
+            {
+                "type": event,
+                "timestamp": self.now,
+                "api_version": CURRENT_API_VERSION,
+                "data": self._data_for(event),
+            },
+            from_attributes=True,
+        )
+
+    def _data_for(self, event: WebhookEventType) -> Any:
+        match event:
+            case WebhookEventType.checkout_created:
+                return self.checkout
+            case WebhookEventType.checkout_updated:
+                self.checkout.status = CheckoutStatus.confirmed
+                return self.checkout
+            case WebhookEventType.checkout_expired:
+                self.checkout.status = CheckoutStatus.expired
+                self.checkout.expires_at = self.now - timedelta(minutes=1)
+                return self.checkout
+            case (
+                WebhookEventType.customer_created
+                | WebhookEventType.customer_updated
+                | WebhookEventType.customer_deleted
+            ):
+                return self.customer
+            case WebhookEventType.customer_state_changed:
+                return self.customer_state
+            case WebhookEventType.customer_seat_assigned:
+                return self.seat
+            case WebhookEventType.customer_seat_claimed:
+                self.seat.status = SeatStatus.claimed
+                self.seat.claimed_at = self.now
+                self.seat.invitation_token = None
+                return self.seat
+            case WebhookEventType.customer_seat_revoked:
+                self.seat.status = SeatStatus.revoked
+                self.seat.revoked_at = self.now
+                self.seat.invitation_token = None
+                return self.seat
+            case (
+                WebhookEventType.member_created
+                | WebhookEventType.member_updated
+                | WebhookEventType.member_deleted
+            ):
+                return self.member
+            case (
+                WebhookEventType.discount_created
+                | WebhookEventType.discount_updated
+                | WebhookEventType.discount_deleted
+            ):
+                return self.discount
+            case WebhookEventType.order_created:
+                self.order.status = OrderStatus.pending
+                return self.order
+            case WebhookEventType.order_updated | WebhookEventType.order_paid:
+                return self.order
+            case WebhookEventType.order_refunded:
+                self.order.status = OrderStatus.refunded
+                self.order.refunded_amount = self.order.net_amount
+                self.order.refunded_tax_amount = self.order.tax_amount
+                return self.order
+            case (
+                WebhookEventType.subscription_created
+                | WebhookEventType.subscription_updated
+                | WebhookEventType.subscription_active
+                | WebhookEventType.subscription_uncanceled
+                | WebhookEventType.subscription_resumed
+            ):
+                return self.subscription
+            case WebhookEventType.subscription_canceled:
+                self.subscription.cancel_at_period_end = True
+                self.subscription.canceled_at = self.now
+                self.subscription.ends_at = self.subscription.current_period_end
+                return self.subscription
+            case WebhookEventType.subscription_cycled:
+                start = self.subscription.current_period_end
+                self.subscription.current_period_start = start
+                self.subscription.current_period_end = self._next_period(start)
+                return self.subscription
+            case WebhookEventType.subscription_revoked:
+                self.subscription.status = SubscriptionStatus.canceled
+                self.subscription.canceled_at = self.now
+                self.subscription.ends_at = self.now
+                self.subscription.ended_at = self.now
+                return self.subscription
+            case WebhookEventType.subscription_past_due:
+                self.subscription.status = SubscriptionStatus.past_due
+                self.subscription.past_due_at = self.now
+                return self.subscription
+            case WebhookEventType.subscription_paused:
+                self.subscription.status = SubscriptionStatus.paused
+                return self.subscription
+            case WebhookEventType.refund_created | WebhookEventType.refund_updated:
+                return self.refund
+            case WebhookEventType.product_created | WebhookEventType.product_updated:
+                return self.product
+            case WebhookEventType.organization_updated:
+                return self.organization
+            case WebhookEventType.benefit_created | WebhookEventType.benefit_updated:
+                return self.benefit
+            case (
+                WebhookEventType.benefit_grant_created
+                | WebhookEventType.benefit_grant_updated
+                | WebhookEventType.benefit_grant_cycled
+            ):
+                return self.benefit_grant
+            case WebhookEventType.benefit_grant_revoked:
+                self.benefit_grant.set_revoked()
+                return self.benefit_grant
+            case _:
+                raise ValueError(f"Event {event} cannot be triggered")
+
+    def _uuid(self) -> uuid.UUID:
+        return uuid.UUID(int=self.random.getrandbits(128), version=4)
+
+    def _next_period(self, start: datetime) -> datetime:
+        return SubscriptionRecurringInterval.month.get_next_period(start, start.day, 1)
+
+    @cached_property
+    def product(self) -> Product:
+        created_at = self.now - timedelta(days=30)
+        product = with_column_defaults(
+            Product(
+                id=self._uuid(),
+                created_at=created_at,
+                name="Pro Plan",
+                description="Everything you need to ship.",
+                is_tax_applicable=True,
+                recurring_interval=SubscriptionRecurringInterval.month,
+                recurring_interval_count=1,
+                visibility=Visibility.public,
+                organization=self.organization,
+                organization_id=self.organization.id,
+                user_metadata={},
+                all_prices=[],
+                prices=[],
+                product_benefits=[],
+                product_medias=[],
+                attached_custom_fields=[],
+            )
+        )
+        price = with_column_defaults(
+            ProductPriceFixed(
+                id=self._uuid(),
+                created_at=created_at,
+                price_amount=1000,
+                price_currency="usd",
+                product=product,
+                product_id=product.id,
+                source=ProductPriceSource.catalog,
+            )
+        )
+        product.all_prices = [price]
+        product.prices = [price]
+        return product
+
+    @cached_property
+    def price(self) -> ProductPriceFixed:
+        return self.product.prices[0]  # type: ignore[return-value]
+
+    @cached_property
+    def customer(self) -> Customer:
+        name = self.personas[0]
+        return with_column_defaults(
+            Customer(
+                id=self._uuid(),
+                created_at=self.now - timedelta(days=7),
+                email=email_for(name),
+                email_verified=True,
+                name=name,
+                organization=self.organization,
+                organization_id=self.organization.id,
+                billing_address=Address.model_validate(
+                    {**self.random.choice(ADDRESSES), "country": "SE"}
+                ),
+                user_metadata={},
+            )
+        )
+
+    @cached_property
+    def checkout(self) -> Checkout:
+        return with_column_defaults(
+            Checkout(
+                id=self._uuid(),
+                created_at=self.now,
+                payment_processor=PaymentProcessor.stripe,
+                status=CheckoutStatus.open,
+                expires_at=self.now + timedelta(hours=1),
+                client_secret=f"polar_c_{self.random.getrandbits(80):020x}",
+                user_metadata={},
+                customer_metadata={},
+                payment_processor_metadata={},
+                amount=self.price.price_amount,
+                net_amount=self.price.price_amount,
+                tax_amount=0,
+                currency="usd",
+                organization=self.organization,
+                organization_id=self.organization.id,
+                product_price=self.price,
+                product_price_id=self.price.id,
+                product=self.product,
+                product_id=self.product.id,
+                checkout_products=[
+                    with_column_defaults(
+                        CheckoutProduct(
+                            product=self.product,
+                            product_id=self.product.id,
+                            order=0,
+                            ad_hoc_prices=[],
+                        )
+                    )
+                ],
+                customer=self.customer,
+                customer_id=self.customer.id,
+                customer_billing_address=self.customer.billing_address,
+            )
+        )
+
+    @cached_property
+    def subscription(self) -> Subscription:
+        start = self.now - timedelta(days=3)
+        return with_column_defaults(
+            Subscription(
+                id=self._uuid(),
+                created_at=start,
+                recurring_interval=SubscriptionRecurringInterval.month,
+                recurring_interval_count=1,
+                status=SubscriptionStatus.active,
+                tax_behavior=TaxBehavior.exclusive,
+                tax_exempted=False,
+                current_period_start=start,
+                current_period_end=self._next_period(start),
+                anchor_day=start.day,
+                amount=self.price.price_amount,
+                net_amount=self.price.price_amount,
+                cancel_at_period_end=False,
+                started_at=start,
+                organization=self.organization,
+                organization_id=self.organization.id,
+                customer=self.customer,
+                customer_id=self.customer.id,
+                product=self.product,
+                product_id=self.product.id,
+                subscription_product_prices=[
+                    with_column_defaults(
+                        SubscriptionProductPrice.from_price(self.price)
+                    )
+                ],
+                currency="usd",
+                user_metadata={},
+            )
+        )
+
+    @cached_property
+    def order(self) -> Order:
+        amount = self.price.price_amount
+        return with_column_defaults(
+            Order(
+                id=self._uuid(),
+                created_at=self.now,
+                status=OrderStatus.paid,
+                subtotal_amount=amount,
+                net_amount=amount,
+                tax_amount=0,
+                discount_amount=0,
+                refunded_amount=0,
+                refunded_tax_amount=0,
+                applied_balance_amount=0,
+                items=[
+                    with_column_defaults(
+                        OrderItem(
+                            id=self._uuid(),
+                            created_at=self.now,
+                            label=self.product.name,
+                            amount=amount,
+                            net_amount=amount,
+                            tax_amount=0,
+                            proration=False,
+                            product_price=self.price,
+                            product_price_id=self.price.id,
+                        )
+                    )
+                ],
+                currency="usd",
+                tax_behavior=TaxBehavior.exclusive,
+                billing_reason=OrderBillingReasonInternal.subscription_create,
+                billing_name=self.customer.name,
+                billing_address=self.customer.billing_address,
+                invoice_number=f"INV-{self.random.randint(1000, 9999)}",
+                organization=self.organization,
+                organization_id=self.organization.id,
+                customer=self.customer,
+                customer_id=self.customer.id,
+                product=self.product,
+                product_id=self.product.id,
+                subscription=self.subscription,
+                subscription_id=self.subscription.id,
+                checkout=self.checkout,
+                checkout_id=self.checkout.id,
+                custom_field_data={},
+                user_metadata={},
+            )
+        )
+
+    @cached_property
+    def payment(self) -> Payment:
+        return with_column_defaults(
+            Payment(
+                id=self._uuid(),
+                created_at=self.now,
+                processor=PaymentProcessor.stripe,
+                status=PaymentStatus.succeeded,
+                amount=self.order.net_amount,
+                currency="usd",
+                method="card",
+                method_metadata={"brand": "visa", "last4": "4242"},
+                customer_email=self.customer.email,
+                processor_id=f"pi_{self.random.getrandbits(96):024x}",
+                organization=self.organization,
+                organization_id=self.organization.id,
+                checkout=self.checkout,
+                checkout_id=self.checkout.id,
+                order=self.order,
+                order_id=self.order.id,
+            )
+        )
+
+    @cached_property
+    def refund(self) -> Refund:
+        return with_column_defaults(
+            Refund(
+                id=self._uuid(),
+                created_at=self.now,
+                status=RefundStatus.succeeded,
+                reason=RefundReason.customer_request,
+                amount=self.order.net_amount,
+                tax_amount=self.order.tax_amount,
+                currency="usd",
+                destination_details={},
+                payment=self.payment,
+                payment_id=self.payment.id,
+                order=self.order,
+                order_id=self.order.id,
+                subscription=self.subscription,
+                subscription_id=self.subscription.id,
+                customer=self.customer,
+                customer_id=self.customer.id,
+                organization=self.organization,
+                organization_id=self.organization.id,
+                revoke_benefits=False,
+                processor=PaymentProcessor.stripe,
+                processor_id=f"re_{self.random.getrandbits(96):024x}",
+                processor_reason="requested_by_customer",
+            )
+        )
+
+    @cached_property
+    def benefit(self) -> Benefit:
+        return with_column_defaults(
+            Benefit(
+                id=self._uuid(),
+                created_at=self.now - timedelta(days=30),
+                type=BenefitType.custom,
+                description="Access to the fika room",
+                is_tax_applicable=True,
+                organization=self.organization,
+                organization_id=self.organization.id,
+                user_metadata={},
+                selectable=True,
+                deletable=True,
+                properties={"note": None},
+            )
+        )
+
+    @cached_property
+    def benefit_grant(self) -> BenefitGrant:
+        grant = with_column_defaults(
+            BenefitGrant(
+                id=self._uuid(),
+                created_at=self.now,
+                benefit=self.benefit,
+                benefit_id=self.benefit.id,
+                customer=self.customer,
+                customer_id=self.customer.id,
+                subscription=self.subscription,
+                subscription_id=self.subscription.id,
+                properties={},
+            )
+        )
+        grant.set_granted()
+        return grant
+
+    @cached_property
+    def member(self) -> Member:
+        name = self.personas[1]
+        return with_column_defaults(
+            Member(
+                id=self._uuid(),
+                created_at=self.now - timedelta(days=1),
+                customer=self.customer,
+                customer_id=self.customer.id,
+                organization_id=self.organization.id,
+                email=email_for(name),
+                name=name,
+                role=MemberRole.member,
+            )
+        )
+
+    @cached_property
+    def seat(self) -> CustomerSeat:
+        return with_column_defaults(
+            CustomerSeat(
+                id=self._uuid(),
+                created_at=self.now,
+                status=SeatStatus.pending,
+                customer=self.customer,
+                customer_id=self.customer.id,
+                invitation_token=f"polar_st_{self.random.getrandbits(128):032x}",
+                seat_metadata={},
+                member=self.member,
+                member_id=self.member.id,
+                email=self.member.email,
+                subscription=self.subscription,
+                subscription_id=self.subscription.id,
+            )
+        )
+
+    @cached_property
+    def discount(self) -> DiscountPercentage:
+        return with_column_defaults(
+            DiscountPercentage(
+                id=self._uuid(),
+                created_at=self.now - timedelta(days=2),
+                name="Fika week",
+                type=DiscountType.percentage,
+                code="FIKA20",
+                duration=DiscountDuration.once,
+                organization=self.organization,
+                organization_id=self.organization.id,
+                discount_products=[],
+                redemptions_count=0,
+                basis_points=2000,
+            )
+        )
+
+    @cached_property
+    def customer_state(self) -> CustomerState:
+        customer = self.customer
+        customer.active_subscriptions = [self.subscription]
+        customer.granted_benefits = [self.benefit_grant]
+        customer.active_meters = []
+        return _CustomerStateAdapter.validate_python(customer, from_attributes=True)

--- a/server/polar/cli/schemas.py
+++ b/server/polar/cli/schemas.py
@@ -1,0 +1,40 @@
+from typing import Any
+from uuid import UUID
+
+from pydantic import Field
+
+from polar.kit.schemas import Schema
+from polar.models.webhook_endpoint import WebhookEventType
+
+
+class TriggerEvent(Schema):
+    type: WebhookEventType
+    description: str = Field(
+        description="One-line description of when Polar sends this event."
+    )
+
+
+class TriggerRequest(Schema):
+    event: WebhookEventType
+    overrides: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Payload fields to override, keyed by dotted path "
+            "relative to the payload root, e.g. `data.amount`."
+        ),
+    )
+    seed: int | None = Field(
+        default=None,
+        description="Seed for generated IDs and numbers, for reproducible payloads.",
+    )
+    deliver: bool = Field(
+        default=True,
+        description="Send the event to the organization's active CLI listener.",
+    )
+
+
+class TriggerResponse(Schema):
+    webhook_event_id: UUID
+    event: WebhookEventType
+    delivered: bool
+    payload: dict[str, Any]

--- a/server/polar/cli/service.py
+++ b/server/polar/cli/service.py
@@ -1,0 +1,169 @@
+import json
+import typing
+from collections.abc import Sequence
+from typing import Any
+from uuid import UUID
+
+from pydantic import ValidationError
+
+from polar.exceptions import PolarError, PolarRequestValidationError
+from polar.kit.utils import generate_uuid
+from polar.models import Organization
+from polar.models.webhook_endpoint import WebhookEventType
+from polar.redis import Redis
+from polar.webhook.eventstream import publish_webhook_event
+from polar.webhook.webhooks import WebhookPayload, WebhookPayloadTypeAdapter
+
+from .fixtures import SUPPORTED_EVENTS, TriggerFixtures
+from .listener import has_active_listener
+from .schemas import TriggerEvent, TriggerRequest, TriggerResponse
+
+
+class NoActiveListener(PolarError):
+    def __init__(self, organization: Organization) -> None:
+        self.organization = organization
+        super().__init__(
+            f"No CLI is listening for {organization.slug}. "
+            "Run `polar listen <url>` in another terminal first.",
+            status_code=409,
+        )
+
+
+def _event_descriptions() -> dict[WebhookEventType, str]:
+    descriptions: dict[WebhookEventType, str] = {}
+    union, *_ = typing.get_args(WebhookPayload)
+    for payload_class in typing.get_args(union):
+        (event,) = typing.get_args(payload_class.model_fields["type"].annotation)
+        docstring = (payload_class.__doc__ or "").strip()
+        descriptions[event] = docstring.splitlines()[0] if docstring else ""
+    return descriptions
+
+
+def list_trigger_events() -> Sequence[TriggerEvent]:
+    descriptions = _event_descriptions()
+    return [
+        TriggerEvent(type=event, description=descriptions.get(event, ""))
+        for event in SUPPORTED_EVENTS
+    ]
+
+
+def _override_error(path: str, value: Any, message: str) -> PolarRequestValidationError:
+    return PolarRequestValidationError(
+        [
+            {
+                "loc": ("body", "overrides", path),
+                "msg": message,
+                "type": "value_error",
+                "input": value,
+            }
+        ]
+    )
+
+
+PROTECTED_OVERRIDE_PATHS = frozenset({"type"})
+
+
+def _list_index(target: list[Any], segment: str, path: str, value: Any) -> int:
+    try:
+        index = int(segment)
+    except ValueError:
+        raise _override_error(
+            path, value, f"{segment!r} is not a valid list index"
+        ) from None
+    if not -len(target) <= index < len(target):
+        raise _override_error(path, value, f"List index {index} is out of range")
+    return index
+
+
+def apply_overrides(payload: dict[str, Any], overrides: dict[str, Any]) -> None:
+    for path, value in overrides.items():
+        if path in PROTECTED_OVERRIDE_PATHS:
+            raise _override_error(path, value, f"{path!r} cannot be overridden")
+        *parents, leaf = path.split(".")
+        target: Any = payload
+        for segment in parents:
+            if isinstance(target, list):
+                target = target[_list_index(target, segment, path, value)]
+            elif isinstance(target, dict):
+                target = target.setdefault(segment, {})
+            else:
+                raise _override_error(
+                    path, value, f"Cannot set {segment!r} on a {type(target).__name__}"
+                )
+        if isinstance(target, list):
+            target[_list_index(target, leaf, path, value)] = value
+        elif isinstance(target, dict):
+            target[leaf] = value
+        else:
+            raise _override_error(
+                path, value, f"Cannot set {leaf!r} on a {type(target).__name__}"
+            )
+
+
+def _lookup(payload: Any, path: str) -> Any:
+    target = payload
+    for segment in path.split("."):
+        if isinstance(target, list):
+            target = target[int(segment)]
+        elif isinstance(target, dict) and segment in target:
+            target = target[segment]
+        else:
+            raise KeyError(segment)
+    return target
+
+
+def _reject_dropped_overrides(
+    serialized: dict[str, Any], overrides: dict[str, Any]
+) -> None:
+    for path, value in overrides.items():
+        try:
+            _lookup(serialized, path)
+        except KeyError, IndexError, ValueError:
+            raise _override_error(
+                path, value, f"{path!r} is not a field of this payload"
+            ) from None
+
+
+async def trigger_event(
+    redis: Redis, organization: Organization, request: TriggerRequest
+) -> TriggerResponse:
+    fixtures = TriggerFixtures(organization, seed=request.seed)
+    payload = json.loads(fixtures.build(request.event).get_raw_payload())
+    apply_overrides(payload, request.overrides)
+
+    try:
+        validated = WebhookPayloadTypeAdapter.validate_python(payload)
+    except ValidationError as e:
+        raise PolarRequestValidationError(
+            [
+                {
+                    "loc": ("body", "overrides", *error["loc"]),
+                    "msg": error["msg"],
+                    "type": error["type"],
+                    "input": error["input"],
+                }
+                for error in e.errors()
+            ]
+        ) from e
+
+    raw_payload = validated.get_raw_payload()
+    serialized = json.loads(raw_payload)
+    _reject_dropped_overrides(serialized, request.overrides)
+
+    webhook_event_id: UUID = generate_uuid()
+    if request.deliver:
+        if not await has_active_listener(redis, organization.id):
+            raise NoActiveListener(organization)
+        await publish_webhook_event(
+            organization_id=organization.id,
+            payload=raw_payload,
+            webhook_event_id=webhook_event_id,
+            triggered=True,
+        )
+
+    return TriggerResponse(
+        webhook_event_id=webhook_event_id,
+        event=request.event,
+        delivered=request.deliver,
+        payload=serialized,
+    )

--- a/server/polar/webhook/eventstream.py
+++ b/server/polar/webhook/eventstream.py
@@ -24,6 +24,9 @@ def _get_check_redis() -> Redis:
 async def publish_webhook_event(
     organization_id: UUID,
     payload: str,
+    *,
+    webhook_event_id: UUID | None = None,
+    triggered: bool = False,
 ) -> None:
     """
     Publish a webhook event to the eventstream for CLI listeners.
@@ -31,6 +34,9 @@ async def publish_webhook_event(
     Args:
         organization_id: The organization to publish the event for
         payload: The raw JSON string of the webhook payload
+        webhook_event_id: Identifier for the event, generated when omitted
+        triggered: Whether the event was produced by `polar trigger`
+            rather than by real activity
     """
     redis = _get_check_redis()
     if not await has_active_listener(redis, organization_id):
@@ -39,8 +45,9 @@ async def publish_webhook_event(
     await publish(
         WebhookEvent.webhook_created,
         {
-            "webhook_event_id": str(generate_uuid()),
+            "webhook_event_id": str(webhook_event_id or generate_uuid()),
             "payload": payload,
+            "triggered": triggered,
         },
         organization_id=organization_id,
     )

--- a/server/tests/cli/test_trigger.py
+++ b/server/tests/cli/test_trigger.py
@@ -1,0 +1,301 @@
+import json
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.cli.fixtures import (
+    SUPPORTED_EVENTS,
+    TriggerFixtures,
+    with_column_defaults,
+)
+from polar.cli.listener import mark_active
+from polar.cli.schemas import TriggerRequest
+from polar.cli.service import (
+    NoActiveListener,
+    apply_overrides,
+    list_trigger_events,
+    trigger_event,
+)
+from polar.exceptions import PolarRequestValidationError
+from polar.models import Organization
+from polar.models.organization import STATUS_CAPABILITIES, OrganizationStatus
+from polar.models.webhook_endpoint import WebhookEventType
+from polar.redis import Redis
+
+
+@pytest.fixture
+def organization() -> Organization:
+    organization = with_column_defaults(
+        Organization(
+            id=uuid.uuid4(),
+            created_at=datetime(2025, 7, 1, tzinfo=UTC),
+            name="Acme Corp",
+            slug="acme-corp",
+            status=OrganizationStatus.ACTIVE,
+            customer_invoice_prefix="ACME",
+            avatar_url=None,
+            account=None,
+            payout_account=None,
+        )
+    )
+    organization.capabilities = {**STATUS_CAPABILITIES[OrganizationStatus.ACTIVE]}
+    return organization
+
+
+class TestTriggerFixtures:
+    @pytest.mark.parametrize("event", SUPPORTED_EVENTS)
+    def test_builds_every_supported_event(
+        self, organization: Organization, event: WebhookEventType
+    ) -> None:
+        payload = TriggerFixtures(organization, seed=1).build(event)
+
+        assert payload.type == event
+        raw = json.loads(payload.get_raw_payload())
+        assert raw["type"] == event
+        assert raw["data"]["id"]
+
+    def test_seed_makes_payloads_reproducible(self, organization: Organization) -> None:
+        first = TriggerFixtures(organization, seed=7)
+        second = TriggerFixtures(organization, seed=7)
+        other_order = TriggerFixtures(organization, seed=7)
+        different = TriggerFixtures(organization, seed=8)
+        first.build(WebhookEventType.order_paid)
+        second.build(WebhookEventType.order_paid)
+        other_order.build(WebhookEventType.customer_seat_claimed)
+        different.build(WebhookEventType.order_paid)
+
+        assert first.order.id == second.order.id
+        assert first.order.id != different.order.id
+        assert first.customer.name == other_order.customer.name
+        assert first.member.name == other_order.member.name
+
+    def test_objects_are_consistent_with_each_other(
+        self, organization: Organization
+    ) -> None:
+        fixtures = TriggerFixtures(organization, seed=1)
+        order = json.loads(
+            fixtures.build(WebhookEventType.order_paid).get_raw_payload()
+        )["data"]
+
+        assert order["customer_id"] == order["customer"]["id"]
+        assert order["product_id"] == order["product"]["id"]
+        assert order["subscription_id"] == order["subscription"]["id"]
+        assert order["subscription"]["product_id"] == order["product_id"]
+        assert order["subscription"]["amount"] == fixtures.price.price_amount
+        assert order["net_amount"] == fixtures.price.price_amount
+        assert order["product"]["organization_id"] == str(organization.id)
+
+    @pytest.mark.parametrize(
+        ("event", "check"),
+        [
+            (
+                WebhookEventType.checkout_expired,
+                lambda data, now: data.status == "expired" and data.expires_at < now,
+            ),
+            (
+                WebhookEventType.order_refunded,
+                lambda data, now: (
+                    data.status == "refunded"
+                    and data.refunded_amount == data.net_amount
+                ),
+            ),
+            (
+                WebhookEventType.subscription_canceled,
+                lambda data, now: (
+                    data.cancel_at_period_end
+                    and data.ends_at == data.current_period_end
+                ),
+            ),
+            (
+                WebhookEventType.subscription_revoked,
+                lambda data, now: data.status == "canceled" and data.ended_at == now,
+            ),
+            (
+                WebhookEventType.subscription_past_due,
+                lambda data, now: data.status == "past_due",
+            ),
+            (
+                WebhookEventType.customer_seat_claimed,
+                lambda data, now: data.status == "claimed" and data.claimed_at == now,
+            ),
+            (
+                WebhookEventType.customer_seat_revoked,
+                lambda data, now: data.status == "revoked" and data.revoked_at == now,
+            ),
+            (
+                WebhookEventType.benefit_grant_revoked,
+                lambda data, now: data.is_revoked,
+            ),
+        ],
+    )
+    def test_lifecycle_events_carry_the_matching_state(
+        self,
+        organization: Organization,
+        event: WebhookEventType,
+        check: Callable[[Any, datetime], bool],
+    ) -> None:
+        fixtures = TriggerFixtures(organization, seed=1)
+        payload = fixtures.build(event)
+
+        assert check(payload.data, fixtures.now)
+
+
+def test_list_trigger_events_covers_every_event_type() -> None:
+    events = list_trigger_events()
+
+    assert {event.type for event in events} == set(WebhookEventType)
+    assert all(event.description for event in events)
+
+
+class TestApplyOverrides:
+    def test_sets_nested_and_indexed_paths(self) -> None:
+        payload = {"data": {"amount": 1, "items": [{"label": "a"}]}}
+
+        apply_overrides(
+            payload,
+            {"data.amount": 2, "data.items.0.label": "b", "data.metadata.plan": "pro"},
+        )
+
+        assert payload == {
+            "data": {
+                "amount": 2,
+                "items": [{"label": "b"}],
+                "metadata": {"plan": "pro"},
+            }
+        }
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "data.items.x.label",
+            "data.items.5.label",
+            "data.amount.cents",
+            "type",
+        ],
+    )
+    def test_rejects_invalid_paths_with_a_validation_error(self, path: str) -> None:
+        payload = {"type": "order.paid", "data": {"amount": 1, "items": [{}]}}
+
+        with pytest.raises(PolarRequestValidationError):
+            apply_overrides(payload, {path: "x"})
+
+
+@pytest.mark.asyncio
+class TestTriggerEvent:
+    async def test_requires_an_active_listener(
+        self, redis: Redis, organization: Organization
+    ) -> None:
+        with pytest.raises(NoActiveListener):
+            await trigger_event(
+                redis,
+                organization,
+                TriggerRequest(event=WebhookEventType.order_created),
+            )
+
+    async def test_publishes_to_the_listener(
+        self, redis: Redis, organization: Organization, mocker: MockerFixture
+    ) -> None:
+        publish = mocker.patch("polar.cli.service.publish_webhook_event")
+        await mark_active(redis, organization.id)
+
+        response = await trigger_event(
+            redis,
+            organization,
+            TriggerRequest(
+                event=WebhookEventType.order_paid,
+                overrides={"data.customer.email": "vip@example.com"},
+            ),
+        )
+
+        assert response.delivered is True
+        assert response.payload["data"]["customer"]["email"] == "vip@example.com"
+        publish.assert_called_once()
+        kwargs = publish.call_args.kwargs
+        assert kwargs["organization_id"] == organization.id
+        assert kwargs["webhook_event_id"] == response.webhook_event_id
+        assert kwargs["triggered"] is True
+        assert json.loads(kwargs["payload"])["data"]["customer"]["email"] == (
+            "vip@example.com"
+        )
+
+    async def test_skips_delivery_when_asked(
+        self, redis: Redis, organization: Organization, mocker: MockerFixture
+    ) -> None:
+        publish = mocker.patch("polar.cli.service.publish_webhook_event")
+
+        response = await trigger_event(
+            redis,
+            organization,
+            TriggerRequest(event=WebhookEventType.subscription_active, deliver=False),
+        )
+
+        assert response.delivered is False
+        assert response.payload["type"] == "subscription.active"
+        publish.assert_not_called()
+
+    async def test_rejects_overrides_the_schema_would_drop(
+        self, redis: Redis, organization: Organization
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError) as error:
+            await trigger_event(
+                redis,
+                organization,
+                TriggerRequest(
+                    event=WebhookEventType.order_paid,
+                    overrides={"data.nonexistent": 5000},
+                    deliver=False,
+                ),
+            )
+
+        assert "data.nonexistent" in str(error.value.errors())
+
+    async def test_allows_overrides_inside_free_form_metadata(
+        self, redis: Redis, organization: Organization
+    ) -> None:
+        response = await trigger_event(
+            redis,
+            organization,
+            TriggerRequest(
+                event=WebhookEventType.order_paid,
+                overrides={"data.metadata.plan": "pro"},
+                deliver=False,
+            ),
+        )
+
+        assert response.payload["data"]["metadata"] == {"plan": "pro"}
+
+    async def test_response_payload_matches_what_is_delivered(
+        self, redis: Redis, organization: Organization, mocker: MockerFixture
+    ) -> None:
+        publish = mocker.patch("polar.cli.service.publish_webhook_event")
+        await mark_active(redis, organization.id)
+
+        response = await trigger_event(
+            redis,
+            organization,
+            TriggerRequest(
+                event=WebhookEventType.order_paid,
+                overrides={"data.subtotal_amount": "5000"},
+            ),
+        )
+
+        assert response.payload["data"]["subtotal_amount"] == 5000
+        assert response.payload == json.loads(publish.call_args.kwargs["payload"])
+
+    async def test_rejects_overrides_that_break_the_schema(
+        self, redis: Redis, organization: Organization
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await trigger_event(
+                redis,
+                organization,
+                TriggerRequest(
+                    event=WebhookEventType.order_paid,
+                    overrides={"data.subtotal_amount": "not-a-number"},
+                    deliver=False,
+                ),
+            )


### PR DESCRIPTION
## Summary

For our new CLI we want to allow users to trigger webhook events, e.g `polar trigger order.created`, which sends a fixture webhook event to their local server to our `polar listen` tunnel.

This is achieved by:

* `GET /v1/cli/events` - To help user find all possible events with `polar trigger list` so they don't have to guess
* `POST /v1/cli/trigger/{organization_id}` - Which builds a payload of the selected event

The triggered events has a `x-polar-triggered: true` header so the user can differentiate it from real ones.

<img width="1840" height="1134" alt="Screenshot 2026-09-09 at 18 22 03" src="https://github.com/user-attachments/assets/a171945c-82ed-470c-9eb6-e0d64cfe308f" />


Partially fixes https://linear.app/polarsh/issue/PLR-108/add-trigger-command

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

