### PR TITLE
Add explicit API version monitoring

### DIFF
--- a/server/monitoring/grafana/dashboards/api-slo.json
+++ b/server/monitoring/grafana/dashboards/api-slo.json
@@ -1344,8 +1344,8 @@
                       "group": "prometheus",
                       "kind": "DataQuery",
                       "spec": {
-                        "expr": "sum by (api_version) (rate(polar_http_request_total{env=\"$env\", endpoint=~\"$endpoint\", method=~\"$method\", api_version!=\"\"}[$__rate_interval]))",
-                        "legendFormat": "{{api_version}}"
+                        "expr": "sum by (api_version, api_version_set) (rate(polar_http_request_total{env=\"$env\", endpoint=~\"$endpoint\", method=~\"$method\", api_version!=\"\"}[$__rate_interval]))",
+                        "legendFormat": "{{api_version}} (explicit: {{api_version_set}})"
                       },
                       "version": "v0"
                     },
@@ -1357,7 +1357,7 @@
               "transformations": []
             }
           },
-          "description": "Resolved API version for routed requests. Requests without Polar-Version use Current. Rejected versions and existing metric exclusions are not counted.",
+          "description": "Resolved API version and whether Polar-Version was explicitly set for routed requests. Requests without Polar-Version use Current. Rejected versions and existing metric exclusions are not counted.",
           "id": 36,
           "links": [],
           "title": "Request Rate by API Version",

--- a/server/polar/kit/versioning.py
+++ b/server/polar/kit/versioning.py
@@ -200,6 +200,7 @@ class APIVersionMiddleware:
             await self.app(scope, receive, send)
             return
 
+        api_version_set = Headers(scope=scope).get(VERSION_HEADER) is not None
         try:
             api_version = APIVersion.from_scope(scope, default=self.default_version)
         except ValueError:
@@ -215,6 +216,7 @@ class APIVersionMiddleware:
             return
 
         scope.setdefault("state", {})["api_version"] = api_version
+        scope["state"]["api_version_set"] = api_version_set
 
         async def send_wrapper(message: Message) -> None:
             if message["type"] == "http.response.start":

--- a/server/polar/middlewares.py
+++ b/server/polar/middlewares.py
@@ -43,6 +43,10 @@ class LogCorrelationIdMiddleware:
             api_version = scope.get("state", {}).get("api_version")
             if api_version is not None:
                 root_span.set_attribute("api_version", str(api_version))
+                root_span.set_attribute(
+                    "api_version_set",
+                    scope.get("state", {}).get("api_version_set", False),
+                )
 
         # Capture client identification headers (sent by the mobile app)
         # so we can correlate API traffic to specific client builds for

--- a/server/polar/observability/http_metrics.py
+++ b/server/polar/observability/http_metrics.py
@@ -5,8 +5,8 @@ These metrics track all HTTP endpoints (except those in METRICS_DENY_LIST
 or belonging to METRICS_EXCLUDED_APPS) for availability and latency SLIs.
 
 Metrics:
-- polar_http_request_total: Counter by endpoint, method, status_code, api_version
-- polar_http_request_duration_seconds: Histogram by endpoint, method, api_version
+- polar_http_request_total: Counter by endpoint, method, status_code, api_version, api_version_set
+- polar_http_request_duration_seconds: Histogram by endpoint, method, api_version, api_version_set
 """
 
 import os
@@ -55,7 +55,7 @@ def exclude_app_from_metrics(app: "ASGIApp") -> None:
 HTTP_REQUEST_TOTAL = Counter(
     "polar_http_request_total",
     "Total number of HTTP requests",
-    ["endpoint", "method", "status_code", "api_version"],
+    ["endpoint", "method", "status_code", "api_version", "api_version_set"],
 )
 
 # HTTP request duration histogram for latency SLI
@@ -68,7 +68,7 @@ HTTP_REQUEST_TOTAL = Counter(
 HTTP_REQUEST_DURATION_SECONDS = Histogram(
     "polar_http_request_duration_seconds",
     "HTTP request duration in seconds",
-    ["endpoint", "method", "api_version"],
+    ["endpoint", "method", "api_version", "api_version_set"],
     buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
 )
 

--- a/server/polar/observability/http_middleware.py
+++ b/server/polar/observability/http_middleware.py
@@ -54,17 +54,21 @@ class HttpMetricsMiddleware:
             if path_template is not None:
                 duration = time.perf_counter() - start_time
                 method = scope.get("method", "UNKNOWN")
-                api_version = str(scope.get("state", {}).get("api_version", ""))
+                state = scope.get("state", {})
+                api_version = str(state.get("api_version", ""))
+                api_version_set = str(state.get("api_version_set", False)).lower()
 
                 HTTP_REQUEST_TOTAL.labels(
                     endpoint=path_template,
                     method=method,
                     status_code=status_code,
                     api_version=api_version,
+                    api_version_set=api_version_set,
                 ).inc()
 
                 HTTP_REQUEST_DURATION_SECONDS.labels(
                     endpoint=path_template,
                     method=method,
                     api_version=api_version,
+                    api_version_set=api_version_set,
                 ).observe(duration)

--- a/server/tests/kit/test_versioning.py
+++ b/server/tests/kit/test_versioning.py
@@ -2,7 +2,7 @@ import dataclasses
 from typing import Annotated
 
 import pytest
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.openapi.utils import get_openapi
 from fastapi.routing import iter_route_contexts
 from fastapi.testclient import TestClient
@@ -133,6 +133,10 @@ def test_versioned_routes() -> None:
     async def next_only_endpoint() -> str:
         return "next-only"
 
+    @router.get("/version-state")
+    async def version_state(request: Request) -> dict[str, bool]:
+        return {"api_version_set": request.scope["state"]["api_version_set"]}
+
     app = FastAPI(openapi_url=None)
     add_versioned_routers(
         app, router, [], [current_version, next_version], current_version
@@ -147,6 +151,11 @@ def test_versioned_routes() -> None:
     response = client.get("/items", headers={"Polar-Version": "2026-10"})
     assert response.json() == {"endpoint": "next", "dependency": "overridden"}
     assert response.headers["Polar-Version"] == "2026-10"
+
+    assert client.get("/version-state").json() == {"api_version_set": False}
+    assert client.get(
+        "/version-state", headers={"Polar-Version": "2026-04"}
+    ).json() == {"api_version_set": True}
 
     assert client.get("/next-only").status_code == 404
     assert (


### PR DESCRIPTION
## Summary
- add `api_version_set` to Prometheus HTTP metrics
- add `api_version_set` to Logfire request spans
- distinguish explicit `Polar-Version` requests from middleware fallbacks in Grafana

## Verification
- focused versioning and observability tests pass (20 tests)
- Ruff format/check pass
- Grafana dashboard JSON validates

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

