### PR TITLE
server: add concurrent pending webhook health index

### DIFF
--- a/server/migrations/versions/2026-09-11-1543_add_pending_webhook_health_index.py
+++ b/server/migrations/versions/2026-09-11-1543_add_pending_webhook_health_index.py
@@ -1,0 +1,59 @@
+"""add pending webhook health index
+
+Revision ID: fea5ce44fb88
+Revises: 1b299ae956f3
+Create Date: 2026-09-11 15:43:39.011912
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "fea5ce44fb88"
+down_revision = "1b299ae956f3"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX_NAME = "ix_webhook_events_created_at_pending"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET lock_timeout = '5s'")
+        try:
+            # A failed concurrent build can leave an invalid index behind.
+            op.drop_index(
+                INDEX_NAME,
+                table_name="webhook_events",
+                if_exists=True,
+                postgresql_concurrently=True,
+            )
+            op.create_index(
+                INDEX_NAME,
+                "webhook_events",
+                ["created_at"],
+                postgresql_include=["id"],
+                postgresql_where=(
+                    "succeeded IS NULL AND deleted_at IS NULL "
+                    "AND payload IS NOT NULL AND NOT skipped"
+                ),
+                postgresql_concurrently=True,
+            )
+        finally:
+            op.execute("RESET lock_timeout")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET lock_timeout = '5s'")
+        try:
+            op.drop_index(
+                INDEX_NAME,
+                table_name="webhook_events",
+                if_exists=True,
+                postgresql_concurrently=True,
+            )
+        finally:
+            op.execute("RESET lock_timeout")

--- a/server/polar/models/webhook_event.py
+++ b/server/polar/models/webhook_event.py
@@ -24,6 +24,15 @@ class WebhookEvent(RecordModel):
             "created_at",
             postgresql_where="payload IS NOT NULL",
         ),
+        Index(
+            "ix_webhook_events_created_at_pending",
+            "created_at",
+            postgresql_include=["id"],
+            postgresql_where=(
+                "succeeded IS NULL AND deleted_at IS NULL "
+                "AND payload IS NOT NULL AND NOT skipped"
+            ),
+        ),
     )
 
     webhook_endpoint_id: Mapped[UUID] = mapped_column(


### PR DESCRIPTION
## Summary

Add the database index needed to fix the worker `/webhooks` health-check timeout. This is the first PR in the stack; deploy it before the query change, following ADR-0006's separate schema and application rollout.

## What

Add `ix_webhook_events_created_at_pending` on `webhook_events.created_at`, including `id`, for events with no terminal result, no soft deletion, a retained payload, and no skip flag.

## Why

The health probe times out while PostgreSQL scans webhook history to find events with no delivery attempt. A production experiment with this partial index narrowed the six-hour window to 50 candidates. The index was 104 kB; its concurrent build took approximately 24 minutes. The experimental index was removed afterward.

## How

The migration creates and drops the index concurrently outside a transaction, with a session-level five-second lock timeout. It first removes any index left by a failed concurrent build so the migration can be retried. The model declares the same index.

Validated migration upgrade, downgrade, re-upgrade, and `alembic check` against a local database. Scoped Ruff checks pass. The existing application remains compatible; the next PR changes the probe to use the indexed pending-event predicate.

## Checklist

- [x] This PR addresses a single concern
- [x] The diff is reasonably sized and easy to review
- [x] Migration upgrade, downgrade, and model consistency checks pass
- [x] Scoped lint and formatting checks pass
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

