### PR TITLE
feat: show only prepared subscriptions on the migration switch list

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/SwitchPanel.tsx
@@ -18,7 +18,7 @@ import {
   toggleRow,
 } from '../selection'
 import { SwitchPanelView } from './SwitchPanelView'
-import { SwitchFilter } from './switchCopy'
+import { SwitchFilter, switchRecordsParams } from './switchCopy'
 
 const initialSwitchSelection: SelectionState = {
   mode: 'none',
@@ -40,12 +40,7 @@ export function SwitchPanel({ migrationId }: { migrationId: string }) {
   const running = switchReport.data?.running ?? false
   const records = useMigrationRecords(
     migrationId,
-    {
-      entity: 'subscriptions',
-      ...(filter !== 'all' ? { cutoverStatus: filter } : {}),
-      page,
-      limit: pageSize,
-    },
+    switchRecordsParams(filter, page, pageSize),
     running ? 3000 : false,
   )
   const startSwitch = useStartMigrationSwitch(migrationId)

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchCopy.test.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchCopy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { switchRecordsParams } from './switchCopy'
+
+describe('switchRecordsParams', () => {
+  it('always lists prepared subscriptions', () => {
+    expect(switchRecordsParams('all', 1, 20)).toEqual({
+      entity: 'subscriptions',
+      dependenciesImported: true,
+      page: 1,
+      limit: 20,
+    })
+  })
+
+  it('adds the cutover status on a status tab', () => {
+    expect(switchRecordsParams('moved', 2, 50)).toEqual({
+      entity: 'subscriptions',
+      dependenciesImported: true,
+      cutoverStatus: 'moved',
+      page: 2,
+      limit: 50,
+    })
+  })
+})

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/switch/switchCopy.ts
@@ -21,3 +21,20 @@ export const SWITCH_INTRO =
 
 export const SWITCH_UNDONE_WARNING =
   'Polar stops these subscriptions on Stripe and starts billing them. This cannot be undone.'
+
+// Always scoped to prepared subscriptions (customer + product already in
+// Polar). The cutover report uses the same set; listing every staged row
+// would fill the All tab with subscriptions that cannot be switched.
+export function switchRecordsParams(
+  filter: SwitchFilter,
+  page: number,
+  pageSize: number,
+) {
+  return {
+    entity: 'subscriptions' as const,
+    dependenciesImported: true as const,
+    ...(filter !== 'all' ? { cutoverStatus: filter } : {}),
+    page,
+    limit: pageSize,
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Stripe migration **Switch** table listed every staged subscription, including ones that were never prepared. Those rows cannot be switched, but they filled the All tab (often as "No payment method") while the counts still reflected only the prepared set.

## What

Scope the switch listing to subscriptions whose customer and product are already in Polar (`dependencies_imported`).

## Why

The cutover report already counts that prepared set (`2 imported · 1 switched · 1 to switch`). The table should show the same rows, not the rest of the Stripe catalog.

## How

`switchRecordsParams` always sends `dependenciesImported: true`, and still adds `cutoverStatus` on the Left on Stripe / Failed / Switched tabs.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`pnpm exec oxlint --type-aware` on the changed files, `pnpm typecheck` in `clients/apps/web`)
- [x] No unrelated changes or drive-by fixes are included
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efaf4516-3de1-48df-8c7c-7f7a62a15d76?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efaf4516-3de1-48df-8c7c-7f7a62a15d76&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

