### PR TITLE
feat(scripts): auto-add vouched hosts and write as each answer lands

### DIFF
--- a/server/scripts/enforce_frame_ancestors.py
+++ b/server/scripts/enforce_frame_ancestors.py
@@ -24,8 +24,12 @@ Four groups come out of it:
   switched on;
 - done, switched on with nothing outstanding.
 
-The first two are walked one origin at a time: add it or leave it, then switch
-the organization on or not. The third is offered as a single batch.
+Hosts the merchant already vouched for — under the domain on their account, or
+under one already on their own list — are offered together, in one answer, and
+written before anything else is asked. What remains is walked one origin at a
+time, and written as each organization is answered, so a session that dies
+halfway keeps what it decided. The covered organizations are switched on as a
+single batch.
 
 An organization in `ready` is a bet: we know it frames from hosts it has
 listed, not that it never frames from anywhere else. The `breaking` group is
@@ -43,8 +47,12 @@ Usage:
     # For real
     uv run python -m scripts.enforce_frame_ancestors --execute
 
-    # A shortlist
+    # A shortlist, or the busiest few
     uv run python -m scripts.enforce_frame_ancestors --slug acme --execute
+    uv run python -m scripts.enforce_frame_ancestors --limit 20 --execute
+
+    # The standing, asking nothing: fits a scheduled job
+    uv run python -m scripts.enforce_frame_ancestors --report
 """
 
 from dataclasses import dataclass, field
@@ -55,6 +63,7 @@ import structlog
 import typer
 from rich.console import Console
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
 from polar.models import Organization
@@ -82,7 +91,18 @@ MAX_HOSTS = 50
 class Review:
     candidate: Candidate
     enforced: bool
+    observed: list[Observation] = field(default_factory=list)
     reasons: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def vouched(self) -> list[tuple[str, HostStat]]:
+        """Hosts under a domain the merchant named on their account or their
+        own settings page. Neither can be set by whoever opens a checkout."""
+        return [
+            (host, stat)
+            for host, stat in self.decisions
+            if {"site", "listed"} & set(stat.signals)
+        ]
 
     @property
     def slug(self) -> str:
@@ -148,12 +168,41 @@ async def _load_reviews(
             Review(
                 candidate=candidate,
                 enforced=organization.is_frame_ancestors_enforced,
+                observed=observed,
                 reasons=dict(candidate.skipped),
             )
         )
 
     reviews.sort(key=lambda review: -review.candidate.embeds)
     return reviews
+
+
+def _reclassified(review: Review, added: list[str]) -> Review:
+    """The same organization, judged again with the hosts just written."""
+    candidate = Candidate(
+        organization_id=review.candidate.organization_id,
+        slug=review.slug,
+        name=review.candidate.name,
+        website=review.candidate.website,
+        current_hosts=validate_embed_hosts([*review.candidate.current_hosts, *added]),
+    )
+    candidate.embeds = review.candidate.embeds
+    _classify(
+        candidate,
+        review.observed,
+        min_checkouts=MIN_CHECKOUTS,
+        min_days=MIN_DAYS,
+        max_hosts=MAX_HOSTS,
+        include_local=True,
+        require_signal=False,
+        stale_days=RETENTION.days,
+    )
+    return Review(
+        candidate=candidate,
+        enforced=review.enforced,
+        observed=review.observed,
+        reasons=dict(candidate.skipped),
+    )
 
 
 @dataclass
@@ -207,64 +256,93 @@ class Decision:
     enable: bool = False
 
 
-def _decide(groups: Groups) -> list[Decision]:
-    """Walk the organizations that need an answer, one origin at a time."""
-    decisions: list[Decision] = []
-
-    for review in groups.walked:
-        candidate = review.candidate
-        console.rule(
-            f"[bold]{review.slug}[/bold]  "
-            + ("[red]enforced, breaking[/red]" if review.enforced else "not enforced")
+def _auto_add(reviews: list[Review]) -> list[Decision]:
+    """Hosts the merchant already vouched for, offered in one go."""
+    return [
+        Decision(
+            organization_id=review.candidate.organization_id,
+            slug=review.slug,
+            current_hosts=review.candidate.current_hosts,
+            hosts=[host for host, _ in review.vouched],
         )
-        console.print(f"  listed: {candidate.current_hosts or 'nothing'}")
-        for origin, _ in candidate.blocked:
-            console.print(
-                f"  [yellow]{origin}: plain HTTP on a public host, no entry can "
-                "admit it[/yellow]"
-            )
+        for review in reviews
+        if review.vouched
+    ]
 
-        chosen: list[str] = []
-        for host, stat in review.decisions:
-            if typer.confirm(f"  add {_describe(review, host, stat)}?", default=False):
-                chosen.append(host)
 
-        enable = review.enforced
-        if not review.enforced:
-            remaining = [host for host, _ in review.decisions if host not in chosen]
-            if remaining:
-                console.print(
-                    f"  [yellow]{len(remaining)} origin(s) would still be "
-                    f"refused: {', '.join(remaining)}[/yellow]"
-                )
-            enable = typer.confirm("  enable enforcement?", default=False)
-
-        if chosen or (enable and not review.enforced):
-            decisions.append(
-                Decision(
-                    organization_id=candidate.organization_id,
-                    slug=review.slug,
-                    current_hosts=candidate.current_hosts,
-                    hosts=chosen,
-                    enable=enable,
-                )
-            )
-
-    if groups.ready and typer.confirm(
-        f"\nEnable enforcement for the {len(groups.ready)} covered organizations?",
+def _confirm_auto_add(decisions: list[Decision], reviews: list[Review]) -> bool:
+    by_id = {review.candidate.organization_id: review for review in reviews}
+    console.rule("[bold]Vouched for by the merchant")
+    for decision in decisions:
+        review = by_id[decision.organization_id]
+        breaking = " [red](breaking)[/red]" if review.breaking else ""
+        for host, stat in review.vouched:
+            console.print(f"  {review.slug}{breaking}: {_describe(review, host, stat)}")
+    hosts = sum(len(decision.hosts) for decision in decisions)
+    return typer.confirm(
+        f"\nAdd these {hosts} host(s) to {len(decisions)} organization(s)?",
         default=False,
-    ):
-        decisions += [
-            Decision(
-                organization_id=review.candidate.organization_id,
-                slug=review.slug,
-                current_hosts=review.candidate.current_hosts,
-                enable=True,
-            )
-            for review in groups.ready
-        ]
+    )
 
-    return decisions
+
+def _decide_one(review: Review) -> Decision | None:
+    """One organization, one origin at a time."""
+    candidate = review.candidate
+    console.rule(
+        f"[bold]{review.slug}[/bold]  "
+        + ("[red]enforced, breaking[/red]" if review.enforced else "not enforced")
+    )
+    console.print(f"  listed: {candidate.current_hosts or 'nothing'}")
+    for origin, _ in candidate.blocked:
+        console.print(
+            f"  [yellow]{origin}: plain HTTP on a public host, no entry can "
+            "admit it[/yellow]"
+        )
+
+    chosen: list[str] = []
+    for host, stat in review.decisions:
+        if typer.confirm(f"  add {_describe(review, host, stat)}?", default=False):
+            chosen.append(host)
+
+    enable = review.enforced
+    if not review.enforced:
+        remaining = [host for host, _ in review.decisions if host not in chosen]
+        if remaining:
+            console.print(
+                f"  [yellow]{len(remaining)} origin(s) would still be refused: "
+                f"{', '.join(remaining)}[/yellow]"
+            )
+        enable = typer.confirm("  enable enforcement?", default=False)
+
+    if not chosen and not (enable and not review.enforced):
+        return None
+    return Decision(
+        organization_id=candidate.organization_id,
+        slug=review.slug,
+        current_hosts=candidate.current_hosts,
+        hosts=chosen,
+        enable=enable,
+    )
+
+
+def _report(groups: Groups) -> None:
+    """Everything a daily job can say without asking anything."""
+    for title, reviews in (
+        ("Breaking now", groups.breaking),
+        ("Waiting on a decision", groups.deciding),
+    ):
+        if not reviews:
+            continue
+        console.print(f"\n[bold]{title}[/bold]")
+        for review in reviews:
+            origins = ", ".join(host for host, _ in review.decisions)
+            blocked = ", ".join(
+                f"{origin} (HTTP)" for origin, _ in review.candidate.blocked
+            )
+            console.print(
+                f"  {review.slug}  {review.candidate.embeds} framed  "
+                f"{origins}{'  ' + blocked if blocked else ''}"
+            )
 
 
 async def _apply(session: AsyncSession, decisions: list[Decision]) -> None:
@@ -330,6 +408,29 @@ async def _apply(session: AsyncSession, decisions: list[Decision]) -> None:
     console.print(f"\n[green]Wrote {written} organization(s).")
 
 
+async def _write(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    decisions: list[Decision],
+    *,
+    execute: bool,
+) -> None:
+    """One transaction per batch, taken only once the answers are in."""
+    if not decisions:
+        return
+
+    hosts = sum(len(decision.hosts) for decision in decisions)
+    enabled = sum(1 for decision in decisions if decision.enable)
+    if not execute:
+        console.print(
+            f"[yellow]Rehearsal — --execute would add {hosts} host(s) and "
+            f"switch on {enabled} organization(s)."
+        )
+        return
+
+    async with sessionmaker() as session:
+        await _apply(session, decisions)
+
+
 @cli.command()
 @typer_async
 async def enforce_frame_ancestors(
@@ -340,6 +441,12 @@ async def enforce_frame_ancestors(
     ),
     execute: bool = typer.Option(
         False, help="Write the answers (default: rehearse, write nothing)"
+    ),
+    report: bool = typer.Option(
+        False, help="Print the standing and exit, asking nothing."
+    ),
+    limit: int = typer.Option(
+        0, help="Stop after this many organizations, busiest first (0: all)."
     ),
     slug: list[str] = typer.Option([], help="Only these organizations."),
     window: int = typer.Option(
@@ -354,26 +461,50 @@ async def enforce_frame_ancestors(
         # transaction that whole time holds a snapshot on the primary.
         async with sessionmaker() as session:
             reviews = await _load_reviews(session, observations, slug)
+        if limit:
+            reviews = reviews[:limit]
+
+        _summary(_partition(reviews))
+        if report:
+            _report(_partition(reviews))
+            return
+
+        vouched = _auto_add(reviews)
+        if vouched and _confirm_auto_add(vouched, reviews):
+            await _write(sessionmaker, vouched, execute=execute)
+            written = {decision.organization_id: decision.hosts for decision in vouched}
+            reviews = [
+                _reclassified(review, written[review.candidate.organization_id])
+                if review.candidate.organization_id in written
+                else review
+                for review in reviews
+            ]
 
         groups = _partition(reviews)
-        _summary(groups)
+        # Written as we go: a session that dies mid-review keeps what it
+        # answered, and the next run picks up from the list as it now stands.
+        for review in groups.walked:
+            decision = _decide_one(review)
+            if decision is not None:
+                await _write(sessionmaker, [decision], execute=execute)
 
-        decisions = _decide(groups)
-        if not decisions:
-            console.print("[green]Nothing to write.")
-            return
-
-        hosts = sum(len(decision.hosts) for decision in decisions)
-        enabled = sum(1 for decision in decisions if decision.enable)
-        if not execute:
-            console.print(
-                f"[yellow]Rehearsal — --execute would add {hosts} host(s) "
-                f"and switch on {enabled} organization(s)."
+        if groups.ready and typer.confirm(
+            f"\nEnable enforcement for the {len(groups.ready)} covered organizations?",
+            default=False,
+        ):
+            await _write(
+                sessionmaker,
+                [
+                    Decision(
+                        organization_id=review.candidate.organization_id,
+                        slug=review.slug,
+                        current_hosts=review.candidate.current_hosts,
+                        enable=True,
+                    )
+                    for review in groups.ready
+                ],
+                execute=execute,
             )
-            return
-
-        async with sessionmaker() as session:
-            await _apply(session, decisions)
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
## Summary

Bucket orgs with strong signals (framed domain = org website) to be able to write them at once instead of one by one and write along the way for the others instead of waiting for the end of the list so if the ssh session is killed nothing is lost.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

