### PR TITLE
Make "dev up" more robust for fresh installs

### DIFF
--- a/dev/cli/cli.py
+++ b/dev/cli/cli.py
@@ -34,6 +34,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
+from logo import print_banner
 from shared import (
     CLIENTS_DIR,
     SERVER_DIR,
@@ -179,19 +180,7 @@ def up(
     Installs dependencies, starts infrastructure, runs migrations,
     and prompts to configure GitHub and Stripe integrations.
     """
-    console.print()
-    console.print(
-        Panel(
-            Text(
-                "Setting up Polar development environment",
-                justify="center",
-                style="bold",
-            ),
-            border_style="blue",
-            padding=(1, 4),
-        )
-    )
-    console.print()
+    print_banner("Polar dev", "Setting up your development environment")
 
     ctx = Context(
         clean=clean,
@@ -209,6 +198,7 @@ def up(
         _track_up_step(module.__name__, step_started_at, success, clean)
         if not success:
             console.print(f"\n[red]Setup failed at step {i}/{total}: {name}[/red]")
+            console.print("Fix the issue above and run [bold]dev up[/bold] again. Finished steps are skipped.")
             raise typer.Exit(1)
         console.print()
 

--- a/dev/cli/logo.py
+++ b/dev/cli/logo.py
@@ -1,0 +1,36 @@
+from rich.text import Text
+
+from shared import console
+
+LOGOMARK = (
+    "         ▄▄▄████████▄▄▄",
+    "      ▄███▀████▀▀████████▄",
+    "    ▄███▀▄███▀    ▀███ ▀███▄",
+    "  ▄███▀▄██▄█▀      ▀███ ▀████▄",
+    " ▄██▀ ▄██ ██        ███  ██▄▀█▄",
+    " ███ ▄██ ██          ██▄ ▀██ ██",
+    "███  ██  ██          ███  ██  ██",
+    "██▀ ███  ██          ███ ███  ██",
+    "██  ███  ██          ██  ███ ▄██",
+    "██  ██▀ ███          ██  ██  ███",
+    " ██ ███  ██          ██ ██▀ ███▀",
+    " ▀█▄▀██  ███        ██ ██▀ ▄██▀",
+    "  ▀█▄██▄ ███▄      ▄█▀██▀ ███▀",
+    "    ▀███▄ ███▄    ▄███▀ ▄██▀",
+    "      ▀████████▄▄▄███▄███▀",
+    "         ▀▀█████████▀▀▀",
+)
+LOGOMARK_WIDTH = max(len(line) for line in LOGOMARK)
+
+
+def print_banner(title: str, subtitle: str) -> None:
+    middle = len(LOGOMARK) // 2
+    captions = {middle - 1: Text(title, style="bold"), middle: Text(subtitle, style="dim")}
+    console.print("\n")
+    for index, line in enumerate(LOGOMARK):
+        row = Text(line)
+        if index in captions:
+            row.pad_right(LOGOMARK_WIDTH + 4 - len(line))
+            row.append_text(captions[index])
+        console.print(row)
+    console.print("\n")

--- a/dev/cli/shared.py
+++ b/dev/cli/shared.py
@@ -1,9 +1,11 @@
 """Shared utilities and context for the Polar Development CLI."""
 
+import json
 import os
 import shutil
 import socket
 import subprocess
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -129,6 +131,132 @@ def step_status(success: bool, message: str, detail: str = "") -> None:
         console.print(f"  {icon} {message}  [dim]{detail}[/dim]")
     else:
         console.print(f"  {icon} {message}")
+
+
+def step_failed(
+    message: str,
+    detail: str,
+    result: subprocess.CompletedProcess | None = None,
+    hints: tuple[str, ...] = (),
+    lines: int = 30,
+) -> None:
+    """Report a failed step: status line, the command's output tail, then how to fix it."""
+    step_status(False, message, detail)
+    print_output_tail(result, lines)
+    if hints:
+        console.print("  [bold]To fix:[/bold]")
+        for hint in hints:
+            console.print(f"    • {hint}")
+
+
+def print_output_tail(
+    result: subprocess.CompletedProcess | None, lines: int = 30, max_line_length: int = 200
+) -> None:
+    """Print the last lines of a failed command's output, stdout and stderr combined."""
+    if result is None:
+        return
+    output = "\n".join(part.strip() for part in (result.stdout, result.stderr) if part and part.strip())
+    if not output:
+        return
+    tail = [
+        line if len(line) <= max_line_length else line[: max_line_length - 1] + "…"
+        for line in output.splitlines()[-lines:]
+    ]
+    console.print(Padding(Text("\n".join(tail), style="dim"), (0, 0, 0, 4)))
+
+
+_BROKEN_CLT_MARKERS = (
+    "tapi error",
+    "unknown architecture",
+    "linker command failed",
+    "xcrun: error",
+    "invalid active developer path",
+    "does not contain",
+)
+
+
+def looks_like_broken_clt(output: str) -> bool:
+    """Whether build output points at outdated or broken macOS Command Line Tools."""
+    lowered = output.lower()
+    return any(marker in lowered for marker in _BROKEN_CLT_MARKERS)
+
+
+def check_clt_can_link() -> bool:
+    """Compile and link a trivial program against a system framework.
+
+    An outdated or half-updated Command Line Tools install passes `xcode-select -p`
+    but fails here, the same way native Python extensions fail later in `uv sync`.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        source = Path(tmp) / "clt_check.c"
+        source.write_text("int main(void) { return 0; }\n")
+        result = run_command(
+            ["cc", "-framework", "CoreFoundation", "-o", str(Path(tmp) / "clt_check"), str(source)],
+            capture=True,
+            timeout=60,
+        )
+    return result is not None and result.returncode == 0
+
+
+def print_clt_repair_hint() -> None:
+    """Explain how to fix Command Line Tools that can't build native code."""
+    console.print(
+        "  [yellow]The macOS Command Line Tools can't build native code."
+        " This happens when they are outdated or only partially updated.[/yellow]"
+    )
+    console.print("  Fix them, then run [bold]dev up[/bold] again:")
+    console.print(
+        "    1. System Settings → General → Software Update:"
+        " install the [bold]Command Line Tools for Xcode[/bold] update if one is offered"
+    )
+    console.print(
+        '       (or: [bold]softwareupdate --list[/bold], then [bold]softwareupdate --install "<label>"[/bold])'
+    )
+    console.print(
+        "    2. If no update is offered, reinstall them:"
+        " [bold]sudo rm -rf /Library/Developer/CommandLineTools && xcode-select --install[/bold]"
+    )
+
+
+def required_pnpm_version() -> str | None:
+    """The pnpm version pinned in clients/package.json, if any."""
+    try:
+        manager = json.loads((CLIENTS_DIR / "package.json").read_text()).get("packageManager", "")
+    except (OSError, ValueError):
+        return None
+    return manager.removeprefix("pnpm@") if manager.startswith("pnpm@") else None
+
+
+def install_pnpm() -> subprocess.CompletedProcess | None:
+    """Install the pinned pnpm via corepack, falling back to npm."""
+    spec = f"pnpm@{required_pnpm_version() or 'latest'}"
+    result = run_command(["corepack", "enable"], capture=True)
+    if result and result.returncode == 0:
+        result = run_command(["corepack", "prepare", spec, "--activate"], capture=True)
+        if result and result.returncode == 0:
+            return result
+    return run_command(["npm", "install", "-g", spec], capture=True)
+
+
+def ensure_pnpm() -> bool:
+    """Make sure pnpm is available, installing it when Node is present but pnpm is not."""
+    if check_command_exists("pnpm"):
+        step_status(True, "pnpm", get_command_version("pnpm") or "installed")
+        return True
+
+    console.print("  [yellow]pnpm not found, installing...[/yellow]")
+    result = install_pnpm()
+    if result is not None and result.returncode == 0 and check_command_exists("pnpm"):
+        step_status(True, "pnpm", f"installed ({get_command_version('pnpm') or ''})".replace(" ()", ""))
+        return True
+
+    step_status(False, "pnpm", "installation failed")
+    print_output_tail(result)
+    console.print(
+        f"  [dim]Install manually: npm install -g pnpm@{required_pnpm_version() or 'latest'},"
+        " then run dev up again[/dim]"
+    )
+    return False
 
 
 def check_env_file_exists(path: Path) -> bool:

--- a/dev/cli/up_steps/01_check_prerequisites.py
+++ b/dev/cli/up_steps/01_check_prerequisites.py
@@ -1,15 +1,20 @@
 """Check and install required tools."""
 
 import platform
+import re
 import time
+from pathlib import Path
 
 from shared import (
     Context,
+    check_clt_can_link,
     check_command_exists,
     console,
     get_command_version,
     is_docker_running,
+    print_clt_repair_hint,
     run_command,
+    step_failed,
     step_spinner,
     step_status,
 )
@@ -87,6 +92,40 @@ def install_xcode_clt() -> bool:
     return False
 
 
+_CLT_ON_DEMAND_FLAG = Path("/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress")
+_CLT_LABEL = re.compile(r"\*\s*Label:\s*(Command Line Tools for Xcode[ \d.]*-([\d.]+))\s*$", re.MULTILINE)
+
+
+def find_clt_update_label() -> str | None:
+    """Ask softwareupdate for the newest Command Line Tools package.
+
+    The flag file makes softwareupdate list Command Line Tools packages, the
+    same trick Homebrew's installer uses to install them without the GUI.
+    """
+    try:
+        _CLT_ON_DEMAND_FLAG.touch()
+        result = run_command(["softwareupdate", "--list"], capture=True, timeout=300)
+    finally:
+        _CLT_ON_DEMAND_FLAG.unlink(missing_ok=True)
+    if result is None or result.returncode != 0:
+        return None
+    matches = _CLT_LABEL.findall(result.stdout + result.stderr)
+    if not matches:
+        return None
+    return max(matches, key=lambda match: tuple(int(n) for n in match[1].split(".")))[0]
+
+
+def update_xcode_clt() -> bool:
+    """Install the latest Command Line Tools through softwareupdate."""
+    with step_spinner("Looking for a Command Line Tools update..."):
+        label = find_clt_update_label()
+    if label is None:
+        return False
+    console.print(f"  [dim]Installing '{label}' (this can take a while and may ask for your password)[/dim]")
+    result = run_command(["sudo", "softwareupdate", "--install", label], capture=False, timeout=3600)
+    return result is not None and result.returncode == 0 and check_clt_can_link()
+
+
 def run(ctx: Context) -> bool:
     """Check and install prerequisites: Docker, uv, pnpm, Node.js."""
     prereqs_ok = True
@@ -95,7 +134,16 @@ def run(ctx: Context) -> bool:
     # Xcode Command Line Tools (macOS) - required for git, compilers, etc.
     if system == "Darwin":
         if is_xcode_clt_installed():
-            step_status(True, "Xcode CLT", "installed")
+            if check_clt_can_link():
+                step_status(True, "Xcode CLT", "installed")
+            else:
+                console.print("  [yellow]Xcode Command Line Tools are installed but can't build native code, updating...[/yellow]")
+                if update_xcode_clt():
+                    step_status(True, "Xcode CLT", "updated")
+                else:
+                    step_status(False, "Xcode CLT", "update failed")
+                    print_clt_repair_hint()
+                    prereqs_ok = False
         else:
             console.print("  [yellow]Xcode Command Line Tools not found, installing...[/yellow]")
             if install_xcode_clt():
@@ -181,9 +229,12 @@ def run(ctx: Context) -> bool:
                 run_command(["uv", "tool", "update-shell"], capture=True)
                 step_status(True, "Tinybird CLI", "installed (restart your shell to pick up PATH changes)")
         else:
-            step_status(False, "Tinybird CLI", "installation failed")
-            if result:
-                console.print(f"[dim]{result.stderr}[/dim]")
+            step_failed(
+                "Tinybird CLI",
+                "installation failed",
+                result,
+                hints=("Install it manually: [bold]curl -sSL https://tinybird.co/install.sh | bash[/bold]",),
+            )
             prereqs_ok = False
 
     return prereqs_ok

--- a/dev/cli/up_steps/02_setup_node.py
+++ b/dev/cli/up_steps/02_setup_node.py
@@ -7,9 +7,10 @@ from pathlib import Path
 from shared import (
     ROOT_DIR,
     Context,
-    check_command_exists,
     console,
+    ensure_pnpm,
     get_command_version,
+    print_output_tail,
     run_command,
     step_spinner,
     step_status,
@@ -34,8 +35,13 @@ def _nvm_script() -> Path:
 def _run_with_nvm(nvm_cmd: str, capture: bool = True) -> "subprocess.CompletedProcess | None":
     """Run a command inside a bash shell with nvm sourced."""
 
-    cmd = f'source "{_nvm_script()}" && {nvm_cmd}'
-    return run_command(["bash", "-c", cmd], cwd=ROOT_DIR, capture=capture)
+    cmd = f'source "{_nvm_script()}" --no-use && {nvm_cmd}'
+    return run_command(
+        ["bash", "-c", cmd],
+        cwd=ROOT_DIR,
+        capture=capture,
+        env={"NVM_DIR": str(_nvm_script().parent)},
+    )
 
 
 def install_nvm() -> bool:
@@ -44,9 +50,10 @@ def install_nvm() -> bool:
         ["bash", "-c", "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash"],
         capture=True,
     )
-    if result and result.returncode != 0 and result.stderr:
-        console.print(f"  [dim]{result.stderr[:500]}[/dim]")
-    return result is not None and result.returncode == 0
+    if result is None or result.returncode != 0:
+        print_output_tail(result)
+        return False
+    return is_nvm_installed()
 
 
 def run_nvm_install_node() -> bool:
@@ -55,9 +62,10 @@ def run_nvm_install_node() -> bool:
         return False
 
     result = _run_with_nvm(f"nvm install {REQUIRED_NODE_MAJOR}")
-    if result and result.returncode != 0 and result.stderr:
-        console.print(f"  [dim]{result.stderr[:500]}[/dim]")
-    return result is not None and result.returncode == 0
+    if result is None or result.returncode != 0:
+        print_output_tail(result)
+        return False
+    return True
 
 
 def activate_nvm_node() -> bool:
@@ -77,17 +85,6 @@ def activate_nvm_node() -> bool:
                 os.environ["PATH"] = f"{bin_dir}:{current_path}"
             return True
     return False
-
-
-def install_pnpm() -> bool:
-    """Install pnpm using corepack or npm."""
-    result = run_command(["corepack", "enable"], capture=True)
-    if result and result.returncode == 0:
-        result = run_command(["corepack", "prepare", "pnpm@latest", "--activate"], capture=True)
-        if result and result.returncode == 0:
-            return True
-    result = run_command(["npm", "install", "-g", "pnpm"], capture=True)
-    return result is not None and result.returncode == 0
 
 
 def run(ctx: Context) -> bool:
@@ -112,7 +109,7 @@ def run(ctx: Context) -> bool:
 
     if current_node_major == REQUIRED_NODE_MAJOR:
         step_status(True, "Node version", f"v{current_node_major} (matches required)")
-        return True
+        return ensure_pnpm()
 
     # Wrong or missing Node version
     if current_node_major:
@@ -136,7 +133,10 @@ def run(ctx: Context) -> bool:
             step_status(True, f"Node {REQUIRED_NODE_MAJOR}", "installed via nvm")
         else:
             step_status(False, f"Node {REQUIRED_NODE_MAJOR}", "installation failed")
-            console.print(f"  [dim]Try manually: nvm install {REQUIRED_NODE_MAJOR}[/dim]")
+            console.print(
+                f"  [dim]Try manually: source ~/.nvm/nvm.sh && nvm install {REQUIRED_NODE_MAJOR},"
+                " then run dev up again[/dim]"
+            )
             return False
 
     # Activate nvm Node
@@ -148,14 +148,4 @@ def run(ctx: Context) -> bool:
         console.print("Then run [bold]dev up[/bold] again.")
         return False
 
-    # Re-check pnpm now that we have Node
-    if not check_command_exists("pnpm"):
-        console.print("  [yellow]Installing pnpm...[/yellow]")
-        if install_pnpm():
-            version = get_command_version("pnpm")
-            step_status(True, "pnpm", f"installed ({version})" if version else "installed")
-        else:
-            step_status(False, "pnpm", "installation failed")
-            return False
-
-    return True
+    return ensure_pnpm()

--- a/dev/cli/up_steps/03_setup_environment.py
+++ b/dev/cli/up_steps/03_setup_environment.py
@@ -7,6 +7,7 @@ from shared import (
     Context,
     check_env_file_exists,
     run_command,
+    step_failed,
     step_status,
 )
 
@@ -32,5 +33,12 @@ def run(ctx: Context) -> bool:
         step_status(True, "Environment files", "generated")
         return True
     else:
-        step_status(False, "Environment files", "generation failed")
+        step_failed(
+            "Environment files",
+            "generation failed",
+            hints=(
+                "The error above comes from dev/setup-environment; run [bold]./dev/setup-environment[/bold] directly to retry",
+                "Without server/.env the Docker containers can't start, so this must succeed before continuing",
+            ),
+        )
         return False

--- a/dev/cli/up_steps/04_start_infrastructure.py
+++ b/dev/cli/up_steps/04_start_infrastructure.py
@@ -3,8 +3,8 @@
 from shared import (
     SERVER_DIR,
     Context,
-    console,
     run_command,
+    step_failed,
     step_spinner,
     step_status,
 )
@@ -59,9 +59,17 @@ def run(ctx: Context) -> bool:
         step_status(True, "Docker containers", f"started ({', '.join(services)})" if services else "started")
         return True
     else:
-        step_status(False, "Docker containers", "failed to start")
-        if result and result.stderr:
-            console.print(f"[dim]{result.stderr}[/dim]")
-        if result and result.stdout:
-            console.print(f"[dim]{result.stdout}[/dim]")
+        output = f"{result.stdout}\n{result.stderr}" if result else ""
+        if "port is already allocated" in output or "address already in use" in output:
+            hints = (
+                "Another program is using one of the ports (5432, 6379, 9000, 7181): stop it, or change the port in server/.env",
+                "Find it with [bold]lsof -i :5432[/bold] (swap in the port from the error above)",
+            )
+        else:
+            hints = (
+                "[bold]docker compose ps -a[/bold] in server/ shows which container failed",
+                "[bold]docker compose logs <service>[/bold] in server/ shows why",
+                "Is Docker Desktop running and finished starting? Check the whale icon in the menu bar",
+            )
+        step_failed("Docker containers", "failed to start", result, hints)
         return False

--- a/dev/cli/up_steps/05_wait_for_services.py
+++ b/dev/cli/up_steps/05_wait_for_services.py
@@ -8,6 +8,8 @@ from shared import (
     ROOT_DIR,
     SERVER_DIR,
     Context,
+    console,
+    print_output_tail,
     run_command,
     step_spinner,
     step_status,
@@ -78,20 +80,47 @@ def wait_for_tinybird_and_get_token(timeout: int = 90) -> str | None:
     return None
 
 
+def _report_service_timeout(label: str, service: str, timeout: int) -> None:
+    step_status(False, label, f"not ready after {timeout}s")
+    status = run_command(
+        ["docker", "compose", "ps", "-a", service, "--format", "{{.Name}}: {{.Status}}"],
+        cwd=SERVER_DIR,
+        capture=True,
+    )
+    if status and status.stdout.strip():
+        console.print(f"    [dim]{status.stdout.strip()}[/dim]")
+    logs = run_command(
+        ["docker", "compose", "logs", "--no-color", "--tail", "10", service],
+        cwd=SERVER_DIR,
+        capture=True,
+    )
+    console.print(f"  [bold]Last log lines from the {service} container:[/bold]")
+    print_output_tail(logs, lines=10)
+    console.print("  [bold]To fix:[/bold]")
+    console.print(
+        "    • A container that exited right away usually means server/.env is missing or incomplete:"
+        " run [bold]./dev/setup-environment[/bold], then [bold]dev up[/bold] again"
+    )
+    console.print(
+        f"    • Otherwise restart it with [bold]docker compose restart {service}[/bold] in server/"
+        f" and check [bold]docker compose logs {service}[/bold]"
+    )
+
+
 def run(ctx: Context) -> bool:
     """Wait for PostgreSQL, Redis, and optionally Tinybird to be ready."""
     with step_spinner("Waiting for PostgreSQL..."):
         if wait_for_postgres(timeout=60):
             step_status(True, "PostgreSQL", "ready")
         else:
-            step_status(False, "PostgreSQL", "timeout after 60s")
+            _report_service_timeout("PostgreSQL", "db", 60)
             return False
 
     with step_spinner("Waiting for Redis..."):
         if wait_for_redis(timeout=60):
             step_status(True, "Redis", "ready")
         else:
-            step_status(False, "Redis", "timeout after 60s")
+            _report_service_timeout("Redis", "redis", 60)
             return False
 
     with step_spinner("Waiting for Tinybird..."):

--- a/dev/cli/up_steps/06_install_python_deps.py
+++ b/dev/cli/up_steps/06_install_python_deps.py
@@ -3,7 +3,9 @@
 from shared import (
     SERVER_DIR,
     Context,
-    console,
+    looks_like_broken_clt,
+    print_clt_repair_hint,
+    print_output_tail,
     run_command,
     step_spinner,
     step_status,
@@ -21,6 +23,7 @@ def run(ctx: Context) -> bool:
             return True
         else:
             step_status(False, "uv sync", "failed")
-            if result:
-                console.print(f"[dim]{result.stderr}[/dim]")
+            print_output_tail(result, lines=60)
+            if result and looks_like_broken_clt(result.stderr or ""):
+                print_clt_repair_hint()
             return False

--- a/dev/cli/up_steps/07_install_js_deps.py
+++ b/dev/cli/up_steps/07_install_js_deps.py
@@ -3,7 +3,9 @@
 from shared import (
     CLIENTS_DIR,
     Context,
-    console,
+    check_command_exists,
+    ensure_pnpm,
+    print_output_tail,
     run_command,
     step_spinner,
     step_status,
@@ -14,15 +16,15 @@ NAME = "Installing JavaScript dependencies"
 
 def run(ctx: Context) -> bool:
     """Run pnpm install to install JS dependencies."""
+    if not check_command_exists("pnpm") and not ensure_pnpm():
+        return False
+
     with step_spinner("Running pnpm install..."):
         result = run_command(["pnpm", "install"], cwd=CLIENTS_DIR, capture=True)
-        if result and result.returncode == 0:
-            step_status(True, "pnpm install", "complete")
-            return True
-        else:
-            step_status(False, "pnpm install", "failed")
-            if result:
-                output = result.stderr or result.stdout
-                if output:
-                    console.print(f"[dim]{output}[/dim]")
-            return False
+    if result and result.returncode == 0:
+        step_status(True, "pnpm install", "complete")
+        return True
+
+    step_status(False, "pnpm install", "failed")
+    print_output_tail(result, lines=40)
+    return False

--- a/dev/cli/up_steps/08_build_packages.py
+++ b/dev/cli/up_steps/08_build_packages.py
@@ -3,8 +3,8 @@
 from shared import (
     CLIENTS_DIR,
     Context,
-    console,
     run_command,
+    step_failed,
     step_spinner,
     step_status,
 )
@@ -24,7 +24,14 @@ def run(ctx: Context) -> bool:
             step_status(True, "Packages built", "ui, client, checkout, customer-portal")
             return True
         else:
-            step_status(False, "Package build", "failed")
-            if result and result.stderr:
-                console.print(f"[dim]{result.stderr[:500]}[/dim]")
+            step_failed(
+                "Package build",
+                "failed",
+                result,
+                hints=(
+                    "Run [bold]pnpm turbo run build --filter=./packages/*[/bold] in clients/ to see the full log",
+                    "If the error mentions a missing module, run [bold]pnpm install[/bold] in clients/ first",
+                ),
+                lines=40,
+            )
             return False

--- a/dev/cli/up_steps/10_build_email_templates.py
+++ b/dev/cli/up_steps/10_build_email_templates.py
@@ -4,8 +4,8 @@ from shared import (
     SERVER_DIR,
     Context,
     check_email_binary_exists,
-    console,
     run_command,
+    step_failed,
     step_spinner,
     step_status,
 )
@@ -27,8 +27,14 @@ def run(ctx: Context) -> bool:
             step_status(True, "Email templates", "built")
             return True
         else:
-            step_status(False, "Email templates", "build failed (optional)")
-            if result:
-                console.print(f"[dim]{result.stderr}[/dim]")
-            # Don't fail - emails are optional for basic dev
-            return True
+            step_failed(
+                "Email templates",
+                "build failed",
+                result,
+                hints=(
+                    "The API and tests refuse to start without server/emails/bin/react-email-pkg, so this can't be skipped",
+                    "Run [bold]uv run task emails[/bold] in server/ to retry with the full log",
+                ),
+                lines=40,
+            )
+            return False

--- a/dev/cli/up_steps/11_run_migrations.py
+++ b/dev/cli/up_steps/11_run_migrations.py
@@ -3,8 +3,8 @@
 from shared import (
     SERVER_DIR,
     Context,
-    console,
     run_command,
+    step_failed,
     step_spinner,
     step_status,
 )
@@ -22,7 +22,15 @@ def run(ctx: Context) -> bool:
             step_status(True, "Database migrations", "applied")
             return True
         else:
-            step_status(False, "Database migrations", "failed")
-            if result:
-                console.print(f"[dim]{result.stderr}[/dim]")
+            step_failed(
+                "Database migrations",
+                "failed",
+                result,
+                hints=(
+                    "Is PostgreSQL up? [bold]dev status[/bold] shows it; [bold]docker compose logs db[/bold] in server/ shows why not",
+                    "Run [bold]uv run task db_migrate[/bold] in server/ to retry with the full log",
+                    "A stale local database can be rebuilt with [bold]dev db reset[/bold] (this wipes local data)",
+                ),
+                lines=40,
+            )
             return False

--- a/dev/cli/up_steps/12_build_backoffice.py
+++ b/dev/cli/up_steps/12_build_backoffice.py
@@ -3,8 +3,8 @@
 from shared import (
     SERVER_DIR,
     Context,
-    console,
     run_command,
+    step_failed,
     step_spinner,
     step_status,
 )
@@ -36,7 +36,11 @@ def run(ctx: Context) -> bool:
             step_status(True, "Backoffice assets", "built")
             return True
         else:
-            step_status(False, "Backoffice assets", "build failed")
-            if result and result.stderr:
-                console.print(f"[dim]{result.stderr[:500]}[/dim]")
+            step_failed(
+                "Backoffice assets",
+                "build failed",
+                result,
+                hints=("Run [bold]uv run task backoffice[/bold] in server/ to retry with the full log",),
+                lines=40,
+            )
             return False


### PR DESCRIPTION
## Summary

Pieter just got a new computer and faced some issues with `dev up` that this PR will tackle:

- We now automatically detect an outdated install of Xcode's "Command Line Tools" and try to update automatically with `softwareupdate` (Apple's own tool for macOS related updates, pretty neat)
- If `uv sync` fails we print a fix instead of just the build failure
- Fix install of `pnpm`
- Every failing step in `dev up` now gives hints on how to fix it
- If something fails in `dev up`, we will now tell you that running the command again will resume from where it failed
- If we fail to build email templates we now properly throw an error
- If we fail to build backoffice templates we now properly throw an error
- Add a lil' something something when you run `dev up`

For already onboarded users this PR doesn't do much, except for better error handling.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

