### PR TITLE
fix(scripts): drop our own origin from the observed framing hosts

### DIFF
--- a/server/scripts/enforce_frame_ancestors.py
+++ b/server/scripts/enforce_frame_ancestors.py
@@ -269,9 +269,9 @@ def _decide(groups: Groups) -> list[Decision]:
 
 async def _apply(session: AsyncSession, decisions: list[Decision]) -> None:
     """Re-read under lock: a merchant may have edited their own list while the
-    prompts were open. `populate_existing` is what makes that re-read real —
-    without it the rows already in the identity map keep the values loaded
-    before the questions, and the comparison below compares stale with stale.
+    prompts were open. `populate_existing` says the locked row wins over
+    anything already loaded, so this holds however the sessions above are
+    arranged.
     """
     organizations = {
         organization.id: organization
@@ -350,25 +350,29 @@ async def enforce_frame_ancestors(
     engine = create_async_engine("script")
     sessionmaker = create_async_sessionmaker(engine)
     try:
+        # Read, then let go: answering takes as long as it takes, and an open
+        # transaction that whole time holds a snapshot on the primary.
         async with sessionmaker() as session:
             reviews = await _load_reviews(session, observations, slug)
-            groups = _partition(reviews)
-            _summary(groups)
 
-            decisions = _decide(groups)
-            if not decisions:
-                console.print("[green]Nothing to write.")
-                return
+        groups = _partition(reviews)
+        _summary(groups)
 
-            hosts = sum(len(decision.hosts) for decision in decisions)
-            enabled = sum(1 for decision in decisions if decision.enable)
-            if not execute:
-                console.print(
-                    f"[yellow]Rehearsal — --execute would add {hosts} host(s) "
-                    f"and switch on {enabled} organization(s)."
-                )
-                return
+        decisions = _decide(groups)
+        if not decisions:
+            console.print("[green]Nothing to write.")
+            return
 
+        hosts = sum(len(decision.hosts) for decision in decisions)
+        enabled = sum(1 for decision in decisions if decision.enable)
+        if not execute:
+            console.print(
+                f"[yellow]Rehearsal — --execute would add {hosts} host(s) "
+                f"and switch on {enabled} organization(s)."
+            )
+            return
+
+        async with sessionmaker() as session:
             await _apply(session, decisions)
     finally:
         await engine.dispose()

--- a/server/scripts/frame_ancestors_observations.py
+++ b/server/scripts/frame_ancestors_observations.py
@@ -29,6 +29,8 @@ MAX_SLICE = timedelta(days=14)
 MAX_ROWS = 10_000
 MESSAGE = "Embedded checkout framing policy resolved"
 
+OUR_ORIGINS = ("https://polar.sh", "https://sandbox.polar.sh")
+
 Observation = tuple[str, int, datetime]
 
 _QUERY = f"""
@@ -41,6 +43,7 @@ FROM records
 WHERE message = '{MESSAGE}'
   AND attributes->>'fetch_dest' = 'iframe'
   AND attributes->>'frame_origin' IS NOT NULL
+  AND attributes->>'frame_origin' NOT IN {tuple(OUR_ORIGINS)}
 GROUP BY 1, 2
 """
 


### PR DESCRIPTION
## Summary

The script was prompting me to add polar.sh to the allow list because it's the referer of a navigation inside the iframe. excluding our own domain.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

