### PR TITLE
server: fix webhook health query timeouts

### DIFF
--- a/server/polar/webhook/repository.py
+++ b/server/polar/webhook/repository.py
@@ -26,27 +26,27 @@ class WebhookEventRepository(
 ):
     model = WebhookEvent
 
-    async def get_all_undelivered(
+    async def count_undelivered(
         self, older_than: datetime | None = None, newer_than: datetime | None = None
-    ) -> Sequence[WebhookEvent]:
+    ) -> int:
         statement = (
             self.get_base_statement()
-            .join(
-                WebhookDelivery,
-                WebhookDelivery.webhook_event_id == WebhookEvent.id,
-                isouter=True,
-            )
+            .with_only_columns(func.count(WebhookEvent.id))
             .where(
-                WebhookDelivery.id.is_(None),
+                WebhookEvent.succeeded.is_(None),
                 WebhookEvent.payload.is_not(None),
                 ~WebhookEvent.skipped,
+                ~select(WebhookDelivery.id)
+                .where(WebhookDelivery.webhook_event_id == WebhookEvent.id)
+                .exists(),
             )
         )
         if older_than is not None:
             statement = statement.where(WebhookEvent.created_at < older_than)
         if newer_than is not None:
             statement = statement.where(WebhookEvent.created_at > newer_than)
-        return await self.get_all(statement)
+        result = await self.session.execute(statement)
+        return result.scalar_one()
 
     async def get_recent_by_endpoint(
         self, endpoint_id: UUID, *, limit: int

--- a/server/polar/worker/_health.py
+++ b/server/polar/worker/_health.py
@@ -91,15 +91,15 @@ async def webhooks(request: Request) -> JSONResponse:
     async_sessionmaker: AsyncSessionMaker = request.state.async_sessionmaker
     async with async_sessionmaker() as session:
         repository = WebhookEventRepository(session)
-        undelivered_webhooks = await repository.get_all_undelivered(
+        undelivered_webhooks = await repository.count_undelivered(
             older_than=utc_now() - UNDELIVERED_WEBHOOKS_MINIMUM_AGE,
             newer_than=utc_now() - UNDELIVERED_WEBHOOKS_MAXIMUM_AGE,
         )
-        if len(undelivered_webhooks) > UNDELIVERED_WEBHOOKS_ALERT_THRESHOLD:
+        if undelivered_webhooks > UNDELIVERED_WEBHOOKS_ALERT_THRESHOLD:
             return JSONResponse(
                 {
                     "status": "error",
-                    "undelivered_webhooks": len(undelivered_webhooks),
+                    "undelivered_webhooks": undelivered_webhooks,
                 },
                 status_code=503,
             )

--- a/server/tests/webhooks/test_health.py
+++ b/server/tests/webhooks/test_health.py
@@ -1,0 +1,71 @@
+import json
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+import polar.worker._health as health_module
+from polar.kit.utils import utc_now
+from polar.models import WebhookDelivery, WebhookEndpoint, WebhookEvent
+from polar.models.webhook_endpoint import WebhookEventType
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+@pytest.mark.asyncio
+class TestWebhooks:
+    async def test_counts_only_unattempted_pending_events(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        webhook_endpoint_organization: WebhookEndpoint,
+        mocker: MockerFixture,
+    ) -> None:
+        now = utc_now()
+        mocker.patch.object(health_module, "utc_now", return_value=now)
+        request = MagicMock()
+        request.state.async_sessionmaker.return_value.__aenter__.return_value = session
+        event_fields = {
+            "webhook_endpoint": webhook_endpoint_organization,
+            "type": WebhookEventType.customer_created,
+            "payload": "{}",
+            "created_at": now - timedelta(minutes=10),
+        }
+
+        excluded_event_fields: list[dict[str, object]] = [
+            {"created_at": now - timedelta(minutes=5)},
+            {"created_at": now - timedelta(hours=6)},
+            {"payload": None},
+            {"skipped": True},
+            {"deleted_at": now},
+            {"succeeded": True},
+            {"succeeded": False},
+        ]
+        for excluded_fields in excluded_event_fields:
+            await save_fixture(WebhookEvent(**(event_fields | excluded_fields)))
+
+        for succeeded, deleted_at in [(True, None), (False, None), (False, now)]:
+            event = WebhookEvent(**event_fields)
+            await save_fixture(event)
+            await save_fixture(
+                WebhookDelivery(
+                    webhook_event=event,
+                    webhook_endpoint=webhook_endpoint_organization,
+                    succeeded=succeeded,
+                    deleted_at=deleted_at,
+                )
+            )
+
+        for count in range(13):
+            if count:
+                await save_fixture(WebhookEvent(**event_fields))
+
+            response = await health_module.webhooks(request)
+
+            assert response.status_code == (503 if count > 10 else 200)
+            assert json.loads(bytes(response.body)) == (
+                {"status": "error", "undelivered_webhooks": count}
+                if count > 10
+                else {"status": "ok"}
+            )


### PR DESCRIPTION
## Summary

Fix the worker `/webhooks` health probe timing out in PostgreSQL by counting pending events without loading their payloads. This is the second PR in the stack; deploy #14422 first.

## What

Replace `get_all_undelivered` with `count_undelivered`. Filter events to pending status and use `NOT EXISTS` to exclude any event with a delivery attempt, including failed or soft-deleted attempts.

The probe retains its exact `undelivered_webhooks` count, the existing five-minute to six-hour time window, and HTTP 503 when the count exceeds 10.

## Why

Logfire traces showed asyncpg timing out on the health query, and Render recorded HTTP 500 responses after approximately 30 seconds. Loading full events through the delivery anti-join made the probe scan substantial webhook history even when the backlog was small.

## How

Use the partial index introduced by the preceding PR to restrict candidate events, then return a SQL aggregate. Keep the delivery existence check because pending status alone can include events that already had failed attempts.

During the production index experiment, an equivalent candidate query completed in 24.8 ms and the subsequent exact count completed in 0.26 ms with a warm cache. After removing the experimental index, the candidate query took 285 ms with a warm cache and touched 153,160 buffers. These are database-query measurements, not endpoint latency measurements.

Validation: 24 webhook/worker health tests pass, including exact counts through 12 events, the 200/503 threshold, time boundaries, event exclusions, and delivery-attempt exclusions. Scoped mypy, Ruff, formatting, and the repository's custom AST linters pass.

## Checklist

- [x] This PR addresses a single concern
- [x] The diff is reasonably sized and easy to review
- [x] New behavior is covered by an integration test
- [x] Scoped lint and type checks and custom AST linters pass
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

