### PR TITLE
backoffice: Switch to advertised Tailscale servie

### DIFF
--- a/server/docker/run_private_backoffice.sh
+++ b/server/docker/run_private_backoffice.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 umask 077
 
 : "${POLAR_BACKOFFICE_HOST:?Set the private backoffice hostname}"
-tailscale_auth_key="${TS_AUTHKEY:?Set a reusable, non-ephemeral Tailscale auth key}"
+tailscale_oauth_secret="${TS_AUTHKEY:?Set the Tailscale OAuth client secret}"
 cloudflare_api_token="${CLOUDFLARE_API_TOKEN:?Set a DNS token scoped to the polar.sh zone}"
 unset TS_AUTHKEY CLOUDFLARE_API_TOKEN
 
@@ -21,7 +21,7 @@ cleanup() {
 trap cleanup EXIT
 trap 'exit 0' TERM INT
 
-TS_AUTHKEY="$tailscale_auth_key" start containerboot
+TS_KUBE_SECRET="" TS_AUTHKEY="$tailscale_oauth_secret" start containerboot
 
 start uv run uvicorn polar.app:app \
   --host 127.0.0.1 --port 10000 --workers 1 \

--- a/terraform/global/production.tf
+++ b/terraform/global/production.tf
@@ -693,10 +693,10 @@ resource "tfe_variable" "private_backoffice_enabled_production" {
   variable_set_id = tfe_variable_set.production.id
 }
 
-resource "tfe_variable" "private_backoffice_tailscale_auth_key_production" {
-  key             = "private_backoffice_tailscale_auth_key"
+resource "tfe_variable" "private_backoffice_tailscale_oauth_client_secret_production" {
+  key             = "private_backoffice_tailscale_oauth_client_secret"
   category        = "terraform"
-  description     = "Tailscale auth key for the private backoffice replica in production"
+  description     = "Tailscale OAuth client secret for the private backoffice replica in production"
   sensitive       = true
   variable_set_id = tfe_variable_set.production.id
 }
@@ -712,6 +712,6 @@ resource "tfe_variable" "private_backoffice_cloudflare_api_token_production" {
 resource "tfe_variable" "private_backoffice_tailscale_ip_production" {
   key             = "private_backoffice_tailscale_ip"
   category        = "terraform"
-  description     = "Assigned Tailscale IPv4 address for the private backoffice replica in production"
+  description     = "Stable Tailscale Service IPv4 address for the private backoffice replica in production"
   variable_set_id = tfe_variable_set.production.id
 }

--- a/terraform/global/sandbox.tf
+++ b/terraform/global/sandbox.tf
@@ -575,10 +575,10 @@ resource "tfe_variable" "private_backoffice_enabled_sandbox" {
   variable_set_id = tfe_variable_set.sandbox.id
 }
 
-resource "tfe_variable" "private_backoffice_tailscale_auth_key_sandbox" {
-  key             = "private_backoffice_tailscale_auth_key"
+resource "tfe_variable" "private_backoffice_tailscale_oauth_client_secret_sandbox" {
+  key             = "private_backoffice_tailscale_oauth_client_secret"
   category        = "terraform"
-  description     = "Tailscale auth key for the private backoffice replica in sandbox"
+  description     = "Tailscale OAuth client secret for the private backoffice replica in sandbox"
   sensitive       = true
   variable_set_id = tfe_variable_set.sandbox.id
 }
@@ -594,6 +594,6 @@ resource "tfe_variable" "private_backoffice_cloudflare_api_token_sandbox" {
 resource "tfe_variable" "private_backoffice_tailscale_ip_sandbox" {
   key             = "private_backoffice_tailscale_ip"
   category        = "terraform"
-  description     = "Assigned Tailscale IPv4 address for the private backoffice replica in sandbox"
+  description     = "Stable Tailscale Service IPv4 address for the private backoffice replica in sandbox"
   variable_set_id = tfe_variable_set.sandbox.id
 }

--- a/terraform/global/test.tf
+++ b/terraform/global/test.tf
@@ -553,10 +553,10 @@ resource "tfe_variable" "private_backoffice_enabled_test" {
   variable_set_id = tfe_variable_set.test.id
 }
 
-resource "tfe_variable" "private_backoffice_tailscale_auth_key_test" {
-  key             = "private_backoffice_tailscale_auth_key"
+resource "tfe_variable" "private_backoffice_tailscale_oauth_client_secret_test" {
+  key             = "private_backoffice_tailscale_oauth_client_secret"
   category        = "terraform"
-  description     = "Tailscale auth key for the private backoffice replica in test"
+  description     = "Tailscale OAuth client secret for the private backoffice replica in test"
   sensitive       = true
   variable_set_id = tfe_variable_set.test.id
 }
@@ -572,6 +572,6 @@ resource "tfe_variable" "private_backoffice_cloudflare_api_token_test" {
 resource "tfe_variable" "private_backoffice_tailscale_ip_test" {
   key             = "private_backoffice_tailscale_ip"
   category        = "terraform"
-  description     = "Assigned Tailscale IPv4 address for the private backoffice replica in test"
+  description     = "Stable Tailscale Service IPv4 address for the private backoffice replica in test"
   variable_set_id = tfe_variable_set.test.id
 }

--- a/terraform/modules/render_service/backoffice.tf
+++ b/terraform/modules/render_service/backoffice.tf
@@ -2,7 +2,7 @@ variable "private_backoffice" {
   description = "Optional private replica using the existing admin sessions."
   type = object({
     hostname             = string
-    auth_key             = string
+    oauth_client_secret  = string
     cloudflare_api_token = string
     tags                 = optional(string, "tag:backoffice")
     plan                 = optional(string, "standard")
@@ -37,9 +37,13 @@ resource "render_private_service" "backoffice" {
   secret_files = {
     "tailscale-serve.json" = {
       content = jsonencode({
-        TCP = {
-          "443" = {
-            TCPForward = "127.0.0.1:8443"
+        Services = {
+          "svc:polar-backoffice-${var.environment}" = {
+            TCP = {
+              "443" = {
+                TCPForward = "127.0.0.1:8443"
+              }
+            }
           }
         }
       })
@@ -90,12 +94,12 @@ resource "render_private_service" "backoffice" {
     POLAR_ALLOWED_HOSTS      = { value = jsonencode(distinct(concat(jsondecode(var.api_service_config.allowed_hosts), [var.private_backoffice.hostname]))) }
     POLAR_CORS_ORIGINS       = { value = var.api_service_config.cors_origins }
     POLAR_DATABASE_POOL_SIZE = { value = "5" }
-    TS_AUTHKEY               = { value = var.private_backoffice.auth_key }
+    TS_AUTHKEY               = { value = "${var.private_backoffice.oauth_client_secret}?ephemeral=true&preauthorized=true" }
     TS_HOSTNAME              = { value = "polar-backoffice-${var.environment}" }
-    TS_STATE_DIR             = { value = "/var/lib/backoffice/tailscale" }
+    TS_STATE_DIR             = { value = "" }
     TS_USERSPACE             = { value = "true" }
     TS_ACCEPT_DNS            = { value = "false" }
-    TS_EXTRA_ARGS            = { value = "--advertise-tags=${var.private_backoffice.tags} --accept-routes=false" }
+    TS_EXTRA_ARGS            = { value = "--advertise-tags=${var.private_backoffice.tags},tag:${var.environment} --accept-routes=false" }
     TS_SERVE_CONFIG          = { value = "/etc/secrets/tailscale-serve.json" }
     TS_ENABLE_HEALTH_CHECK   = { value = "true" }
     TS_LOCAL_ADDR_PORT       = { value = "127.0.0.1:9002" }

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -151,7 +151,7 @@ module "production" {
   environment = "production"
   private_backoffice = var.private_backoffice_enabled ? {
     hostname             = local.private_backoffice_hostname
-    auth_key             = var.private_backoffice_tailscale_auth_key
+    oauth_client_secret  = var.private_backoffice_tailscale_oauth_client_secret
     cloudflare_api_token = var.private_backoffice_cloudflare_api_token
   } : null
   render_environment_id  = render_project.polar.environments["Production"].id

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -574,8 +574,8 @@ variable "private_backoffice_enabled" {
   default     = false
 }
 
-variable "private_backoffice_tailscale_auth_key" {
-  description = "Tailscale auth key for the private backoffice replica."
+variable "private_backoffice_tailscale_oauth_client_secret" {
+  description = "Tailscale OAuth client secret for the private backoffice replica."
   type        = string
   sensitive   = true
   default     = ""
@@ -589,7 +589,7 @@ variable "private_backoffice_cloudflare_api_token" {
 }
 
 variable "private_backoffice_tailscale_ip" {
-  description = "Assigned Tailscale IPv4 address; leave empty until the node is provisioned."
+  description = "Stable TailVIP IPv4 address of the pre-created Tailscale Service."
   type        = string
   default     = ""
 

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -104,7 +104,7 @@ module "sandbox" {
   environment = "sandbox"
   private_backoffice = var.private_backoffice_enabled ? {
     hostname             = local.private_backoffice_hostname
-    auth_key             = var.private_backoffice_tailscale_auth_key
+    oauth_client_secret  = var.private_backoffice_tailscale_oauth_client_secret
     cloudflare_api_token = var.private_backoffice_cloudflare_api_token
   } : null
   render_environment_id  = data.tfe_outputs.production.values.sandbox_environment_id

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -485,8 +485,8 @@ variable "private_backoffice_enabled" {
   default     = false
 }
 
-variable "private_backoffice_tailscale_auth_key" {
-  description = "Tailscale auth key for the private backoffice replica."
+variable "private_backoffice_tailscale_oauth_client_secret" {
+  description = "Tailscale OAuth client secret for the private backoffice replica."
   type        = string
   sensitive   = true
   default     = ""
@@ -500,7 +500,7 @@ variable "private_backoffice_cloudflare_api_token" {
 }
 
 variable "private_backoffice_tailscale_ip" {
-  description = "Assigned Tailscale IPv4 address; leave empty until the node is provisioned."
+  description = "Stable TailVIP IPv4 address of the pre-created Tailscale Service."
   type        = string
   default     = ""
 

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -118,7 +118,7 @@ module "test" {
   environment = "test"
   private_backoffice = var.private_backoffice_enabled ? {
     hostname             = local.private_backoffice_hostname
-    auth_key             = var.private_backoffice_tailscale_auth_key
+    oauth_client_secret  = var.private_backoffice_tailscale_oauth_client_secret
     cloudflare_api_token = var.private_backoffice_cloudflare_api_token
   } : null
   render_environment_id  = local.environment_id

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -463,8 +463,8 @@ variable "private_backoffice_enabled" {
   default     = false
 }
 
-variable "private_backoffice_tailscale_auth_key" {
-  description = "Tailscale auth key for the private backoffice replica."
+variable "private_backoffice_tailscale_oauth_client_secret" {
+  description = "Tailscale OAuth client secret for the private backoffice replica."
   type        = string
   sensitive   = true
   default     = ""
@@ -478,7 +478,7 @@ variable "private_backoffice_cloudflare_api_token" {
 }
 
 variable "private_backoffice_tailscale_ip" {
-  description = "Assigned Tailscale IPv4 address; leave empty until the node is provisioned."
+  description = "Stable TailVIP IPv4 address of the pre-created Tailscale Service."
   type        = string
   default     = ""
 


### PR DESCRIPTION
Instead of having a static auth key, we use advertised services in Tailscale.

This also switches the authentication to oauth.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

