### PR TITLE
Rank backoffice organization search by match quality

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -20,7 +20,7 @@ from fastapi import Depends, HTTPException, Query, Request
 from fastapi.datastructures import FormData
 from pydantic import UUID4, BaseModel, Field, ValidationError, field_validator
 from pydantic_core import PydanticCustomError, SchemaSerializer, core_schema
-from sqlalchemy import Select, and_, false, func, or_, select
+from sqlalchemy import ColumnElement, Select, and_, case, false, func, or_, select
 from sqlalchemy.orm import contains_eager, joinedload
 from sse_starlette.sse import EventSourceResponse
 from tagflow import tag, text
@@ -519,6 +519,15 @@ def _normalize_search(q: str | None) -> str | None:
     return (q.strip() or None) if q else None
 
 
+def _search_match(term: str) -> ColumnElement[bool]:
+    return or_(organization_ilike(term), Organization.email.ilike(term))
+
+
+def _search_rank(q: str) -> ColumnElement[int]:
+    """Rank an `%q%` trigram match: exact first, then prefix, then substring."""
+    return case((_search_match(q), 0), (_search_match(f"{q}%"), 1), else_=2)
+
+
 def _apply_sql_sort(stmt: Select[Any], sort: str, direction: str) -> Select[Any]:
     is_desc = direction == "desc"
     if sort == "name":
@@ -643,6 +652,7 @@ async def list_organizations(
         )
 
     search_too_short = False
+    search_rank: ColumnElement[int] | None = None
     if q:
         try:
             stmt = stmt.where(Organization.id == uuid.UUID(q))
@@ -654,13 +664,8 @@ async def list_organizations(
                 search_too_short = True
                 stmt = stmt.where(false())
             else:
-                search_term = f"%{q}%"
-                stmt = stmt.where(
-                    or_(
-                        organization_ilike(search_term),
-                        Organization.email.ilike(search_term),
-                    )
-                )
+                stmt = stmt.where(_search_match(f"%{q}%"))
+                search_rank = _search_rank(q)
 
     # Country filter
     if country:
@@ -731,6 +736,12 @@ async def list_organizations(
     # keep the historical "asc" default.
     if direction is None:
         direction = "desc" if priority_sort else "asc"
+
+    # A `%term%` match hits anywhere in the name, slug or email, so an exact
+    # or prefix match can land pages deep. Rank it up front, unless the
+    # operator picked a column to sort by.
+    if search_rank is not None and sort == "priority":
+        stmt = stmt.order_by(search_rank)
 
     signals_by_org: dict[uuid.UUID, Signals] = {}
     organizations: list[Organization]

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -18,6 +18,7 @@ from polar.organization_review.repository import OrganizationReviewRepository
 from polar.organization_review.schemas import AUPSection
 from polar.postgres import AsyncSession, get_db_session
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_account, create_organization
 
 
 @pytest_asyncio.fixture
@@ -605,6 +606,36 @@ class TestListSearch:
         assert response.status_code == 200
         assert "Enter at least 3 characters to search." in response.text
         assert organization.name not in response.text
+
+    async def test_ranks_exact_then_prefix_then_substring(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        user: User,
+    ) -> None:
+        # Ordered so the default sort (status, then oldest in status) would
+        # return them relevance-last without the ranking.
+        organizations = [
+            ("Substring Org", "the-acme-group", datetime(2025, 1, 1, tzinfo=UTC)),
+            ("Prefix Org", "acme-industries", datetime(2025, 1, 2, tzinfo=UTC)),
+            ("Exact Org", "acme", datetime(2025, 1, 3, tzinfo=UTC)),
+        ]
+        for name, slug, status_updated_at in organizations:
+            account = await create_account(save_fixture, user)
+            organization = await create_organization(save_fixture, account)
+            organization.name = name
+            organization.slug = slug
+            organization.status_updated_at = status_updated_at
+            await save_fixture(organization)
+
+        response = await backoffice_client.get("/organizations/", params={"q": "acme"})
+
+        assert response.status_code == 200
+        positions = [
+            response.text.index(name)
+            for name in ("Exact Org", "Prefix Org", "Substring Org")
+        ]
+        assert positions == sorted(positions)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Order search results on exact matches, then prefixed matches, then partial matches.

It's impossible to find `polar` itself right now 😁 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

