### PR TITLE
Allow deleting products that never had a sale

### DIFF
--- a/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
@@ -3,8 +3,8 @@ import { useModal } from '@/components/Modal/useModal'
 import LegacyRecurringProductPrices from '@/components/Products/LegacyRecurringProductPrices'
 import ProductPriceLabel from '@/components/Products/ProductPriceLabel'
 import { toast } from '@/components/Toast/use-toast'
-import { useMetrics, useUpdateProduct } from '@/hooks/queries'
-import { apiErrorToast } from '@/utils/api/errors'
+import { useDeleteProduct, useMetrics, useUpdateProduct } from '@/hooks/queries'
+import { apiErrorToast, extractApiErrorMessage } from '@/utils/api/errors'
 import { getChartRangeParams } from '@/utils/metrics'
 import { hasLegacyRecurringPrices } from '@/utils/product'
 import MoreVert from '@mui/icons-material/MoreVert'
@@ -81,6 +81,7 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
   })
 
   const updateProduct = useUpdateProduct(organization)
+  const deleteProduct = useDeleteProduct(organization)
   const router = useRouter()
 
   const {
@@ -93,6 +94,12 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
     isShown: isUnarchiveModalShown,
     hide: hideUnarchiveModal,
     show: showUnarchiveModal,
+  } = useModal()
+
+  const {
+    isShown: isDeleteModalShown,
+    hide: hideDeleteModal,
+    show: showDeleteModal,
   } = useModal()
 
   const handleArchiveProduct = useCallback(async () => {
@@ -132,6 +139,24 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
       description: 'Product has been successfully unarchived',
     })
   }, [product, updateProduct])
+
+  const handleDeleteProduct = useCallback(async () => {
+    const { error } = await deleteProduct.mutateAsync(product)
+
+    if (error) {
+      toast({
+        title: 'Error Deleting Product',
+        description: extractApiErrorMessage(error),
+      })
+      return
+    }
+
+    toast({
+      title: 'Product Deleted',
+      description: 'Product has been permanently deleted',
+    })
+    router.push(`/dashboard/${organization.slug}/products`)
+  }, [product, deleteProduct, router, organization])
 
   return (
     <Tabs defaultValue="overview" className="h-full">
@@ -242,6 +267,11 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
                       <DropdownMenuItem onClick={showUnarchiveModal}>
                         Unarchive Product
                       </DropdownMenuItem>
+                      {product.is_deletable && (
+                        <DropdownMenuItem destructive onClick={showDeleteModal}>
+                          Delete Permanently
+                        </DropdownMenuItem>
+                      )}
                     </>
                   )}
                 </DropdownMenuContent>
@@ -286,6 +316,16 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
           isShown={isUnarchiveModalShown}
           hide={hideUnarchiveModal}
           destructiveText="Unarchive"
+        />
+        <ConfirmModal
+          title="Delete Product"
+          description="This product has never been sold and will be permanently deleted. This action cannot be undone."
+          onConfirm={handleDeleteProduct}
+          isShown={isDeleteModalShown}
+          hide={hideDeleteModal}
+          confirmPrompt={product.name}
+          destructiveText="Delete"
+          destructive
         />
       </DashboardBody>
     </Tabs>

--- a/clients/apps/web/src/hooks/queries/products.ts
+++ b/clients/apps/web/src/hooks/queries/products.ts
@@ -120,6 +120,27 @@ export const useUpdateProduct = (organization: schemas['Organization']) =>
     },
   })
 
+export const useDeleteProduct = (organization: schemas['Organization']) =>
+  useMutation({
+    mutationFn: (product: schemas['Product']) => {
+      return api.DELETE('/v1/products/{id}', {
+        params: { path: { id: product.id } },
+      })
+    },
+    onSuccess: async (result, variables) => {
+      if (result.error) {
+        return
+      }
+      const queryClient = getQueryClient()
+      queryClient.invalidateQueries({
+        queryKey: ['products', { organizationId: organization.id }],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['products', { id: variables.id }],
+      })
+    },
+  })
+
 export const useUpdateProducts = () =>
   useMutation({
     mutationFn: ({

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -2449,7 +2449,16 @@ export interface paths {
     get: operations['products:get']
     put?: never
     post?: never
-    delete?: never
+    /**
+     * Delete Product
+     * @description Delete a product.
+     *
+     *     Only products that never had an order, subscription or trial can be deleted.
+     *     Products with sales can only be archived.
+     *
+     *     **Scopes**: `products:write`
+     */
+    delete: operations['products:delete']
     options?: never
     head?: never
     /**
@@ -32086,6 +32095,11 @@ export interface components {
       organization_id: string
       metadata: components['schemas']['MetadataOutputType']
       /**
+       * Is Deletable
+       * @description Whether the product can be permanently deleted. Only products that never had an order, subscription or trial can be deleted; the others can only be archived.
+       */
+      is_deletable: boolean
+      /**
        * Prices
        * @description List of prices for this product.
        */
@@ -32367,6 +32381,17 @@ export interface components {
       readonly size_readable: string
       /** Public Url */
       readonly public_url: string
+    }
+    /** ProductNotDeletable */
+    ProductNotDeletable: {
+      /**
+       * Error
+       * @example ProductNotDeletable
+       * @constant
+       */
+      error: 'ProductNotDeletable'
+      /** Detail */
+      detail: string
     }
     ProductPrice:
       | components['schemas']['ProductPriceFixed']
@@ -46331,6 +46356,62 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'products:delete': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Product deleted. */
+      204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description You don't have the permission to delete this product. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Product not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Product has sales and cannot be deleted. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ProductNotDeletable']
         }
       }
       /** @description Validation Error */

--- a/docs/features/products.mdx
+++ b/docs/features/products.mdx
@@ -228,9 +228,13 @@ A few things to know:
 
 ## Archive a product
 
-Products can be archived but not permanently deleted. Click **Archive** from the product menu and the product disappears from new checkouts.
+Products can be archived at any time. Click **Archive** from the product menu and the product disappears from new checkouts.
 
 Existing customers keep their access, and active subscriptions keep renewing. You can unarchive at any time from the same menu to make the product available again.
+
+## Delete a product
+
+A product that never had an order, subscription or trial can be permanently deleted. Archive it first, then click **Delete Permanently** from the product menu. The option only appears for products without sales, and the `is_deletable` field on the API tells you whether a product qualifies.
 
 ## FAQ
 

--- a/server/polar/discount/repository.py
+++ b/server/polar/discount/repository.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from sqlalchemy import (
     ColumnElement,
     ColumnExpressionArgument,
+    delete,
     distinct,
     func,
     or_,
@@ -16,6 +17,7 @@ from polar.models import (
     Checkout,
     Customer,
     Discount,
+    DiscountProduct,
     DiscountRedemption,
     Order,
     Payment,
@@ -29,6 +31,12 @@ from polar.models.refund import RefundReason, RefundStatus
 
 class DiscountRepository(RepositoryBase[Discount], RepositoryIDMixin[Discount, UUID]):
     model = Discount
+
+    async def remove_product(self, product_id: UUID) -> None:
+        statement = delete(DiscountProduct).where(
+            DiscountProduct.product_id == product_id
+        )
+        await self.session.execute(statement)
 
     async def get_by_code_and_organization_for_update(
         self,

--- a/server/polar/models/product.py
+++ b/server/polar/models/product.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Any
 from uuid import UUID
 
 from alembic_utils.pg_function import PGFunction
@@ -13,14 +13,26 @@ from sqlalchemy import (
     Integer,
     Text,
     Uuid,
+    and_,
     case,
+    column,
+    event,
+    exists,
     or_,
     select,
+    table,
 )
 from sqlalchemy.dialects.postgresql import CITEXT, TSVECTOR
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import (
+    Mapped,
+    column_property,
+    declared_attr,
+    mapped_column,
+    relationship,
+)
+from sqlalchemy.orm.attributes import set_committed_value
 
 from polar.enums import MeterInterval, SubscriptionRecurringInterval
 from polar.kit.db.models import RecordModel
@@ -53,6 +65,16 @@ class ProductBillingType(StrEnum):
 # Alias over the shared `Visibility` enum that keeps the public OpenAPI/SDK
 # component named `ProductVisibility` for backwards compatibility.
 ProductVisibility = Annotated[Visibility, SetSchemaReference("ProductVisibility")]
+
+
+# Referenced by table name rather than model to avoid circular imports: these
+# models import from `polar.product` while this module is still loading.
+_PRODUCT_SALES_TABLES = (
+    table("orders", column("product_id", Uuid)),
+    table("subscriptions", column("product_id", Uuid)),
+    table("subscription_updates", column("product_id", Uuid)),
+    table("trial_redemptions", column("product_id", Uuid)),
+)
 
 
 class Product(VisibilityMixin, TrialConfigurationMixin, MetadataMixin, RecordModel):
@@ -172,6 +194,27 @@ class Product(VisibilityMixin, TrialConfigurationMixin, MetadataMixin, RecordMod
         back_populates="product",
     )
 
+    @declared_attr
+    def is_deletable(cls) -> Mapped[bool]:
+        """
+        Whether the product can be permanently deleted.
+
+        Only products that never had a sale (order, subscription or trial)
+        can be deleted; the others can only be archived.
+        """
+        return column_property(
+            and_(
+                *(
+                    ~exists()
+                    .where(referencing_table.c.product_id == cls.id)
+                    .correlate_except(referencing_table)
+                    for referencing_table in _PRODUCT_SALES_TABLES
+                )
+            ),
+            # Sales come from other flows, never from a product flush
+            expire_on_flush=False,
+        )
+
     def get_price(
         self, id: UUID, *, include_archived: bool = False
     ) -> "ProductPrice | None":
@@ -234,6 +277,13 @@ class Product(VisibilityMixin, TrialConfigurationMixin, MetadataMixin, RecordMod
             (cls.is_recurring, ProductBillingType.recurring),
             else_=ProductBillingType.one_time,
         )
+
+
+@event.listens_for(Product, "init")
+def _set_new_product_deletable(target: Product, args: Any, kwargs: Any) -> None:
+    # `is_deletable` is only loaded from the database on query: a product
+    # instantiated in-session has no sales yet, so populate it upfront.
+    set_committed_value(target, "is_deletable", True)
 
 
 products_search_vector_update_function = PGFunction(

--- a/server/polar/product/endpoints.py
+++ b/server/polar/product/endpoints.py
@@ -24,6 +24,7 @@ from polar.routing import APIRouter
 from . import auth
 from .schemas import Product as ProductSchema
 from .schemas import ProductBenefitsUpdate, ProductCreate, ProductID, ProductUpdate
+from .service import ProductNotDeletable
 from .service import product as product_service
 from .sorting import ProductSortProperty
 
@@ -198,3 +199,39 @@ async def update_benefits(
         session, product, benefits_update.benefits, auth_subject
     )
     return product
+
+
+@router.delete(
+    "/{id}",
+    status_code=204,
+    summary="Delete Product",
+    responses={
+        204: {"description": "Product deleted."},
+        403: {
+            "description": "You don't have the permission to delete this product.",
+            "model": NotPermitted.schema(),
+        },
+        404: ProductNotFound,
+        409: {
+            "description": "Product has sales and cannot be deleted.",
+            "model": ProductNotDeletable.schema(),
+        },
+    },
+)
+async def delete(
+    id: ProductID,
+    auth_subject: auth.CreatorProductsWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    """
+    Delete a product.
+
+    Only products that never had an order, subscription or trial can be deleted.
+    Products with sales can only be archived.
+    """
+    product = await product_service.get(session, auth_subject, id)
+
+    if product is None:
+        raise ResourceNotFound()
+
+    await product_service.delete(session, product, auth_subject)

--- a/server/polar/product/schemas.py
+++ b/server/polar/product/schemas.py
@@ -1096,6 +1096,13 @@ class Product(MetadataOutputMixin, ProductBase):
     A product.
     """
 
+    is_deletable: bool = Field(
+        description=(
+            "Whether the product can be permanently deleted. "
+            "Only products that never had an order, subscription or trial "
+            "can be deleted; the others can only be archived."
+        )
+    )
     prices: ProductPriceList
     benefits: BenefitList
     medias: ProductMediaList

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -18,8 +18,10 @@ from polar.authz.types import AccessibleOrganizationID
 from polar.benefit.service import benefit as benefit_service
 from polar.checkout_link.repository import CheckoutLinkRepository
 from polar.custom_field.service import custom_field as custom_field_service
+from polar.discount.repository import DiscountRepository
 from polar.enums import SubscriptionRecurringInterval
 from polar.exceptions import (
+    PolarError,
     PolarRequestValidationError,
     ValidationError,
 )
@@ -69,6 +71,19 @@ from .schemas import (
     ProductUpdate,
 )
 from .sorting import ProductSortProperty
+
+
+class ProductError(PolarError): ...
+
+
+class ProductNotDeletable(ProductError):
+    def __init__(self, product_id: uuid.UUID) -> None:
+        self.product_id = product_id
+        message = (
+            "This product has orders, subscriptions or trials "
+            "and cannot be deleted. Archive it instead."
+        )
+        super().__init__(message, 409)
 
 
 class _SavepointRollback(Exception):
@@ -582,6 +597,28 @@ class ProductService:
         await self._after_product_updated(session, product)
 
         return product, added_benefits, deleted_benefits
+
+    async def delete(
+        self,
+        session: AsyncSession,
+        product: Product,
+        auth_subject: AuthSubject[User | Organization],
+    ) -> Product:
+        await assert_resource_permission(
+            session, auth_subject, product, OrganizationPermission.products_manage
+        )
+
+        if not product.is_deletable:
+            raise ProductNotDeletable(product.id)
+
+        if not product.is_archived:
+            product = await self._archive(session, product)
+
+        discount_repository = DiscountRepository.from_session(session)
+        await discount_repository.remove_product(product.id)
+
+        repository = ProductRepository.from_session(session)
+        return await repository.soft_delete(product)
 
     async def get_validated_prices(
         self,

--- a/server/tests/product/test_endpoints.py
+++ b/server/tests/product/test_endpoints.py
@@ -6,6 +6,7 @@ from httpx import AsyncClient
 
 from polar.models import (
     Benefit,
+    Customer,
     Organization,
     Product,
     ProductPriceFixed,
@@ -16,6 +17,7 @@ from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_custom_field,
+    create_order,
     create_product,
     create_product_unit_based,
     set_product_benefits,
@@ -565,3 +567,65 @@ class TestUpdateProductBenefits:
 
         json = response.json()
         assert len(json["benefits"]) == 1
+
+
+@pytest.mark.asyncio
+class TestDeleteProduct:
+    async def test_anonymous(self, client: AsyncClient, product: Product) -> None:
+        response = await client.delete(f"/v1/products/{product.id}")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_not_existing(self, client: AsyncClient) -> None:
+        response = await client.delete(f"/v1/products/{uuid.uuid4()}")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_product(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product_organization_second: Product,
+    ) -> None:
+        response = await client.delete(f"/v1/products/{product_organization_second.id}")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_not_deletable(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+        user_organization: UserOrganization,
+    ) -> None:
+        await create_order(save_fixture, customer=customer, product=product)
+
+        response = await client.get(f"/v1/products/{product.id}")
+        assert response.status_code == 200
+        assert response.json()["is_deletable"] is False
+
+        response = await client.delete(f"/v1/products/{product.id}")
+
+        assert response.status_code == 409
+
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        client: AsyncClient,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(f"/v1/products/{product.id}")
+        assert response.status_code == 200
+        assert response.json()["is_deletable"] is True
+
+        response = await client.delete(f"/v1/products/{product.id}")
+
+        assert response.status_code == 204
+
+        response = await client.get(f"/v1/products/{product.id}")
+        assert response.status_code == 404

--- a/server/tests/product/test_service.py
+++ b/server/tests/product/test_service.py
@@ -16,6 +16,7 @@ from polar.kit.pagination import PaginationParams
 from polar.kit.trial import TrialInterval
 from polar.models import (
     Benefit,
+    Customer,
     File,
     Meter,
     Organization,
@@ -24,6 +25,7 @@ from polar.models import (
     UserOrganization,
 )
 from polar.models.benefit import BenefitType
+from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.file import FileServiceTypes, ProductMediaFile
 from polar.models.organization import OrganizationStatus
 from polar.models.product_price import (
@@ -55,6 +57,7 @@ from polar.product.schemas import (
     ProductPriceUnitBasedCreate,
     ProductUpdate,
 )
+from polar.product.service import ProductNotDeletable
 from polar.product.service import product as product_service
 from polar.product.sorting import ProductSortProperty
 from polar.product.tiers import Tiers, TiersInput, TierType
@@ -64,8 +67,12 @@ from tests.fixtures.random_objects import (
     METER_ID,
     create_benefit,
     create_checkout_link,
+    create_discount,
     create_meter,
+    create_order,
     create_product,
+    create_subscription,
+    create_trial_redemption,
     set_product_benefits,
 )
 
@@ -2872,6 +2879,137 @@ class TestUpdateBenefits:
                 ),
             ]
         )
+
+
+@pytest.mark.asyncio
+class TestDelete:
+    @pytest.mark.auth
+    async def test_not_deletable_with_order(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        product: Product,
+        customer: Customer,
+        user_organization: UserOrganization,
+    ) -> None:
+        await create_order(save_fixture, customer=customer, product=product)
+        product = await self._reload(session, auth_subject, product)
+
+        assert not product.is_deletable
+        with pytest.raises(ProductNotDeletable):
+            await product_service.delete(session, product, auth_subject)
+
+        assert product.deleted_at is None
+
+    @pytest.mark.auth
+    async def test_not_deletable_with_subscription(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        product: Product,
+        customer: Customer,
+        user_organization: UserOrganization,
+    ) -> None:
+        await create_subscription(save_fixture, product=product, customer=customer)
+        product = await self._reload(session, auth_subject, product)
+
+        assert not product.is_deletable
+        with pytest.raises(ProductNotDeletable):
+            await product_service.delete(session, product, auth_subject)
+
+    @pytest.mark.auth
+    async def test_not_deletable_with_trial_redemption(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        product: Product,
+        customer: Customer,
+        user_organization: UserOrganization,
+    ) -> None:
+        await create_trial_redemption(
+            save_fixture,
+            customer=customer,
+            customer_email="customer@example.com",
+            product=product,
+        )
+        product = await self._reload(session, auth_subject, product)
+
+        assert not product.is_deletable
+        with pytest.raises(ProductNotDeletable):
+            await product_service.delete(session, product, auth_subject)
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_valid(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        organization: Organization,
+        product: Product,
+        product_second: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        checkout_link = await create_checkout_link(save_fixture, products=[product])
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            products=[product, product_second],
+        )
+        product = await self._reload(session, auth_subject, product)
+
+        assert product.is_deletable
+        deleted_product = await product_service.delete(session, product, auth_subject)
+
+        assert deleted_product.deleted_at is not None
+        assert deleted_product.is_archived
+
+        await session.refresh(checkout_link, {"deleted_at"})
+        assert checkout_link.deleted_at is not None
+
+        await session.refresh(discount, {"discount_products"})
+        assert [
+            discount_product.product_id
+            for discount_product in discount.discount_products
+        ] == [product_second.id]
+
+        assert await product_service.get(session, auth_subject, product.id) is None
+
+    @pytest.mark.auth
+    async def test_valid_archived(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        product.is_archived = True
+        await save_fixture(product)
+        product = await self._reload(session, auth_subject, product)
+
+        deleted_product = await product_service.delete(session, product, auth_subject)
+
+        assert deleted_product.deleted_at is not None
+
+    async def _reload(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        product: Product,
+    ) -> Product:
+        await session.refresh(product, {"is_deletable"})
+        reloaded_product = await product_service.get(session, auth_subject, product.id)
+        assert reloaded_product is not None
+        return reloaded_product
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Products could only be archived. Add a `DELETE /v1/products/{id}` endpoint
that soft-deletes a product, restricted to products without any order,
subscription, scheduled subscription update or trial redemption. Deleting
also archives the product (so checkout links are cleaned up) and removes it
from discounts.

Expose `is_deletable` on the `Product` schema, computed in the database as
a column property, so clients don't have to derive it. A product
instantiated in-session is marked deletable upfront, since the property is
otherwise only loaded on query.

In the dashboard, archived products get a "Delete Permanently" entry in the
product menu, shown only when the backend reports the product as deletable,
behind a confirmation that requires typing the product name.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0177698hETuxixZVmccyKit5

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/14676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

