### PR TITLE
Add subscription.migrated event on Stripe cutover

### DIFF
--- a/clients/apps/web/src/components/Timeline/renderers.tsx
+++ b/clients/apps/web/src/components/Timeline/renderers.tsx
@@ -93,6 +93,10 @@ const timelineRenderers: TimelineRendererMap = {
   },
   'subscription.billing_period_updated': { importance: 'low' },
   'subscription.update_cleared': { importance: 'low' },
+  'subscription.migrated': {
+    importance: 'high',
+    summary: ({ metadata }) => metadata.stripe_subscription_id,
+  },
   'subscription.uncanceled': { importance: 'high' },
   'subscription.reactivated': { importance: 'high' },
   'subscription.reinstated': { importance: 'high' },

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -7029,6 +7029,30 @@ export interface webhooks {
     patch?: never
     trace?: never
   }
+  'subscription.migrated': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * subscription_migrated
+     * @description Sent when a subscription is migrated from Stripe to Polar.
+     *
+     *     The payload maps Polar IDs to the original Stripe subscription and customer.
+     *
+     *     **Discord & Slack support:** None
+     */
+    post: operations['_endpointsubscription_migrated_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   'refund.created': {
     parameters: {
       query?: never
@@ -35764,6 +35788,134 @@ export interface components {
       /** @description The meter associated with this subscription. */
       meter: components['schemas']['Meter']
     }
+    /**
+     * SubscriptionMigrated
+     * @description Mapping from a Stripe subscription Polar has taken over.
+     */
+    SubscriptionMigrated: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The Polar subscription ID.
+       * @example e5149aae-e521-42b9-b24c-abb3d71eea2e
+       */
+      id: string
+      /**
+       * Customer Id
+       * Format: uuid4
+       * @description The Polar customer ID.
+       * @example 992fae2a-2a17-4b7a-8d9e-e287cf90131b
+       */
+      customer_id: string
+      /**
+       * Product Id
+       * Format: uuid4
+       * @description The Polar product ID.
+       * @example d8dd2de1-21b7-4a41-8bc3-ce909c0cfe23
+       */
+      product_id: string
+      /**
+       * Stripe Subscription Id
+       * @description The original Stripe subscription ID.
+       * @example sub_1NqJ9K2eZvKYlo2C
+       */
+      stripe_subscription_id: string
+      /**
+       * Stripe Customer Id
+       * @description The original Stripe customer ID.
+       * @example cus_NffrFeUfNV2Hib
+       */
+      stripe_customer_id: string
+    }
+    /**
+     * SubscriptionMigratedEvent
+     * @description An event created by Polar when a subscription is migrated from Stripe.
+     */
+    SubscriptionMigratedEvent: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Timestamp
+       * Format: date-time
+       * @description The timestamp of the event.
+       * @example 2026-01-01T00:00:00.000000Z
+       */
+      timestamp: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the event.
+       * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
+       */
+      organization_id: string
+      /**
+       * Customer Id
+       * @description ID of the customer in your Polar organization associated with the event.
+       */
+      customer_id: string | null
+      /** @description The customer associated with the event. */
+      customer: components['schemas']['Customer'] | null
+      /**
+       * External Customer Id
+       * @description ID of the customer in your system associated with the event.
+       */
+      external_customer_id: string | null
+      /**
+       * Member Id
+       * @description ID of the member within the customer's organization who performed the action inside B2B.
+       */
+      member_id?: string | null
+      /**
+       * External Member Id
+       * @description ID of the member in your system within the customer's organization who performed the action inside B2B.
+       */
+      external_member_id?: string | null
+      /**
+       * Child Count
+       * @description Number of direct child events linked to this event.
+       * @default 0
+       */
+      child_count: number
+      /**
+       * Parent Id
+       * @description The ID of the parent event.
+       */
+      parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
+       * Source
+       * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
+       * @constant
+       */
+      source: 'system'
+      /**
+       * @description The name of the event. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      name: 'subscription.migrated'
+      metadata: components['schemas']['SubscriptionMigratedMetadata']
+    }
+    /** SubscriptionMigratedMetadata */
+    SubscriptionMigratedMetadata: {
+      /** Subscription Id */
+      subscription_id: string
+      /** Customer Id */
+      customer_id: string
+      /** Product Id */
+      product_id: string
+      /** Stripe Subscription Id */
+      stripe_subscription_id: string
+      /** Stripe Customer Id */
+      stripe_customer_id: string
+    }
     /** SubscriptionNotScheduledToCancel */
     SubscriptionNotScheduledToCancel: {
       /**
@@ -37319,6 +37471,7 @@ export interface components {
       | components['schemas']['SubscriptionReinstatedEvent']
       | components['schemas']['SubscriptionPausedEvent']
       | components['schemas']['SubscriptionResumedEvent']
+      | components['schemas']['SubscriptionMigratedEvent']
       | components['schemas']['SubscriptionUncanceledEvent']
       | components['schemas']['SubscriptionProductUpdatedEvent']
       | components['schemas']['SubscriptionSeatsUpdatedEvent']
@@ -39571,6 +39724,7 @@ export interface components {
       | 'subscription.past_due'
       | 'subscription.paused'
       | 'subscription.resumed'
+      | 'subscription.migrated'
       | 'refund.created'
       | 'refund.updated'
       | 'product.created'
@@ -39997,6 +40151,31 @@ export interface components {
       /** Api Version */
       api_version: string
       data: components['schemas']['Subscription']
+    }
+    /**
+     * WebhookSubscriptionMigratedPayload
+     * @description Sent when a subscription is migrated from Stripe to Polar.
+     *
+     *     The payload maps Polar IDs to the original Stripe subscription and customer.
+     *
+     *     **Discord & Slack support:** None
+     */
+    WebhookSubscriptionMigratedPayload: {
+      /**
+       * Type
+       * @example subscription.migrated
+       * @constant
+       */
+      type: 'subscription.migrated'
+      /**
+       * Timestamp
+       * Format: date-time
+       * @example 2026-01-01T00:00:00.000000Z
+       */
+      timestamp: string
+      /** Api Version */
+      api_version: string
+      data: components['schemas']['SubscriptionMigrated']
     }
     /**
      * WebhookSubscriptionPastDuePayload
@@ -62267,6 +62446,39 @@ export interface operations {
       }
     }
   }
+  _endpointsubscription_migrated_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['WebhookSubscriptionMigratedPayload']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   _endpointrefund_created_post: {
     parameters: {
       query?: never
@@ -72008,6 +72220,9 @@ export const subscriptionExportColumnValues: ReadonlyArray<
   'trial_start',
   'trial_end',
 ]
+export const subscriptionMigratedEventNameValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SubscriptionMigratedEvent']['name']
+> = ['subscription.migrated']
 export const subscriptionPastDueEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionPastDueEvent']['name']
 > = ['subscription.past_due']
@@ -72564,6 +72779,7 @@ export const webhookEventTypeValues: ReadonlyArray<
   'subscription.past_due',
   'subscription.paused',
   'subscription.resumed',
+  'subscription.migrated',
   'refund.created',
   'refund.updated',
   'product.created',

--- a/docs/integrate/webhooks/events.mdx
+++ b/docs/integrate/webhooks/events.mdx
@@ -176,6 +176,15 @@ In order to properly implement logic for handling subscriptions, you should look
   >
     Fired when a paused subscription resumes. A new billing period starts and the customer is charged immediately.
   </Card>
+
+  <Card
+    title="subscription.migrated"
+    icon="link"
+    href="/api-reference/current/subscription_migrated"
+    horizontal
+  >
+    Fired when Polar takes over billing of a Stripe subscription. Maps Polar IDs to the original Stripe subscription and customer.
+  </Card>
 </Columns>
 
 #### Cancellation Sequences

--- a/server/polar/cli/fixtures.py
+++ b/server/polar/cli/fixtures.py
@@ -42,6 +42,7 @@ from polar.models.product_price import ProductPriceSource
 from polar.models.refund import RefundReason, RefundStatus
 from polar.models.subscription import SubscriptionStatus
 from polar.models.webhook_endpoint import WebhookEventType
+from polar.subscription.schemas import SubscriptionMigrated
 from polar.version import CURRENT_API_VERSION
 from polar.webhook.webhooks import BaseWebhookPayload, WebhookPayloadTypeAdapter
 
@@ -217,6 +218,14 @@ class TriggerFixtures:
             case WebhookEventType.subscription_paused:
                 self.subscription.status = SubscriptionStatus.paused
                 return self.subscription
+            case WebhookEventType.subscription_migrated:
+                return SubscriptionMigrated(
+                    id=self.subscription.id,
+                    customer_id=self.customer.id,
+                    product_id=self.product.id,
+                    stripe_subscription_id="sub_1NqJ9K2eZvKYlo2C",
+                    stripe_customer_id="cus_NffrFeUfNV2Hib",
+                )
             case WebhookEventType.refund_created | WebhookEventType.refund_updated:
                 return self.refund
             case WebhookEventType.product_created | WebhookEventType.product_updated:

--- a/server/polar/event/schemas.py
+++ b/server/polar/event/schemas.py
@@ -35,6 +35,7 @@ from polar.event.system import (
     SubscriptionCanceledMetadata,
     SubscriptionCreatedMetadata,
     SubscriptionCycledMetadata,
+    SubscriptionMigratedMetadata,
     SubscriptionPastDueMetadata,
     SubscriptionPausedMetadata,
     SubscriptionProductUpdatedMetadata,
@@ -452,6 +453,17 @@ class SubscriptionResumedEvent(SystemEventBase):
     )
 
 
+class SubscriptionMigratedEvent(SystemEventBase):
+    """An event created by Polar when a subscription is migrated from Stripe."""
+
+    name: Literal[SystemEventEnum.subscription_migrated] = Field(
+        description=_NAME_DESCRIPTION
+    )
+    metadata: SubscriptionMigratedMetadata = Field(
+        validation_alias=AliasChoices("user_metadata", "metadata")
+    )
+
+
 class SubscriptionProductUpdatedEvent(SystemEventBase):
     """An event created by Polar when a subscription changes the product."""
 
@@ -666,6 +678,7 @@ SystemEvent = Annotated[
     | SubscriptionReinstatedEvent
     | SubscriptionPausedEvent
     | SubscriptionResumedEvent
+    | SubscriptionMigratedEvent
     | SubscriptionUncanceledEvent
     | SubscriptionProductUpdatedEvent
     | SubscriptionSeatsUpdatedEvent

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -35,6 +35,7 @@ class SystemEvent(StrEnum):
     subscription_units_updated = "subscription.units_updated"
     subscription_billing_period_updated = "subscription.billing_period_updated"
     subscription_update_cleared = "subscription.update_cleared"
+    subscription_migrated = "subscription.migrated"
     order_paid = "order.paid"
     order_refunded = "order.refunded"
     order_voided = "order.voided"
@@ -77,6 +78,7 @@ SYSTEM_EVENT_LABELS: dict[str, str] = {
     "subscription.units_updated": "Subscription Units Updated",
     "subscription.billing_period_updated": "Subscription Billing Period Updated",
     "subscription.update_cleared": "Subscription Update Cleared",
+    "subscription.migrated": "Subscription Migrated",
     "customer.created": "Customer Created",
     "customer.updated": "Customer Updated",
     "customer.deleted": "Customer Deleted",
@@ -455,6 +457,21 @@ class SubscriptionUpdateClearedEvent(Event):
         source: Mapped[Literal[EventSource.system]]
         name: Mapped[Literal[SystemEvent.subscription_update_cleared]]
         user_metadata: Mapped[SubscriptionUpdateClearedMetadata]  # type: ignore[assignment]
+
+
+class SubscriptionMigratedMetadata(TypedDict):
+    subscription_id: str
+    customer_id: str
+    product_id: str
+    stripe_subscription_id: str
+    stripe_customer_id: str
+
+
+class SubscriptionMigratedEvent(Event):
+    if TYPE_CHECKING:
+        source: Mapped[Literal[EventSource.system]]
+        name: Mapped[Literal[SystemEvent.subscription_migrated]]
+        user_metadata: Mapped[SubscriptionMigratedMetadata]  # type: ignore[assignment]
 
 
 class OrderPaidMetadata(TypedDict):
@@ -872,6 +889,15 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: SubscriptionUpdateClearedMetadata,
+) -> Event: ...
+
+
+@overload
+def build_system_event(
+    name: Literal[SystemEvent.subscription_migrated],
+    customer: Customer,
+    organization: Organization,
+    metadata: SubscriptionMigratedMetadata,
 ) -> Event: ...
 
 

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -20,6 +20,7 @@ from polar.models import (
     Customer,
     MerchantMigration,
     MerchantMigrationRecord,
+    MerchantMigrationSourcePlatform,
     PaymentMethod,
     Product,
     Subscription,
@@ -247,6 +248,7 @@ class SubscriptionCutover:
             )
 
         current_period_start, current_period_end = self._period(source, subscription)
+        stripe_subscription_id, stripe_customer_id = self._stripe_ids(source)
         try:
             await subscription_service.activate_imported(
                 self.session,
@@ -256,6 +258,8 @@ class SubscriptionCutover:
                 trial_end=self._trial_end(source),
                 anchor_day=source.anchor_day,
                 payment_method=payment_method,
+                stripe_subscription_id=stripe_subscription_id,
+                stripe_customer_id=stripe_customer_id,
             )
         except Exception:
             # The source is stopped and this rolls back, ledger row included, so
@@ -390,6 +394,7 @@ class SubscriptionCutover:
             )
 
         current_period_start, current_period_end = self._period(source, subscription)
+        stripe_subscription_id, stripe_customer_id = self._stripe_ids(source)
         try:
             await subscription_service.activate_imported(
                 self.session,
@@ -399,6 +404,8 @@ class SubscriptionCutover:
                 trial_end=self._trial_end(source),
                 anchor_day=source.anchor_day,
                 payment_method=payment_method,
+                stripe_subscription_id=stripe_subscription_id,
+                stripe_customer_id=stripe_customer_id,
             )
         except Exception:
             log.exception(
@@ -588,3 +595,10 @@ class SubscriptionCutover:
         if source.trial_end is None or source.trial_end <= utc_now():
             return None
         return source.trial_end
+
+    def _stripe_ids(
+        self, source: CanonicalSubscription
+    ) -> tuple[str | None, str | None]:
+        if self.migration.source_platform != MerchantMigrationSourcePlatform.stripe:
+            return None, None
+        return source.source_id, source.customer_source_id

--- a/server/polar/models/webhook_endpoint.py
+++ b/server/polar/models/webhook_endpoint.py
@@ -43,6 +43,7 @@ class WebhookEventType(StrEnum):
     subscription_past_due = "subscription.past_due"
     subscription_paused = "subscription.paused"
     subscription_resumed = "subscription.resumed"
+    subscription_migrated = "subscription.migrated"
     refund_created = "refund.created"
     refund_updated = "refund.updated"
     product_created = "product.created"

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -23,6 +23,7 @@ from polar.kit.schemas import (
     CUSTOMER_ID_EXAMPLE,
     METER_ID_EXAMPLE,
     PRODUCT_ID_EXAMPLE,
+    SUBSCRIPTION_ID_EXAMPLE,
     IDSchema,
     Int32,
     MergeJSONSchema,
@@ -274,6 +275,31 @@ class Subscription(CustomFieldDataOutputMixin, MetadataOutputMixin, Subscription
             "Pending subscription update that will be applied at the beginning of the next period. "
             "If `null`, there is no pending update."
         )
+    )
+
+
+class SubscriptionMigrated(IDSchema):
+    """Mapping from a Stripe subscription Polar has taken over."""
+
+    id: UUID4 = Field(
+        description="The Polar subscription ID.",
+        examples=[SUBSCRIPTION_ID_EXAMPLE],
+    )
+    customer_id: UUID4 = Field(
+        description="The Polar customer ID.",
+        examples=[CUSTOMER_ID_EXAMPLE],
+    )
+    product_id: UUID4 = Field(
+        description="The Polar product ID.",
+        examples=[PRODUCT_ID_EXAMPLE],
+    )
+    stripe_subscription_id: str = Field(
+        description="The original Stripe subscription ID.",
+        examples=["sub_1NqJ9K2eZvKYlo2C"],
+    )
+    stripe_customer_id: str = Field(
+        description="The original Stripe customer ID.",
+        examples=["cus_NffrFeUfNV2Hib"],
     )
 
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -43,6 +43,7 @@ from polar.event.system import (
     SubscriptionCanceledMetadata,
     SubscriptionCreatedMetadata,
     SubscriptionCycledMetadata,
+    SubscriptionMigratedMetadata,
     SubscriptionPastDueMetadata,
     SubscriptionPausedMetadata,
     SubscriptionReactivatedMetadata,
@@ -117,6 +118,7 @@ from polar.product.guard import (
 from polar.product.price_set import NoPricesForCurrencies, PriceSet
 from polar.product.repository import ProductRepository
 from polar.product.service import product as product_service
+from polar.subscription.schemas import SubscriptionMigrated
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job, make_bulk_job_delay_calculator
 
@@ -917,6 +919,8 @@ class SubscriptionService:
         trial_end: datetime | None,
         anchor_day: int | None = None,
         payment_method: PaymentMethod,
+        stripe_subscription_id: str | None = None,
+        stripe_customer_id: str | None = None,
     ) -> Subscription:
         """Hand billing of an imported subscription over to Polar (the cutover).
 
@@ -954,6 +958,12 @@ class SubscriptionService:
 
         await self.enqueue_benefits_grants(session, subscription)
         await self._on_subscription_updated(session, subscription)
+        await self._on_subscription_migrated(
+            session,
+            subscription,
+            stripe_subscription_id=stripe_subscription_id,
+            stripe_customer_id=stripe_customer_id,
+        )
         enqueue_job("customer.state_changed", subscription.customer_id)
 
         log.info(
@@ -3580,6 +3590,54 @@ class SubscriptionService:
     ) -> None:
         await self._send_webhook(
             session, subscription, WebhookEventType.subscription_updated
+        )
+
+    async def _on_subscription_migrated(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        *,
+        stripe_subscription_id: str | None,
+        stripe_customer_id: str | None,
+    ) -> None:
+        if not stripe_subscription_id or not stripe_customer_id:
+            return
+
+        repository = SubscriptionRepository.from_session(session)
+        loaded = await repository.get_by_id(
+            subscription.id, options=repository.get_eager_options()
+        )
+        if loaded is None:
+            return
+        subscription = loaded
+
+        metadata = SubscriptionMigratedMetadata(
+            subscription_id=str(subscription.id),
+            customer_id=str(subscription.customer_id),
+            product_id=str(subscription.product_id),
+            stripe_subscription_id=stripe_subscription_id,
+            stripe_customer_id=stripe_customer_id,
+        )
+        await event_service.create_event(
+            session,
+            build_system_event(
+                SystemEvent.subscription_migrated,
+                customer=subscription.customer,
+                organization=subscription.organization,
+                metadata=metadata,
+            ),
+        )
+        await webhook_service.send(
+            session,
+            subscription.organization,
+            WebhookEventType.subscription_migrated,
+            SubscriptionMigrated(
+                id=subscription.id,
+                customer_id=subscription.customer_id,
+                product_id=subscription.product_id,
+                stripe_subscription_id=stripe_subscription_id,
+                stripe_customer_id=stripe_customer_id,
+            ),
         )
 
     async def _on_subscription_activated(

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -54,6 +54,7 @@ from polar.models.webhook_endpoint import (
     WebhookFormat,
 )
 from polar.organization.resolver import get_payload_organization
+from polar.subscription.schemas import SubscriptionMigrated
 from polar.user_organization.service import (
     user_organization as user_organization_service,
 )
@@ -734,6 +735,15 @@ class WebhookService:
         target: Organization,
         event: Literal[WebhookEventType.subscription_resumed],
         data: Subscription,
+    ) -> list[WebhookEvent]: ...
+
+    @overload
+    async def send(
+        self,
+        session: AsyncSession,
+        target: Organization,
+        event: Literal[WebhookEventType.subscription_migrated],
+        data: SubscriptionMigrated,
     ) -> list[WebhookEvent]: ...
 
     @overload

--- a/server/polar/webhook/webhooks.py
+++ b/server/polar/webhook/webhooks.py
@@ -61,6 +61,9 @@ from polar.organization.schemas import Organization as OrganizationSchema
 from polar.product.schemas import Product as ProductSchema
 from polar.refund.schemas import Refund as RefundSchema
 from polar.subscription.schemas import Subscription as SubscriptionSchema
+from polar.subscription.schemas import (
+    SubscriptionMigrated as SubscriptionMigratedSchema,
+)
 
 WebhookTypeObject = (
     tuple[Literal[WebhookEventType.checkout_created], Checkout]
@@ -88,6 +91,7 @@ WebhookTypeObject = (
     | tuple[Literal[WebhookEventType.subscription_uncanceled], Subscription]
     | tuple[Literal[WebhookEventType.subscription_cycled], Subscription]
     | tuple[Literal[WebhookEventType.subscription_past_due], Subscription]
+    | tuple[Literal[WebhookEventType.subscription_migrated], SubscriptionMigratedSchema]
     | tuple[Literal[WebhookEventType.refund_created], Refund]
     | tuple[Literal[WebhookEventType.refund_updated], Refund]
     | tuple[Literal[WebhookEventType.product_created], Product]
@@ -1256,6 +1260,25 @@ class WebhookSubscriptionResumedPayload(WebhookSubscriptionUpdatedPayloadBase):
         return self._get_resumed_slack_payload(target)
 
 
+class WebhookSubscriptionMigratedPayload(BaseWebhookPayload):
+    """
+    Sent when a subscription is migrated from Stripe to Polar.
+
+    The payload maps Polar IDs to the original Stripe subscription and customer.
+
+    **Discord & Slack support:** None
+    """
+
+    type: Literal[WebhookEventType.subscription_migrated]
+    data: SubscriptionMigratedSchema
+
+    def get_discord_payload(self, target: User | Organization) -> str:
+        raise SkipEvent(self.type, WebhookFormat.discord)
+
+    def get_slack_payload(self, target: User | Organization) -> str:
+        raise SkipEvent(self.type, WebhookFormat.slack)
+
+
 class WebhookRefundBase(BaseWebhookPayload):
     """
     Base Refund
@@ -1544,6 +1567,7 @@ WebhookPayload = Annotated[
     | WebhookSubscriptionPastDuePayload
     | WebhookSubscriptionPausedPayload
     | WebhookSubscriptionResumedPayload
+    | WebhookSubscriptionMigratedPayload
     | WebhookRefundCreatedPayload
     | WebhookRefundUpdatedPayload
     | WebhookProductCreatedPayload

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 import stripe as stripe_lib
 from pytest_mock import MockerFixture
 
+from polar.event.system import SystemEvent
 from polar.kit.utils import utc_now
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
@@ -42,6 +43,7 @@ from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from polar.subscription.repository import SubscriptionRepository
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.events import get_all_by_name
 from tests.fixtures.random_objects import (
     create_customer,
     create_payment_method,
@@ -231,6 +233,16 @@ class TestRun:
         assert subscription.customer_id == imported_customer.id
         assert subscription.payment_method_id is not None
         assert subscription.user_metadata["stripe_subscription_id"] == "sub_1"
+        events = await get_all_by_name(session, SystemEvent.subscription_migrated)
+        assert len(events) == 1
+        assert events[0].customer_id == imported_customer.id
+        assert events[0].user_metadata == {
+            "subscription_id": str(subscription.id),
+            "customer_id": str(imported_customer.id),
+            "product_id": str(subscription.product_id),
+            "stripe_subscription_id": "sub_1",
+            "stripe_customer_id": "cus_1",
+        }
 
     async def test_creates_from_dependencies_imported_on_earlier_migration(
         self,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -4131,6 +4131,73 @@ class TestActivateImported:
 
         assert updated.anchor_day == 31
 
+    async def test_emits_subscription_migrated_with_stripe_ids(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+        payment_method: PaymentMethod,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        reset_hooks(subscription_hooks)
+
+        updated = await subscription_service.activate_imported(
+            session,
+            subscription,
+            current_period_start=utc_now(),
+            current_period_end=utc_now() + timedelta(days=30),
+            trial_end=None,
+            payment_method=payment_method,
+            stripe_subscription_id="sub_1NqJ9K2eZvKYlo2C",
+            stripe_customer_id="cus_NffrFeUfNV2Hib",
+        )
+
+        events = await get_all_by_name(session, SystemEvent.subscription_migrated)
+        assert len(events) == 1
+        assert events[0].customer_id == customer.id
+        assert events[0].user_metadata == {
+            "subscription_id": str(updated.id),
+            "customer_id": str(customer.id),
+            "product_id": str(product.id),
+            "stripe_subscription_id": "sub_1NqJ9K2eZvKYlo2C",
+            "stripe_customer_id": "cus_NffrFeUfNV2Hib",
+        }
+
+    async def test_skips_subscription_migrated_without_stripe_ids(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+        payment_method: PaymentMethod,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        reset_hooks(subscription_hooks)
+
+        await subscription_service.activate_imported(
+            session,
+            subscription,
+            current_period_start=utc_now(),
+            current_period_end=utc_now() + timedelta(days=30),
+            trial_end=None,
+            payment_method=payment_method,
+        )
+
+        assert await get_all_by_name(session, SystemEvent.subscription_migrated) == []
+
 
 async def create_event_billing_entry(
     save_fixture: SaveFixture,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Related Issue**: Polar system event + webhook when a Stripe subscription is taken over at cutover.

Merchants migrating from Stripe need a dedicated signal when Polar starts billing a subscription, with enough IDs to map Stripe records to Polar.

## What

Adds a `subscription.migrated` Polar event and webhook, fired when an imported Stripe subscription is activated at cutover.

Payload is a mapping, not the full subscription resource:

- Polar `id` (subscription), `customer_id`, `product_id`
- Original `stripe_subscription_id` and `stripe_customer_id`

## Why

`subscription.updated` already fires at cutover, but it does not carry Stripe identifiers. Merchants need an explicit cutover event to wire Stripe customers/subscriptions to Polar IDs.

## How

- New `SystemEvent.subscription_migrated` with `SubscriptionMigratedMetadata`
- New `WebhookEventType.subscription_migrated` with a compact `SubscriptionMigrated` schema (Discord/Slack skipped)
- `activate_imported` emits the event only when both Stripe IDs are provided
- Cutover passes those IDs for Stripe migrations only (Paddle/Lemon Squeezy do not emit this event)
- Timeline renderer, webhook docs card, and generated API client updated

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16062460-11eb-43a8-b5b7-357e2f6b1a06?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16062460-11eb-43a8-b5b7-357e2f6b1a06&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

