### PR TITLE
fix(auth): re-arm Turnstile after an expired or failed challenge

### DIFF
--- a/clients/apps/web/src/hooks/useTurnstile.test.tsx
+++ b/clients/apps/web/src/hooks/useTurnstile.test.tsx
@@ -1,0 +1,107 @@
+import { act, render } from '@testing-library/react'
+import { useEffect } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTurnstile } from './useTurnstile'
+
+interface RenderOptions {
+  callback?: (token: string) => void
+  'error-callback'?: () => void
+  'expired-callback'?: () => void
+}
+
+const WIDGET_ID = 'widget-1'
+
+let renderOptions: RenderOptions
+const turnstileMock = {
+  render: vi.fn((_container: HTMLElement, options: RenderOptions) => {
+    renderOptions = options
+    return WIDGET_ID
+  }),
+  execute: vi.fn(),
+  reset: vi.fn(),
+  remove: vi.fn(),
+}
+
+type Turnstile = ReturnType<typeof useTurnstile>
+
+let turnstile: Turnstile
+
+const Harness = () => {
+  const hook = useTurnstile('test-action')
+  const { containerRef } = hook
+  useEffect(() => {
+    turnstile = hook
+  }, [hook])
+  return <div ref={containerRef} />
+}
+
+beforeEach(() => {
+  Object.assign(window, { turnstile: turnstileMock })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  Reflect.deleteProperty(window, 'turnstile')
+})
+
+describe('useTurnstile', () => {
+  it('resolves with the token issued by the challenge', async () => {
+    render(<Harness />)
+
+    act(() => turnstile.execute())
+    expect(turnstileMock.execute).toHaveBeenCalledTimes(1)
+
+    act(() => renderOptions.callback!('token-1'))
+
+    await expect(turnstile.getToken()).resolves.toBe('token-1')
+    expect(turnstileMock.execute).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs a fresh challenge after the token expires', async () => {
+    render(<Harness />)
+
+    act(() => turnstile.execute())
+    act(() => renderOptions.callback!('token-1'))
+    act(() => renderOptions['expired-callback']!())
+
+    expect(turnstileMock.reset).toHaveBeenCalledWith(WIDGET_ID)
+
+    const token = turnstile.getToken()
+    expect(turnstileMock.execute).toHaveBeenCalledTimes(2)
+
+    act(() => renderOptions.callback!('token-2'))
+    await expect(token).resolves.toBe('token-2')
+  })
+
+  it('fails a pending submit on error and re-arms for the next one', async () => {
+    render(<Harness />)
+
+    act(() => turnstile.execute())
+
+    const failed = turnstile.getToken()
+    act(() => renderOptions['error-callback']!())
+    await expect(failed).resolves.toBeNull()
+
+    const token = turnstile.getToken()
+    expect(turnstileMock.execute).toHaveBeenCalledTimes(2)
+
+    act(() => renderOptions.callback!('token-2'))
+    await expect(token).resolves.toBe('token-2')
+  })
+
+  it('times out when the challenge never settles', async () => {
+    vi.useFakeTimers()
+    try {
+      render(<Harness />)
+
+      const token = turnstile.getToken()
+      await act(async () => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      await expect(token).resolves.toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/clients/apps/web/src/hooks/useTurnstile.ts
+++ b/clients/apps/web/src/hooks/useTurnstile.ts
@@ -57,6 +57,16 @@ export const useTurnstile = (action: string) => {
     }
   }, [])
 
+  const reset = useCallback(() => {
+    const turnstile = (window as TurnstileWindow).turnstile
+    const widgetId = widgetIdRef.current
+    tokenRef.current = null
+    executedRef.current = false
+    if (turnstile && widgetId) {
+      turnstile.reset(widgetId)
+    }
+  }, [])
+
   const render = useCallback(() => {
     const turnstile = (window as TurnstileWindow).turnstile
     const container = containerRef.current
@@ -73,14 +83,16 @@ export const useTurnstile = (action: string) => {
       execution: 'execute',
       size: 'flexible',
       callback: settleToken,
-      'error-callback': () => settleToken(null),
-      // Turnstile refreshes expired tokens on its own, so only drop the stale
-      // one and let the next callback settle any pending submit.
-      'expired-callback': () => {
-        tokenRef.current = null
+      // A failed or expired challenge leaves the widget without a token and
+      // Turnstile doesn't queue another execute on its own, so re-arm it for
+      // the next getToken() instead of letting that one wait out the timeout.
+      'error-callback': () => {
+        settleToken(null)
+        reset()
       },
+      'expired-callback': reset,
     })
-  }, [action, settleToken])
+  }, [action, settleToken, reset])
 
   useEffect(() => {
     render()
@@ -130,16 +142,6 @@ export const useTurnstile = (action: string) => {
       }),
     [execute],
   )
-
-  const reset = useCallback(() => {
-    const turnstile = (window as TurnstileWindow).turnstile
-    const widgetId = widgetIdRef.current
-    tokenRef.current = null
-    executedRef.current = false
-    if (turnstile && widgetId) {
-      turnstile.reset(widgetId)
-    }
-  }, [])
 
   return { containerRef, render, execute, getToken, reset }
 }


### PR DESCRIPTION
Turnstile only executes when the user chooses to log in via email, but it could go stale in a very weird edge case. This cleans things up so that a new execution will trigger and not block during sign-in.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

