### PR TITLE
Enforce benefit-revocation grace period with an hourly cron

### DIFF
--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -39,6 +39,7 @@ from polar.kit.repository import (
     SortingClause,
 )
 from polar.models import (
+    BenefitGrant,
     Customer,
     CustomerSeat,
     Discount,
@@ -551,6 +552,46 @@ class SubscriptionRepository(
             .options(*options)
         )
         return await self.get_all(statement)
+
+    async def get_grace_expired_past_due_ids(self, now: datetime) -> Sequence[UUID]:
+        """
+        Find past_due/unpaid subscriptions whose organization benefit revocation
+        grace period has expired but which still have at least one active grant,
+        so their benefits can be re-evaluated for revocation.
+        """
+        grace_period_days = Organization.subscription_settings[
+            "benefit_revocation_grace_period"
+        ].as_integer()
+
+        active_grant_exists = (
+            select(BenefitGrant.id)
+            .where(
+                BenefitGrant.subscription_id == Subscription.id,
+                BenefitGrant.granted_at.is_not(None),
+                BenefitGrant.revoked_at.is_(None),
+                BenefitGrant.deleted_at.is_(None),
+            )
+            .correlate(Subscription)
+            .exists()
+        )
+
+        statement = (
+            select(Subscription.id)
+            .join(Organization, Organization.id == Subscription.organization_id)
+            .where(
+                Subscription.status.in_(
+                    [SubscriptionStatus.past_due, SubscriptionStatus.unpaid]
+                ),
+                Subscription.past_due_at.is_not(None),
+                grace_period_days > 0,
+                Subscription.past_due_at + grace_period_days * timedelta(days=1)
+                <= sa.literal(now, sa.TIMESTAMP(timezone=True)),
+                active_grant_exists,
+                ~Subscription.is_deleted,
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()
 
     def get_sorting_clause(self, property: SubscriptionSortProperty) -> SortingClause:
         match property:

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -254,6 +254,30 @@ async def send_renewal_reminder(subscription_id: uuid.UUID) -> None:
 
 
 @actor(
+    actor_name="subscription.scan_grace_expired_revocations",
+    cron_trigger=CronTrigger.from_crontab("0 * * * *"),
+    priority=TaskPriority.LOW,
+)
+async def scan_grace_expired_revocations() -> None:
+    """Re-enqueue benefit revocation for past_due/unpaid subscriptions whose grace
+    period has expired.
+
+    The grace gate is otherwise only re-evaluated as a side effect of dunning
+    payment-retry events, and non-recoverable declines skip straight to the past_due
+    deadline without firing one. This hourly safety net ensures benefits are revoked
+    once the configured grace period elapses, independently of the dunning schedule.
+    """
+    now = utc_now()
+
+    async with AsyncSessionMaker() as session:
+        repository = SubscriptionRepository.from_session(session)
+        subscription_ids = await repository.get_grace_expired_past_due_ids(now)
+
+    for subscription_id in subscription_ids:
+        enqueue_job("subscription.enqueue_benefits_grants", subscription_id)
+
+
+@actor(
     actor_name="subscription.scan_trial_conversion_reminders",
     cron_trigger=CronTrigger.from_crontab("30 * * * *"),
     priority=TaskPriority.LOW,

--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -15,6 +15,7 @@ from polar.subscription.service import SubscriptionMeterCycleLag, SubscriptionSe
 from polar.subscription.tasks import (  # type: ignore[attr-defined]
     SubscriptionDoesNotExist,
     SubscriptionTierDoesNotExist,
+    scan_grace_expired_revocations,
     subscription_cancel_for_organization,
     subscription_cycle,
     subscription_enqueue_benefits_grants,
@@ -25,6 +26,8 @@ from polar.subscription.tasks import (  # type: ignore[attr-defined]
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_active_subscription,
+    create_benefit,
+    create_benefit_grant,
     create_subscription,
 )
 
@@ -353,3 +356,150 @@ class TestSubscriptionCycle:
         assert refreshed.scheduler_locked_at is None
         assert refreshed.current_period_end is not None
         assert refreshed.current_period_end > old_period_end
+
+
+async def _set_grace_period(
+    save_fixture: SaveFixture, organization: Organization, days: int
+) -> None:
+    organization.subscription_settings = {
+        **organization.subscription_settings,
+        "benefit_revocation_grace_period": days,
+    }
+    await save_fixture(organization)
+
+
+@pytest.mark.asyncio
+class TestScanGraceExpiredRevocations:
+    async def test_past_due_beyond_grace_is_enqueued(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        now = utc_now()
+        await _set_grace_period(save_fixture, product.organization, 2)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+            past_due_at=now - timedelta(days=3),
+        )
+        benefit = await create_benefit(save_fixture, organization=product.organization)
+        await create_benefit_grant(
+            save_fixture,
+            customer=customer,
+            benefit=benefit,
+            granted=True,
+            subscription=subscription,
+        )
+        enqueue_job_mock = mocker.patch("polar.subscription.tasks.enqueue_job")
+
+        session.expunge_all()
+
+        await scan_grace_expired_revocations()
+
+        enqueue_job_mock.assert_called_once_with(
+            "subscription.enqueue_benefits_grants", subscription.id
+        )
+
+    async def test_past_due_within_grace_is_not_enqueued(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        now = utc_now()
+        await _set_grace_period(save_fixture, product.organization, 2)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+            past_due_at=now - timedelta(days=1),
+        )
+        benefit = await create_benefit(save_fixture, organization=product.organization)
+        await create_benefit_grant(
+            save_fixture,
+            customer=customer,
+            benefit=benefit,
+            granted=True,
+            subscription=subscription,
+        )
+        enqueue_job_mock = mocker.patch("polar.subscription.tasks.enqueue_job")
+
+        session.expunge_all()
+
+        await scan_grace_expired_revocations()
+
+        enqueue_job_mock.assert_not_called()
+
+    async def test_zero_grace_is_not_enqueued(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        now = utc_now()
+        await _set_grace_period(save_fixture, product.organization, 0)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+            past_due_at=now - timedelta(days=5),
+        )
+        benefit = await create_benefit(save_fixture, organization=product.organization)
+        await create_benefit_grant(
+            save_fixture,
+            customer=customer,
+            benefit=benefit,
+            granted=True,
+            subscription=subscription,
+        )
+        enqueue_job_mock = mocker.patch("polar.subscription.tasks.enqueue_job")
+
+        session.expunge_all()
+
+        await scan_grace_expired_revocations()
+
+        enqueue_job_mock.assert_not_called()
+
+    async def test_already_revoked_grant_is_not_enqueued(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        now = utc_now()
+        await _set_grace_period(save_fixture, product.organization, 2)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+            past_due_at=now - timedelta(days=3),
+        )
+        benefit = await create_benefit(save_fixture, organization=product.organization)
+        await create_benefit_grant(
+            save_fixture,
+            customer=customer,
+            benefit=benefit,
+            granted=False,
+            subscription=subscription,
+        )
+        enqueue_job_mock = mocker.patch("polar.subscription.tasks.enqueue_job")
+
+        session.expunge_all()
+
+        await scan_grace_expired_revocations()
+
+        enqueue_job_mock.assert_not_called()


### PR DESCRIPTION
The benefit revocation grace period relies on a failed dunning attempt to revoke the benefits.

For unrecoverable decline codes, we skip dunning attempts.

1 + 1 → for unrecoverable decline codes, when the benefit revocation grace period is not set to 'immediately revoke', we don't revoke the benefits after the grace period, but only after 21 days after the dunning cycle ends.

Open question: this is now acting as a fail-safe for when dunning attempts are skipped, but maybe it's cleaner to decouple the revocation and the dunning attempts completely? But then how do we ensure they run in order (i.e. we don't revoke first only to try the payment after, and on successful payment, re-grant).

The other approach could be to no longer skip the dunning attempts on non-recoverable error codes (i.e. stop scheduling directly at `past_due_deadline`), but instead stick to the existing dunning schedule, but decide not to attempt the payment at all based on the previous payment attempts error code. To be fair, I think I like this better. 

Generated PR description:

---

## The bug

When a subscription renewal fails and the subscription goes `past_due`, benefits are only re-evaluated for revocation as a *side effect* of dunning payment-retry events. The grace gate (`_is_within_revocation_grace_period` in `polar/subscription/service.py`) is only consulted when something re-calls `enqueue_benefits_grants` — which, for a past_due subscription, only the dunning handlers in `polar/order/service.py` do.

## Root cause

For **non-recoverable** declines (`UNRECOVERABLE_DECLINE_CODES` in `polar/models/payment.py`, e.g. `do_not_honor`), `_handle_first_dunning_attempt` schedules the next attempt directly at the `past_due_deadline` (= `past_due_at` + 21 days). So **no dunning event fires between `past_due` and the deadline**, and the grace gate is never re-evaluated. Benefits stay granted for the full ~21-day dunning window instead of the organization's configured grace period (e.g. 2 days). Recoverable declines mostly work but drift.

## The fix

Add an hourly cron `subscription.scan_grace_expired_revocations` that scans `past_due`/`unpaid` subscriptions whose organization `benefit_revocation_grace_period` has expired and which **still hold at least one active grant**, and re-enqueues `subscription.enqueue_benefits_grants` for each. The existing grace gate then lets revocation proceed. Re-enqueueing is idempotent (a no-op if already revoked); the query filters on an EXISTS against still-granted `benefit_grants` to avoid needless work. The cron is an independent safety net — it does not touch the dunning schedule or non-recoverable-decline behavior.

- `polar/subscription/repository.py` — new `get_grace_expired_past_due_ids(now)`
- `polar/subscription/tasks.py` — new hourly cron actor (mirrors `scan_renewal_reminders`)
- `tests/subscription/test_tasks.py` — E2E coverage: past-grace enqueued; within-grace not; grace=0 not; already-revoked grant not

## Validation

- `uv run task lint` and `uv run task lint_types` pass.
- `POLAR_ENV=testing uv run python -m pytest tests/subscription/test_tasks.py` — 19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

