### PR TITLE
fix(payout): don't move an organization off a payout account that works

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1009,6 +1009,11 @@ class OrganizationService:
                 payout_account_id=previous_payout_account_id,
             )
 
+        enqueue_job(
+            "organization.sync_payout_account_website",
+            organization_id=organization.id,
+        )
+
         # Reusing an already-ready payout account doesn't fire a Stripe
         # `account.updated` webhook, so attempt activation here too.
         await self.maybe_activate(session, organization)

--- a/server/polar/payout_account/endpoints.py
+++ b/server/polar/payout_account/endpoints.py
@@ -57,7 +57,7 @@ async def create(
     auth_subject: AuthorizeWebPayoutsWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> PayoutAccount:
-    return await payout_account_service.create(
+    return await payout_account_service.create_or_resume(
         auth_subject, session, payout_account_create
     )
 

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -118,7 +118,7 @@ class PayoutAccountService:
         )
         return await repository.get_one_or_none(statement)
 
-    async def create(
+    async def create_or_resume(
         self,
         auth_subject: AuthSubject[User],
         session: AsyncSession,
@@ -128,6 +128,20 @@ class PayoutAccountService:
             session, auth_subject, payout_account_create
         )
 
+        current = None
+        if organization.payout_account_id is not None:
+            repository = PayoutAccountRepository.from_session(session)
+            current = await repository.get_by_id(organization.payout_account_id)
+
+        # An unfinished account in the same country is the one the merchant was
+        # already onboarding, so hand it back instead of opening a second one.
+        if (
+            current is not None
+            and not current.is_payout_ready
+            and current.country == payout_account_create.country
+        ):
+            return current
+
         payout_account = await self._create_stripe_account(
             session,
             auth_subject.subject,
@@ -135,15 +149,17 @@ class PayoutAccountService:
             organization.name,
         )
 
-        organization_repository = OrganizationRepository.from_session(session)
-        organization.payout_account = payout_account
-        await organization_repository.update(organization)
+        # Don't make it active while a ready account is still paying them out.
+        if current is None or not current.is_payout_ready:
+            organization_repository = OrganizationRepository.from_session(session)
+            organization.payout_account = payout_account
+            await organization_repository.update(organization)
 
-        # Stripe reads the organization's website off the connected account.
-        enqueue_job(
-            "organization.sync_payout_account_website",
-            organization_id=organization.id,
-        )
+            # Stripe reads the organization's website off the connected account.
+            enqueue_job(
+                "organization.sync_payout_account_website",
+                organization_id=organization.id,
+            )
 
         return payout_account
 

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -5180,6 +5180,33 @@ class TestSetPayoutAccount:
             )
 
     @pytest.mark.auth
+    async def test_enqueues_website_sync(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        organization.payout_account = None
+        await save_fixture(organization)
+
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        await organization_service.set_payout_account(
+            session, organization, payout_account
+        )
+
+        enqueue_job_mock.assert_any_call(
+            "organization.sync_payout_account_website",
+            organization_id=organization.id,
+        )
+
+    @pytest.mark.auth
     async def test_activates_when_all_gates_pass(
         self,
         session: AsyncSession,

--- a/server/tests/payout_account/test_service.py
+++ b/server/tests/payout_account/test_service.py
@@ -31,6 +31,22 @@ from tests.fixtures.random_objects import (
 )
 
 
+def _stripe_account(id: str, country: str = "US") -> stripe_lib.Account:
+    return stripe_lib.Account.construct_from(
+        {
+            "id": id,
+            "email": "merchant@example.com",
+            "country": country,
+            "default_currency": "usd",
+            "details_submitted": False,
+            "charges_enabled": False,
+            "payouts_enabled": False,
+            "business_type": None,
+        },
+        None,
+    )
+
+
 @pytest.fixture(autouse=True)
 def stripe_service_mock(mocker: MockerFixture) -> StripeService:
     mock = mocker.MagicMock(spec=StripeService)
@@ -67,7 +83,7 @@ class TestCreate:
         )
         enqueue_job_mock = mocker.patch("polar.payout_account.service.enqueue_job")
 
-        await payout_account_service.create(
+        await payout_account_service.create_or_resume(
             auth_subject,
             session,
             PayoutAccountCreate(
@@ -81,6 +97,94 @@ class TestCreate:
             "organization.sync_payout_account_website",
             organization_id=organization.id,
         )
+
+    @pytest.mark.auth
+    async def test_resumes_an_unfinished_account(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user: User,
+        user_organization: UserOrganization,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        unfinished = await create_payout_account(
+            save_fixture, organization, user, is_payouts_enabled=False, country="US"
+        )
+
+        payout_account = await payout_account_service.create_or_resume(
+            auth_subject,
+            session,
+            PayoutAccountCreate(
+                type=PayoutAccountType.stripe,
+                organization_id=organization.id,
+                country=StripeAccountCountry.US,
+            ),
+        )
+
+        assert payout_account.id == unfinished.id
+        stripe_service_mock.create_account.assert_not_called()  # type: ignore[attr-defined]
+
+    @pytest.mark.auth
+    async def test_another_country_creates_a_new_account(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user: User,
+        user_organization: UserOrganization,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        unfinished = await create_payout_account(
+            save_fixture, organization, user, is_payouts_enabled=False, country="US"
+        )
+        stripe_service_mock.create_account.return_value = _stripe_account("acct_fr")  # type: ignore[attr-defined]
+
+        payout_account = await payout_account_service.create_or_resume(
+            auth_subject,
+            session,
+            PayoutAccountCreate(
+                type=PayoutAccountType.stripe,
+                organization_id=organization.id,
+                country=StripeAccountCountry.FR,
+            ),
+        )
+
+        await session.flush()
+        assert payout_account.id != unfinished.id
+        assert organization.payout_account_id == payout_account.id
+
+    @pytest.mark.auth
+    async def test_does_not_unlink_a_ready_account(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user: User,
+        user_organization: UserOrganization,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        ready = await create_payout_account(
+            save_fixture, organization, user, is_payouts_enabled=True
+        )
+        stripe_service_mock.create_account.return_value = _stripe_account("acct_new")  # type: ignore[attr-defined]
+
+        payout_account = await payout_account_service.create_or_resume(
+            auth_subject,
+            session,
+            PayoutAccountCreate(
+                type=PayoutAccountType.stripe,
+                organization_id=organization.id,
+                country=StripeAccountCountry.US,
+            ),
+        )
+
+        await session.flush()
+        assert payout_account.id != ready.id
+        assert organization.payout_account_id == ready.id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Creating a payout account also made it the organization's, unconditionally. A merchant who opened a second one lost the payouts of the first.

Plain ticket mentionned: "My June 16 account is Ready, but the new Sep 9 account is Active and says Setup required."

Now the organization only moves onto the new account when nothing is paying it out yet, and the new account gets the organization's website either way, since Stripe reads it during onboarding.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

