### PR TITLE
tf: Temporarily stop ignoring image changes

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -254,7 +254,7 @@ resource "render_web_service" "worker" {
   }
 
   lifecycle {
-    ignore_changes = [runtime_source.image]
+    # ignore_changes = [runtime_source.image]
   }
 
   custom_domains = length(each.value.custom_domains) > 0 ? each.value.custom_domains : null


### PR DESCRIPTION
The Render terraform provider validates all of the config sent, even for the ignored changes. This means that we are validating that the image exists.

The image that we have in our state is the playwright image that we stopped using in June, which no longer has the referenced hash stored. This is causing all of our applies to fail.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

