### PR TITLE
docs: add a placeholder API changelog page

### DIFF
--- a/docs/changelog/api.mdx
+++ b/docs/changelog/api.mdx
@@ -1,0 +1,19 @@
+---
+rss: true
+title: API Changelog
+description: Stay up to date with the latest changes introduced in our API
+---
+
+Polar uses date-based API versions to evolve the API without unexpectedly changing
+the contract your integration depends on. Versions use the `YYYY-MM` format, such
+as `2026-10`, and apply to API requests, responses, webhook payloads, and SDK types. [Read more](/api-reference/current/versioning)
+
+<Update label="2026-10">
+
+**This will become the Current version on October 1st.**
+
+</Update>
+
+<Update label="2026-04">
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1047,7 +1047,7 @@
       {
         "tab": "Changelog",
         "icon": "signal-stream",
-        "pages": ["changelog/recent"]
+        "pages": ["changelog/recent", "changelog/api"]
       },
       {
         "tab": "Support",


### PR DESCRIPTION

Some people already asked for the link so they can setup an agent to monitor it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

