### PR TITLE
Make `is_free_product_price` multi-currency aware

### DIFF
--- a/server/polar/models/checkout.py
+++ b/server/polar/models/checkout.py
@@ -331,9 +331,13 @@ class Checkout(
 
     @property
     def is_free_product_price(self) -> bool:
-        if self.product_prices is None:
+        product_prices = self.product_prices
+        if product_prices is None:
             return False
-        return all(price.is_free for price in self.product_prices)
+        currency_prices = [
+            price for price in product_prices if price.price_currency == self.currency
+        ]
+        return bool(currency_prices) and all(price.is_free for price in currency_prices)
 
     @property
     def has_metered_prices(self) -> bool:

--- a/server/polar/models/checkout.py
+++ b/server/polar/models/checkout.py
@@ -325,21 +325,25 @@ class Checkout(
 
     @property
     def is_discount_applicable(self) -> bool:
-        if self.product_prices is None:
+        if self.product_prices_currency is None:
             return False
-        return any(is_discount_applicable(price) for price in self.product_prices)
+        return any(
+            is_discount_applicable(price) for price in self.product_prices_currency
+        )
 
     @property
     def is_free_product_price(self) -> bool:
-        if self.product_prices is None:
+        if self.product_prices_currency is None:
             return False
-        return all(price.is_free for price in self.product_prices)
+        return bool(self.product_prices_currency) and all(
+            price.is_free for price in self.product_prices_currency
+        )
 
     @property
     def has_metered_prices(self) -> bool:
-        if self.product_prices is None:
+        if self.product_prices_currency is None:
             return False
-        return any(is_metered_price(price) for price in self.product_prices)
+        return any(is_metered_price(price) for price in self.product_prices_currency)
 
     @property
     def is_payment_required(self) -> bool:
@@ -479,7 +483,7 @@ class Checkout(
         return prices
 
     @property
-    def product_prices(self) -> list[ProductPrice] | None:
+    def product_prices_currency(self) -> list[ProductPrice] | None:
         if self.product_id is None:
             return None
         return [

--- a/server/polar/models/checkout.py
+++ b/server/polar/models/checkout.py
@@ -334,10 +334,7 @@ class Checkout(
         product_prices = self.product_prices
         if product_prices is None:
             return False
-        currency_prices = [
-            price for price in product_prices if price.price_currency == self.currency
-        ]
-        return bool(currency_prices) and all(price.is_free for price in currency_prices)
+        return bool(product_prices) and all(price.is_free for price in product_prices)
 
     @property
     def has_metered_prices(self) -> bool:
@@ -486,7 +483,11 @@ class Checkout(
     def product_prices(self) -> list[ProductPrice] | None:
         if self.product_id is None:
             return None
-        return self.prices[self.product_id]
+        return [
+            price
+            for price in self.prices[self.product_id]
+            if price.price_currency == self.currency
+        ]
 
 
 @event.listens_for(Checkout, "before_update")

--- a/server/polar/models/checkout.py
+++ b/server/polar/models/checkout.py
@@ -331,10 +331,9 @@ class Checkout(
 
     @property
     def is_free_product_price(self) -> bool:
-        product_prices = self.product_prices
-        if product_prices is None:
+        if self.product_prices is None:
             return False
-        return bool(product_prices) and all(price.is_free for price in product_prices)
+        return all(price.is_free for price in self.product_prices)
 
     @property
     def has_metered_prices(self) -> bool:

--- a/server/tests/models/test_checkout.py
+++ b/server/tests/models/test_checkout.py
@@ -172,11 +172,6 @@ class TestIsFreeProductPrice:
         )
 
         assert checkout.is_free_product_price is expected_free
-        assert checkout.is_payment_form_required is not expected_free
-        assert checkout.is_payment_setup_required is not expected_free
-
-        checkout.currency = "gbp"
-        assert checkout.is_free_product_price is False
 
     async def test_free_base_with_paid_component(
         self,
@@ -192,7 +187,6 @@ class TestIsFreeProductPrice:
         checkout = await create_checkout(save_fixture, products=[product], seats=1)
 
         assert checkout.is_free_product_price is False
-        assert checkout.is_payment_form_required is True
 
 
 @pytest.mark.asyncio
@@ -221,11 +215,6 @@ class TestHasMeteredPrices:
         checkout.net_amount = 0
 
         assert checkout.has_metered_prices is expected_metered
-        assert checkout.is_payment_setup_required is expected_metered
-        assert checkout.is_payment_form_required is expected_metered
-
-        checkout.currency = "gbp"
-        assert checkout.has_metered_prices is False
 
 
 @pytest.mark.asyncio
@@ -251,9 +240,6 @@ class TestIsDiscountApplicable:
         )
 
         assert checkout.is_discount_applicable is expected_applicable
-
-        checkout.currency = "gbp"
-        assert checkout.is_discount_applicable is False
 
 
 @pytest.mark.asyncio

--- a/server/tests/models/test_checkout.py
+++ b/server/tests/models/test_checkout.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from datetime import UTC, datetime
+from decimal import Decimal
 
 import pytest
 
@@ -7,7 +8,7 @@ from polar.config import settings
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.address import Address, CountryAlpha2
 from polar.kit.trial import TrialInterval
-from polar.models import Checkout, Organization, Product
+from polar.models import Checkout, Meter, Organization, Product
 from polar.models.checkout import BillingAddressFieldMode, CheckoutStatus
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
@@ -192,6 +193,67 @@ class TestIsFreeProductPrice:
 
         assert checkout.is_free_product_price is False
         assert checkout.is_payment_form_required is True
+
+
+@pytest.mark.asyncio
+class TestHasMeteredPrices:
+    @pytest.mark.parametrize(
+        ("currency", "expected_metered"), [("usd", False), ("eur", True)]
+    )
+    async def test_selected_currency(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        meter: Meter,
+        currency: str,
+        expected_metered: bool,
+    ) -> None:
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(0, None, None, "usd"), (meter, Decimal("0.01"), None, "eur")],
+        )
+        checkout = await create_checkout(
+            save_fixture, products=[product], currency=currency
+        )
+        checkout.amount = 0
+        checkout.net_amount = 0
+
+        assert checkout.has_metered_prices is expected_metered
+        assert checkout.is_payment_setup_required is expected_metered
+        assert checkout.is_payment_form_required is expected_metered
+
+        checkout.currency = "gbp"
+        assert checkout.has_metered_prices is False
+
+
+@pytest.mark.asyncio
+class TestIsDiscountApplicable:
+    @pytest.mark.parametrize(
+        ("currency", "expected_applicable"), [("usd", False), ("eur", True)]
+    )
+    async def test_selected_currency(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        currency: str,
+        expected_applicable: bool,
+    ) -> None:
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=None,
+            prices=[(0, "usd"), (1000, "eur")],
+        )
+        checkout = await create_checkout(
+            save_fixture, products=[product], currency=currency
+        )
+
+        assert checkout.is_discount_applicable is expected_applicable
+
+        checkout.currency = "gbp"
+        assert checkout.is_discount_applicable is False
 
 
 @pytest.mark.asyncio

--- a/server/tests/models/test_checkout.py
+++ b/server/tests/models/test_checkout.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 import pytest
 
 from polar.config import settings
+from polar.enums import SubscriptionRecurringInterval
 from polar.kit.address import Address, CountryAlpha2
 from polar.kit.trial import TrialInterval
 from polar.models import Checkout, Organization, Product
@@ -145,6 +146,52 @@ async def test_is_free_product_price_for_zero_fixed_price(
 
     assert checkout.is_free_product_price is True
     assert checkout.is_payment_form_required is False
+
+
+@pytest.mark.asyncio
+class TestIsFreeProductPrice:
+    @pytest.mark.parametrize(
+        ("currency", "expected_free"), [("usd", True), ("eur", False)]
+    )
+    async def test_selected_currency(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        currency: str,
+        expected_free: bool,
+    ) -> None:
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(0, "usd"), (1000, "eur")],
+        )
+        checkout = await create_checkout(
+            save_fixture, products=[product], currency=currency
+        )
+
+        assert checkout.is_free_product_price is expected_free
+        assert checkout.is_payment_form_required is not expected_free
+        assert checkout.is_payment_setup_required is not expected_free
+
+        checkout.currency = "gbp"
+        assert checkout.is_free_product_price is False
+
+    async def test_free_base_with_paid_component(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(0, "usd"), ("seat", 1000, "usd"), (0, "eur")],
+        )
+        checkout = await create_checkout(save_fixture, products=[product], seats=1)
+
+        assert checkout.is_free_product_price is False
+        assert checkout.is_payment_form_required is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Surfaced by #14388 but fixes it properly.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

