### PR TITLE
CLI: Constrain how we write commands/services with custom Oxlint rules

### DIFF
--- a/clients/packages/cli/.oxlintrc.json
+++ b/clients/packages/cli/.oxlintrc.json
@@ -1,5 +1,19 @@
 {
   "$schema": "../../node_modules/oxlint/configuration_schema.json",
   "ignorePatterns": ["node_modules/**", "dist/**", "bin/**"],
-  "extends": ["../oxlint-config/oxlint-base.json"]
+  "extends": ["../oxlint-config/oxlint-base.json"],
+  "plugins": ["typescript", "import", "unicorn"],
+  "jsPlugins": ["./lint/polar.js"],
+  "rules": {
+    "import/no-cycle": "error",
+    "unicorn/no-process-exit": "error",
+    "polar/command-boundaries": "error",
+    "polar/command-descriptions": "error",
+    "polar/no-ansi-escapes": "error",
+    "polar/no-effect-run-outside-entrypoint": "error",
+    "polar/no-hardcoded-hosts": "error",
+    "polar/no-process-env": "error",
+    "polar/service-boundaries": "error",
+    "polar/test-colocation": "error"
+  }
 }

--- a/clients/packages/cli/lint/ast.js
+++ b/clients/packages/cli/lint/ast.js
@@ -1,14 +1,33 @@
-export const isMember = (node, objectName, propertyName) =>
-  node.type === 'MemberExpression' &&
-  node.object.type === 'Identifier' &&
-  node.object.name === objectName &&
-  node.property.type === 'Identifier' &&
-  (propertyName === undefined || node.property.name === propertyName)
+export const propertyName = (node) => {
+  if (node.type !== 'MemberExpression') return undefined
+  if (!node.computed && node.property.type === 'Identifier') {
+    return node.property.name
+  }
+  if (node.computed && node.property.type === 'Literal') {
+    return typeof node.property.value === 'string'
+      ? node.property.value
+      : undefined
+  }
+  return undefined
+}
+
+export const isMember = (node, objectName, expected) => {
+  if (node.type !== 'MemberExpression') return false
+  if (node.object.type !== 'Identifier' || node.object.name !== objectName) {
+    return false
+  }
+  const name = propertyName(node)
+  return name !== undefined && (expected === undefined || name === expected)
+}
 
 const filenameOf = (context) => context.filename ?? context.getFilename()
 
 const isTestFile = (filename) =>
   filename.endsWith('.test.ts') || filename.includes('/utils/test-utils/')
+
+export const isTest = (context) => isTestFile(filenameOf(context))
+
+export const inSource = (context) => filenameOf(context).includes('/src/')
 
 export const inDirectory = (context, directory) => {
   const filename = filenameOf(context)

--- a/clients/packages/cli/lint/ast.js
+++ b/clients/packages/cli/lint/ast.js
@@ -1,0 +1,21 @@
+export const isMember = (node, objectName, propertyName) =>
+  node.type === 'MemberExpression' &&
+  node.object.type === 'Identifier' &&
+  node.object.name === objectName &&
+  node.property.type === 'Identifier' &&
+  (propertyName === undefined || node.property.name === propertyName)
+
+const filenameOf = (context) => context.filename ?? context.getFilename()
+
+const isTestFile = (filename) =>
+  filename.endsWith('.test.ts') || filename.includes('/utils/test-utils/')
+
+export const inDirectory = (context, directory) => {
+  const filename = filenameOf(context)
+  return filename.includes(`/src/${directory}/`) && !isTestFile(filename)
+}
+
+export const isFile = (context, ...paths) => {
+  const filename = filenameOf(context)
+  return paths.some((path) => filename.endsWith(`/src/${path}`))
+}

--- a/clients/packages/cli/lint/polar.js
+++ b/clients/packages/cli/lint/polar.js
@@ -1,0 +1,22 @@
+import commandBoundaries from './rules/command-boundaries.js'
+import commandDescriptions from './rules/command-descriptions.js'
+import noAnsiEscapes from './rules/no-ansi-escapes.js'
+import noEffectRunOutsideEntrypoint from './rules/no-effect-run-outside-entrypoint.js'
+import noHardcodedHosts from './rules/no-hardcoded-hosts.js'
+import noProcessEnv from './rules/no-process-env.js'
+import serviceBoundaries from './rules/service-boundaries.js'
+import testColocation from './rules/test-colocation.js'
+
+export default {
+  meta: { name: 'polar' },
+  rules: {
+    'command-boundaries': commandBoundaries,
+    'command-descriptions': commandDescriptions,
+    'no-ansi-escapes': noAnsiEscapes,
+    'no-effect-run-outside-entrypoint': noEffectRunOutsideEntrypoint,
+    'no-hardcoded-hosts': noHardcodedHosts,
+    'no-process-env': noProcessEnv,
+    'service-boundaries': serviceBoundaries,
+    'test-colocation': testColocation,
+  },
+}

--- a/clients/packages/cli/lint/rules/command-boundaries.js
+++ b/clients/packages/cli/lint/rules/command-boundaries.js
@@ -1,4 +1,4 @@
-import { inDirectory } from '../ast.js'
+import { inDirectory, isMember } from '../ast.js'
 
 const forbiddenImports = [
   {
@@ -47,7 +47,13 @@ export default {
         if (rule) context.report({ node, messageId: rule.messageId })
       },
       CallExpression(node) {
-        if (node.callee.type === 'Identifier' && node.callee.name === 'fetch') {
+        const { callee } = node
+        const bare = callee.type === 'Identifier' && callee.name === 'fetch'
+        const global =
+          isMember(callee, 'globalThis', 'fetch') ||
+          isMember(callee, 'self', 'fetch') ||
+          isMember(callee, 'window', 'fetch')
+        if (bare || global) {
           context.report({ node, messageId: 'fetch' })
         }
       },

--- a/clients/packages/cli/lint/rules/command-boundaries.js
+++ b/clients/packages/cli/lint/rules/command-boundaries.js
@@ -1,0 +1,56 @@
+import { inDirectory } from '../ast.js'
+
+const forbiddenImports = [
+  {
+    matches: (source) => source.startsWith('effect/unstable/http'),
+    messageId: 'http',
+  },
+  {
+    matches: (source) => source.startsWith('@polar-sh/sdk'),
+    messageId: 'sdk',
+  },
+  {
+    matches: (source) =>
+      [
+        '@/services/api',
+        '@/services/client',
+        '@/services/config',
+        '@/services/credentials',
+        '@/services/oauth',
+      ].includes(source),
+    messageId: 'lowLevel',
+  },
+]
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'A command in src/commands must not talk to the API directly. It parses input, calls a service, and prints the result.',
+    },
+    messages: {
+      http: 'Commands must not call the API directly. Add or use a method on a service in src/services.',
+      sdk: 'Commands must not use the SDK directly. Go through the Polar service.',
+      lowLevel:
+        'Commands use the high-level services (Auth, Organizations, Polar, Trigger), not the ones underneath them.',
+      fetch:
+        'Commands must not make HTTP requests. Add or use a method on a service in src/services.',
+    },
+  },
+  create(context) {
+    if (!inDirectory(context, 'commands')) return {}
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value
+        const rule = forbiddenImports.find(({ matches }) => matches(source))
+        if (rule) context.report({ node, messageId: rule.messageId })
+      },
+      CallExpression(node) {
+        if (node.callee.type === 'Identifier' && node.callee.name === 'fetch') {
+          context.report({ node, messageId: 'fetch' })
+        }
+      },
+    }
+  },
+}

--- a/clients/packages/cli/lint/rules/command-descriptions.js
+++ b/clients/packages/cli/lint/rules/command-descriptions.js
@@ -1,0 +1,99 @@
+import { inDirectory } from '../ast.js'
+
+const namespaces = new Set(['Command', 'Flag', 'Argument'])
+
+const namespaceOf = (callee) =>
+  callee.type === 'MemberExpression' &&
+  callee.object.type === 'Identifier' &&
+  namespaces.has(callee.object.name) &&
+  callee.property.type === 'Identifier'
+    ? callee.object.name
+    : undefined
+
+const combinators = new Set(['optional', 'atLeast', 'between', 'map'])
+
+const isConstructor = (node) => {
+  if (node.type !== 'CallExpression') return false
+  const namespace = namespaceOf(node.callee)
+  if (namespace === undefined) return false
+  const method = node.callee.property.name
+  const constructs =
+    namespace === 'Command'
+      ? method === 'make'
+      : !method.startsWith('with') && !combinators.has(method)
+  return (
+    constructs &&
+    node.arguments[0]?.type === 'Literal' &&
+    typeof node.arguments[0].value === 'string'
+  )
+}
+
+const isPipeCall = (node) =>
+  node.type === 'CallExpression' &&
+  node.callee.type === 'MemberExpression' &&
+  node.callee.property.type === 'Identifier' &&
+  node.callee.property.name === 'pipe'
+
+const unwrapPipes = (node) => {
+  const steps = []
+  let current = node
+  while (isPipeCall(current)) {
+    steps.push(...current.arguments)
+    current = current.callee.object
+  }
+  return { root: current, steps }
+}
+
+const describes = (combinator, namespace) =>
+  combinator.type === 'CallExpression' &&
+  namespaceOf(combinator.callee) === namespace &&
+  combinator.callee.property.name === 'withDescription'
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Every command, flag and argument declares a description so --help is complete.',
+    },
+    messages: {
+      missing:
+        '{{kind}} "{{name}}" has no description. Pipe it through {{namespace}}.withDescription so it shows up in --help.',
+    },
+  },
+  create(context) {
+    if (!inDirectory(context, 'commands')) return {}
+    const described = new Set()
+    const constructors = []
+    return {
+      CallExpression(node) {
+        if (isConstructor(node)) {
+          constructors.push(node)
+          return
+        }
+        if (!isPipeCall(node)) return
+        const { root, steps } = unwrapPipes(node)
+        if (!isConstructor(root)) return
+        const namespace = namespaceOf(root.callee)
+        if (steps.some((step) => describes(step, namespace))) {
+          described.add(root)
+        }
+      },
+      'Program:exit'() {
+        for (const node of constructors) {
+          if (described.has(node)) continue
+          const namespace = namespaceOf(node.callee)
+          context.report({
+            node,
+            messageId: 'missing',
+            data: {
+              kind: namespace === 'Command' ? 'Command' : namespace,
+              name: node.arguments[0].value,
+              namespace,
+            },
+          })
+        }
+      },
+    }
+  },
+}

--- a/clients/packages/cli/lint/rules/no-ansi-escapes.js
+++ b/clients/packages/cli/lint/rules/no-ansi-escapes.js
@@ -1,0 +1,28 @@
+import { isFile } from '../ast.js'
+
+const ansi = new RegExp(`${String.fromCharCode(27)}\\[`)
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: { description: 'Terminal styling goes through utils/ui.' },
+    messages: {
+      ansi: 'Do not hand-write ANSI escape codes. Use the helpers in utils/ui.',
+    },
+  },
+  create(context) {
+    if (isFile(context, 'utils/ui.ts')) return {}
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string' && ansi.test(node.value)) {
+          context.report({ node, messageId: 'ansi' })
+        }
+      },
+      TemplateElement(node) {
+        if (ansi.test(node.value.cooked ?? node.value.raw)) {
+          context.report({ node, messageId: 'ansi' })
+        }
+      },
+    }
+  },
+}

--- a/clients/packages/cli/lint/rules/no-effect-run-outside-entrypoint.js
+++ b/clients/packages/cli/lint/rules/no-effect-run-outside-entrypoint.js
@@ -1,0 +1,40 @@
+import { isFile, isMember } from '../ast.js'
+
+const runners = new Set([
+  'runPromise',
+  'runPromiseExit',
+  'runSync',
+  'runSyncExit',
+  'runFork',
+  'runCallback',
+])
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Effects are run once, in the entrypoint, so every failure reaches the shared error handler and telemetry.',
+    },
+    messages: {
+      run: 'Do not run Effects here. Return the Effect and let cli.ts run it, or fork it inside Effect with Effect.forkDaemon.',
+      main: 'BunRuntime.runMain belongs in cli.ts only.',
+    },
+  },
+  create(context) {
+    if (isFile(context, 'cli.ts')) return {}
+    const filename = context.filename ?? context.getFilename()
+    if (filename.endsWith('.test.ts') || filename.includes('/test-utils/')) {
+      return {}
+    }
+    return {
+      MemberExpression(node) {
+        if (isMember(node, 'Effect') && runners.has(node.property.name)) {
+          context.report({ node, messageId: 'run' })
+        } else if (isMember(node, 'BunRuntime', 'runMain')) {
+          context.report({ node, messageId: 'main' })
+        }
+      },
+    }
+  },
+}

--- a/clients/packages/cli/lint/rules/no-hardcoded-hosts.js
+++ b/clients/packages/cli/lint/rules/no-hardcoded-hosts.js
@@ -1,0 +1,35 @@
+import { isFile } from '../ast.js'
+
+const apiHost = /(?:^|[/.@])(?:sandbox-)?api\.polar\.sh\b/
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'API hosts live in services/api.ts so POLAR_API_URL and environment selection apply everywhere.',
+    },
+    messages: {
+      host: 'Do not hard-code the Polar API host. Build the URL with apiUrl from services/api.ts.',
+    },
+  },
+  create(context) {
+    if (isFile(context, 'services/api.ts')) return {}
+    const filename = context.filename ?? context.getFilename()
+    if (filename.endsWith('.test.ts') || filename.includes('/test-utils/')) {
+      return {}
+    }
+    return {
+      Literal(node) {
+        if (typeof node.value === 'string' && apiHost.test(node.value)) {
+          context.report({ node, messageId: 'host' })
+        }
+      },
+      TemplateElement(node) {
+        if (apiHost.test(node.value.cooked ?? node.value.raw)) {
+          context.report({ node, messageId: 'host' })
+        }
+      },
+    }
+  },
+}

--- a/clients/packages/cli/lint/rules/no-process-env.js
+++ b/clients/packages/cli/lint/rules/no-process-env.js
@@ -1,0 +1,39 @@
+import { inDirectory, isFile, isMember } from '../ast.js'
+
+const allowed = [
+  'cli.ts',
+  'services/api.ts',
+  'services/auth.ts',
+  'services/config.ts',
+  'services/telemetry.ts',
+]
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Environment variables are read once, in an injectable default, so tests stay hermetic.',
+    },
+    messages: {
+      env: 'Read environment variables through an injectable service (see the Environment reference in services/api.ts), not process.env.',
+    },
+  },
+  create(context) {
+    if (
+      isFile(context, ...allowed) ||
+      (!inDirectory(context, 'services') &&
+        !inDirectory(context, 'commands') &&
+        !inDirectory(context, 'utils'))
+    ) {
+      return {}
+    }
+    return {
+      MemberExpression(node) {
+        if (isMember(node, 'process', 'env')) {
+          context.report({ node, messageId: 'env' })
+        }
+      },
+    }
+  },
+}

--- a/clients/packages/cli/lint/rules/no-process-env.js
+++ b/clients/packages/cli/lint/rules/no-process-env.js
@@ -1,4 +1,4 @@
-import { inDirectory, isFile, isMember } from '../ast.js'
+import { inSource, isFile, isMember, isTest } from '../ast.js'
 
 const allowed = [
   'cli.ts',
@@ -20,12 +20,7 @@ export default {
     },
   },
   create(context) {
-    if (
-      isFile(context, ...allowed) ||
-      (!inDirectory(context, 'services') &&
-        !inDirectory(context, 'commands') &&
-        !inDirectory(context, 'utils'))
-    ) {
+    if (!inSource(context) || isTest(context) || isFile(context, ...allowed)) {
       return {}
     }
     return {

--- a/clients/packages/cli/lint/rules/service-boundaries.js
+++ b/clients/packages/cli/lint/rules/service-boundaries.js
@@ -1,0 +1,65 @@
+import { inDirectory, isMember } from '../ast.js'
+
+const outputCalls = new Set(['log', 'error', 'warn', 'info', 'debug'])
+
+const forbiddenImports = [
+  {
+    matches: (source) => source.startsWith('@/commands/'),
+    messageId: 'command',
+  },
+  {
+    matches: (source) => source === '@/utils/ui',
+    messageId: 'print',
+  },
+  {
+    matches: (source) => source === 'effect/unstable/cli',
+    messageId: 'prompt',
+  },
+]
+
+const isProcessStream = (node) =>
+  node.type === 'MemberExpression' &&
+  node.property.type === 'Identifier' &&
+  node.property.name === 'write' &&
+  (isMember(node.object, 'process', 'stdout') ||
+    isMember(node.object, 'process', 'stderr'))
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'A service in src/services must not depend on a command, print, or prompt. It returns data and typed errors; the command renders them.',
+    },
+    messages: {
+      command:
+        'Services must not depend on commands. Move the shared code into a service or a schema.',
+      print:
+        'Services must not print. Return data or a typed error and let the command render it.',
+      prompt:
+        'Services must not prompt or parse flags. That belongs in a command.',
+    },
+  },
+  create(context) {
+    if (!inDirectory(context, 'services')) return {}
+    return {
+      ImportDeclaration(node) {
+        const source = node.source.value
+        const rule = forbiddenImports.find(({ matches }) => matches(source))
+        if (rule) context.report({ node, messageId: rule.messageId })
+      },
+      MemberExpression(node) {
+        if (
+          (isMember(node, 'Console') || isMember(node, 'console')) &&
+          outputCalls.has(node.property.name)
+        ) {
+          context.report({ node, messageId: 'print' })
+        } else if (isProcessStream(node)) {
+          context.report({ node, messageId: 'print' })
+        } else if (isMember(node, 'Prompt')) {
+          context.report({ node, messageId: 'prompt' })
+        }
+      },
+    }
+  },
+}

--- a/clients/packages/cli/lint/rules/service-boundaries.js
+++ b/clients/packages/cli/lint/rules/service-boundaries.js
@@ -1,7 +1,5 @@
 import { inDirectory, isMember } from '../ast.js'
 
-const outputCalls = new Set(['log', 'error', 'warn', 'info', 'debug'])
-
 const forbiddenImports = [
   {
     matches: (source) => source.startsWith('@/commands/'),
@@ -49,10 +47,7 @@ export default {
         if (rule) context.report({ node, messageId: rule.messageId })
       },
       MemberExpression(node) {
-        if (
-          (isMember(node, 'Console') || isMember(node, 'console')) &&
-          outputCalls.has(node.property.name)
-        ) {
+        if (isMember(node, 'Console') || isMember(node, 'console')) {
           context.report({ node, messageId: 'print' })
         } else if (isProcessStream(node)) {
           context.report({ node, messageId: 'print' })

--- a/clients/packages/cli/lint/rules/test-colocation.js
+++ b/clients/packages/cli/lint/rules/test-colocation.js
@@ -1,0 +1,34 @@
+const subjectOf = (filename) => {
+  const match = /\/src\/(.+?)(?:\/index)?\.test\.ts$/.exec(filename)
+  return match?.[1]
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'A test file sits next to the module it covers and is named after it.',
+    },
+    messages: {
+      subject:
+        'This test does not import "@/{{subject}}". Name test files after the module they cover and keep them next to it.',
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename()
+    const subject = subjectOf(filename)
+    if (!subject) return {}
+    let found = false
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === `@/${subject}`) found = true
+      },
+      'Program:exit'(node) {
+        if (!found) {
+          context.report({ node, messageId: 'subject', data: { subject } })
+        }
+      },
+    }
+  },
+}


### PR DESCRIPTION
## Summary

This PR will add a few custom Oxlint to enforce some standards for the CLI:


### Separation of concerns

* `polar/service-boundaries` - Services return data and errors, they never print, prompt, or import a command
* `polar/command-boundaries` - Commands talk to the API through a service, never directly

### DX/UX
* `polar/command-descriptions` - For DX, every command needs a description
* `polar/no-ansi-escapes` - We should only use `ui.ts` to format output
* `polar/no-effect-run-outside-entrypoint` - Only `cli.ts` runs Effects, so every failure reaches the one error handler

### Env
* `polar/no-hardcoded-hosts` - API hosts live in `api.ts` only so `POLAR_API_URL` applies everywhere
* `polar/no-process-env` - `process.env` may only be read in `cli.ts`

### MiSC
* `polar/test-colocation` - Tests should live as a sibling to the file it's testing


Fixes https://linear.app/polarsh/issue/PLR-136/enforce-conventions-with-lint-rules

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

