### PR TITLE
CLI: Add "trigger" command for testing webhooks

### DIFF
--- a/clients/packages/cli/README.md
+++ b/clients/packages/cli/README.md
@@ -33,6 +33,62 @@ Bun `1.4.2` is the runtime, test runner, and binary compiler; pnpm manages depen
 Run the CLI from source with `bun src/cli.ts <command>` in this directory, or
 compile the release binary with `pnpm build:binary` and run `./polar`.
 
+**To run against a local Polar API** instead of sandbox or production, point the CLI
+at it with `POLAR_API_URL` and authenticate with an organization access token
+created in the local dashboard (scopes `webhooks:read`, `webhooks:write`,
+`organizations:read`). The token replaces `auth login`, so there is no browser
+flow and no environment to choose:
+
+```bash
+export POLAR_API_URL=http://127.0.0.1:8000
+export POLAR_ACCESS_TOKEN=polar_oat_...
+bun src/cli.ts listen http://localhost:4321/webhooks
+bun src/cli.ts trigger order.created
+```
+
+The URL passed to `listen` is the app you are integrating Polar into, the one
+that receives webhooks.
+
+### Testing webhook triggers
+
+This walks through the full loop against sandbox or production. Against a local
+Polar API, set the two variables from the section above instead and skip step 1;
+everything else is the same.
+
+**1. Sign in and pick an organization.** Use `--sandbox` or `--production`. The browser opens for consent, then you choose an organization. Every command after this uses that organization's environment.
+
+```bash
+bun src/cli.ts auth login --sandbox
+bun src/cli.ts auth whoami
+```
+
+**2. Start a webhook receiver** in its own terminal. This stands in for your
+own app's webhook route; if you have one, point the tunnel at that instead.
+The one-liner logs each event it receives:
+
+```bash
+bun -e 'Bun.serve({ port: 4321, fetch: async (req) => { const b = await req.json(); console.log(b.type, "triggered:", req.headers.get("x-polar-triggered"), "customer:", b.data?.customer?.email ?? b.data?.email); return new Response("ok") } })'
+```
+
+**3. Open the tunnel** in a second terminal. You should see the connection banner with the organization name and the signing secret:
+
+```bash
+bun src/cli.ts listen http://localhost:4321/webhooks
+```
+
+**4. Trigger events** from a third terminal. Start with the catalog, then send a few:
+
+```bash
+bun src/cli.ts trigger --list
+bun src/cli.ts trigger order.created
+bun src/cli.ts trigger
+bun src/cli.ts trigger order.paid --override data.customer.email=astrid.lindgren@polar.sh --override data.subtotal_amount=99900 --seed 7
+bun src/cli.ts trigger customer_seat.assigned --seed 1 && bun src/cli.ts trigger customer_seat.claimed --seed 1 && bun src/cli.ts trigger customer_seat.revoked --seed 1
+bun src/cli.ts trigger customer.created --json --seed 3
+```
+
+Each trigger prints a confirmation, the listen terminal logs the forwarded event with your server's status code, and the receiver prints the payload type with `triggered: true`. Nothing is created in the organization: the dashboard shows no new orders, customers, or webhook deliveries.
+
 ## Releases
 
 Add a changeset from `clients/` with `pnpm exec changeset` and select `polar-cli`.

--- a/clients/packages/cli/src/cli.ts
+++ b/clients/packages/cli/src/cli.ts
@@ -3,6 +3,7 @@ import { Cause, Effect, Layer, Runtime, Stdio } from 'effect'
 import { CliConfig, Command, GlobalFlag } from 'effect/unstable/cli'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { listen } from '@/commands/listen'
+import { trigger } from '@/commands/trigger'
 import { auth } from '@/commands/auth'
 import { update } from '@/commands/update'
 import { describeError } from '@/utils/errors'
@@ -13,6 +14,7 @@ import * as Organizations from '@/services/organizations'
 import * as OAuth from '@/services/oauth'
 import * as Polar from '@/services/polar'
 import * as Telemetry from '@/services/telemetry'
+import * as Trigger from '@/services/trigger'
 import {
   checkForUpdateInBackground,
   showUpdateNotice,
@@ -21,7 +23,7 @@ import * as ui from '@/utils/ui'
 import { VERSION } from '@/version'
 
 const mainCommand = Command.make('polar').pipe(
-  Command.withSubcommands([auth, listen, update]),
+  Command.withSubcommands([auth, listen, trigger, update]),
 )
 
 const cli = Command.run(mainCommand, {
@@ -37,6 +39,9 @@ const polarLayer = Polar.layer.pipe(Layer.provide(authLayer))
 const organizationsLayer = Organizations.layer.pipe(
   Layer.provide(Layer.mergeAll(authLayer, polarLayer, configLayer)),
 )
+const triggerLayer = Trigger.layer.pipe(
+  Layer.provide(Layer.mergeAll(authLayer, FetchHttpClient.layer)),
+)
 const telemetryLayer = Telemetry.layer.pipe(
   Layer.provide(Layer.mergeAll(BunServices.layer, Telemetry.detachedSender)),
 )
@@ -44,6 +49,7 @@ const services = Layer.mergeAll(
   authLayer,
   polarLayer,
   organizationsLayer,
+  triggerLayer,
   telemetryLayer,
   BunServices.layer,
   FetchHttpClient.layer,

--- a/clients/packages/cli/src/commands/listen.test.ts
+++ b/clients/packages/cli/src/commands/listen.test.ts
@@ -3,7 +3,8 @@ import { Console, Effect, Fiber, Redacted } from 'effect'
 import { FetchHttpClient } from 'effect/unstable/http'
 import { AuthError, type PolarEnvironment } from '@/schemas/Auth'
 import { Auth } from '@/services/auth'
-import { authenticatedStreamClient, startListening } from '@/commands/listen'
+import { startListening } from '@/commands/listen'
+import { authenticatedClient } from '@/services/api'
 import { captureConsole } from '@/utils/test-utils/cli'
 import { fakeAuth, overrideCredential } from '@/utils/test-utils/services'
 
@@ -107,6 +108,7 @@ describe('startListening', () => {
     await tick()
     const rawPayload = '{ "type": "order.created", "data": {} }'
     const headers = {
+      'x-polar-triggered': 'true',
       'user-agent': 'polar.sh webhooks',
       'content-type': 'application/json',
       'webhook-id': 'wh_1',
@@ -196,7 +198,7 @@ describe('startListening', () => {
   })
 })
 
-describe('authenticatedStreamClient', () => {
+describe('authenticatedClient', () => {
   let token: string
   let source: 'keyring' | 'override'
   let requests: string[]
@@ -226,7 +228,7 @@ describe('authenticatedStreamClient', () => {
   }
 
   const makeClient = (environment: PolarEnvironment) =>
-    authenticatedStreamClient(environment).pipe(
+    authenticatedClient(environment).pipe(
       Effect.provide(FetchHttpClient.layer),
       Effect.provideService(FetchHttpClient.Fetch, forward as typeof fetch),
     )

--- a/clients/packages/cli/src/commands/listen.ts
+++ b/clients/packages/cli/src/commands/listen.ts
@@ -6,18 +6,16 @@ import {
   Exit,
   Option,
   Schema,
-  Scope,
   Stream,
 } from 'effect'
 import { Argument, Command } from 'effect/unstable/cli'
 import { Sse } from 'effect/unstable/encoding'
 import {
   FetchHttpClient,
-  HttpClient,
   HttpClientRequest,
   HttpClientResponse,
 } from 'effect/unstable/http'
-import { Auth } from '@/services/auth'
+import { apiUrl, authenticatedClient } from '@/services/api'
 import { Organizations } from '@/services/organizations'
 import { org } from '@/commands/flags'
 import { loginCommand, type PolarEnvironment } from '@/schemas/Auth'
@@ -27,11 +25,6 @@ import {
   ListenWebhookEvent,
 } from '@/schemas/Events'
 import * as ui from '@/utils/ui'
-
-export const LISTEN_BASE_URLS = {
-  production: 'https://api.polar.sh/v1/cli/listen',
-  sandbox: 'https://sandbox-api.polar.sh/v1/cli/listen',
-} as const
 
 export class ListenError extends Data.TaggedError('ListenError')<{
   message: string
@@ -92,39 +85,6 @@ export interface StartListeningOptions {
   ) => Promise<Response>
 }
 
-export const authenticatedStreamClient = (environment: PolarEnvironment) =>
-  Effect.gen(function* () {
-    const auth = yield* Auth
-    const client = HttpClient.withScope(yield* HttpClient.HttpClient)
-    let retried = false
-    return HttpClient.transform(client, (_response, request) =>
-      Effect.gen(function* () {
-        const credential = yield* auth.resolve(environment)
-        const requestScope = yield* Scope.fork(yield* Effect.scope)
-        const response = yield* client
-          .execute(
-            HttpClientRequest.bearerToken(request, credential.accessToken),
-          )
-          .pipe(Effect.provideService(Scope.Scope, requestScope))
-        if (
-          response.status !== 401 ||
-          retried ||
-          credential.source === 'override'
-        )
-          return response
-        retried = true
-        yield* Scope.close(requestScope, Exit.void)
-        const refreshed = yield* auth.resolve(
-          environment,
-          credential.accessToken,
-        )
-        return yield* client.execute(
-          HttpClientRequest.bearerToken(request, refreshed.accessToken),
-        )
-      }),
-    )
-  })
-
 export const startListening = ({
   listenUrl,
   forwardUrl,
@@ -133,7 +93,7 @@ export const startListening = ({
   forward = fetch,
 }: StartListeningOptions) =>
   Effect.gen(function* () {
-    const client = yield* authenticatedStreamClient(environment)
+    const client = yield* authenticatedClient(environment)
     let bannerShown = false
     let retryDelay = Duration.millis(3000)
     let lastEventId: string | undefined
@@ -310,8 +270,12 @@ export const listen = Command.make('listen', { url, org }, ({ url, org }) =>
       Option.getOrUndefined(org),
     )
     const { environment } = organization
+    const listenUrl = yield* apiUrl(
+      environment,
+      `/cli/listen/${organization.id}`,
+    )
     return yield* startListening({
-      listenUrl: `${LISTEN_BASE_URLS[environment]}/${organization.id}`,
+      listenUrl,
       forwardUrl: url,
       organizationName: organization.name,
       environment,

--- a/clients/packages/cli/src/commands/trigger/catalog.test.ts
+++ b/clients/packages/cli/src/commands/trigger/catalog.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest'
+import { formatCatalog } from '@/commands/trigger/catalog'
+import { stripAnsi } from '@/utils/test-utils/cli'
+
+test('groups events by resource with aligned descriptions', () => {
+  const output = stripAnsi(
+    formatCatalog([
+      { type: 'checkout.created', description: 'A checkout was created.' },
+      { type: 'checkout.expired', description: 'A checkout expired.' },
+      { type: 'order.paid', description: 'An order was paid.' },
+    ]),
+  )
+
+  expect(output).toContain('  checkout\n')
+  expect(output).toContain('    checkout.created  A checkout was created.')
+  expect(output).toContain('    checkout.expired  A checkout expired.')
+  expect(output).toContain('\n\n  order\n')
+  expect(output).toContain('    order.paid        An order was paid.')
+  expect(output).toContain('polar trigger <event>')
+})

--- a/clients/packages/cli/src/commands/trigger/catalog.ts
+++ b/clients/packages/cli/src/commands/trigger/catalog.ts
@@ -1,0 +1,25 @@
+import type { TriggerEvent } from '@/services/trigger'
+import * as ui from '@/utils/ui'
+
+export const formatCatalog = (events: ReadonlyArray<TriggerEvent>) => {
+  const width = Math.max(0, ...events.map((event) => event.type.length))
+  const lines: string[] = [ui.blank]
+  let resource = ''
+  for (const event of events) {
+    const [eventResource = event.type] = event.type.split('.')
+    if (eventResource !== resource) {
+      if (resource) lines.push(ui.blank)
+      resource = eventResource
+      lines.push(`  ${ui.bold(resource)}`)
+    }
+    lines.push(
+      `    ${ui.cyan(event.type.padEnd(width))}  ${ui.dim(event.description)}`,
+    )
+  }
+  lines.push(
+    ui.blank,
+    ui.step(`Send one with ${ui.command('polar trigger <event>')}`),
+    ui.blank,
+  )
+  return lines.join('\n')
+}

--- a/clients/packages/cli/src/commands/trigger/index.test.ts
+++ b/clients/packages/cli/src/commands/trigger/index.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import { Effect } from 'effect'
+import { trigger as triggerCommand } from '@/commands/trigger'
+import type { ActiveOrganization } from '@/schemas/Auth'
+import { Organizations } from '@/services/organizations'
+import {
+  NoActiveListener,
+  PayloadRejected,
+  Trigger,
+  TriggerError,
+  UnknownEvent,
+} from '@/services/trigger'
+import {
+  keys,
+  runCli,
+  type RunCliOptions,
+  stripAnsi,
+} from '@/utils/test-utils/cli'
+import { fakeOrganizations, fakeTrigger } from '@/utils/test-utils/services'
+
+const acme: ActiveOrganization = {
+  id: 'org-1',
+  name: 'Acme',
+  slug: 'acme',
+  environment: 'sandbox',
+}
+const beta: ActiveOrganization = {
+  id: 'org-2',
+  name: 'Beta',
+  slug: 'beta',
+  environment: 'production',
+}
+const catalog = [
+  { type: 'checkout.created', description: 'Sent when a checkout is created.' },
+  { type: 'order.paid', description: 'Sent when an order is paid.' },
+]
+
+let organizations: ReturnType<typeof fakeOrganizations>
+let trigger: ReturnType<typeof fakeTrigger>
+
+const run = (args: string[], options?: RunCliOptions) => {
+  const cli = runCli(triggerCommand, args, options)
+  const promise = Effect.runPromise(
+    cli.effect.pipe(
+      Effect.provideService(Organizations, organizations.organizations),
+      Effect.provideService(Trigger, trigger.trigger),
+    ),
+  )
+  return { promise, output: cli.output }
+}
+
+beforeEach(() => {
+  organizations = fakeOrganizations({
+    items: [acme, beta],
+    selected: { id: acme.id, environment: acme.environment },
+  })
+  trigger = fakeTrigger({ events: catalog })
+})
+
+describe('trigger', () => {
+  test('sends the event to the active organization', async () => {
+    const { promise, output } = run(['order.created'])
+    await promise
+
+    expect(trigger.state.sent).toEqual([
+      {
+        organization: acme,
+        request: { event: 'order.created', overrides: {}, deliver: true },
+      },
+    ])
+    expect(output()).toContain('Sent order.created to Acme (sandbox)')
+    expect(output()).toContain('evt-1')
+  })
+
+  test('passes overrides, seed and --org through', async () => {
+    const { promise } = run([
+      'order.paid',
+      '--org',
+      'org-2',
+      '--override',
+      'data.customer.email=vip@example.com',
+      '--seed',
+      '42',
+    ])
+    await promise
+
+    expect(trigger.state.sent[0]).toEqual({
+      organization: beta,
+      request: {
+        event: 'order.paid',
+        overrides: { 'data.customer.email': 'vip@example.com' },
+        seed: 42,
+        deliver: true,
+      },
+    })
+  })
+
+  test('prints the payload instead of delivering with --json', async () => {
+    const { promise, output } = run(['order.created', '--json'])
+    await promise
+
+    expect(trigger.state.sent[0]?.request.deliver).toBe(false)
+    expect(JSON.parse(output())).toEqual({
+      type: 'order.created',
+      data: { id: 'ord-1' },
+    })
+  })
+
+  test('lets you pick an event interactively', async () => {
+    const { promise, output } = run([], {
+      interactive: true,
+      input: [...keys.type('order.paid'), keys.enter],
+    })
+    await promise
+
+    expect(trigger.state.sent[0]?.request.event).toBe('order.paid')
+    expect(output()).toContain('Sent order.paid to Acme')
+  })
+
+  test('lists the catalog for the organization environment', async () => {
+    const { promise, output } = run(['--list'])
+    await promise
+
+    expect(output()).toContain('checkout.created')
+    expect(output()).toContain('Sent when an order is paid.')
+    expect(trigger.state.sent).toHaveLength(0)
+  })
+
+  test('requires an event name when not interactive', async () => {
+    const { promise } = run([])
+
+    await expect(promise).rejects.toThrow('An event name is required')
+    expect(trigger.state.sent).toHaveLength(0)
+  })
+
+  test('rejects malformed and duplicate overrides before resolving anything', async () => {
+    await expect(
+      run(['order.created', '--override', 'nope']).promise,
+    ).rejects.toThrow('Invalid override')
+    await expect(
+      run(['order.created', '--override', 'a=1', '--override', 'a=2']).promise,
+    ).rejects.toThrow('more than once')
+    expect(trigger.state.sent).toHaveLength(0)
+  })
+
+  test.each([
+    [
+      new NoActiveListener({ organization: acme }),
+      'Nothing is listening for Acme',
+    ],
+    [
+      new UnknownEvent({ event: 'order.create', suggestion: 'order.created' }),
+      'Did you mean polar trigger order.created',
+    ],
+    [new UnknownEvent({ event: 'payout.done' }), 'polar trigger --list'],
+    [
+      new PayloadRejected({
+        detail: [{ loc: ['body', 'overrides', 'data', 'x'], msg: 'bad' }],
+      }),
+      'data.x: bad',
+    ],
+    [
+      new TriggerError({ message: 'Could not reach the Polar API' }),
+      'Could not reach',
+    ],
+  ])('explains %s', async (failure, expected) => {
+    trigger.state.failure = failure
+    const { promise } = run(['order.create'])
+
+    const error = (await promise.then(
+      () => undefined,
+      (error: unknown) => error,
+    )) as { message: string; hint?: string }
+    expect(stripAnsi(`${error.message} ${error.hint ?? ''}`)).toContain(
+      expected,
+    )
+  })
+
+  test('explains when the catalog cannot be loaded', async () => {
+    trigger.state.listFailure = new TriggerError({
+      message: 'Could not reach the Polar API',
+    })
+    const { promise } = run(['--list'])
+
+    await expect(promise).rejects.toThrow('Could not reach the Polar API')
+  })
+})

--- a/clients/packages/cli/src/commands/trigger/index.ts
+++ b/clients/packages/cli/src/commands/trigger/index.ts
@@ -1,0 +1,139 @@
+import { Console, Effect, Option, Stdio } from 'effect'
+import { Argument, Command, Flag, Prompt } from 'effect/unstable/cli'
+import { org } from '@/commands/flags'
+import { formatCatalog } from '@/commands/trigger/catalog'
+import { describeRejection, parseOverrides } from '@/commands/trigger/overrides'
+import { Organizations } from '@/services/organizations'
+import { Trigger, TriggerError, type TriggerEvent } from '@/services/trigger'
+import * as ui from '@/utils/ui'
+
+const event = Argument.string('event').pipe(
+  Argument.withDescription(
+    'Webhook event to send, e.g. order.created. Omit to pick from a list.',
+  ),
+  Argument.optional,
+)
+
+const override = Flag.string('override').pipe(
+  Flag.withDescription(
+    'Override a payload field, as path=value. Values are sent as text; use null, a JSON object, array or quoted string for other types. Repeatable.',
+  ),
+  Flag.atLeast(0),
+)
+
+const seed = Flag.integer('seed').pipe(
+  Flag.withDescription('Seed for generated IDs, for a reproducible payload'),
+  Flag.optional,
+)
+
+const json = Flag.boolean('json').pipe(
+  Flag.withDefault(false),
+  Flag.withDescription('Print the payload as JSON instead of sending it'),
+)
+
+const list = Flag.boolean('list').pipe(
+  Flag.withDefault(false),
+  Flag.withDescription('List every event you can trigger, with descriptions'),
+)
+
+const interactive = Effect.gen(function* () {
+  const stdio = yield* Stdio.Stdio
+  return (yield* stdio.stdinIsTerminal) && (yield* stdio.stdoutIsTerminal)
+})
+
+const pickEvent = (events: ReadonlyArray<TriggerEvent>) =>
+  Prompt.autoComplete({
+    message: 'Select an event to send',
+    filterPlaceholder: 'Type to filter, e.g. order',
+    choices: events.map((item) => ({
+      value: item.type,
+      title: item.type,
+      description: item.description,
+    })),
+  })
+
+const listHint = `Run ${ui.command('polar trigger --list')} to see every event`
+
+export const trigger = Command.make(
+  'trigger',
+  { event, org, override, seed, json, list },
+  ({ event, org, override, seed, json, list }) =>
+    Effect.gen(function* () {
+      const overrides = yield* parseOverrides(override)
+      if (!list && Option.isNone(event) && !(yield* interactive)) {
+        return yield* new TriggerError({
+          message: 'An event name is required when not running interactively',
+          hint: `Try ${ui.command('polar trigger order.created')} or ${ui.command('polar trigger --list')}`,
+        })
+      }
+
+      const organizations = yield* Organizations
+      const organization = yield* organizations.resolve(
+        Option.getOrUndefined(org),
+      )
+      const { environment } = organization
+      const trigger = yield* Trigger
+
+      if (list) {
+        const events = yield* trigger.listEvents(environment)
+        return yield* Console.log(formatCatalog(events))
+      }
+
+      const eventType = Option.isSome(event)
+        ? event.value
+        : yield* pickEvent(yield* trigger.listEvents(environment))
+
+      const result = yield* trigger
+        .send(organization, {
+          event: eventType,
+          overrides,
+          ...Option.match(seed, {
+            onNone: () => ({}),
+            onSome: (seed) => ({ seed }),
+          }),
+          deliver: !json,
+        })
+        .pipe(
+          Effect.catchTags({
+            NoActiveListener: () =>
+              new TriggerError({
+                message: `Nothing is listening for ${organization.name} in ${environment}`,
+                hint: `Run ${ui.command('polar listen <url>')} in another terminal, then try again`,
+              }),
+            UnknownEvent: ({ event, suggestion }) =>
+              new TriggerError({
+                message: `Unknown event "${event}"`,
+                hint: suggestion
+                  ? `Did you mean ${ui.command(`polar trigger ${suggestion}`)}? ${listHint}`
+                  : listHint,
+              }),
+            PayloadRejected: ({ detail }) =>
+              new TriggerError({
+                message: 'The API rejected the request',
+                hint: describeRejection(detail),
+              }),
+          }),
+        )
+
+      if (json) {
+        return yield* Console.log(JSON.stringify(result.payload, null, 2))
+      }
+      yield* Console.log(
+        [
+          ui.blank,
+          ui.success(
+            `Sent ${ui.cyan(result.event)} to ${ui.bold(organization.name)} ${ui.dim(`(${environment})`)}`,
+          ),
+          ui.keyValue([
+            ['Event ID', ui.dim(result.webhookEventId)],
+            ['Delivered to', `your ${ui.command('polar listen')} terminal`],
+          ]),
+          ui.blank,
+        ].join('\n'),
+      )
+    }),
+).pipe(
+  Command.withDescription(
+    'Send a sample webhook event to your local server through polar listen. Run with --list to see every event.',
+  ),
+)

--- a/clients/packages/cli/src/commands/trigger/overrides.test.ts
+++ b/clients/packages/cli/src/commands/trigger/overrides.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest'
+import { Effect } from 'effect'
+import {
+  describeRejection,
+  parseOverride,
+  parseOverrides,
+} from '@/commands/trigger/overrides'
+
+describe('parseOverride', () => {
+  test.each([
+    ['data.amount=2000', ['data.amount', '2000']],
+    ['data.postal_code=90210', ['data.postal_code', '90210']],
+    [
+      'data.customer.email=jane@example.com',
+      ['data.customer.email', 'jane@example.com'],
+    ],
+    ['data.metadata.plan="pro"', ['data.metadata.plan', 'pro']],
+    ['data.paid=true', ['data.paid', 'true']],
+    ['data.discount=null', ['data.discount', null]],
+    ['data.metadata={"plan":"pro"}', ['data.metadata', { plan: 'pro' }]],
+    ['data.items=[1]', ['data.items', [1]]],
+    ['data.items.0.label=a=b', ['data.items.0.label', 'a=b']],
+    ['data.note={not json', ['data.note', '{not json']],
+  ])('parses %s', async (input, expected) => {
+    expect(await Effect.runPromise(parseOverride(input))).toEqual(expected)
+  })
+
+  test.each(['no-equals', '=value'])('rejects %s', async (input) => {
+    const error = await Effect.runPromise(
+      parseOverride(input).pipe(Effect.flip),
+    )
+    expect(error._tag).toBe('TriggerError')
+    expect(error.hint).toContain('path=value')
+  })
+})
+
+describe('parseOverrides', () => {
+  test('builds an object from the pairs', async () => {
+    expect(await Effect.runPromise(parseOverrides(['a=1', 'b.c="x"']))).toEqual(
+      { a: '1', 'b.c': 'x' },
+    )
+  })
+
+  test('rejects a path given twice', async () => {
+    const error = await Effect.runPromise(
+      parseOverrides(['data.amount=1', 'data.amount=2']).pipe(Effect.flip),
+    )
+    expect(error.message).toContain('more than once')
+  })
+})
+
+describe('describeRejection', () => {
+  test('lists field errors without the body and overrides prefix', () => {
+    expect(
+      describeRejection([
+        { loc: ['body', 'overrides', 'data', 'amount'], msg: 'not an int' },
+        { loc: [], msg: 'unknown' },
+      ]),
+    ).toBe('data.amount: not an int\n    unknown')
+  })
+
+  test('stringifies non-list details', () => {
+    expect(describeRejection('boom')).toBe('boom')
+  })
+})

--- a/clients/packages/cli/src/commands/trigger/overrides.ts
+++ b/clients/packages/cli/src/commands/trigger/overrides.ts
@@ -1,0 +1,59 @@
+import { Effect } from 'effect'
+import { TriggerError } from '@/services/trigger'
+
+type Override = readonly [path: string, value: unknown]
+
+const parseValue = (raw: string): unknown => {
+  if (raw === 'null') return null
+  if (!/^[[{"]/.test(raw)) return raw
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return raw
+  }
+}
+
+export const parseOverride = (
+  input: string,
+): Effect.Effect<Override, TriggerError> => {
+  const separator = input.indexOf('=')
+  if (separator <= 0) {
+    return Effect.fail(
+      new TriggerError({
+        message: `Invalid override "${input}"`,
+        hint: 'Use the form path=value, e.g. --override data.customer.email=jane@example.com',
+      }),
+    )
+  }
+  return Effect.succeed([
+    input.slice(0, separator),
+    parseValue(input.slice(separator + 1)),
+  ] as const)
+}
+
+export const parseOverrides = (inputs: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const entries = yield* Effect.forEach(inputs, parseOverride)
+    const seen = new Set<string>()
+    for (const [path] of entries) {
+      if (seen.has(path)) {
+        return yield* new TriggerError({
+          message: `Override "${path}" was given more than once`,
+        })
+      }
+      seen.add(path)
+    }
+    return Object.fromEntries(entries)
+  })
+
+export const describeRejection = (detail: unknown) => {
+  if (!Array.isArray(detail)) return String(detail)
+  return detail
+    .map((error: { loc?: unknown[]; msg?: string }) => {
+      const location = (error.loc ?? [])
+        .filter((segment) => segment !== 'body' && segment !== 'overrides')
+        .join('.')
+      return location ? `${location}: ${error.msg}` : String(error.msg)
+    })
+    .join('\n    ')
+}

--- a/clients/packages/cli/src/schemas/Events.ts
+++ b/clients/packages/cli/src/schemas/Events.ts
@@ -17,13 +17,7 @@ export const ListenWebhookEvent = Schema.Struct({
     webhook_event_id: Schema.String,
     payload: Schema.String,
   }),
-  headers: Schema.Struct({
-    'user-agent': Schema.Literal('polar.sh webhooks'),
-    'content-type': Schema.Literal('application/json'),
-    'webhook-id': Schema.String,
-    'webhook-timestamp': Schema.String,
-    'webhook-signature': Schema.String,
-  }),
+  headers: Schema.Record(Schema.String, Schema.String),
 })
 
 export const ListenEvent = Schema.Union([

--- a/clients/packages/cli/src/services/api.test.ts
+++ b/clients/packages/cli/src/services/api.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'vitest'
+import { Effect } from 'effect'
+import {
+  apiOrigin,
+  apiUrl,
+  describeApiFailure,
+  Environment,
+} from '@/services/api'
+
+const withEnv = <A>(
+  effect: Effect.Effect<A>,
+  env: Record<string, string | undefined>,
+) => Effect.runSync(effect.pipe(Effect.provideService(Environment, env)))
+
+describe('apiUrl', () => {
+  test('uses the environment origin by default', () => {
+    expect(withEnv(apiUrl('sandbox', '/cli/events'), {})).toBe(
+      'https://sandbox-api.polar.sh/v1/cli/events',
+    )
+    expect(withEnv(apiUrl('production', '/cli/events'), {})).toBe(
+      'https://api.polar.sh/v1/cli/events',
+    )
+  })
+
+  test('honors POLAR_API_URL and strips trailing slashes', () => {
+    expect(
+      withEnv(apiUrl('production', '/cli/events'), {
+        POLAR_API_URL: 'http://127.0.0.1:8000//',
+      }),
+    ).toBe('http://127.0.0.1:8000/v1/cli/events')
+  })
+
+  test.each([
+    'http://localhost:8000',
+    'http://127.0.0.1:8000',
+    'http://api.polar.localhost',
+    'https://api.staging.example',
+  ])('accepts %s', (value) => {
+    expect(withEnv(apiOrigin('sandbox'), { POLAR_API_URL: value })).toBe(value)
+  })
+
+  test('rejects plain http to a non-local host', () => {
+    expect(() =>
+      withEnv(apiOrigin('sandbox'), { POLAR_API_URL: 'http://api.example' }),
+    ).toThrow('must use https unless it points at localhost')
+  })
+
+  test.each(['not a url', 'ftp://127.0.0.1'])('rejects %s', (value) => {
+    expect(() =>
+      withEnv(apiOrigin('sandbox'), { POLAR_API_URL: value }),
+    ).toThrow('POLAR_API_URL must be an http(s) URL')
+  })
+
+  test.each(['', '   '])('treats %j POLAR_API_URL as unset', (value) => {
+    expect(withEnv(apiOrigin('sandbox'), { POLAR_API_URL: value })).toBe(
+      'https://sandbox-api.polar.sh',
+    )
+  })
+})
+
+describe('describeApiFailure', () => {
+  test.each([
+    [401, 'Authentication rejected for sandbox', 'polar auth login --sandbox'],
+    [403, 'You do not have access to this organization', 'webhooks:write'],
+    [404, 'could not be found in sandbox', 'polar auth org'],
+    [503, 'returned an error (503)', 'try again shortly'],
+  ])('describes %d', (status, message, hint) => {
+    const failure = describeApiFailure(status, 'sandbox')
+    expect(failure.message).toContain(message)
+    expect(failure.hint).toContain(hint)
+  })
+
+  test('has no hint for other statuses', () => {
+    expect(describeApiFailure(418, 'sandbox')).toEqual({
+      message: 'The API returned an unexpected status (418)',
+    })
+  })
+})

--- a/clients/packages/cli/src/services/api.ts
+++ b/clients/packages/cli/src/services/api.ts
@@ -1,0 +1,121 @@
+import { Context, Effect, Exit, Scope } from 'effect'
+import { HttpClient, HttpClientRequest } from 'effect/unstable/http'
+import { Auth } from '@/services/auth'
+import { loginCommand, orgCommand, type PolarEnvironment } from '@/schemas/Auth'
+
+type Env = Record<string, string | undefined>
+
+export const Environment = Context.Reference<Env>('polar/Api/Environment', {
+  defaultValue: () => process.env,
+})
+
+const API_ORIGINS = {
+  production: 'https://api.polar.sh',
+  sandbox: 'https://sandbox-api.polar.sh',
+} as const
+
+const isLoopback = (host: string) =>
+  host === 'localhost' ||
+  host.endsWith('.localhost') ||
+  host === '[::1]' ||
+  /^127\.\d+\.\d+\.\d+$/.test(host)
+
+const parseOverride = (value: string) => {
+  const url = (() => {
+    try {
+      return new URL(value)
+    } catch {
+      return undefined
+    }
+  })()
+  if (!url || !['http:', 'https:'].includes(url.protocol)) {
+    return new Error(`POLAR_API_URL must be an http(s) URL, got "${value}"`)
+  }
+  if (url.protocol === 'http:' && !isLoopback(url.hostname)) {
+    return new Error(
+      `POLAR_API_URL must use https unless it points at localhost, got "${value}". Tokens would otherwise be sent in plain text.`,
+    )
+  }
+  return url.origin
+}
+
+export const apiOrigin = (environment: PolarEnvironment) =>
+  Effect.flatMap(Environment, (env) => {
+    const override = env['POLAR_API_URL']?.trim()
+    if (!override) return Effect.succeed(API_ORIGINS[environment])
+    const parsed = parseOverride(override)
+    return parsed instanceof Error ? Effect.die(parsed) : Effect.succeed(parsed)
+  })
+
+export const apiUrl = (environment: PolarEnvironment, path: string) =>
+  Effect.map(apiOrigin(environment), (origin) => `${origin}/v1${path}`)
+
+export interface ApiFailure {
+  message: string
+  hint?: string
+}
+
+export const describeApiFailure = (
+  status: number,
+  environment: PolarEnvironment,
+): ApiFailure => {
+  switch (status) {
+    case 401:
+      return {
+        message: `Authentication rejected for ${environment}`,
+        hint: `Check POLAR_ACCESS_TOKEN or run ${loginCommand(environment)} --new-session`,
+      }
+    case 403:
+      return {
+        message: 'You do not have access to this organization',
+        hint: 'The token needs the webhooks:read and webhooks:write scopes',
+      }
+    case 404:
+      return {
+        message: `The organization could not be found in ${environment}`,
+        hint: `Check --org or run ${orgCommand} to pick another one`,
+      }
+    default:
+      return status >= 500
+        ? {
+            message: `The Polar API returned an error (${status})`,
+            hint: 'It may be having issues, try again shortly',
+          }
+        : { message: `The API returned an unexpected status (${status})` }
+  }
+}
+
+export const authenticatedClient = (environment: PolarEnvironment) =>
+  Effect.gen(function* () {
+    const auth = yield* Auth
+    const client = HttpClient.withScope(yield* HttpClient.HttpClient)
+    let retried = false
+    return HttpClient.transform(client, (_response, request) =>
+      Effect.gen(function* () {
+        const credential = yield* auth.resolve(environment)
+        const requestScope = yield* Scope.fork(yield* Effect.scope)
+        const response = yield* client
+          .execute(
+            HttpClientRequest.bearerToken(request, credential.accessToken),
+          )
+          .pipe(Effect.provideService(Scope.Scope, requestScope))
+        if (
+          response.status !== 401 ||
+          retried ||
+          credential.source === 'override'
+        )
+          return response
+        retried = true
+        yield* Scope.close(requestScope, Exit.void)
+        const refreshed = yield* auth.resolve(
+          environment,
+          credential.accessToken,
+        )
+        return yield* client.execute(
+          HttpClientRequest.bearerToken(request, refreshed.accessToken),
+        )
+      }),
+    )
+  })
+
+export type ApiClient = Effect.Success<ReturnType<typeof authenticatedClient>>

--- a/clients/packages/cli/src/services/oauth.ts
+++ b/clients/packages/cli/src/services/oauth.ts
@@ -15,6 +15,7 @@ import {
   HttpClientResponse,
 } from 'effect/unstable/http'
 import open from 'open'
+import { apiUrl } from '@/services/api'
 import {
   AuthError,
   loginCommand,
@@ -29,9 +30,6 @@ const PRODUCTION_CLIENT_ID = 'polar_ci_gBnJ_Yv_uSGm5mtoPa2cCA'
 
 const SANDBOX_AUTHORIZATION_URL = 'https://sandbox.polar.sh/oauth2/authorize'
 const PRODUCTION_AUTHORIZATION_URL = 'https://polar.sh/oauth2/authorize'
-
-const SANDBOX_TOKEN_URL = 'https://sandbox-api.polar.sh/v1/oauth2/token'
-const PRODUCTION_TOKEN_URL = 'https://api.polar.sh/v1/oauth2/token'
 
 const config = {
   scopes: [
@@ -131,7 +129,7 @@ export const exchange = (
     )
     const client = HttpClient.withScope(yield* HttpClient.HttpClient)
     const request = HttpClientRequest.post(
-      environment === 'production' ? PRODUCTION_TOKEN_URL : SANDBOX_TOKEN_URL,
+      yield* apiUrl(environment, '/oauth2/token'),
     ).pipe(HttpClientRequest.bodyUrlParams(params))
     const response = yield* client.execute(request).pipe(
       Effect.mapError(

--- a/clients/packages/cli/src/services/polar.ts
+++ b/clients/packages/cli/src/services/polar.ts
@@ -1,6 +1,7 @@
 import { createPolar, type Polar as PolarSDK } from '@polar-sh/sdk/2026-04'
 import { Context, Effect, Layer, Redacted } from 'effect'
 import { AuthError, loginCommand, type PolarEnvironment } from '@/schemas/Auth'
+import { apiOrigin } from '@/services/api'
 import { Auth } from '@/services/auth'
 
 export class Polar extends Context.Service<Polar, PolarImpl>()('Polar') {}
@@ -21,8 +22,10 @@ export const make = Effect.gen(function* () {
   const getClient = (environment: PolarEnvironment = 'sandbox') =>
     Effect.gen(function* () {
       const { accessToken } = yield* auth.resolve(environment)
+      const baseUrl = yield* apiOrigin(environment)
       return createPolar({
         environment,
+        baseUrl,
         accessToken: Redacted.value(accessToken),
       })
     })
@@ -33,12 +36,14 @@ export const make = Effect.gen(function* () {
   ) =>
     Effect.gen(function* () {
       const credential = yield* auth.resolve(environment)
+      const baseUrl = yield* apiOrigin(environment)
       const request = (accessToken: Redacted.Redacted<string>) =>
         Effect.tryPromise({
           try: () =>
             fn(
               createPolar({
                 environment,
+                baseUrl,
                 accessToken: Redacted.value(accessToken),
               }),
             ),

--- a/clients/packages/cli/src/services/trigger.test.ts
+++ b/clients/packages/cli/src/services/trigger.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, test } from 'vitest'
+import { Effect } from 'effect'
+import type { ActiveOrganization } from '@/schemas/Auth'
+import { Auth } from '@/services/auth'
+import { closestEvent, make } from '@/services/trigger'
+import { fakeHttp } from '@/utils/test-utils/http'
+import { fakeAuth } from '@/utils/test-utils/services'
+
+const acme: ActiveOrganization = {
+  id: 'org-1',
+  name: 'Acme',
+  slug: 'acme',
+  environment: 'sandbox',
+}
+const eventsUrl = 'https://sandbox-api.polar.sh/v1/cli/events'
+const triggerUrl = 'https://sandbox-api.polar.sh/v1/cli/trigger/org-1'
+const catalog = [
+  { type: 'order.created', description: 'Created.' },
+  { type: 'order.paid', description: 'Paid.' },
+]
+
+let api: ReturnType<typeof fakeHttp>
+
+const service = () =>
+  make.pipe(
+    Effect.provide(api.layer),
+    Effect.provideService(Auth, fakeAuth({ environment: 'sandbox' }).auth),
+  )
+
+const listEvents = () =>
+  Effect.runPromise(
+    service().pipe(Effect.flatMap((trigger) => trigger.listEvents('sandbox'))),
+  )
+
+const send = (
+  overrides: Record<string, unknown> = {},
+  event = 'order.created',
+) =>
+  Effect.runPromise(
+    service().pipe(
+      Effect.flatMap((trigger) =>
+        trigger.send(acme, { event, overrides, deliver: true }),
+      ),
+    ),
+  )
+
+const failure = (promise: Promise<unknown>) =>
+  promise.then(
+    () => {
+      throw new Error('expected failure')
+    },
+    (error: unknown) =>
+      error as { _tag: string; message?: string; hint?: string },
+  )
+
+beforeEach(() => {
+  api = fakeHttp()
+})
+
+describe('closestEvent', () => {
+  const events = [
+    'order.created',
+    'order.paid',
+    'subscription.canceled',
+    'benefit_grant.created',
+  ]
+
+  test.each([
+    ['order.create', 'order.created'],
+    ['order_created', 'order.created'],
+    ['ORDER-PAID', 'order.paid'],
+    ['subscripton.cancelled', 'subscription.canceled'],
+    ['benefit-grant-created', 'benefit_grant.created'],
+  ])('suggests %s -> %s', (input, expected) => {
+    expect(closestEvent(input, events)).toBe(expected)
+  })
+
+  test('gives up when nothing is close', () => {
+    expect(closestEvent('payout.completed', events)).toBeUndefined()
+  })
+})
+
+describe('listEvents', () => {
+  test('returns the catalog with the bearer token', async () => {
+    api.routes[`GET ${eventsUrl}`] = Response.json(catalog)
+
+    expect(await listEvents()).toEqual(catalog)
+    expect(api.requests[0]!.headers.get('Authorization')).toBe('Bearer token')
+  })
+
+  test.each([
+    [401, 'Authentication rejected for sandbox'],
+    [403, 'You do not have access to this organization'],
+    [503, 'returned an error (503)'],
+  ])('maps a %d', async (status, message) => {
+    api.routes[`GET ${eventsUrl}`] = new Response(null, { status })
+
+    const error = await failure(listEvents())
+    expect(error._tag).toBe('TriggerError')
+    expect(error.message).toContain(message)
+  })
+
+  test('maps network failures', async () => {
+    const error = await failure(listEvents())
+    expect(error.message).toBe('Could not reach the Polar API')
+  })
+})
+
+describe('send', () => {
+  test('posts the request and maps the response', async () => {
+    api.routes[`POST ${triggerUrl}`] = Response.json({
+      webhook_event_id: 'evt-1',
+      event: 'order.created',
+      delivered: true,
+      payload: { type: 'order.created' },
+    })
+
+    const result = await send({ 'data.amount': '5' })
+
+    expect(result).toEqual({
+      webhookEventId: 'evt-1',
+      event: 'order.created',
+      delivered: true,
+      payload: { type: 'order.created' },
+    })
+    expect(await api.requests[0]!.clone().json()).toEqual({
+      event: 'order.created',
+      overrides: { 'data.amount': '5' },
+      deliver: true,
+    })
+  })
+
+  test('reports a missing listener', async () => {
+    api.routes[`POST ${triggerUrl}`] = new Response(null, { status: 409 })
+
+    expect((await failure(send()))._tag).toBe('NoActiveListener')
+  })
+
+  test('suggests the closest event when the API rejects the name', async () => {
+    api.routes[`POST ${triggerUrl}`] = Response.json(
+      { detail: [{ loc: ['body', 'event'], msg: 'enum' }] },
+      { status: 422 },
+    )
+    api.routes[`GET ${eventsUrl}`] = Response.json(catalog)
+
+    const error = await failure(send({}, 'order.create'))
+    expect(error).toMatchObject({
+      _tag: 'UnknownEvent',
+      suggestion: 'order.created',
+    })
+    expect(api.requests).toHaveLength(2)
+  })
+
+  test('reports rejected payloads with their detail', async () => {
+    api.routes[`POST ${triggerUrl}`] = Response.json(
+      {
+        detail: [{ loc: ['body', 'overrides', 'data', 'amount'], msg: 'bad' }],
+      },
+      { status: 422 },
+    )
+
+    const error = await failure(send({ 'data.amount': 'x' }))
+    expect(error).toMatchObject({ _tag: 'PayloadRejected' })
+  })
+
+  test.each([
+    [401, 'Authentication rejected for sandbox'],
+    [404, 'could not be found in sandbox'],
+    [418, 'unexpected status (418)'],
+  ])('maps a %d', async (status, message) => {
+    api.routes[`POST ${triggerUrl}`] = new Response(null, { status })
+
+    expect((await failure(send())).message).toContain(message)
+  })
+})

--- a/clients/packages/cli/src/services/trigger.ts
+++ b/clients/packages/cli/src/services/trigger.ts
@@ -1,0 +1,223 @@
+import { Context, Data, Effect, Layer, Schema } from 'effect'
+import { HttpClientRequest, HttpClientResponse } from 'effect/unstable/http'
+import type {
+  ActiveOrganization,
+  AuthError,
+  PolarEnvironment,
+} from '@/schemas/Auth'
+import {
+  type ApiClient,
+  apiUrl,
+  authenticatedClient,
+  describeApiFailure,
+} from '@/services/api'
+
+export class TriggerError extends Data.TaggedError('TriggerError')<{
+  message: string
+  hint?: string
+}> {}
+
+export class NoActiveListener extends Data.TaggedError('NoActiveListener')<{
+  organization: ActiveOrganization
+}> {}
+
+export class UnknownEvent extends Data.TaggedError('UnknownEvent')<{
+  event: string
+  suggestion?: string
+}> {}
+
+export class PayloadRejected extends Data.TaggedError('PayloadRejected')<{
+  detail: unknown
+}> {}
+
+const TriggerEventSchema = Schema.Struct({
+  type: Schema.String,
+  description: Schema.String,
+})
+export type TriggerEvent = typeof TriggerEventSchema.Type
+
+const TriggerResponseSchema = Schema.Struct({
+  webhook_event_id: Schema.String,
+  event: Schema.String,
+  delivered: Schema.Boolean,
+  payload: Schema.Unknown,
+})
+
+const ErrorResponseSchema = Schema.Struct({ detail: Schema.Unknown })
+
+export interface TriggerRequest {
+  event: string
+  overrides: Record<string, unknown>
+  seed?: number
+  deliver: boolean
+}
+
+export interface TriggerResult {
+  webhookEventId: string
+  event: string
+  delivered: boolean
+  payload: unknown
+}
+
+export type SendError =
+  | AuthError
+  | TriggerError
+  | NoActiveListener
+  | UnknownEvent
+  | PayloadRejected
+
+export class Trigger extends Context.Service<
+  Trigger,
+  {
+    listEvents: (
+      environment: PolarEnvironment,
+    ) => Effect.Effect<ReadonlyArray<TriggerEvent>, AuthError | TriggerError>
+    send: (
+      organization: ActiveOrganization,
+      request: TriggerRequest,
+    ) => Effect.Effect<TriggerResult, SendError>
+  }
+>()('Trigger') {}
+
+const normalizeEventName = (name: string) =>
+  name.toLowerCase().replace(/[-_]/g, '.')
+
+const editDistance = (a: string, b: string) => {
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index)
+  for (let i = 1; i <= a.length; i++) {
+    const current = [i]
+    for (let j = 1; j <= b.length; j++) {
+      current[j] = Math.min(
+        previous[j]! + 1,
+        current[j - 1]! + 1,
+        previous[j - 1]! + (a[i - 1] === b[j - 1] ? 0 : 1),
+      )
+    }
+    previous = current
+  }
+  return previous[b.length]!
+}
+
+export const closestEvent = (
+  input: string,
+  events: ReadonlyArray<string>,
+): string | undefined => {
+  const wanted = normalizeEventName(input)
+  const exact = events.find((event) => normalizeEventName(event) === wanted)
+  if (exact) return exact
+  const ranked = events
+    .map((event) => ({
+      event,
+      distance: editDistance(wanted, normalizeEventName(event)),
+    }))
+    .sort((a, b) => a.distance - b.distance)
+  const best = ranked[0]
+  return best && best.distance <= Math.max(3, Math.floor(wanted.length / 3))
+    ? best.event
+    : undefined
+}
+
+const isUnknownEventError = (detail: unknown) =>
+  Array.isArray(detail) &&
+  detail.some(
+    (error: { loc?: unknown[] }) =>
+      Array.isArray(error.loc) && error.loc.join('.') === 'body.event',
+  )
+
+const apiFailure = (status: number, environment: PolarEnvironment) => {
+  const { message, hint } = describeApiFailure(status, environment)
+  return hint
+    ? new TriggerError({ message, hint })
+    : new TriggerError({ message })
+}
+
+const unreachable = (error: { message: string }) =>
+  new TriggerError({
+    message: 'Could not reach the Polar API',
+    hint: error.message,
+  })
+
+const unexpectedResponse = () =>
+  new TriggerError({ message: 'Unexpected response from the API' })
+
+export const make = Effect.gen(function* () {
+  const clients: Record<PolarEnvironment, ApiClient> = {
+    sandbox: yield* authenticatedClient('sandbox'),
+    production: yield* authenticatedClient('production'),
+  }
+
+  const listEvents = (environment: PolarEnvironment) =>
+    Effect.gen(function* () {
+      const response = yield* clients[environment].execute(
+        HttpClientRequest.get(yield* apiUrl(environment, '/cli/events')),
+      )
+      if (response.status !== 200) {
+        return yield* apiFailure(response.status, environment)
+      }
+      return yield* HttpClientResponse.schemaBodyJson(
+        Schema.Array(TriggerEventSchema),
+      )(response)
+    }).pipe(
+      Effect.scoped,
+      Effect.catchTags({
+        HttpClientError: unreachable,
+        SchemaError: unexpectedResponse,
+      }),
+    )
+
+  const send = (organization: ActiveOrganization, request: TriggerRequest) =>
+    Effect.gen(function* () {
+      const { environment } = organization
+      const httpRequest = yield* HttpClientRequest.post(
+        yield* apiUrl(environment, `/cli/trigger/${organization.id}`),
+      ).pipe(HttpClientRequest.bodyJson(request))
+      const response = yield* clients[environment].execute(httpRequest)
+
+      if (response.status === 409) {
+        return yield* new NoActiveListener({ organization })
+      }
+      if (response.status === 422) {
+        const body =
+          yield* HttpClientResponse.schemaBodyJson(ErrorResponseSchema)(
+            response,
+          )
+        if (isUnknownEventError(body.detail)) {
+          const events = yield* listEvents(environment)
+          const suggestion = closestEvent(
+            request.event,
+            events.map((item) => item.type),
+          )
+          return yield* new UnknownEvent({
+            event: request.event,
+            ...(suggestion ? { suggestion } : {}),
+          })
+        }
+        return yield* new PayloadRejected({ detail: body.detail })
+      }
+      if (response.status !== 200) {
+        return yield* apiFailure(response.status, environment)
+      }
+
+      const result = yield* HttpClientResponse.schemaBodyJson(
+        TriggerResponseSchema,
+      )(response)
+      return {
+        webhookEventId: result.webhook_event_id,
+        event: result.event,
+        delivered: result.delivered,
+        payload: result.payload,
+      }
+    }).pipe(
+      Effect.scoped,
+      Effect.catchTags({
+        HttpClientError: unreachable,
+        HttpBodyError: () =>
+          new TriggerError({ message: 'Could not encode the request' }),
+        SchemaError: unexpectedResponse,
+      }),
+    )
+
+  return Trigger.of({ listEvents, send })
+})
+
+export const layer = Layer.effect(Trigger, make)

--- a/clients/packages/cli/src/utils/errors.test.ts
+++ b/clients/packages/cli/src/utils/errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { ListenError } from '@/commands/listen'
+import { TriggerError } from '@/services/trigger'
 import { UpdateError } from '@/commands/update'
 import { describeError } from '@/utils/errors'
 import { AuthError } from '@/schemas/Auth'
@@ -22,6 +23,15 @@ describe('describeError', () => {
     })
     expect(describeError({ _tag: 'Other' })).toEqual({
       title: 'An unexpected error occurred',
+    })
+  })
+
+  test('describes trigger errors with their own hint', () => {
+    expect(
+      describeError(new TriggerError({ message: 'Nope', hint: 'Do this' })),
+    ).toEqual({ title: 'Nope', hint: 'Do this' })
+    expect(describeError(new TriggerError({ message: 'Nope' }))).toEqual({
+      title: 'Nope',
     })
   })
 

--- a/clients/packages/cli/src/utils/errors.ts
+++ b/clients/packages/cli/src/utils/errors.ts
@@ -1,4 +1,5 @@
 import type { ListenError } from '@/commands/listen'
+import type { TriggerError } from '@/services/trigger'
 import type { UpdateError } from '@/commands/update'
 import type { AuthError } from '@/schemas/Auth'
 import type { GitHubReleaseError } from '@/services/github-releases'
@@ -6,6 +7,7 @@ import type { GitHubReleaseError } from '@/services/github-releases'
 export type CommandError =
   | AuthError
   | ListenError
+  | TriggerError
   | UpdateError
   | GitHubReleaseError
 
@@ -34,9 +36,13 @@ const isCommandError = (error: unknown): error is CommandError =>
   typeof error === 'object' &&
   error !== null &&
   '_tag' in error &&
-  ['AuthError', 'ListenError', 'UpdateError', 'GitHubReleaseError'].includes(
-    String(error._tag),
-  )
+  [
+    'AuthError',
+    'ListenError',
+    'TriggerError',
+    'UpdateError',
+    'GitHubReleaseError',
+  ].includes(String(error._tag))
 
 export const describeError = (error: unknown): ErrorDescription => {
   if (!isCommandError(error)) {
@@ -48,6 +54,10 @@ export const describeError = (error: unknown): ErrorDescription => {
   switch (error._tag) {
     case 'AuthError':
       return { title: error.message }
+    case 'TriggerError':
+      return error.hint
+        ? { title: error.message, hint: error.hint }
+        : { title: error.message }
     case 'ListenError': {
       const hint = listenHint(error.code)
       return hint ? { title: error.message, hint } : { title: error.message }

--- a/clients/packages/cli/src/utils/test-utils/cli.ts
+++ b/clients/packages/cli/src/utils/test-utils/cli.ts
@@ -10,6 +10,7 @@ import {
   Terminal,
 } from 'effect'
 import { Command } from 'effect/unstable/cli'
+import { Environment as ApiEnvironment } from '@/services/api'
 
 export const stripAnsi = (text: string) => Bun.stripANSI(text)
 
@@ -115,6 +116,7 @@ export const runCli = <Name extends string, Input, E, R, ContextInput>(
       ),
     ),
     Effect.provideService(Console.Console, console),
+    Effect.provideService(ApiEnvironment, {}),
   )
   return {
     effect,

--- a/clients/packages/cli/src/utils/test-utils/services.ts
+++ b/clients/packages/cli/src/utils/test-utils/services.ts
@@ -14,6 +14,14 @@ import { Credentials } from '@/services/credentials'
 import { OAuth } from '@/services/oauth'
 import { Organizations } from '@/services/organizations'
 import { Polar } from '@/services/polar'
+import {
+  type SendError,
+  Trigger,
+  type TriggerError,
+  type TriggerEvent,
+  type TriggerRequest,
+  type TriggerResult,
+} from '@/services/trigger'
 
 export const session = (
   accessToken = 'access',
@@ -264,4 +272,44 @@ export const fakePolar = (client: unknown) => {
       }),
   })
   return { polar, state }
+}
+
+interface TriggerState {
+  events: TriggerEvent[]
+  result: TriggerResult
+  failure: SendError | undefined
+  listFailure: TriggerError | undefined
+  sent: Array<{ organization: ActiveOrganization; request: TriggerRequest }>
+}
+
+export const fakeTrigger = (initial: Partial<TriggerState> = {}) => {
+  const state: TriggerState = {
+    events: [],
+    result: {
+      webhookEventId: 'evt-1',
+      event: 'order.created',
+      delivered: true,
+      payload: { type: 'order.created', data: { id: 'ord-1' } },
+    },
+    failure: undefined,
+    listFailure: undefined,
+    sent: [],
+    ...initial,
+  }
+  const trigger = Trigger.of({
+    listEvents: () =>
+      Effect.suspend(() =>
+        state.listFailure
+          ? Effect.fail(state.listFailure)
+          : Effect.succeed(state.events),
+      ),
+    send: (organization, request) =>
+      Effect.suspend(() => {
+        state.sent.push({ organization, request })
+        return state.failure
+          ? Effect.fail(state.failure)
+          : Effect.succeed({ ...state.result, event: request.event })
+      }),
+  })
+  return { trigger, state }
 }

--- a/clients/packages/cli/src/utils/test-utils/setup.ts
+++ b/clients/packages/cli/src/utils/test-utils/setup.ts
@@ -1,0 +1,1 @@
+delete process.env['POLAR_API_URL']

--- a/clients/packages/cli/vitest.config.ts
+++ b/clients/packages/cli/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     },
   },
   test: {
+    setupFiles: ['./src/utils/test-utils/setup.ts'],
     coverage: {
       provider: 'istanbul',
       include: ['src/**/*.ts', 'scripts/**/*.js'],


### PR DESCRIPTION
## Summary

This PR builds upon the new CLI backend (introduced in https://github.com/polarsource/polar/pull/14347) which will allow users to trigger webhook events from the CLI with `polar trigger <event>`.

## How to test

### 0. Optional local env
Add this to all of your terminal sessions to run against a local environment:

```bash
export POLAR_API_URL=http://127.0.0.1:8000
export POLAR_ACCESS_TOKEN=polar_oat_...
```

If not, we'll default to production.

### 1. Sign into your dashboard and pick your org

```bash
# Skip this if running against a local server
bun src/cli.ts auth login
```

### 2. Start local webhook server

```bash
bun -e 'Bun.serve({ port: 4321, fetch: async (req) => { const b = await req.json(); console.log(b.type, "triggered:", req.headers.get("x-polar-triggered"), "customer:", b.data?.customer?.email ?? b.data?.email); return new Response("ok") } })'
```

### 3. Open the tunnel

```bash
bun src/cli.ts listen http://localhost:4321/webhooks
```

### 4. Send events

```bash
bun src/cli.ts trigger --list
bun src/cli.ts trigger order.created
bun src/cli.ts trigger order.paid --override data.customer.email=foobar@polar.sh
```

<img width="1840" height="1134" alt="Screenshot 2026-09-09 at 18 22 03" src="https://github.com/user-attachments/assets/3c02cd75-a478-4037-ac27-6d5f007b8f88" />



Fixes https://linear.app/polarsh/issue/PLR-108/add-trigger-command