### PR TITLE
Remove mobile application token expiration bypass

### DIFF
--- a/server/polar/oauth2/repository.py
+++ b/server/polar/oauth2/repository.py
@@ -1,5 +1,4 @@
 import time
-from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import delete, or_, select, update
@@ -32,7 +31,7 @@ class OAuth2TokenRepository(RepositoryBase[OAuth2Token]):
         )
         await self.session.execute(statement)
 
-    async def delete_expired(self, *, exclude_client_ids: Sequence[str] = ()) -> None:
+    async def delete_expired(self) -> None:
         now = int(time.time())
         statement = delete(OAuth2Token).where(
             OAuth2Token.issued_at + OAuth2Token.expires_in < now,
@@ -41,8 +40,4 @@ class OAuth2TokenRepository(RepositoryBase[OAuth2Token]):
                 OAuth2Token.refresh_token_revoked_at != 0,
             ),
         )
-        if exclude_client_ids:
-            statement = statement.where(
-                OAuth2Token.client_id.notin_(exclude_client_ids)
-            )
         await self.session.execute(statement)

--- a/server/polar/oauth2/service/oauth2_token.py
+++ b/server/polar/oauth2/service/oauth2_token.py
@@ -6,7 +6,7 @@ import structlog
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
-from polar.config import Environment, settings
+from polar.config import settings
 from polar.email.schemas import OAuth2LeakedTokenEmail, OAuth2LeakedTokenProps
 from polar.email.sender import enqueue_email_template
 from polar.enums import TokenType
@@ -21,16 +21,6 @@ from polar.user_organization.service import (
 )
 
 log: Logger = structlog.get_logger()
-
-# TEMPORARY: the Polar app (iOS/Android/web, @polar-sh/app) does not refresh
-# its access tokens and crashes on 401. Until the app's auth flow is fixed,
-# expired tokens issued to it are still accepted but logged. Source of truth
-# for these IDs: clients/apps/app/hooks/oauth.ts.
-_APP_CLIENT_IDS: dict[Environment, str] = {
-    Environment.production: "polar_ci_yZLBGwoWZVsOdfN5CODRwVSTlJfwJhXqwg65e2CuNMZ",
-    Environment.development: "polar_ci_hbFdMZZRghgdm2F4LMceQSrcQNunmjlh6ukGJ1dG0Vg",
-}
-APP_CLIENT_ID: str | None = _APP_CLIENT_IDS.get(settings.ENV)
 
 
 class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
@@ -53,15 +43,7 @@ class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
             return None
 
         if cast(bool, token.is_expired()):
-            if token.client_id != APP_CLIENT_ID:
-                return None
-            log.warning(
-                "Allowing expired access token from Polar app client",
-                token_id=token.id,
-                client_id=token.client_id,
-                expires_at=token.expires_at,
-                expired_seconds_ago=int(time.time()) - token.expires_at,
-            )
+            return None
 
         if not token.sub.can_authenticate:
             return None
@@ -70,10 +52,7 @@ class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
 
     async def delete_expired(self, session: AsyncSession) -> None:
         repository = OAuth2TokenRepository.from_session(session)
-        exclude_client_ids: list[str] = []
-        if APP_CLIENT_ID is not None:
-            exclude_client_ids.append(APP_CLIENT_ID)
-        await repository.delete_expired(exclude_client_ids=exclude_client_ids)
+        await repository.delete_expired()
 
     async def revoke_for_sso_enforcement(
         self, session: AsyncSession, organization_id: UUID

--- a/server/tests/oauth2/service/test_oauth2_token.py
+++ b/server/tests/oauth2/service/test_oauth2_token.py
@@ -228,39 +228,6 @@ class TestGetByAccessToken:
         )
         assert result is None
 
-    async def test_expired_token_app_client(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        oauth2_client: OAuth2Client,
-        user: User,
-        mocker: MockerFixture,
-    ) -> None:
-        mocker.patch(
-            "polar.oauth2.service.oauth2_token.APP_CLIENT_ID",
-            oauth2_client.client_id,
-        )
-
-        await create_oauth2_token(
-            save_fixture,
-            client=oauth2_client,
-            access_token="polar_at_u_123",
-            refresh_token="polar_rt_u_123",
-            scopes=["openid"],
-            user=user,
-            issued_at=int(time.time()) - 7200,
-            expires_in=3600,
-        )
-
-        log_mock = mocker.patch("polar.oauth2.service.oauth2_token.log")
-
-        result = await oauth2_token_service.get_by_access_token(
-            session, "polar_at_u_123"
-        )
-        assert result is not None
-        assert result.client_id == oauth2_client.client_id
-        log_mock.warning.assert_called_once()
-
 
 @pytest.mark.asyncio
 class TestDeleteExpired:
@@ -360,37 +327,6 @@ class TestDeleteExpired:
         await oauth2_token_service.delete_expired(session)
 
         preserved = await session.get(OAuth2Token, valid.id)
-        assert preserved is not None
-
-    async def test_preserves_app_client_tokens(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        oauth2_client: OAuth2Client,
-        user: User,
-        mocker: MockerFixture,
-    ) -> None:
-        mocker.patch(
-            "polar.oauth2.service.oauth2_token.APP_CLIENT_ID",
-            oauth2_client.client_id,
-        )
-
-        expired = await create_oauth2_token(
-            save_fixture,
-            client=oauth2_client,
-            access_token="polar_at_u_app",
-            refresh_token="polar_rt_u_app",
-            scopes=["openid"],
-            user=user,
-            issued_at=int(time.time()) - 7200,
-            expires_in=3600,
-        )
-        expired.refresh_token = None  # pyright: ignore
-        await save_fixture(expired)
-
-        await oauth2_token_service.delete_expired(session)
-
-        preserved = await session.get(OAuth2Token, expired.id)
         assert preserved is not None
 
 


### PR DESCRIPTION

Let's consider now the mobile app is up to date and able to recover from expired tokens.

This reverts commit 0174e95130076489cb2a6c37de5b17ce18d7f6b4.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

